### PR TITLE
fix(docs): fix pagination text visibility on hover for selected item

### DIFF
--- a/apps/docs/src/examples/components/pagination/basic.vue
+++ b/apps/docs/src/examples/components/pagination/basic.vue
@@ -29,7 +29,7 @@
         />
         <Pagination.Item
           v-else
-          class="w-9 h-9 rounded border border-divider flex items-center justify-center bg-surface hover:bg-surface-tint data-[selected]:bg-primary data-[selected]:text-on-primary data-[selected]:border-primary"
+          class="w-9 h-9 rounded border border-divider flex items-center justify-center bg-surface hover:bg-surface-tint data-[selected]:bg-primary data-[selected]:text-on-primary data-[selected]:border-primary data-[selected]:hover:bg-primary"
           :value="item.value as number"
         >
           {{ item.value }}


### PR DESCRIPTION
Add data-[selected]:hover:bg-primary to maintain primary background
when hovering over the active pagination item, ensuring text remains
visible in both light and dark themes.