### PR TITLE
fix(ci): use actions/checkout@v4 instead of non-existent v5

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
       deployments: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: vuetifyjs/setup-action@master
       - run: pnpm run build:docs
         env:

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - uses: vuetifyjs/setup-action@master
 


### PR DESCRIPTION
The docs-deploy and storybook-deploy workflows were incorrectly using
actions/checkout@v5 which doesn't exist yet (v4 is the latest stable).
This was causing workflow failures.