### PR TITLE
chore: rename @vuetify/0 to @vuetify/v0 in all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A foundational Vue 3 component library providing lightweight, headless building 
 
 This monorepo contains two primary packages:
 
-### `@vuetify/0`
+### `@vuetify/v0`
 Core foundational components and composables:
 
 **Components:**
@@ -77,14 +77,14 @@ Components in vuetify0 should be:
 ### Installation
 
 ```bash
-pnpm add @vuetify/0 @vuetify/paper
+pnpm add @vuetify/v0 @vuetify/paper
 ```
 
 ### Basic Setup
 
 ```vue
 <script setup>
-import { Avatar, createThemePlugin } from '@vuetify/0'
+import { Avatar, createThemePlugin } from '@vuetify/v0'
 import { V0Paper } from '@vuetify/paper'
 
 // Install theme plugin

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,7 @@
     "vite": "catalog:"
   },
   "dependencies": {
-    "@vuetify/0": "workspace:*",
+    "@vuetify/v0": "workspace:*",
     "@vuetify/paper": "workspace:*",
     "lucide-vue-next": "^0.534.0",
     "markdown-it-attrs": "^4.3.1",

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
   // Components
-  import { Atom, useBreakpoints } from '@vuetify/0'
+  import { Atom, useBreakpoints } from '@vuetify/v0'
 
   // Icons
   import { Github, Menu } from 'lucide-vue-next'
 
   // Types
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
   import { useAppContext } from '@/composables/useApp'
 
   const { as = 'header' } = defineProps<AtomProps>()

--- a/apps/docs/src/components/app/AppDivider.vue
+++ b/apps/docs/src/components/app/AppDivider.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-  import { Atom } from '@vuetify/0'
+  import { Atom } from '@vuetify/v0'
 
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
 
   export interface AppDividerProps extends AtomProps {
     orientation?: 'horizontal' | 'vertical'

--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
   // Components
-  import { Atom, useBreakpoints } from '@vuetify/0'
+  import { Atom, useBreakpoints } from '@vuetify/v0'
 
   // Types
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
 
   const { as = 'footer' } = defineProps<AtomProps>()
 

--- a/apps/docs/src/components/app/AppMain.vue
+++ b/apps/docs/src/components/app/AppMain.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-  import { useBreakpoints } from '@vuetify/0'
+  import { useBreakpoints } from '@vuetify/v0'
 
   const breakpoints = useBreakpoints()
 </script>

--- a/apps/docs/src/components/app/AppNav.vue
+++ b/apps/docs/src/components/app/AppNav.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-  import { Atom, useBreakpoints } from '@vuetify/0'
+  import { Atom, useBreakpoints } from '@vuetify/v0'
 
   import { useAppContext } from '@/composables/useApp'
 
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
 
   const { as = 'nav' } = defineProps<AtomProps>()
 

--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
   // Components
-  import { Atom } from '@vuetify/0'
+  import { Atom } from '@vuetify/v0'
   import { RouterLink } from 'vue-router'
 
   // Types
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
   import type { RouterLinkProps } from 'vue-router'
 
   export interface NavItem {

--- a/apps/docs/src/composables/useApp.ts
+++ b/apps/docs/src/composables/useApp.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@vuetify/0'
+import { createContext } from '@vuetify/v0'
 import type { ShallowRef } from 'vue'
 
 export const [useAppContext, provideAppContext] = createContext<{

--- a/apps/docs/src/pages/components/components.md
+++ b/apps/docs/src/pages/components/components.md
@@ -28,7 +28,7 @@ The foundational component that all other components build upon. Provides dynami
 
 ```html
 <script setup>
-import { Atom } from '@vuetify/0'
+import { Atom } from '@vuetify/v0'
 </script>
 
 <template>
@@ -49,7 +49,7 @@ Multi-source avatar component with automatic fallback priority and loading state
 
 ```html
 <script setup>
-import { Avatar } from '@vuetify/0'
+import { Avatar } from '@vuetify/v0'
 </script>
 
 <template>
@@ -78,7 +78,7 @@ Selection management for collections of items with single/multiple selection mod
 
 ```html
 <script setup>
-import { Group } from '@vuetify/0'
+import { Group } from '@vuetify/v0'
 import { ref } from 'vue'
 
 const selected = ref([])
@@ -107,7 +107,7 @@ Step-based navigation for wizards and multi-step processes.
 
 ```html
 <script setup>
-import { Step } from '@vuetify/0'
+import { Step } from '@vuetify/v0'
 import { ref } from 'vue'
 
 const currentStep = ref('step1')
@@ -132,7 +132,7 @@ CSS anchor-positioned popover system with automatic positioning.
 
 ```html
 <script setup>
-import { Popover } from '@vuetify/0'
+import { Popover } from '@vuetify/v0'
 </script>
 
 <template>
@@ -156,7 +156,7 @@ Provide and inject context for sharing state across component trees.
 
 ```html
 <script setup>
-import { Context } from '@vuetify/0'
+import { Context } from '@vuetify/v0'
 
 const contextValue = { user: 'John', theme: 'dark' }
 </script>
@@ -177,7 +177,7 @@ Responsive utilities for adaptive layouts.
 
 ```html
 <script setup>
-import { Breakpoints } from '@vuetify/0'
+import { Breakpoints } from '@vuetify/v0'
 </script>
 
 <template>
@@ -197,7 +197,7 @@ Theme management with CSS variable injection.
 
 ```html
 <script setup>
-import { Theme } from '@vuetify/0'
+import { Theme } from '@vuetify/v0'
 </script>
 
 <template>
@@ -217,7 +217,7 @@ SSR hydration management.
 
 ```html
 <script setup>
-import { Hydration } from '@vuetify/0'
+import { Hydration } from '@vuetify/v0'
 </script>
 
 <template>
@@ -238,7 +238,7 @@ Components can be composed together for complex functionality:
 
 ```html
 <script setup>
-import { Group, Step, Theme } from '@vuetify/0'
+import { Group, Step, Theme } from '@vuetify/v0'
 </script>
 
 <template>

--- a/apps/docs/src/pages/composables/foundation/create-context.md
+++ b/apps/docs/src/pages/composables/foundation/create-context.md
@@ -48,7 +48,7 @@ It's easy to create a global context that can be used throughout your applicatio
 ```ts
 // src/composables/my-context.ts
 
-import { createContext } from '@vuetify/0'
+import { createContext } from '@vuetify/v0'
 
 interface MyContext {
   collection: Map<string, string>

--- a/apps/docs/src/pages/composables/foundation/create-trinity.md
+++ b/apps/docs/src/pages/composables/foundation/create-trinity.md
@@ -36,7 +36,7 @@ The **createTrinity** factory function is a type-safe utility for generating a 3
 The trinity pattern is the marrying of provide and inject with a context object. It provides a clean and type safe way to create a sharable singleton state.
 
 ```ts
-import { createContext, createTrinity } from '@vuetify/0'
+import { createContext, createTrinity } from '@vuetify/v0'
 
 interface User {
   id: string
@@ -62,7 +62,7 @@ The following is an example of how to create a context for authentication in a V
 
 ```ts
 // state/auth.ts
-import { createContext, createTrinity } from '@vuetify/0'
+import { createContext, createTrinity } from '@vuetify/v0'
 import { ref, toRef } from 'vue'
 
 import type { ComputedGetter, Readonly, Ref } from 'vue'

--- a/apps/docs/src/pages/composables/registration/use-registry.md
+++ b/apps/docs/src/pages/composables/registration/use-registry.md
@@ -73,8 +73,8 @@ The `useRegistry` composable provides a powerful interface for managing collecti
 
 ```ts
 // src/composables/my-registry.ts
-import { useRegistry } from '@vuetify/0'
-import { createContext } from '@vuetify/0'
+import { useRegistry } from '@vuetify/v0'
+import { createContext } from '@vuetify/v0'
 
 // Simple usage
 export const useMyRegistry = () => useRegistry()
@@ -190,8 +190,8 @@ console.log(registry.collection.size) // 0
 The `useRegistry` composable works seamlessly with the factory functions for creating context providers:
 
 ```ts
-import { useRegistry } from '@vuetify/0'
-import { createContext, createTrinity } from '@vuetify/0'
+import { useRegistry } from '@vuetify/v0'
+import { createContext, createTrinity } from '@vuetify/v0'
 
 // Simple context approach
 const [useMyContext, provideMyContext] = createContext('my-registry')
@@ -286,8 +286,8 @@ The following example demonstrates creating a registry for reusable icon svg pat
 ```ts
 // src/composables/icons.ts
 
-import { useRegistry } from '@vuetify/0'
-import { createContext } from '@vuetify/0'
+import { useRegistry } from '@vuetify/v0'
+import { createContext } from '@vuetify/v0'
 
 const [useIconContext, provideIconContext] = createContext('icons')
 

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -1,5 +1,5 @@
 // Vuetify0
-import { createBreakpointsPlugin, createHydrationPlugin, createLoggerPlugin, createThemePlugin } from '@vuetify/0'
+import { createBreakpointsPlugin, createHydrationPlugin, createLoggerPlugin, createThemePlugin } from '@vuetify/v0'
 
 // Types
 import type { App } from 'vue'

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('src', import.meta.url)),
-      '@vuetify/0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
       '@vuetify/paper': fileURLToPath(new URL('../../packages/paper/src', import.meta.url)),
       // internal
       '#v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@vuetify/paper": "workspace:*",
-    "@vuetify/0": "workspace:*"
+    "@vuetify/v0": "workspace:*"
   },
   "devDependencies": {
     "@storybook/vue3-vite": "^9.0.13",

--- a/apps/storybook/stories/Avatar.stories.ts
+++ b/apps/storybook/stories/Avatar.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { Avatar } from '@vuetify/0'
+import { Avatar } from '@vuetify/v0'
 
 const meta: Meta<typeof Avatar.Root> = {
   title: 'Components/Avatar',

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@vuetify/0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
       '@vuetify/paper': fileURLToPath(new URL('../../packages/paper/src', import.meta.url)),
       // internal
       '#v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vuetify/0",
+  "name": "@vuetify/v0",
   "version": "0.0.0",
   "description": "Vuetify0",
   "license": "MIT",

--- a/packages/0/vitest.config.ts
+++ b/packages/0/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('src', import.meta.url)),
-      '@vuetify/0': fileURLToPath(new URL('src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('src', import.meta.url)),
       '@vuetify/paper': fileURLToPath(new URL('../paper/src', import.meta.url)),
       // internal
       '#v0': fileURLToPath(new URL('src', import.meta.url)),

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@vuetify/0": "workspace:*"
+    "@vuetify/v0": "workspace:*"
   },
   "devDependencies": {
     "@vue/test-utils": "catalog:",

--- a/packages/paper/src/components/V0Paper/V0Paper.vue
+++ b/packages/paper/src/components/V0Paper/V0Paper.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
   // Components
-  import { Atom } from '@vuetify/0'
+  import { Atom } from '@vuetify/v0'
 
   // Composables
   import { useBorder } from '#paper/composables/useBorder'
@@ -14,7 +14,7 @@
   import { toRef } from 'vue'
 
   // Types
-  import type { AtomProps } from '@vuetify/0'
+  import type { AtomProps } from '@vuetify/v0'
   import type { BorderProps } from '#paper/composables/useBorder'
   import type { ColorProps } from '#paper/composables/useColor'
   import type { DimensionProps } from '#paper/composables/useDimensions'

--- a/packages/paper/vite.config.ts
+++ b/packages/paper/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', '@vuetify/0'],
+      external: ['vue', '@vuetify/v0'],
     },
     copyPublicDir: false,
   },

--- a/packages/paper/vitest.config.ts
+++ b/packages/paper/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('src', import.meta.url)),
-      '@vuetify/0': fileURLToPath(new URL('../0/src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('../0/src', import.meta.url)),
       '@vuetify/paper': fileURLToPath(new URL('src', import.meta.url)),
       // internal
       '#v0': fileURLToPath(new URL('../0/src', import.meta.url)),

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "vue": "catalog:",
     "@vuetify/paper": "workspace:*",
-    "@vuetify/0": "workspace:*"
+    "@vuetify/v0": "workspace:*"
   }
 }

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('src', import.meta.url)),
-      '@vuetify/0': fileURLToPath(new URL('../packages/0/src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('../packages/0/src', import.meta.url)),
       '@vuetify/paper': fileURLToPath(new URL('../packages/paper/src', import.meta.url)),
       // internal
       '#v0': fileURLToPath(new URL('../packages/0/src', import.meta.url)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,12 +73,12 @@ importers:
 
   apps/docs:
     dependencies:
-      '@vuetify/0':
-        specifier: workspace:*
-        version: link:../../packages/0
       '@vuetify/paper':
         specifier: workspace:*
         version: link:../../packages/paper
+      '@vuetify/v0':
+        specifier: workspace:*
+        version: link:../../packages/0
       lucide-vue-next:
         specifier: ^0.534.0
         version: 0.534.0(vue@3.5.17(typescript@5.8.3))
@@ -134,12 +134,12 @@ importers:
 
   apps/storybook:
     dependencies:
-      '@vuetify/0':
-        specifier: workspace:*
-        version: link:../../packages/0
       '@vuetify/paper':
         specifier: workspace:*
         version: link:../../packages/paper
+      '@vuetify/v0':
+        specifier: workspace:*
+        version: link:../../packages/0
     devDependencies:
       '@storybook/vue3-vite':
         specifier: ^9.0.13
@@ -192,7 +192,7 @@ importers:
 
   packages/paper:
     dependencies:
-      '@vuetify/0':
+      '@vuetify/v0':
         specifier: workspace:*
         version: link:../0
       vue:
@@ -214,12 +214,12 @@ importers:
 
   playground:
     dependencies:
-      '@vuetify/0':
-        specifier: workspace:*
-        version: link:../packages/0
       '@vuetify/paper':
         specifier: workspace:*
         version: link:../packages/paper
+      '@vuetify/v0':
+        specifier: workspace:*
+        version: link:../packages/0
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -3642,8 +3642,8 @@ packages:
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
-  vue-component-type-helpers@3.0.4:
-    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
+  vue-component-type-helpers@3.0.5:
+    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -4174,7 +4174,7 @@ snapshots:
       storybook: 9.0.13(@testing-library/dom@10.4.0)
       type-fest: 2.19.0
       vue: 3.5.17(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.4
+      vue-component-type-helpers: 3.0.5
 
   '@stylistic/eslint-plugin@4.4.1(eslint@9.32.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -7514,7 +7514,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.10: {}
 
-  vue-component-type-helpers@3.0.4: {}
+  vue-component-type-helpers@3.0.5: {}
 
   vue-docgen-api@4.79.2(vue@3.5.17(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
As we can't use @vuetify/0 in npm/github packages, this PR renames to use the @vuetify/v0 name