### PR TITLE
feat(types): make RegistryTicket.value generic for type safety

### DIFF
--- a/packages/0/src/components/Group/GroupItem.vue
+++ b/packages/0/src/components/Group/GroupItem.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="V = unknown">
   // Composables
   import { useGroup } from '#v0/composables/useGroup'
 
@@ -17,7 +17,7 @@
       /** Optional display label (passed through to slot, not used in registration) */
       label?: string
       /** Value associated with this item */
-      value: any
+      value: V | undefined
       /** Whether this item is currently selected */
       isSelected: boolean
       /** Disables this specific item */
@@ -32,7 +32,7 @@
       unselect: () => void
       /** Toggle this item's group state */
       toggle: () => void
-    }) => any
+    }) => unknown
   }>()
 
   const {
@@ -49,7 +49,7 @@
     /** Disables this specific item */
     disabled?: MaybeRef<boolean>
     /** Value associated with this item */
-    value?: any
+    value?: V
     /** Namespace for dependency injection */
     namespace?: string
   }>()

--- a/packages/0/src/components/Selection/SelectionItem.vue
+++ b/packages/0/src/components/Selection/SelectionItem.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="V = unknown">
   // Composables
   import { useSelection } from '#v0/composables/useSelection'
 
@@ -17,7 +17,7 @@
       /** Optional display label (passed through to slot, not used in registration) */
       label?: string
       /** Value associated with this item */
-      value: any
+      value: V | undefined
       /** Whether this item is currently selected */
       isSelected: boolean
       /** Disables this specific item */
@@ -32,7 +32,7 @@
       unselect: () => void
       /** Toggle this item's selection state */
       toggle: () => void
-    }) => any
+    }) => unknown
   }>()
 
   const {
@@ -49,7 +49,7 @@
     /** Disables this specific item */
     disabled?: MaybeRef<boolean>
     /** Value associated with this item */
-    value?: any
+    value?: V
     /** Namespace for dependency injection */
     namespace?: string
   }>()

--- a/packages/0/src/components/Single/SingleItem.vue
+++ b/packages/0/src/components/Single/SingleItem.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="V = unknown">
   // Composables
   import { useSingle } from '#v0/composables/useSingle'
 
@@ -17,7 +17,7 @@
       /** Optional display label (passed through to slot, not used in registration) */
       label?: string
       /** Value associated with this item */
-      value: any
+      value: V | undefined
       /** Whether this item is currently selected */
       isSelected: boolean
       /** Disables this specific item */
@@ -32,7 +32,7 @@
       unselect: () => void
       /** Toggle this item's single state */
       toggle: () => void
-    }) => any
+    }) => unknown
   }>()
 
   const {
@@ -49,7 +49,7 @@
     /** Disables this specific item */
     disabled?: MaybeRef<boolean>
     /** Value associated with this item */
-    value?: any
+    value?: V
     /** Namespace for dependency injection */
     namespace?: string
   }>()

--- a/packages/0/src/components/Step/StepItem.vue
+++ b/packages/0/src/components/Step/StepItem.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="V = unknown">
   // Composables
   import { useStep } from '#v0/composables/useStep'
 
@@ -17,7 +17,7 @@
       /** Optional display label (passed through to slot, not used in registration) */
       label?: string
       /** Value associated with this item */
-      value: any
+      value: V | undefined
       /** Whether this item is currently selected */
       isSelected: boolean
       /** Disables this specific item */
@@ -32,7 +32,7 @@
       unselect: () => void
       /** Toggle this item's step state */
       toggle: () => void
-    }) => any
+    }) => unknown
   }>()
 
   const {
@@ -49,7 +49,7 @@
     /** Disables this specific item */
     disabled?: MaybeRef<boolean>
     /** Value associated with this item */
-    value?: any
+    value?: V
     /** Namespace for dependency injection */
     namespace?: string
   }>()

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -37,9 +37,7 @@ import type { App } from 'vue'
 import type { TokenCollection, TokenValue } from '#v0/composables/useTokens'
 import type { RegistryOptions } from '#v0/composables/useRegistry'
 
-export interface FeatureTicket extends GroupTicket {
-  value: TokenValue
-}
+export interface FeatureTicket extends GroupTicket<TokenValue> {}
 
 export interface FeatureContext<Z extends FeatureTicket = FeatureTicket> extends GroupContext<Z> {
   /* Get the variation value of a feature, or a fallback if not set */

--- a/packages/0/src/composables/useForm/index.ts
+++ b/packages/0/src/composables/useForm/index.ts
@@ -41,7 +41,7 @@ export type FormValidationRule = (value: unknown) => FormValidationResult
 
 export type FormValue = Ref<unknown> | ShallowRef<unknown>
 
-export interface FormTicket extends RegistryTicket {
+export interface FormTicket<V = unknown> extends RegistryTicket<V> {
   validate: (silent?: boolean) => Promise<boolean>
   reset: () => void
   validateOn: 'submit' | 'change' | string

--- a/packages/0/src/composables/useGroup/index.ts
+++ b/packages/0/src/composables/useGroup/index.ts
@@ -32,7 +32,7 @@ import type { ID } from '#v0/types'
 import type { SelectionContext, SelectionContextOptions, SelectionOptions, SelectionTicket } from '#v0/composables/useSelection'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 
-export interface GroupTicket extends SelectionTicket {}
+export interface GroupTicket<V = unknown> extends SelectionTicket<V> {}
 
 export interface GroupContext<Z extends GroupTicket> extends SelectionContext<Z> {
   selectedIndexes: ComputedRef<Set<number>>

--- a/packages/0/src/composables/useQueue/index.ts
+++ b/packages/0/src/composables/useQueue/index.ts
@@ -31,7 +31,7 @@ import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { ID } from '#v0/types'
 import type { App } from 'vue'
 
-export interface QueueTicket extends RegistryTicket {
+export interface QueueTicket<V = unknown> extends RegistryTicket<V> {
   /**
    * Timeout in milliseconds
    *

--- a/packages/0/src/composables/useRegistry/index.ts
+++ b/packages/0/src/composables/useRegistry/index.ts
@@ -29,7 +29,7 @@ import type { ID } from '#v0/types'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { App } from 'vue'
 
-export interface RegistryTicket {
+export interface RegistryTicket<V = unknown> {
   /** The unique identifier. Is randomly generated if not provided. */
   id: ID
   /**
@@ -39,7 +39,7 @@ export interface RegistryTicket {
    */
   index: number
   /** The value associated with the ticket. If not provided, it defaults to the index. */
-  value: any
+  value: V
   /**
    * Whether the value is derived from index.
    *

--- a/packages/0/src/composables/useSelection/index.ts
+++ b/packages/0/src/composables/useSelection/index.ts
@@ -31,7 +31,7 @@ import type { RegistryContext, RegistryOptions, RegistryTicket } from '#v0/compo
 import type { ID } from '#v0/types'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 
-export interface SelectionTicket extends RegistryTicket {
+export interface SelectionTicket<V = unknown> extends RegistryTicket<V> {
   /** Disabled state of the ticket */
   disabled: MaybeRef<boolean>
   /** Whether the ticket is currently selected */

--- a/packages/0/src/composables/useSingle/index.ts
+++ b/packages/0/src/composables/useSingle/index.ts
@@ -28,13 +28,13 @@ import type { ID } from '#v0/types'
 import type { App, ComputedRef } from 'vue'
 import type { SelectionContext, SelectionContextOptions, SelectionOptions, SelectionTicket } from '#v0/composables/useSelection'
 
-export interface SingleTicket extends SelectionTicket {}
+export interface SingleTicket<V = unknown> extends SelectionTicket<V> {}
 
 export interface SingleContext<Z extends SingleTicket> extends SelectionContext<Z> {
   selectedId: ComputedRef<ID | undefined>
   selectedIndex: ComputedRef<number>
   selectedItem: ComputedRef<Z | undefined>
-  selectedValue: ComputedRef<unknown>
+  selectedValue: ComputedRef<Z['value'] | undefined>
 }
 
 export interface SingleOptions extends SelectionOptions {}

--- a/packages/0/src/composables/useStep/index.ts
+++ b/packages/0/src/composables/useStep/index.ts
@@ -29,7 +29,7 @@ import type { App } from 'vue'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { SingleContext, SingleContextOptions, SingleOptions, SingleTicket } from '#v0/composables/useSingle'
 
-export interface StepTicket extends SingleTicket {}
+export interface StepTicket<V = unknown> extends SingleTicket<V> {}
 
 export interface StepContext<Z extends StepTicket> extends SingleContext<Z> {
   /** Select the first Ticket in the collection */

--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -55,13 +55,12 @@ export type ThemeColors = {
 }
 
 export type ThemeRecord = {
-  [key: string]: any
   dark?: boolean
   lazy?: boolean
   colors: ThemeColors
 }
 
-export interface ThemeTicket extends SingleTicket {
+export interface ThemeTicket extends SingleTicket<ThemeColors> {
   /**
    * Indicates whether the theme is dark or light.
    *

--- a/packages/0/src/composables/useTimeline/index.ts
+++ b/packages/0/src/composables/useTimeline/index.ts
@@ -78,7 +78,7 @@ export interface TimelineContext<Z extends TimelineTicket> extends RegistryConte
   redo: () => Z | undefined
 }
 
-export interface TimelineTicket extends RegistryTicket {}
+export interface TimelineTicket<V = unknown> extends RegistryTicket<V> {}
 
 export interface TimelineOptions extends RegistryOptions {
   /**

--- a/packages/0/src/composables/useTokens/index.ts
+++ b/packages/0/src/composables/useTokens/index.ts
@@ -41,7 +41,7 @@ export interface TokenAlias<T = unknown> {
   $deprecated?: boolean | string
 }
 
-export type TokenPrimitive = string | number | boolean | null
+export type TokenPrimitive = string | number | boolean | null | Function
 
 export type TokenValue = TokenPrimitive | TokenAlias
 
@@ -54,7 +54,7 @@ export type FlatTokenCollection = {
   value: TokenValue
 }
 
-export interface TokenTicket extends RegistryTicket {}
+export interface TokenTicket extends RegistryTicket<TokenValue> {}
 
 export interface TokenContext<Z extends TokenTicket> extends RegistryContext<Z> {
   /**


### PR DESCRIPTION
This change adds a generic value type parameter to RegistryTicket and
propagates it through the entire composable hierarchy:

- RegistryTicket<V = unknown> - Base type now accepts value type
- SelectionTicket<V> - Inherits from RegistryTicket<V>
- SingleTicket<V>, GroupTicket<V>, StepTicket<V> - Selection descendants
- FormTicket<V>, QueueTicket<V>, TimelineTicket<V> - Registry extensions
- TokenTicket - Uses RegistryTicket<TokenValue>
- ThemeTicket - Uses SingleTicket<ThemeColors>
- FeatureTicket - Uses GroupTicket<TokenValue>
- PermissionTicket - Uses RegistryTicket<PermissionValue>

Also updates:
- Components (SelectionItem, SingleItem, GroupItem, StepItem) use generic V
- ThemeRecord no longer uses index signature with `any`
- PermissionContext and adapters use `Record<string, unknown>` instead of `any`
- usePermissions refactored to use useRegistry directly

This provides:
- Full type safety for stored values
- IDE autocomplete for ticket.value
- Compile-time error detection
- Zero runtime cost (types only)