### PR TITLE
docs: improve integrations section mobile layout

### DIFF
--- a/apps/docs/src/components/home/HomeIntegrations.vue
+++ b/apps/docs/src/components/home/HomeIntegrations.vue
@@ -23,11 +23,11 @@
   <section class="home-integrations py-12">
     <p class="text-center text-sm opacity-60 mb-6">Works with</p>
 
-    <div class="flex flex-wrap justify-center gap-6">
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 max-w-2xl mx-auto">
       <div
         v-for="integration in integrations"
         :key="integration.name"
-        class="flex items-center gap-2 px-4 py-2 rounded-lg border bg-surface/30 flex-1 md:flex-none"
+        class="flex items-center justify-center gap-2 px-4 py-2 rounded-lg border bg-surface/30"
       >
         <div class="inline-flex text-on-surface">
           <AppIcon :icon="integration.icon" :size="18" />


### PR DESCRIPTION
Use CSS grid with 2 columns on mobile instead of flex-wrap to ensure
even distribution of items across rows.