### PR TITLE
docs(roadmap): avoid scrolling up when expanding milestones

### DIFF
--- a/apps/docs/src/components/docs/DocsRoadmap.vue
+++ b/apps/docs/src/components/docs/DocsRoadmap.vue
@@ -95,14 +95,20 @@
     if (newVal.length === 1) {
       const milestone = store.milestones.find(m => m.number === newVal[0])
       if (milestone) {
-        router.replace({ query: { ...route.query, milestone: milestone.title } })
+        router.replace({
+          query: { ...route.query, milestone: milestone.title },
+          params: { savePosition: true },
+        })
         return
       }
     }
     // Clear milestone param if none or multiple expanded
     if (route.query.milestone) {
       const { milestone: _, ...rest } = route.query
-      router.replace({ query: rest })
+      router.replace({
+        query: rest,
+        params: { savePosition: true },
+      })
     }
   })
 </script>

--- a/apps/docs/src/plugins/router.ts
+++ b/apps/docs/src/plugins/router.ts
@@ -16,6 +16,9 @@ const routerOptions: Omit<RouterOptions, 'history'> = {
     // SSR safety - scrollBehavior only runs client-side but guard for clarity
     if (!IN_BROWSER) return { top: 0 }
 
+    // Avoid scrolling up (requires explicit params field)
+    if ((to.params as any).savePosition) return {}
+
     // If the user navigated via browser back/forward, restore their position
     if (savedPosition) return savedPosition
 


### PR DESCRIPTION
Reproduction:
1. open [Roadmap](https://0.vuetifyjs.com/roadmap) page
2. scroll down (expand first milestone if needed)
3. expand any other milestone

Problem:
- page scrolls up unexpectedly