### PR TITLE
docs: fix home page component links to use correct paths

### DIFF
--- a/apps/docs/src/components/home/HomeDemo.vue
+++ b/apps/docs/src/components/home/HomeDemo.vue
@@ -91,7 +91,7 @@
           <span>Selection.vue</span>
           <router-link
             class="text-primary hover:underline"
-            to="/components/selection"
+            to="/components/providers/selection"
           >
             View docs →
           </router-link>

--- a/apps/docs/src/components/home/HomeEcosystem.vue
+++ b/apps/docs/src/components/home/HomeEcosystem.vue
@@ -1,13 +1,13 @@
 <script lang="ts" setup>
   const components = [
-    { name: 'Atom', to: '/components/atom', description: 'Base primitive element' },
-    { name: 'Avatar', to: '/components/avatar', description: 'User avatars with fallback' },
-    { name: 'ExpansionPanel', to: '/components/expansion-panel', description: 'Collapsible content panels' },
-    { name: 'Group', to: '/components/group', description: 'Multi-select grouping' },
-    { name: 'Pagination', to: '/components/pagination', description: 'Page navigation' },
-    { name: 'Popover', to: '/components/popover', description: 'Floating content' },
-    { name: 'Selection', to: '/components/selection', description: 'Selection state management' },
-    { name: 'Step', to: '/components/step', description: 'Stepper/wizard flows' },
+    { name: 'Atom', to: '/components/primitives/atom', description: 'Base primitive element' },
+    { name: 'Avatar', to: '/components/semantic/avatar', description: 'User avatars with fallback' },
+    { name: 'ExpansionPanel', to: '/components/disclosure/expansion-panel', description: 'Collapsible content panels' },
+    { name: 'Group', to: '/components/providers/group', description: 'Multi-select grouping' },
+    { name: 'Pagination', to: '/components/semantic/pagination', description: 'Page navigation' },
+    { name: 'Popover', to: '/components/disclosure/popover', description: 'Floating content' },
+    { name: 'Selection', to: '/components/providers/selection', description: 'Selection state management' },
+    { name: 'Step', to: '/components/providers/step', description: 'Stepper/wizard flows' },
   ]
 
   const composables = [


### PR DESCRIPTION
Component links were pointing to flat paths like /components/atom but the
actual pages are nested in category directories like /components/primitives/atom.