### PR TITLE
feat(useHotkey): add symbol aliases

### DIFF
--- a/packages/0/src/composables/useHotkey/aliases.ts
+++ b/packages/0/src/composables/useHotkey/aliases.ts
@@ -24,6 +24,9 @@ const keyAliasMap = {
   del: 'delete',
 
   // Symbol aliases
+  plus: '+',
+  slash: '/',
+  underscore: '_',
   minus: '-',
   hyphen: '-',
 } as const

--- a/packages/0/src/composables/useHotkey/index.test.ts
+++ b/packages/0/src/composables/useHotkey/index.test.ts
@@ -335,6 +335,26 @@ describe('useHotkey', () => {
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
+    it.each([
+      ['plus', { key: '+' }],
+      ['slash', { key: '/' }],
+      ['underscore', { key: '_' }],
+      ['shift+plus', { shiftKey: true, key: '+' }],
+      ['shift+slash', { shiftKey: true, key: '/' }],
+      ['shift+underscore', { shiftKey: true, key: '_' }],
+      ['ctrl+plus', { ctrlKey: true, key: '+' }],
+    ])('handles symbol alias %s', (keys, props) => {
+      const callback = vi.fn()
+
+      scope.run(() => {
+        useHotkey(keys, callback)
+      })
+
+      window.dispatchEvent(createKeyboardEvent(props.key, props))
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
     it('handles alias in combination', () => {
       const callback = vi.fn()
 
@@ -1212,6 +1232,23 @@ describe('splitKeyCombination', () => {
     })
   })
 
+  it('parses symbol alias keys', () => {
+    expect(splitKeyCombination('plus')).toEqual({
+      keys: ['+'],
+      separators: [],
+    })
+
+    expect(splitKeyCombination('slash')).toEqual({
+      keys: ['/'],
+      separators: [],
+    })
+
+    expect(splitKeyCombination('underscore')).toEqual({
+      keys: ['_'],
+      separators: [],
+    })
+  })
+
   it('returns empty for invalid combinations', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -1231,6 +1268,13 @@ describe('splitKeyCombination', () => {
   it('handles slash separator', () => {
     expect(splitKeyCombination('ctrl/k')).toEqual({
       keys: ['ctrl', 'k'],
+      separators: ['/'],
+    })
+  })
+
+  it('handles slash separator with aliases', () => {
+    expect(splitKeyCombination('up/down')).toEqual({
+      keys: ['arrowup', 'arrowdown'],
       separators: ['/'],
     })
   })
@@ -1282,6 +1326,17 @@ describe('splitKeyCombination', () => {
       )
       warnSpy.mockRestore()
     })
+
+    it.each(['/', '/a', 'a/', '//', 'ctrl//'])('warns on invalid slash structure: %s', value => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(splitKeyCombination(value)).toEqual({ keys: [], separators: [] })
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid hotkey combination'),
+      )
+
+      warnSpy.mockRestore()
+    })
   })
 })
 
@@ -1296,6 +1351,10 @@ describe('splitKeySequence', () => {
 
   it('handles single key (not a sequence)', () => {
     expect(splitKeySequence('a')).toEqual(['a'])
+  })
+
+  it('handles standalone literal minus in sequence', () => {
+    expect(splitKeySequence('-')).toEqual(['-'])
   })
 
   it('returns empty for invalid sequences', () => {
@@ -1369,6 +1428,12 @@ describe('normalizeKey', () => {
     expect(normalizeKey('space')).toBe(' ')
     expect(normalizeKey('return')).toBe('enter')
     expect(normalizeKey('del')).toBe('delete')
+  })
+
+  it('normalizes symbol aliases', () => {
+    expect(normalizeKey('plus')).toBe('+')
+    expect(normalizeKey('slash')).toBe('/')
+    expect(normalizeKey('underscore')).toBe('_')
   })
 
   it('preserves unknown keys in lowercase', () => {

--- a/packages/0/src/composables/useHotkey/parsing.ts
+++ b/packages/0/src/composables/useHotkey/parsing.ts
@@ -44,10 +44,10 @@ export function splitKeyCombination (combination: string, isInternal = false): C
 
   const hasInvalidStructure = (
     hasInvalidLeadingSeparator ||
-    // Disallow literal + or _ keys (they require shift)
-    combination.includes('++') || combination.includes('__') || combination === '+' || combination === '_' ||
+    // Disallow literal +, /, or _ keys (+ and _ require shift)
+    combination.includes('++') || combination.includes('//') || combination.includes('__') || combination === '+' || combination === '/' || combination === '_' ||
     // Ends with a separator that is not part of a doubled literal
-    (combination.length > 1 && (combination.endsWith('+') || combination.endsWith('_')) && combination.at(-2) !== combination.at(-1)) ||
+    (combination.length > 1 && (combination.endsWith('+') || combination.endsWith('/') || combination.endsWith('_')) && combination.at(-2) !== combination.at(-1)) ||
     // Stand-alone doubled separators (dangling)
     combination === '++' || combination === '--' || combination === '__'
   )
@@ -125,7 +125,7 @@ export function splitKeySequence (str: string): string[] {
 
   // A sequence is invalid if it starts or ends with a separator,
   // unless it is part of a combination (e.g., `shift+-`).
-  const hasInvalidStart = str.startsWith('-') && !['---', '--+'].includes(str)
+  const hasInvalidStart = str.startsWith('-') && !['-', '---', '--+'].includes(str)
   const hasInvalidEnd = str.endsWith('-') && !str.endsWith('+-') && !str.endsWith('_-') && str !== '-' && str !== '---'
 
   if (hasInvalidStart || hasInvalidEnd) {


### PR DESCRIPTION
- Introduced new symbol aliases: 'plus', 'slash', and 'underscore'.
- Updated tests to handle new symbol aliases in various scenarios.