### PR TITLE
feat(Breadcrumbs): declarative compound component with overflow

### DIFF
--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsDivider.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsDivider.vue
@@ -1,0 +1,111 @@
+/**
+ * @module BreadcrumbsDivider
+ *
+ * @remarks
+ * Visual separator between breadcrumb items. Registers with the parent
+ * BreadcrumbsRoot and self-measures width. Supports inline override of
+ * the global divider character via the divider prop.
+ */
+
+<script lang="ts">
+  // Types
+  import type { AtomProps } from '#v0/components/Atom'
+
+  export interface BreadcrumbsDividerProps extends AtomProps {
+    /** Namespace for dependency injection */
+    namespace?: string
+    /** Unique identifier (auto-generated if not provided) */
+    id?: string
+    /** Override divider character (uses global from Root if not provided) */
+    divider?: string
+  }
+
+  export interface BreadcrumbsDividerSlotProps {
+    /** Unique identifier */
+    id: string
+    /** Resolved divider character */
+    divider: string
+    /** Whether this divider is currently visible */
+    isVisible: boolean
+    /** Attributes to bind to the divider element */
+    attrs: {
+      'aria-hidden': 'true'
+      'data-visible': true | undefined
+    }
+  }
+</script>
+
+<script setup lang="ts">
+  // Components
+  import { Atom } from '#v0/components/Atom'
+  import { useBreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+
+  // Utilities
+  import { onUnmounted, toRef, toValue, useTemplateRef, watch } from 'vue'
+
+  // Types
+  import type { BreadcrumbsTicket } from './types'
+
+  defineOptions({ name: 'BreadcrumbsDivider' })
+
+  defineSlots<{
+    default: (props: BreadcrumbsDividerSlotProps) => unknown
+  }>()
+
+  const {
+    as = 'span',
+    renderless,
+    namespace = 'v0:breadcrumbs',
+    id,
+    divider,
+  } = defineProps<BreadcrumbsDividerProps>()
+
+  const el = useTemplateRef('el')
+  const breadcrumbs = useBreadcrumbsRoot(namespace)
+
+  const ticket = breadcrumbs.group.register({
+    id,
+    type: 'divider',
+  } as Partial<BreadcrumbsTicket>)
+
+  // Measure element for overflow calculation
+  watch(
+    () => el.value?.element,
+    element => {
+      breadcrumbs.overflow.measure(ticket.index, element ?? undefined)
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    breadcrumbs.overflow.measure(ticket.index, undefined)
+    breadcrumbs.group.unregister(ticket.id)
+  })
+
+  const resolvedDivider = toRef(() => divider ?? breadcrumbs.divider.value)
+  const isVisible = toRef(() => toValue(ticket.isSelected))
+
+  const slotProps = toRef((): BreadcrumbsDividerSlotProps => ({
+    id: String(ticket.id),
+    divider: resolvedDivider.value,
+    isVisible: isVisible.value,
+    attrs: {
+      'aria-hidden': 'true',
+      'data-visible': isVisible.value || undefined,
+    },
+  }))
+</script>
+
+<template>
+  <Atom
+    v-show="isVisible"
+    ref="el"
+    :as
+    :renderless
+    v-bind="slotProps.attrs"
+  >
+    <slot v-bind="slotProps">
+      {{ resolvedDivider }}
+    </slot>
+  </Atom>
+</template>

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsEllipsis.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsEllipsis.vue
@@ -1,0 +1,112 @@
+/**
+ * @module BreadcrumbsEllipsis
+ *
+ * @remarks
+ * Ellipsis indicator for truncated breadcrumb items. Registers with
+ * BreadcrumbsRoot as type='ellipsis'. Root's watcher controls visibility
+ * based on overflow state - hidden when everything fits, shown when truncating.
+ */
+
+<script lang="ts">
+  // Types
+  import type { AtomProps } from '#v0/components/Atom'
+
+  export interface BreadcrumbsEllipsisProps extends AtomProps {
+    /** Namespace for dependency injection */
+    namespace?: string
+    /** Unique identifier (auto-generated if not provided) */
+    id?: string
+    /** Override ellipsis character (uses global from Root if not provided) */
+    ellipsis?: string
+  }
+
+  export interface BreadcrumbsEllipsisSlotProps {
+    /** Unique identifier */
+    id: string
+    /** Resolved ellipsis character */
+    ellipsis: string
+    /** Whether the ellipsis is visible (items are overflowing) */
+    isVisible: boolean
+    /** Attributes to bind to the ellipsis element */
+    attrs: {
+      'aria-hidden': 'true'
+      'data-visible': true | undefined
+    }
+  }
+</script>
+
+<script setup lang="ts">
+  // Components
+  import { Atom } from '#v0/components/Atom'
+  import { useBreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+
+  // Utilities
+  import { onUnmounted, toRef, toValue, useTemplateRef, watch } from 'vue'
+
+  // Types
+  import type { BreadcrumbsTicket } from './types'
+
+  defineOptions({ name: 'BreadcrumbsEllipsis' })
+
+  defineSlots<{
+    default: (props: BreadcrumbsEllipsisSlotProps) => unknown
+  }>()
+
+  const {
+    as = 'span',
+    renderless,
+    namespace = 'v0:breadcrumbs',
+    id,
+    ellipsis,
+  } = defineProps<BreadcrumbsEllipsisProps>()
+
+  const el = useTemplateRef('el')
+  const breadcrumbs = useBreadcrumbsRoot(namespace)
+
+  // Register as ellipsis type - Root's watcher controls visibility based on overflow
+  const ticket = breadcrumbs.group.register({
+    id,
+    type: 'ellipsis',
+  } as Partial<BreadcrumbsTicket>)
+
+  // Measure element for overflow calculation
+  watch(
+    () => el.value?.element,
+    element => {
+      breadcrumbs.overflow.measure(ticket.index, element ?? undefined)
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    breadcrumbs.overflow.measure(ticket.index, undefined)
+    breadcrumbs.group.unregister(ticket.id)
+  })
+
+  const resolvedEllipsis = toRef(() => ellipsis ?? breadcrumbs.ellipsis.value)
+  const isVisible = toRef(() => toValue(ticket.isSelected))
+
+  const slotProps = toRef((): BreadcrumbsEllipsisSlotProps => ({
+    id: String(ticket.id),
+    ellipsis: resolvedEllipsis.value,
+    isVisible: isVisible.value,
+    attrs: {
+      'aria-hidden': 'true',
+      'data-visible': isVisible.value || undefined,
+    },
+  }))
+</script>
+
+<template>
+  <Atom
+    v-show="isVisible"
+    ref="el"
+    :as
+    :renderless
+    v-bind="slotProps.attrs"
+  >
+    <slot v-bind="slotProps">
+      {{ resolvedEllipsis }}
+    </slot>
+  </Atom>
+</template>

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsItem.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsItem.vue
@@ -1,0 +1,104 @@
+/**
+ * @module BreadcrumbsItem
+ *
+ * @remarks
+ * Individual breadcrumb item that registers with the parent BreadcrumbsRoot.
+ * Self-measures width for overflow calculation. Visibility is controlled
+ * via selection state (v-show bound to isSelected).
+ */
+
+<script lang="ts">
+  // Types
+  import type { AtomProps } from '#v0/components/Atom'
+
+  export interface BreadcrumbsItemProps extends AtomProps {
+    /** Namespace for dependency injection */
+    namespace?: string
+    /** Unique identifier (auto-generated if not provided) */
+    id?: string
+    /** Value associated with this item */
+    value?: unknown
+  }
+
+  export interface BreadcrumbsItemSlotProps {
+    /** Unique identifier */
+    id: string
+    /** Whether this item is currently visible */
+    isVisible: boolean
+    /** Attributes to bind to the item element */
+    attrs: {
+      'data-visible': true | undefined
+    }
+  }
+</script>
+
+<script setup lang="ts">
+  // Components
+  import { Atom } from '#v0/components/Atom'
+  import { useBreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+
+  // Utilities
+  import { onUnmounted, toRef, toValue, useTemplateRef, watch } from 'vue'
+
+  // Types
+  import type { BreadcrumbsTicket } from './types'
+
+  defineOptions({ name: 'BreadcrumbsItem' })
+
+  defineSlots<{
+    default: (props: BreadcrumbsItemSlotProps) => unknown
+  }>()
+
+  const {
+    as = 'li',
+    renderless,
+    namespace = 'v0:breadcrumbs',
+    id,
+    value,
+  } = defineProps<BreadcrumbsItemProps>()
+
+  const el = useTemplateRef('el')
+  const breadcrumbs = useBreadcrumbsRoot(namespace)
+
+  const ticket = breadcrumbs.group.register({
+    id,
+    value,
+    type: 'item',
+  } as Partial<BreadcrumbsTicket>)
+
+  // Measure element for overflow calculation
+  watch(
+    () => el.value?.element,
+    element => {
+      breadcrumbs.overflow.measure(ticket.index, element ?? undefined)
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    breadcrumbs.overflow.measure(ticket.index, undefined)
+    breadcrumbs.group.unregister(ticket.id)
+  })
+
+  const isVisible = toRef(() => toValue(ticket.isSelected))
+
+  const slotProps = toRef((): BreadcrumbsItemSlotProps => ({
+    id: String(ticket.id),
+    isVisible: isVisible.value,
+    attrs: {
+      'data-visible': isVisible.value || undefined,
+    },
+  }))
+</script>
+
+<template>
+  <Atom
+    v-show="isVisible"
+    ref="el"
+    :as
+    :renderless
+    v-bind="slotProps.attrs"
+  >
+    <slot v-bind="slotProps" />
+  </Atom>
+</template>

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsList.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsList.vue
@@ -1,0 +1,49 @@
+/**
+ * @module BreadcrumbsList
+ *
+ * @remarks
+ * Semantic list wrapper for breadcrumb items. Typically renders as an
+ * ordered list and contains BreadcrumbsItem, BreadcrumbsDivider, and
+ * BreadcrumbsEllipsis components.
+ */
+
+<script lang="ts">
+  // Types
+  import type { AtomProps } from '#v0/components/Atom'
+
+  export interface BreadcrumbsListProps extends AtomProps {}
+
+  export interface BreadcrumbsListSlotProps {}
+</script>
+
+<script setup lang="ts">
+  // Components
+  import { Atom } from '#v0/components/Atom'
+  // Composables
+  import { useBreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+
+  defineOptions({ name: 'BreadcrumbsList' })
+
+  defineSlots<{
+    default: (props: BreadcrumbsListSlotProps) => unknown
+  }>()
+
+  const {
+    as = 'ol',
+    namespace = 'v0:breadcrumbs',
+    renderless,
+  } = defineProps<BreadcrumbsListProps & { namespace?: string }>()
+
+  const breadcrumbs = useBreadcrumbsRoot(namespace)
+</script>
+
+<template>
+  <Atom
+    :as
+    class="flex list-none m-0 p-0"
+    :renderless
+    :style="{ gap: `${breadcrumbs.gap.value}px` }"
+  >
+    <slot />
+  </Atom>
+</template>

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
@@ -1,0 +1,167 @@
+/**
+ * @module BreadcrumbsRoot
+ *
+ * @remarks
+ * Root component for responsive breadcrumb navigation using declarative children.
+ *
+ * Uses a Group context with enrollment to track items, and Overflow context
+ * to determine which items fit. Visibility is controlled via selection state:
+ * - Items start selected (visible) via enroll option
+ * - Overflow calculation determines capacity
+ * - Items beyond capacity are unselected (hidden)
+ * - Ellipsis becomes selected (visible) when truncating
+ */
+
+<script lang="ts">
+  // Foundational
+  import { createContext } from '#v0/composables/createContext'
+
+  // Types
+  import type { BreadcrumbsContext, BreadcrumbsTicket } from './types'
+
+  export type { BreadcrumbsContext, BreadcrumbsTicket, BreadcrumbsTicketType } from './types'
+
+  export interface BreadcrumbsRootProps {
+    /** Namespace for dependency injection */
+    namespace?: string
+    /** Polymorphic element type */
+    as?: string
+    /** Default divider character/text */
+    divider?: string
+    /** Default ellipsis character/text */
+    ellipsis?: string
+    /** Gap between items in pixels */
+    gap?: number
+  }
+
+  export interface BreadcrumbsRootSlotProps {
+    /** Whether items are being truncated */
+    isOverflowing: boolean
+    /** Number of items that fit in available space */
+    capacity: number
+    /** Total number of registered items */
+    total: number
+    /** Attributes to bind to the root element */
+    attrs: {
+      'aria-label': 'Breadcrumb'
+    }
+  }
+
+  export const [useBreadcrumbsRoot, provideBreadcrumbsRoot] = createContext<BreadcrumbsContext>()
+</script>
+
+<script setup lang="ts">
+  // Components
+  import { Atom } from '#v0/components/Atom'
+
+  // Composables
+  import { createGroup } from '#v0/composables/createGroup'
+  import { createOverflow } from '#v0/composables/useOverflow'
+
+  // Utilities
+  import { computed, toRef, useTemplateRef, watch } from 'vue'
+
+  defineOptions({ name: 'BreadcrumbsRoot' })
+
+  defineSlots<{
+    default: (props: BreadcrumbsRootSlotProps) => unknown
+  }>()
+
+  const {
+    namespace = 'v0:breadcrumbs',
+    as = 'nav',
+    divider = '/',
+    ellipsis = '…',
+    gap = 8,
+  } = defineProps<BreadcrumbsRootProps>()
+
+  const container = useTemplateRef('container')
+
+  // Create Group with enroll: true so items start selected (visible)
+  const group = createGroup<BreadcrumbsTicket>({
+    enroll: true,
+    multiple: true,
+  })
+
+  // Create Overflow for width measurement
+  const overflow = createOverflow({
+    container: () => container.value?.element,
+    gap: toRef(() => gap),
+    reverse: true, // Prioritize trailing items (current path)
+  })
+
+  const isOverflowing = toRef(() => overflow.isOverflowing.value)
+
+  // Watch capacity changes and update selection
+  watch(
+    [() => overflow.capacity.value, () => group.size],
+    ([capacity, size]) => {
+      if (capacity === Infinity || capacity >= size) {
+        // Everything fits - select all items, hide ellipsis
+        for (const ticket of group.values()) {
+          if (ticket.type === 'ellipsis') {
+            group.unselect(ticket.id)
+          } else if (!ticket.isSelected.value) {
+            group.select(ticket.id)
+          }
+        }
+        return
+      }
+
+      // Overflow - need to hide some items and show ellipsis
+      // Since reverse: true, capacity counts from the end
+      // We need to unselect items from the start that don't fit
+      const items = group.values()
+      const hiddenCount = size - capacity
+
+      let hidden = 0
+      for (const ticket of items) {
+        if (ticket.type === 'ellipsis') {
+          // Show ellipsis when truncating
+          group.select(ticket.id)
+        } else if (hidden < hiddenCount) {
+          // Hide items from the start
+          group.unselect(ticket.id)
+          hidden++
+        } else {
+          // Show remaining items
+          if (!ticket.isSelected.value) {
+            group.select(ticket.id)
+          }
+        }
+      }
+    },
+    { immediate: true },
+  )
+
+  // Provide context to children
+  provideBreadcrumbsRoot(namespace, {
+    group,
+    overflow,
+    divider: computed(() => divider),
+    ellipsis: computed(() => ellipsis),
+    gap: computed(() => gap),
+    isOverflowing,
+  })
+
+  const slotProps = toRef((): BreadcrumbsRootSlotProps => ({
+    isOverflowing: overflow.isOverflowing.value,
+    capacity: overflow.capacity.value,
+    total: group.size,
+    attrs: {
+      'aria-label': 'Breadcrumb',
+    },
+  }))
+</script>
+
+<template>
+  <Atom
+    ref="container"
+    :as
+    v-bind="slotProps.attrs"
+    class="flex"
+    :style="{ gap: `${gap}px` }"
+  >
+    <slot v-bind="slotProps" />
+  </Atom>
+</template>

--- a/packages/0/src/components/Breadcrumbs/index.ts
+++ b/packages/0/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,116 @@
+export { default as BreadcrumbsDivider } from './BreadcrumbsDivider.vue'
+export { default as BreadcrumbsEllipsis } from './BreadcrumbsEllipsis.vue'
+export { default as BreadcrumbsItem } from './BreadcrumbsItem.vue'
+export { default as BreadcrumbsList } from './BreadcrumbsList.vue'
+export { provideBreadcrumbsRoot, useBreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+export { default as BreadcrumbsRoot } from './BreadcrumbsRoot.vue'
+
+export type {
+  BreadcrumbsDividerProps,
+  BreadcrumbsDividerSlotProps,
+} from './BreadcrumbsDivider.vue'
+
+export type {
+  BreadcrumbsEllipsisProps,
+  BreadcrumbsEllipsisSlotProps,
+} from './BreadcrumbsEllipsis.vue'
+
+export type {
+  BreadcrumbsItemProps,
+  BreadcrumbsItemSlotProps,
+} from './BreadcrumbsItem.vue'
+
+export type {
+  BreadcrumbsListProps,
+  BreadcrumbsListSlotProps,
+} from './BreadcrumbsList.vue'
+
+export type {
+  BreadcrumbsRootProps,
+  BreadcrumbsRootSlotProps,
+} from './BreadcrumbsRoot.vue'
+
+export type {
+  BreadcrumbsContext,
+  BreadcrumbsTicket,
+  BreadcrumbsTicketType,
+} from './types'
+
+// Components
+import Divider from './BreadcrumbsDivider.vue'
+import Ellipsis from './BreadcrumbsEllipsis.vue'
+import Item from './BreadcrumbsItem.vue'
+import List from './BreadcrumbsList.vue'
+import Root from './BreadcrumbsRoot.vue'
+
+/**
+ * Breadcrumbs component for responsive navigation trails.
+ *
+ * Uses declarative children for flexible composition. Items, dividers,
+ * and ellipsis register with the root and self-measure for overflow detection.
+ * Visibility is automatically managed based on available space.
+ *
+ * @see https://0.vuetifyjs.com/components/breadcrumbs
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ *   import { Breadcrumbs } from '@vuetify/v0'
+ * </script>
+ *
+ * <template>
+ *   <Breadcrumbs.Root divider="/" as="nav">
+ *     <Breadcrumbs.List as="ol">
+ *       <Breadcrumbs.Item as="li">
+ *         <a href="/">Home</a>
+ *       </Breadcrumbs.Item>
+ *       <Breadcrumbs.Divider />
+ *       <Breadcrumbs.Ellipsis />
+ *       <Breadcrumbs.Divider />
+ *       <Breadcrumbs.Item as="li">
+ *         <a href="/about">About</a>
+ *       </Breadcrumbs.Item>
+ *       <Breadcrumbs.Divider />
+ *       <Breadcrumbs.Item as="li">Team</Breadcrumbs.Item>
+ *     </Breadcrumbs.List>
+ *   </Breadcrumbs.Root>
+ * </template>
+ * ```
+ */
+export const Breadcrumbs = {
+  /**
+   * Root component for breadcrumb navigation.
+   * Creates Group + Overflow context for managing items.
+   *
+   * @see https://0.vuetifyjs.com/components/breadcrumbs#breadcrumbsroot
+   */
+  Root,
+  /**
+   * Semantic list wrapper for breadcrumb items.
+   * Typically renders as `<ol>`.
+   *
+   * @see https://0.vuetifyjs.com/components/breadcrumbs#breadcrumbslist
+   */
+  List,
+  /**
+   * Individual breadcrumb item.
+   * Registers with root and self-measures for overflow.
+   *
+   * @see https://0.vuetifyjs.com/components/breadcrumbs#breadcrumbsitem
+   */
+  Item,
+  /**
+   * Visual separator between breadcrumb items.
+   * Supports inline divider override.
+   *
+   * @see https://0.vuetifyjs.com/components/breadcrumbs#breadcrumbsdivider
+   */
+  Divider,
+  /**
+   * Ellipsis indicator shown when items are truncated.
+   * Auto-hidden until overflow is detected.
+   *
+   * @see https://0.vuetifyjs.com/components/breadcrumbs#breadcrumbsellipsis
+   */
+  Ellipsis,
+}

--- a/packages/0/src/components/Breadcrumbs/types.ts
+++ b/packages/0/src/components/Breadcrumbs/types.ts
@@ -1,0 +1,32 @@
+/**
+ * @module BreadcrumbsTypes
+ *
+ * Shared types for Breadcrumbs components.
+ */
+
+// Types
+import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
+import type { OverflowContext } from '#v0/composables/useOverflow'
+import type { ComputedRef, Ref } from 'vue'
+
+export type BreadcrumbsTicketType = 'item' | 'divider' | 'ellipsis'
+
+export interface BreadcrumbsTicket extends GroupTicket {
+  /** Type of breadcrumb element */
+  type: BreadcrumbsTicketType
+}
+
+export interface BreadcrumbsContext {
+  /** Group context for managing item registration and selection */
+  group: GroupContext<BreadcrumbsTicket>
+  /** Overflow context for width measurement and capacity calculation */
+  overflow: OverflowContext
+  /** Default divider character/text */
+  divider: ComputedRef<string>
+  /** Default ellipsis character/text */
+  ellipsis: ComputedRef<string>
+  /** Gap between items */
+  gap: ComputedRef<number>
+  /** Whether items are being truncated */
+  isOverflowing: Readonly<Ref<boolean>>
+}

--- a/packages/0/src/components/index.ts
+++ b/packages/0/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Atom'
 export * from './Avatar'
+export * from './Breadcrumbs'
 export * from './Dialog'
 export * from './ExpansionPanel'
 export * from './Group'


### PR DESCRIPTION
## Summary
- New declarative Breadcrumbs architecture using Group + Overflow contexts
- Items/Dividers/Ellipsis register and self-measure
- Visibility controlled via selection state
- Ellipsis auto-hides when everything fits, shows when truncating

## Components
- `BreadcrumbsRoot` - context provider, manages visibility
- `BreadcrumbsList` - semantic ol wrapper  
- `BreadcrumbsItem` - breadcrumb link/text
- `BreadcrumbsDivider` - separator with inline override support
- `BreadcrumbsEllipsis` - truncation indicator

## Usage
```vue
<Breadcrumbs.Root divider="/" as="nav">
  <Breadcrumbs.List as="ol">
    <Breadcrumbs.Item as="li"><a href="/">Home</a></Breadcrumbs.Item>
    <Breadcrumbs.Divider />
    <Breadcrumbs.Ellipsis />
    <Breadcrumbs.Divider />
    <Breadcrumbs.Item as="li"><a href="/about">About</a></Breadcrumbs.Item>
  </Breadcrumbs.List>
</Breadcrumbs.Root>
```

## Test plan
- [ ] Manual testing in playground
- [ ] Add unit tests for Breadcrumbs components
- [ ] Test overflow behavior at various widths
- [ ] Verify ellipsis visibility logic