### PR TITLE
refactor(components): unify prop binding and slot handling

### DIFF
--- a/packages/0/src/components/Atom/Atom.vue
+++ b/packages/0/src/components/Atom/Atom.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
   // Utils
-  import { mergeProps, toRef, useAttrs, useTemplateRef } from 'vue'
+  import { toRef, useAttrs, useTemplateRef } from 'vue'
   import { isSelfClosingTag } from '#v0/constants/htmlElements'
 
   // Types
@@ -20,9 +20,7 @@
     element: TemplateRef<HTMLElement | null>
   }
 
-  interface AtomPrivateProps<T extends Record<string, any> = {}> extends AtomProps {
-    props?: T
-  }
+  interface AtomPrivateProps extends AtomProps {}
 </script>
 
 <script setup lang="ts" generic="T extends Record<string, any> = {}">
@@ -33,8 +31,7 @@
   const {
     as = 'div',
     renderless = false,
-    props = {},
-  } = defineProps<AtomPrivateProps<T>>()
+  } = defineProps<AtomPrivateProps>()
 
   const element = useTemplateRef<HTMLElement>('element')
 
@@ -42,7 +39,7 @@
 
   const attrs = useAttrs()
   const isSelfClosing = toRef(() => typeof as === 'string' && isSelfClosingTag(as as keyof HTMLElementTagNameMap))
-  const slotProps = toRef(() => mergeProps(props, attrs) as T)
+  const slotProps = toRef(() => attrs as T)
 </script>
 
 <template>
@@ -54,7 +51,7 @@
   <component
     :is="as"
     v-else-if="!isSelfClosing"
-    v-bind="props"
+    v-bind="slotProps"
     ref="element"
   >
     <slot v-if="!isSelfClosing" v-bind="slotProps" />
@@ -63,6 +60,6 @@
     :is="as"
     v-else
     ref="element"
-    v-bind="props"
+    v-bind="slotProps"
   />
 </template>

--- a/packages/0/src/components/Avatar/AvatarImage.vue
+++ b/packages/0/src/components/Avatar/AvatarImage.vue
@@ -3,14 +3,14 @@
   import { Atom } from '#v0/components/Atom'
 
   // Utilities
-  import { onUnmounted } from 'vue'
+  import { onUnmounted, toRef } from 'vue'
 
   // Types
   import { useAvatarContext } from './AvatarRoot.vue'
   import type { AtomProps } from '#v0/components/Atom'
 
   export interface AvatarImageProps extends AtomProps {
-    size?: string
+    src?: string
     priority?: number
   }
 
@@ -26,7 +26,7 @@
     inheritAttrs: false,
   })
 
-  const { as = 'img', priority = 0 } = defineProps<AvatarImageProps>()
+  const { as = 'img', renderless, priority = 0, ...props } = defineProps<AvatarImageProps>()
 
   const emit = defineEmits<AvatarImageEmits>()
 
@@ -52,21 +52,25 @@
     context.unregister(ticket.id)
   })
 
+  const bindableProps = toRef(() => ({
+    onError,
+    onLoad,
+    role: 'img',
+    ...props,
+  }))
+
+  type BindableProps = typeof bindableProps.value
+
+  defineSlots<{ default: (props: BindableProps) => any }>()
 </script>
 
 <template>
   <Atom
     v-show="ticket.isVisible"
-    v-slot="slotProps"
     :as
-    :props="{
-      role: 'img',
-      onError,
-      onLoad,
-      ...$attrs
-    }"
     :renderless
+    v-bind="bindableProps"
   >
-    <slot v-bind="slotProps" />
+    <slot v-bind="bindableProps" />
   </Atom>
 </template>

--- a/packages/0/src/components/Popover/PopoverRoot.vue
+++ b/packages/0/src/components/Popover/PopoverRoot.vue
@@ -37,6 +37,16 @@
     isActive.value = !isActive.value
   }
 
+  const bindableProps = toRef(() => ({
+    id,
+    isActive,
+    toggle,
+  }))
+
+  type BindableProps = typeof bindableProps.value
+
+  defineSlots<{ default: (props: BindableProps) => any }>()
+
   providePopoverContext({
     isActive,
     toggle,
@@ -47,8 +57,9 @@
 <template>
   <Atom
     :as
-    :props="{ isActive, toggle, id }"
+    :renderless
+    v-bind="bindableProps"
   >
-    <slot />
+    <slot v-bind="bindableProps" />
   </Atom>
 </template>


### PR DESCRIPTION
- Consolidate prop binding logic using toRef in PopoverRoot and AvatarImage
- Remove mergeProps usage in Atom component and simplify slot handling