### PR TITLE
docs: fix code contrast for custom themes

### DIFF
--- a/apps/docs/src/components/docs/DocsApiCard.vue
+++ b/apps/docs/src/components/docs/DocsApiCard.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  // Framework
+  import { useTheme } from '@vuetify/v0'
+
   // Composables
   import { useApiHelpers } from '@/composables/useApiHelpers'
   import { useSettings } from '@/composables/useSettings'
@@ -18,6 +21,7 @@
   }>()
 
   const api = useApiHelpers()
+  const theme = useTheme()
   const settings = useSettings()
 
   const lineWrap = shallowRef(settings.lineWrap.value)
@@ -95,6 +99,7 @@
         :id="`${api.uid}-${key}`"
         class="docs-api-card relative bg-pre group"
         :class="{ 'docs-api-card--wrap': lineWrap.value }"
+        :data-theme="theme.isDark.value ? 'dark' : 'light'"
       >
         <DocsCodeActions
           v-model:wrap="lineWrap"

--- a/apps/docs/src/components/docs/DocsExampleCodePane.vue
+++ b/apps/docs/src/components/docs/DocsExampleCodePane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { useIntersectionObserver, useLogger } from '@vuetify/v0'
+  import { useIntersectionObserver, useLogger, useTheme } from '@vuetify/v0'
 
   // Composables
   import { useSettings } from '@/composables/useSettings'
@@ -26,6 +26,7 @@
 
   const expanded = defineModel<boolean>('expanded', { default: false })
 
+  const theme = useTheme()
   const settings = useSettings()
   const lineWrap = shallowRef(settings.lineWrap.value)
 
@@ -128,6 +129,7 @@
 
     <div
       class="overflow-hidden transition-[max-height] duration-300 ease-out"
+      :data-theme="theme.isDark.value ? 'dark' : 'light'"
       :style="shouldPeek && !expanded ? { maxHeight: peekHeight } : undefined"
     >
       <div v-if="highlightedCode" v-html="highlightedCode" />

--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  // Framework
+  import { useTheme } from '@vuetify/v0'
+
   // Composables
   import { useSettings } from '@/composables/useSettings'
 
@@ -19,6 +22,7 @@
     collapseLines: 15,
   })
 
+  const theme = useTheme()
   const settings = useSettings()
 
   // Local state initialized from global default, per-instance
@@ -82,6 +86,7 @@
 
       <div
         class="transition-[max-height] duration-300 ease-out"
+        :data-theme="theme.isDark.value ? 'dark' : 'light'"
         :style="shouldCollapse && !expanded ? { maxHeight: collapsedHeight } : undefined"
       >
         <slot />


### PR DESCRIPTION
Shiki depends on `data-theme` being either `light` or `dark` and defaults to light mode when custom theme is used.

As a side-note: it would help if we could also make code snippets smaller (14px instead of 16px), so the small text in props preview (popover) that has 11px would not stand out so much as a bug... although we could bump that 11px to 12~13 as well.