### PR TITLE
refactor(useTheme): migrate style injection to adoptedStyleSheets

### DIFF
--- a/packages/0/src/composables/useTheme/adapters/v0.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.ts
@@ -26,6 +26,7 @@ export interface Vuetify0ThemeOptions {
  */
 export class Vuetify0ThemeAdapter extends ThemeAdapter {
   cspNonce?: string
+  sheet?: CSSStyleSheet
 
   constructor (options: Vuetify0ThemeOptions = {}) {
     super(options.prefix ?? 'v0')
@@ -99,19 +100,10 @@ export class Vuetify0ThemeAdapter extends ThemeAdapter {
   upsert (styles: string): void {
     if (!IN_BROWSER) return
 
-    const selector = this.stylesheetId.startsWith('#') ? this.stylesheetId : `#${this.stylesheetId}`
-    const id = this.stylesheetId.startsWith('#') ? this.stylesheetId.slice(1) : this.stylesheetId
-    let styleEl = document.querySelector(selector) as HTMLStyleElement | null
-
-    if (!styleEl) {
-      styleEl = document.createElement('style')
-      styleEl.id = id
-
-      if (this.cspNonce) styleEl.setAttribute('nonce', this.cspNonce)
-
-      document.head.append(styleEl)
+    if (!this.sheet) {
+      this.sheet = new CSSStyleSheet()
+      document.adoptedStyleSheets.push(this.sheet)
     }
-
-    styleEl.textContent = styles
+    this.sheet.replaceSync(styles)
   }
 }

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -329,6 +329,9 @@ describe('createThemePlugin', () => {
   })
 
   it('should inject CSS variables into DOM', async () => {
+    const mockStyleSheets: CSSStyleSheet[] = []
+    const spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => mockStyleSheets)
+
     const app = createApp({
       template: '<div>Test</div>',
     })
@@ -352,12 +355,13 @@ describe('createThemePlugin', () => {
 
     await nextTick()
 
-    const styleEl = document.querySelector('#v0-theme-stylesheet')
-    expect(styleEl).toBeTruthy()
-    expect(styleEl?.textContent).toContain('--v0-primary: #1976d2')
-    expect(styleEl?.textContent).toContain('--v0-secondary: #424242')
+    expect(mockStyleSheets.length).toBeGreaterThan(0)
+    const styleContent = mockStyleSheets[0]!.cssRules?.[0]?.cssText || ''
+    expect(styleContent).toContain('--v0-primary: #1976d2')
+    expect(styleContent).toContain('--v0-secondary: #424242')
 
     app.unmount()
+    spy.mockRestore()
   })
 
   it('should apply theme class to target element', async () => {


### PR DESCRIPTION
<img width="1375" height="410" alt="image" src="https://github.com/user-attachments/assets/713a191c-af03-4a92-97b3-ffe3bff520f5" />

Replace manual style element creation and management with CSSStyleSheet API