### PR TITLE
docs: suppress API popover when selecting text

### DIFF
--- a/apps/docs/src/components/docs/DocsApiHover.vue
+++ b/apps/docs/src/components/docs/DocsApiHover.vue
@@ -190,6 +190,9 @@
     // Skip during navigation to avoid event storms on iOS Safari
     if (isNavigating.value) return
 
+    // Skip if user is holding mouse button (likely selecting text)
+    if (e.buttons !== 0) return
+
     const eventTarget = e.target
     if (!(eventTarget instanceof Element)) return
 


### PR DESCRIPTION
(fixed by Claude, not me)

side-note: Could be considered for an enhancement for Popover if it implements hover trigger.

<details>
<summary>Recording of the problem (imagine the cursor is there)</summary>

[Screencast from 2026-02-02 23-26-15.webm](https://github.com/user-attachments/assets/2c895f44-914e-42fe-ac5d-28b1c42c402f)

</details>