### PR TITLE
refactor(createForm): align register API with registry pattern

### DIFF
--- a/packages/0/src/composables/createForm/index.test.ts
+++ b/packages/0/src/composables/createForm/index.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Composables
+import { createValidation } from '#v0/composables/createValidation'
+
 // Utilities
 import { inject, nextTick, provide } from 'vue'
 
@@ -17,345 +20,203 @@ vi.mock('vue', async () => {
 const mockProvide = vi.mocked(provide)
 const mockInject = vi.mocked(inject)
 
-describe('createForm disabled fields', () => {
-  it('should register disabled fields', () => {
+describe('createForm', () => {
+  it('should register a validation context', () => {
     const form = createForm()
-    const field = form.register({
-      id: 'test',
-      value: 'test',
-      disabled: true,
-      rules: [],
-    })
+    const validation = createValidation()
+    validation.register({ id: 'email', value: '', rules: [v => !!v || 'Required'] })
 
-    expect(field.disabled).toBe(true)
+    const ticket = form.register({ value: validation })
+
+    expect(form.size).toBe(1)
+    expect(ticket.value).toBe(validation)
   })
 
-  it('should default to enabled when disabled is not specified', () => {
+  it('should unregister a validation context', () => {
     const form = createForm()
-    const field = form.register({
-      id: 'test',
-      value: 'test',
-      rules: [],
-    })
+    const validation = createValidation()
+    validation.register({ id: 'email', value: '' })
 
-    expect(field.disabled).toBe(false)
-  })
-})
+    const ticket = form.register({ value: validation })
+    expect(form.size).toBe(1)
 
-describe('createForm integration', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+    form.unregister(ticket.id)
+    expect(form.size).toBe(0)
   })
 
-  it('should validate all fields on submit', async () => {
-    const form = createForm()
-    const mockRule = vi.fn().mockResolvedValue('Error message')
+  it('should have disabled and readonly refs', () => {
+    const form = createForm({ disabled: true, readonly: true })
 
-    const field = form.register({
-      id: 'test',
-      rules: [mockRule],
-      value: 'test-value',
-    })
-
-    await form.submit()
-
-    expect(mockRule).toHaveBeenCalledWith('test-value')
-    expect(field.errors.value).toEqual(['Error message'])
+    expect(form.disabled.value).toBe(true)
+    expect(form.readonly.value).toBe(true)
   })
 
-  it('should correctly compute isValid and isValidating', async () => {
+  it('should default disabled and readonly to false', () => {
     const form = createForm()
-    const mockRule = vi.fn().mockResolvedValue(true)
 
-    form.register({
-      id: 'test',
-      rules: [mockRule],
-      value: 'test-value',
-    })
-
-    const submitPromise = form.submit()
-
-    await nextTick()
-    expect(form.isValidating.value).toBe(true)
-
-    await submitPromise
-
-    expect(form.isValid.value).toBe(true)
-    expect(form.isValidating.value).toBe(false)
+    expect(form.disabled.value).toBe(false)
+    expect(form.readonly.value).toBe(false)
   })
 
   describe('isValid computation', () => {
-    it('should return null when no fields are registered', () => {
+    it('should return null when no validations are registered', () => {
       const form = createForm()
       expect(form.isValid.value).toBe(null)
     })
 
-    it('should return null when fields have not been validated', () => {
+    it('should return null when validations have not been validated', () => {
       const form = createForm()
-      form.register({
-        id: 'field1',
-        value: 'test',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
+      const validation = createValidation()
+      validation.register({ id: 'f1', value: 'test', rules: [v => !!v || 'Required'] })
+      form.register({ value: validation })
 
       expect(form.isValid.value).toBe(null)
     })
 
-    it('should return true when all fields are valid', async () => {
+    it('should return true when all validations are valid', async () => {
       const form = createForm()
-      const field1 = form.register({
-        id: 'field1',
-        value: 'valid',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
-      const field2 = form.register({
-        id: 'field2',
-        value: 'also valid',
-        rules: [v => (v as string).length > 3 || 'Min 3 chars'],
-      })
 
-      await field1.validate()
-      await field2.validate()
+      const v1 = createValidation()
+      const f1 = v1.register({ id: 'f1', value: 'valid', rules: [v => (v as string).length > 0 || 'Required'] })
+      form.register({ value: v1 })
+
+      const v2 = createValidation()
+      const f2 = v2.register({ id: 'f2', value: 'also valid', rules: [v => (v as string).length > 3 || 'Min 3'] })
+      form.register({ value: v2 })
+
+      await f1.validate()
+      await f2.validate()
 
       expect(form.isValid.value).toBe(true)
     })
 
-    it('should return false when any field is invalid', async () => {
+    it('should return false when any validation is invalid', async () => {
       const form = createForm()
-      const field1 = form.register({
-        id: 'field1',
-        value: 'valid',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
-      const field2 = form.register({
-        id: 'field2',
-        value: '',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
 
-      await field1.validate()
-      await field2.validate()
+      const v1 = createValidation()
+      const f1 = v1.register({ id: 'f1', value: 'valid', rules: [v => (v as string).length > 0 || 'Required'] })
+      form.register({ value: v1 })
+
+      const v2 = createValidation()
+      const f2 = v2.register({ id: 'f2', value: '', rules: [v => (v as string).length > 0 || 'Required'] })
+      form.register({ value: v2 })
+
+      await f1.validate()
+      await f2.validate()
 
       expect(form.isValid.value).toBe(false)
     })
 
-    it('should return null when some fields are validated and some are not', async () => {
+    it('should return null when some validations are unvalidated', async () => {
       const form = createForm()
-      const field1 = form.register({
-        id: 'field1',
-        value: 'valid',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
-      form.register({
-        id: 'field2',
-        value: 'not validated',
-        rules: [v => (v as string).length > 0 || 'Required'],
-      })
 
-      await field1.validate()
+      const v1 = createValidation()
+      const f1 = v1.register({ id: 'f1', value: 'valid', rules: [v => !!v || 'Required'] })
+      form.register({ value: v1 })
+
+      const v2 = createValidation()
+      v2.register({ id: 'f2', value: 'test', rules: [v => !!v || 'Required'] })
+      form.register({ value: v2 })
+
+      await f1.validate()
 
       expect(form.isValid.value).toBe(null)
     })
   })
 
-  it('should reset all fields when form.reset() is called', async () => {
-    const form = createForm()
-    const field1 = form.register({
-      id: 'field1',
-      value: 'initial1',
-      rules: [v => (v as string).length > 0 || 'Required'],
-    })
-    const field2 = form.register({
-      id: 'field2',
-      value: 'initial2',
-      rules: [v => (v as string).length > 0 || 'Required'],
-    })
-
-    field1.value = 'changed1'
-    field2.value = 'changed2'
-    await field1.validate()
-    await field2.validate()
-
-    form.reset()
-
-    expect(field1.value).toBe('initial1')
-    expect(field2.value).toBe('initial2')
-    expect(field1.isPristine.value).toBe(true)
-    expect(field2.isPristine.value).toBe(true)
-    expect(field1.isValid.value).toBe(null)
-    expect(field2.isValid.value).toBe(null)
-    expect(field1.errors.value).toEqual([])
-    expect(field2.errors.value).toEqual([])
-  })
-
-  it('should support programmatic register outside component context', () => {
-    const form = createForm()
-
-    const field = form.register({
-      id: 'programmatic',
-      value: 'hello',
-      rules: [v => (v as string).length > 0 || 'Required'],
-    })
-
-    expect(field.value).toBe('hello')
-    expect(field.disabled).toBe(false)
-    expect(typeof field.validate).toBe('function')
-    expect(typeof field.reset).toBe('function')
-  })
-
-  it('should register declarative and programmatic fields in the same registry', () => {
-    const form = createForm()
-
-    const field1 = form.register({
-      id: 'field-a',
-      value: 'a',
-    })
-    const field2 = form.register({
-      id: 'field-b',
-      value: 'b',
-    })
-
-    expect(form.size).toBe(2)
-    expect(form.get('field-a')).toBe(field1)
-    expect(form.get('field-b')).toBe(field2)
-  })
-
-  describe('isPristine tracking', () => {
-    it('should be pristine initially', () => {
+  describe('submit', () => {
+    it('should validate all fields across all validations', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: 'initial',
-        rules: [],
-      })
+      const rule = vi.fn().mockResolvedValue('Error')
 
-      expect(field.isPristine.value).toBe(true)
+      const v1 = createValidation()
+      v1.register({ id: 'f1', value: 'test', rules: [rule] })
+      form.register({ value: v1 })
+
+      await form.submit()
+
+      expect(rule).toHaveBeenCalledWith('test')
     })
 
-    it('should be non-pristine after value change', () => {
+    it('should return false when any field fails validation', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: 'initial',
-        rules: [],
-      })
 
-      field.value = 'changed'
+      const v1 = createValidation()
+      v1.register({ id: 'f1', value: '', rules: [v => !!v || 'Required'] })
+      form.register({ value: v1 })
 
-      expect(field.isPristine.value).toBe(false)
+      const result = await form.submit()
+      expect(result).toBe(false)
     })
 
-    it('should be pristine again after reset', () => {
+    it('should return true when all fields pass', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: 'initial',
-        rules: [],
-      })
 
-      field.value = 'changed'
-      expect(field.isPristine.value).toBe(false)
+      const v1 = createValidation()
+      v1.register({ id: 'f1', value: 'valid', rules: [v => !!v || 'Required'] })
+      form.register({ value: v1 })
 
-      field.reset()
-      expect(field.isPristine.value).toBe(true)
-      expect(field.value).toBe('initial')
+      const result = await form.submit()
+      expect(result).toBe(true)
     })
 
-    it('should be pristine when value is changed back to initial', () => {
+    it('should compute isValidating during submit', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: 'initial',
-        rules: [],
-      })
+      const rule = vi.fn().mockResolvedValue(true)
 
-      field.value = 'changed'
-      expect(field.isPristine.value).toBe(false)
+      const v1 = createValidation()
+      v1.register({ id: 'f1', value: 'test', rules: [rule] })
+      form.register({ value: v1 })
 
-      field.value = 'initial'
-      expect(field.isPristine.value).toBe(true)
-    })
-  })
-
-  describe('generation counter race', () => {
-    it('should only write state from the latest validation', async () => {
-      const form = createForm()
-      let callCount = 0
-      async function slowRule (v: unknown) {
-        const call = ++callCount
-        await new Promise(resolve => setTimeout(resolve, call === 1 ? 100 : 10))
-        return (v as string).length > 3 || `Error from call ${call}`
-      }
-
-      const field = form.register({
-        id: 'test',
-        value: 'ab',
-        rules: [slowRule],
-      })
-
-      const first = field.validate()
-      const second = field.validate()
-
-      await Promise.all([first, second])
-
-      expect(field.errors.value).toEqual(['Error from call 2'])
-    })
-  })
-
-  describe('reset during async validation', () => {
-    it('should discard in-flight result after reset', async () => {
-      const form = createForm()
-      let resolve: () => void
-      async function asyncRule (_v: unknown) {
-        await new Promise<void>(r => {
-          resolve = r
-        })
-        return 'Error'
-      }
-
-      const field = form.register({
-        id: 'test',
-        value: 'test',
-        rules: [asyncRule],
-      })
-
-      const validatePromise = field.validate()
+      const promise = form.submit()
       await nextTick()
-      expect(field.isValidating.value).toBe(true)
+      expect(form.isValidating.value).toBe(true)
 
-      field.reset()
-      expect(field.isValidating.value).toBe(false)
-      expect(field.isValid.value).toBe(null)
-      expect(field.errors.value).toEqual([])
-
-      resolve!()
-      await validatePromise
-
-      expect(field.isValid.value).toBe(null)
-      expect(field.errors.value).toEqual([])
-      expect(field.isValidating.value).toBe(false)
+      await promise
+      expect(form.isValidating.value).toBe(false)
     })
   })
 
-  describe('value defaults', () => {
-    it('should default undefined value to empty string', () => {
+  describe('targeted submit', () => {
+    it('should validate only targeted validation by id', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: undefined,
-      })
+      const v1 = createValidation()
+      v1.register({ id: 'f1', value: '', rules: [() => 'Error'] })
+      const v2 = createValidation()
+      v2.register({ id: 'f2', value: '', rules: [() => 'Error'] })
+      form.register({ id: 'v1', value: v1 })
+      form.register({ id: 'v2', value: v2 })
 
-      expect(field.value).toBe('')
+      const result = await form.submit('v1')
+      expect(result).toBe(false)
+      // v2's fields should not have been validated
+      expect([...v2.values()][0]!.isValid.value).toBe(null)
     })
 
-    it('should default null value to empty string', () => {
+    it('should return true when submitting unknown id', async () => {
       const form = createForm()
-      const field = form.register({
-        id: 'test',
-        value: null,
-      })
+      const result = await form.submit('nonexistent')
+      expect(result).toBe(true)
+    })
+  })
 
-      expect(field.value).toBe('')
+  describe('reset', () => {
+    it('should reset all fields across all validations', async () => {
+      const form = createForm()
+
+      const v1 = createValidation()
+      const f1 = v1.register({ id: 'f1', value: 'initial', rules: [v => !!v || 'Required'] })
+      form.register({ value: v1 })
+
+      f1.value = 'changed'
+      await f1.validate()
+
+      form.reset()
+
+      expect(f1.value).toBe('initial')
+      expect(f1.isPristine.value).toBe(true)
+      expect(f1.isValid.value).toBe(null)
+      expect(f1.errors.value).toEqual([])
     })
   })
 })
@@ -377,17 +238,13 @@ describe('createFormContext', () => {
 
   it('should create context with default namespace', () => {
     const [, provideFormContext, context] = createFormContext()
-
     provideFormContext(context)
 
     expect(mockProvide).toHaveBeenCalledWith('v0:form', context)
   })
 
   it('should create context with custom namespace', () => {
-    const [, provideFormContext, context] = createFormContext({
-      namespace: 'my-form',
-    })
-
+    const [, provideFormContext, context] = createFormContext({ namespace: 'my-form' })
     provideFormContext(context)
 
     expect(mockProvide).toHaveBeenCalledWith('my-form', context)
@@ -396,61 +253,40 @@ describe('createFormContext', () => {
   it('should create a default form context', () => {
     const [,, context] = createFormContext()
 
-    expect(context).toBeDefined()
     expect(typeof context.submit).toBe('function')
-  })
-
-  it('should allow providing custom context', () => {
-    const [, provideFormContext] = createFormContext()
-    const customContext = createForm()
-
-    provideFormContext(customContext)
-
-    expect(mockProvide).toHaveBeenCalledWith('v0:form', customContext)
+    expect(typeof context.reset).toBe('function')
   })
 
   it('should provide context at app level when app is passed', () => {
-    const mockApp = {
-      provide: vi.fn(),
-    } as any
+    const mockApp = { provide: vi.fn() } as any
     const [, provideFormContext, context] = createFormContext()
-
     provideFormContext(context, mockApp)
 
     expect(mockApp.provide).toHaveBeenCalledWith('v0:form', context)
   })
 })
 
-describe('useForm consumer', () => {
+describe('useForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should inject context with default namespace', () => {
+  it('should return form context when provided', () => {
     const mockContext = createForm()
     mockInject.mockReturnValue(mockContext)
 
     const result = useForm()
 
-    expect(mockInject).toHaveBeenCalledWith('v0:form', undefined)
     expect(result).toBe(mockContext)
   })
 
-  it('should inject context with custom namespace', () => {
-    const mockContext = createForm()
-    mockInject.mockReturnValue(mockContext)
+  it('should return undefined when no context is provided', () => {
+    mockInject.mockImplementation(() => {
+      throw new Error('not found')
+    })
 
-    const result = useForm('my-form')
+    const result = useForm()
 
-    expect(mockInject).toHaveBeenCalledWith('my-form', undefined)
-    expect(result).toBe(mockContext)
-  })
-
-  it('should throw when context is not provided', () => {
-    mockInject.mockReturnValue(undefined)
-
-    expect(() => useForm()).toThrow(
-      'Context "v0:form" not found. Ensure it\'s provided by an ancestor.',
-    )
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/0/src/composables/createForm/index.ts
+++ b/packages/0/src/composables/createForm/index.ts
@@ -2,17 +2,17 @@
  * @module createForm
  *
  * @remarks
- * Form validation composable with async rule support and multiple validation modes.
+ * Form composable that coordinates validation across multiple fields.
  *
  * Key features:
- * - Sync and async validation rules
- * - Multiple validation modes (submit, change, combined)
- * - Tri-state isValid (null/true/false)
- * - isPristine tracking
- * - Silent validation mode
- * - Form-level validation and reset
+ * - Pure registry of ValidationContext instances
+ * - Validations auto-register via useForm() injection
+ * - Form-level submit, reset, and aggregate state
+ * - Exposes disabled/readonly refs for component consumption
+ * - Trinity pattern for DI
  *
- * Each field is registered with validation rules and tracks its own state independently.
+ * Per-field validation logic lives in createValidation.
+ * createForm is the mothership — it coordinates, not creates.
  */
 
 // Foundational
@@ -23,7 +23,7 @@ import { createTrinity } from '#v0/composables/createTrinity'
 import { createRegistry } from '#v0/composables/createRegistry'
 
 // Utilities
-import { isNull, isNullOrUndefined, isString } from '#v0/utilities'
+import { isNull, isNullOrUndefined } from '#v0/utilities'
 import { computed, shallowRef, toValue } from 'vue'
 
 // Transformers
@@ -32,50 +32,29 @@ import { toArray } from '#v0/composables/toArray'
 // Types
 import type { RegistryContext, RegistryOptions, RegistryTicket, RegistryTicketInput } from '#v0/composables/createRegistry'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
+import type { ValidationContext } from '#v0/composables/createValidation'
 import type { ID } from '#v0/types'
-import type { App, ComputedRef, Ref, ShallowRef } from 'vue'
+import type { App, ComputedRef, MaybeRefOrGetter, ShallowRef } from 'vue'
 
-export type FormValidationResult = string | true | Promise<string | true>
+export type { FormValidationResult, FormValidationRule } from '#v0/composables/useRules'
 
-export type FormValidationRule = (value: unknown) => FormValidationResult
 
-export type FormValue = Ref<unknown> | ShallowRef<unknown>
+export type FormValue = ValidationContext
 
 /**
- * Input type for form tickets - what users provide to register().
- * Extend this interface to add custom properties.
- *
- * @template V The type of the field value.
+ * User-facing input shape for form tickets.
  */
-export interface FormTicketInput<V = unknown> extends RegistryTicketInput<V> {
-  /** Validation rules for this field */
-  rules?: FormValidationRule[]
-  /** When validation should trigger (inherits from form if not set) */
-  validateOn?: 'submit' | 'change' | string
-  /** Whether this field is disabled */
-  disabled?: boolean
-}
+export interface FormTicketInput extends RegistryTicketInput<FormValue> {}
 
 /**
- * Output type for form tickets - what users receive from get().
- * Includes all input properties plus validation state and methods.
+ * A registered validation in the form registry.
  *
  * @template Z The input ticket type that extends FormTicketInput.
  */
-export type FormTicket<Z extends FormTicketInput = FormTicketInput> = RegistryTicket & Z & {
-  validate: (silent?: boolean) => Promise<boolean>
-  reset: () => void
-  validateOn: 'submit' | 'change' | string
-  disabled: boolean
-  errors: ShallowRef<string[]>
-  rules: FormValidationRule[]
-  isPristine: ShallowRef<boolean>
-  isValid: ShallowRef<boolean | null>
-  isValidating: ShallowRef<boolean>
-}
+export type FormTicket<Z extends FormTicketInput = FormTicketInput> = RegistryTicket<FormValue> & Z
 
 /**
- * Context for managing form field collections with validation.
+ * Context for coordinating validation across multiple fields.
  *
  * @template Z The input ticket type.
  * @template E The output ticket type.
@@ -84,50 +63,62 @@ export interface FormContext<
   Z extends FormTicketInput = FormTicketInput,
   E extends FormTicket<Z> = FormTicket<Z>,
 > extends Omit<RegistryContext<E>, 'register' | 'onboard'> {
-  register: (registration: Partial<Z>) => E
-  onboard: (registrations: Partial<Z>[]) => E[]
+  /** Register a validation context with the form. */
+  register: (registration: Partial<Z> & { value: FormValue }) => E
+  /** Submit: validate specific fields or all. */
   submit: (id?: ID | ID[]) => Promise<boolean>
+  /** Reset all registered validations. */
   reset: () => void
-  validateOn: 'submit' | 'change' | string
+  /** Whether the form is disabled. Components can read this to conditionally disable inputs. */
+  disabled: ShallowRef<boolean>
+  /** Whether the form is readonly. Components can read this to conditionally disable inputs. */
+  readonly: ShallowRef<boolean>
+  /** Aggregate: true if all validations valid, false if any invalid, null if any unvalidated. */
   isValid: ComputedRef<boolean | null>
+  /** Aggregate: true if any validation is in progress. */
   isValidating: ComputedRef<boolean>
 }
 
 export interface FormOptions extends RegistryOptions {
-  validateOn?: 'submit' | 'change' | string
+  /** Whether the form starts disabled. */
+  disabled?: MaybeRefOrGetter<boolean>
+  /** Whether the form starts readonly. */
+  readonly?: MaybeRefOrGetter<boolean>
 }
 
-export interface FormContextOptions extends RegistryOptions {
+export interface FormContextOptions extends FormOptions {
   namespace?: string
-  validateOn?: 'submit' | 'change' | string
 }
 
 /**
  * Creates a new form instance.
  *
+ * A form is a pure registry of validation contexts. Validations register
+ * themselves via `useForm()` injection. The form coordinates submit, reset,
+ * and aggregate state across all registered validations.
+ *
  * @param options The options for the form instance.
- * @template Z The type of the form ticket.
- * @template E The type of the form context.
- * @returns A new form instance.
+ * @returns A new form context.
  *
  * @see https://0.vuetifyjs.com/composables/forms/create-form
  *
  * @example
  * ```ts
- * import { createForm } from '@vuetify/v0'
+ * import { createForm, createValidation } from '@vuetify/v0'
  *
  * const form = createForm()
  *
- * const username = form.register({
- *   id: 'username',
+ * // Validations register themselves — form is just the coordinator
+ * const validation = createValidation()
+ * const email = validation.register({
+ *   id: 'email',
  *   value: '',
- *   rules: [(v) => v.length > 0 || 'Username is required'],
+ *   rules: ['required', 'email'],
  * })
  *
+ * form.register({ value: validation })
+ *
  * await form.submit()
- *
- * console.log(username.errors.value) // ['Username is required']
- *
  * form.reset()
  * ```
  */
@@ -137,157 +128,80 @@ export function createForm<
   R extends FormContext<Z, E> = FormContext<Z, E>,
 > (options?: FormOptions): R {
   const registry = createRegistry<E>(options)
-  const validateOn = options?.validateOn || 'submit'
+  const disabled = shallowRef(false)
+  const readonly = shallowRef(false)
 
-  function parse (value: string): string[] {
-    return value.toLowerCase().split(/\s+/)
-  }
+  if (!isNullOrUndefined(options?.disabled)) disabled.value = toValue(options.disabled) ?? false
+  if (!isNullOrUndefined(options?.readonly)) readonly.value = toValue(options.readonly) ?? false
 
   const isValidating = computed(() => {
     for (const ticket of registry.values()) {
-      if (ticket.isValidating.value) return true
+      if (ticket.value.isValidating.value) return true
     }
     return false
   })
 
   const isValid = computed(() => {
+    let hasNull = false
     let hasFields = false
     for (const ticket of registry.values()) {
       hasFields = true
-      if (ticket.isValid.value === false) return false
-      if (isNull(ticket.isValid.value)) return null
+      if (ticket.value.isValid.value === false) return false
+      if (isNull(ticket.value.isValid.value)) hasNull = true
     }
-    return hasFields ? true : null
+    if (!hasFields) return null
+    return hasNull ? null : true
   })
+
+  function register (registration: Partial<Z> & { value: FormValue }): E {
+    return registry.register(registration as Partial<E>)
+  }
 
   function reset () {
     for (const ticket of registry.values()) {
-      ticket.reset()
-    }
-  }
-
-  async function submit (): Promise<boolean> {
-    return validate([...registry.keys()])
-  }
-
-  async function validate (id: ID | ID[]): Promise<boolean> {
-    const validating = toArray(id)
-    const results = await Promise.all(
-      validating.map(async id => await registry.get(id)?.validate() ?? true),
-    )
-    return results.every(Boolean)
-  }
-
-  function register (registration: Partial<Z>): E {
-    const model = shallowRef(isNullOrUndefined(registration.value) ? '' : toValue(registration.value))
-    const rules = registration.rules || []
-    const errors = shallowRef<string[]>([])
-    const isValidating = shallowRef(false)
-    const initialValue = model.value
-    const triggers = registration.validateOn || validateOn
-
-    const isPristine = shallowRef(true)
-    const isValid = shallowRef<boolean | null>(null)
-
-    function _validatesOn (event: 'submit' | 'change'): boolean {
-      return parse(triggers).includes(event)
-    }
-
-    function _reset () {
-      model.value = initialValue
-      errors.value = []
-      isPristine.value = true
-      isValid.value = null
-      isValidating.value = false
-      validationGeneration++
-    }
-
-    let validationGeneration = 0
-
-    async function validate (silent = false): Promise<boolean> {
-      if (rules.length === 0) return isValid.value = true
-
-      const generation = ++validationGeneration
-      isValidating.value = true
-      try {
-        const results = await Promise.all(rules.map(rule => rule(model.value)))
-        if (generation !== validationGeneration) return isValid.value ?? false
-
-        const errorMessages = results.filter(result => isString(result)) as string[]
-
-        if (!silent) {
-          errors.value = errorMessages
-          isValid.value = errorMessages.length === 0
-          isPristine.value = toValue(model) === initialValue
-        }
-
-        return errorMessages.length === 0
-      } finally {
-        if (generation === validationGeneration) {
-          isValidating.value = false
-        }
+      for (const field of ticket.value.values()) {
+        field.reset()
       }
     }
-
-    const item = {
-      ...registration,
-      rules,
-      errors,
-      disabled: registration.disabled || false,
-      validateOn: triggers,
-      isValidating,
-      isPristine,
-      isValid,
-      reset: _reset,
-      validate,
-    }
-
-    const ticket = registry.register(item as unknown as Partial<E>) as E
-
-    Object.defineProperty(ticket, 'value', {
-      get () {
-        return model.value
-      },
-      set (val) {
-        model.value = val
-        isPristine.value = val === initialValue
-        isValid.value = null
-
-        if (_validatesOn('change')) validate()
-      },
-      enumerable: true,
-      configurable: true,
-    })
-
-    return ticket
   }
 
-  function onboard (registrations: Partial<Z>[]): E[] {
-    return registry.batch(() => registrations.map(r => register(r)))
+  async function submit (id?: ID | ID[]): Promise<boolean> {
+    const ids = id ? toArray(id) : [...registry.keys()]
+    const results = await Promise.all(
+      ids.map(async id => {
+        const ticket = registry.get(id)
+        if (!ticket) return true
+
+        // Submit validates all fields within each validation context
+        const validated = await Promise.all(
+          [...ticket.value.values()].map(field => field.validate()),
+        )
+        return validated.every(Boolean)
+      }),
+    )
+    return results.every(Boolean)
   }
 
   return {
     ...registry,
     register,
-    onboard,
-    reset,
     submit,
-    validateOn,
+    reset,
+    disabled,
+    readonly,
     isValid,
     isValidating,
     get size () {
       return registry.size
     },
-  } as R
+  } as unknown as R
 }
 
 /**
- * Creates a new form context.
+ * Creates a new form context using the Trinity pattern.
  *
  * @param options The options for the form context.
- * @template Z The type of the form ticket.
- * @template E The type of the form context.
- * @returns A new form context.
+ * @returns A Trinity tuple: [useFormContext, provideFormContext, formContext]
  *
  * @see https://0.vuetifyjs.com/composables/forms/create-form
  *
@@ -295,21 +209,7 @@ export function createForm<
  * ```ts
  * import { createFormContext } from '@vuetify/v0'
  *
- * // With default namespace 'v0:form'
- * export const [useMyForm, provideMyForm, myForm] = createFormContext({ validateOn: 'change' })
- *
- * // Or with custom namespace
- * export const [useMyForm, provideMyForm, myForm] = createFormContext({
- *   namespace: 'my-form',
- *   validateOn: 'change',
- * })
- *
- * // In a parent component:
- * provideMyForm()
- *
- * // In a child component:
- * const form = useMyForm()
- * form.register({ id: 'field', value: ref(''), rules: [...] })
+ * export const [useMyForm, provideMyForm, myForm] = createFormContext()
  * ```
  */
 export function createFormContext<
@@ -333,7 +233,7 @@ export function createFormContext<
  * Returns the current form instance.
  *
  * @param namespace The namespace for the form context. Defaults to `'v0:form'`.
- * @returns The current form instance.
+ * @returns The current form instance, or undefined if not provided.
  *
  * @see https://0.vuetifyjs.com/composables/forms/create-form
  *
@@ -344,18 +244,16 @@ export function createFormContext<
  *
  *   const form = useForm()
  * </script>
- *
- * <template>
- *   <div>
- *     <p>Form is {{ form.isValid.value ? 'valid' : 'invalid' }}</p>
- *   </div>
- * </template>
  * ```
  */
 export function useForm<
   Z extends FormTicketInput = FormTicketInput,
   E extends FormTicket<Z> = FormTicket<Z>,
   R extends FormContext<Z, E> = FormContext<Z, E>,
-> (namespace = 'v0:form'): R {
-  return useContext<R>(namespace)
+> (namespace = 'v0:form'): R | undefined {
+  try {
+    return useContext<R>(namespace)
+  } catch {
+    return undefined
+  }
 }


### PR DESCRIPTION
## Summary
- Change `register` from positional args `(validation, id?)` to object pattern `({ id, value })` matching `createRegistry`
- Add `Z, E, R` generics for extensibility consistent with `createSelection`/`createGroup`/`createStep`
- Remove `createFormPlugin` (zero consumers)
- `FormTicket` simplified to `RegistryTicket<ValidationContext>` — use `ticket.value` instead of `ticket.validation`

**Depends on:** #159

## Test plan
- [ ] `pnpm vitest run packages/0/src/composables/createForm/index.test.ts` passes (23 tests)
- [ ] `pnpm typecheck` passes