### PR TITLE
docs: add useRules/createValidation/createForm documentation

### DIFF
--- a/apps/docs/src/composables/useDiscovery/index.test.ts
+++ b/apps/docs/src/composables/useDiscovery/index.test.ts
@@ -302,8 +302,11 @@ describe('useDiscovery', () => {
 
     it('should validate form before moving to next step', async () => {
       const validateSpy = vi.spyOn(discovery.form, 'submit')
-      // Register form field for step-1
-      discovery.form.register({ id: 'step-1', rules: [] })
+      // Register a validation context for step-1
+      const { createValidation } = await import('@vuetify/v0')
+      const validation = createValidation()
+      validation.register({ rules: [] })
+      discovery.form.register({ id: 'step-1', value: validation })
 
       await discovery.next()
 
@@ -314,8 +317,11 @@ describe('useDiscovery', () => {
     it('should not move if form validation fails', async () => {
       const beforeId = discovery.selectedId.value
 
-      // Register form field for step-1 with validation
-      discovery.form.register({ id: 'step-1', rules: [] })
+      // Register a validation context for step-1
+      const { createValidation } = await import('@vuetify/v0')
+      const validation = createValidation()
+      validation.register({ rules: [] })
+      discovery.form.register({ id: 'step-1', value: validation })
 
       // Verify form has the field
       expect(discovery.form.has('step-1')).toBe(true)
@@ -655,13 +661,15 @@ describe('useDiscovery', () => {
       expect(discovery.tours.selectedId.value).toBeUndefined()
     })
 
-    it('should reset form field values', () => {
-      const field = discovery.form.register({ id: 'test-field', rules: [] })
+    it('should reset form field values', async () => {
+      const { createValidation } = await import('@vuetify/v0')
+      const validation = createValidation()
+      const field = validation.register({ id: 'test-field', rules: [] })
+      discovery.form.register({ value: validation })
 
       discovery.reset()
 
       // Form fields remain registered but are reset to pristine state
-      expect(discovery.form.has('test-field')).toBe(true)
       expect(field.isPristine.value).toBe(true)
     })
 

--- a/apps/docs/src/examples/composables/use-rules/FormField.vue
+++ b/apps/docs/src/examples/composables/use-rules/FormField.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+  import type { ValidationTicket } from '@vuetify/v0'
+
+  const { ticket, label, placeholder } = defineProps<{
+    ticket: ValidationTicket
+    label: string
+    placeholder: string
+  }>()
+
+  const emit = defineEmits<{
+    input: [value: string]
+  }>()
+
+  function onInput (event: Event) {
+    emit('input', (event.target as HTMLInputElement).value)
+  }
+</script>
+
+<template>
+  <div>
+    <label class="block text-xs font-medium text-on-surface-variant mb-1">
+      {{ label }}
+    </label>
+
+    <input
+      class="w-full px-3 py-1.5 text-sm border rounded bg-surface text-on-surface"
+      :class="ticket.errors.value.length > 0 ? 'border-error' : 'border-divider'"
+      :placeholder
+      :value="ticket.value"
+      @input="onInput"
+    >
+
+    <p
+      class="mt-0.5 text-xs truncate"
+      :class="ticket.errors.value.length > 0 ? 'text-error' : 'text-transparent'"
+    >
+      {{ ticket.errors.value[0] || '&nbsp;' }}
+    </p>
+  </div>
+</template>

--- a/apps/docs/src/examples/composables/use-rules/context.ts
+++ b/apps/docs/src/examples/composables/use-rules/context.ts
@@ -1,0 +1,10 @@
+import { createRulesContext } from '@vuetify/v0'
+
+export const [, provideRules] = createRulesContext({
+  aliases: {
+    required: v => (v === 0 || !!v) || 'Required',
+    email: v => !v || /^.+@\S+\.\S+$/.test(String(v)) || 'Invalid email',
+    slug: v => !v || /^[a-z][a-z0-9-]*$/.test(String(v)) || 'Lowercase letters, numbers, and hyphens only',
+    prefix: v => !v || /^[A-Z]{4}$/.test(String(v)) || 'Must be exactly 4 uppercase letters',
+  },
+})

--- a/apps/docs/src/examples/composables/use-rules/dashboard.vue
+++ b/apps/docs/src/examples/composables/use-rules/dashboard.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+  import { createValidation } from '@vuetify/v0'
+  import { provideRules } from './context'
+  import FormField from './FormField.vue'
+
+  provideRules()
+
+  const validation = createValidation()
+
+  const fields = [
+    {
+      label: 'Key Name',
+      placeholder: 'e.g. production-api',
+      ticket: validation.register({
+        id: 'name',
+        value: '',
+        rules: ['required', 'slug'],
+      }),
+    },
+    {
+      label: 'Owner Email',
+      placeholder: 'e.g. ops@company.com',
+      ticket: validation.register({
+        id: 'email',
+        value: '',
+        rules: ['required', 'email'],
+      }),
+    },
+    {
+      label: 'Rate Limit (req/s)',
+      placeholder: '1–10000',
+      ticket: validation.register({
+        id: 'rate',
+        value: '',
+        rules: [
+          'required',
+          (v: unknown) => !v || !Number.isNaN(Number(v)) || 'Must be a number',
+        ],
+      }),
+    },
+    {
+      label: 'Prefix',
+      placeholder: 'e.g. PROD',
+      ticket: validation.register({
+        id: 'prefix',
+        value: '',
+        rules: ['required', 'prefix'],
+      }),
+    },
+  ]
+
+  async function onSubmit () {
+    for (const field of validation.values()) {
+      await field.validate()
+    }
+  }
+
+  function onReset () {
+    for (const field of validation.values()) {
+      field.reset()
+    }
+  }
+
+  function onPrefill () {
+    fields[0]!.ticket.value = 'production-api'
+    fields[1]!.ticket.value = 'ops@company.com'
+    fields[2]!.ticket.value = '1000'
+    fields[3]!.ticket.value = 'PROD'
+  }
+
+  function onBreak () {
+    fields[0]!.ticket.value = 'BAD KEY!'
+    fields[1]!.ticket.value = 'not-an-email'
+    fields[2]!.ticket.value = 'abc'
+    fields[3]!.ticket.value = 'lo'
+  }
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Fields -->
+    <div class="grid grid-cols-2 gap-4">
+      <FormField
+        v-for="field in fields"
+        :key="field.ticket.id"
+        :label="field.label"
+        :placeholder="field.placeholder"
+        :ticket="field.ticket"
+        @input="field.ticket.value = $event"
+      />
+    </div>
+
+    <!-- Controls -->
+    <div class="flex flex-wrap gap-2">
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded bg-primary text-on-primary hover:opacity-90"
+        @click="onSubmit"
+      >
+        Validate All
+      </button>
+
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded bg-surface-variant text-on-surface-variant hover:opacity-90"
+        @click="onReset"
+      >
+        Reset
+      </button>
+
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded bg-success text-on-success hover:opacity-90"
+        @click="onPrefill"
+      >
+        Fill Valid Data
+      </button>
+
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded bg-error text-on-error hover:opacity-90"
+        @click="onBreak"
+      >
+        Fill Invalid Data
+      </button>
+    </div>
+
+    <!-- State Panel -->
+    <div class="border border-divider rounded p-3 bg-surface-variant/30">
+      <p class="text-xs font-medium text-on-surface-variant mb-1.5">Validation State</p>
+
+      <div class="grid grid-cols-4 gap-3 text-xs">
+        <div v-for="field in fields" :key="field.ticket.id" class="space-y-0.5">
+          <p class="font-medium text-on-surface">{{ field.ticket.id }}</p>
+
+          <p>
+            <span class="text-on-surface-variant">valid: </span>
+            <span :class="field.ticket.isValid.value === true ? 'text-success' : field.ticket.isValid.value === false ? 'text-error' : 'text-on-surface-variant'">
+              {{ field.ticket.isValid.value ?? 'null' }}
+            </span>
+          </p>
+
+          <p>
+            <span class="text-on-surface-variant">pristine: </span>
+            <span :class="field.ticket.isPristine.value ? 'text-on-surface-variant' : 'text-warning'">
+              {{ field.ticket.isPristine.value }}
+            </span>
+          </p>
+
+          <p>
+            <span class="text-on-surface-variant">errors: </span>
+            <span class="text-error">{{ field.ticket.errors.value.length }}</span>
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-2 pt-2 border-t border-divider flex gap-4 text-xs">
+        <p>
+          <span class="text-on-surface-variant">aggregate isValid: </span>
+          <span
+            class="font-medium"
+            :class="validation.isValid.value === true ? 'text-success' : validation.isValid.value === false ? 'text-error' : 'text-on-surface-variant'"
+          >
+            {{ validation.isValid.value ?? 'null' }}
+          </span>
+        </p>
+
+        <p>
+          <span class="text-on-surface-variant">fields: </span>
+          <span class="text-on-surface">{{ validation.size }}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/docs/src/pages/composables/forms/create-form.md
+++ b/apps/docs/src/pages/composables/forms/create-form.md
@@ -1,89 +1,115 @@
 ---
-title: createForm - Reactive Form Validation for Vue 3
+title: createForm - Form Validation Coordinator for Vue 3
 meta:
 - name: description
-  content: Build reactive forms with validation, field registration, and submission handling. Supports async rules, pristine tracking, and multiple validation modes.
+  content: Coordinate validation across multiple fields with submit, reset, and aggregate state. Pure registry of createValidation instances.
 - name: keywords
-  content: createForm, form, validation, composable, Vue 3, registry, field registration, async validation
+  content: createForm, form, validation, composable, Vue 3, registry, submit, reset
 features:
   category: Composable
   label: 'E: createForm'
   github: /composables/createForm/
   level: 3
 related:
+  - /composables/forms/create-validation
+  - /composables/plugins/use-rules
   - /composables/registration/create-registry
 ---
 
 # createForm
 
-A composable for building reactive forms with validation, field registration, and submission handling. Built on top of the registry system for managing form fields.
+Coordinates validation across multiple fields. A pure registry of `createValidation` instances — it provides `submit()`, `reset()`, and aggregate `isValid`/`isValidating` state. Per-field validation logic lives in `createValidation`. The form is the mothership — it coordinates, not creates.
 
 <DocsPageFeatures :frontmatter />
 
 ## Usage
 
-The form composables provide a powerful interface for managing form state, validation, and submission. Built on the registry pattern, they handle form-specific requirements like validation rules, error states, and field lifecycle management.
-
 ### Creating a Form
 
-Use `createForm` to create a new form instance:
+Create a form and register validation contexts. Each validation owns its own fields and rules:
 
 ```ts collapse no-filename
-import { createForm } from '@vuetify/v0'
+import { createForm, createValidation } from '@vuetify/v0'
 
 const form = createForm()
+const validation = createValidation()
 
-const email = form.register({
+const email = validation.register({
   id: 'email',
   value: '',
-  rules: [
-    (value) => value.includes('@') || 'Must be a valid email',
-    (value) => value.length > 0 || 'Required'
-  ]
+  rules: ['required', 'email'],
 })
 
-console.log(email.value) // ''
-console.log(email.errors.value) // []
+form.register({ value: validation })
+
+await form.submit()
+
+console.log(email.errors.value) // ['Required']
+
+form.reset()
+```
+
+### Auto-Registration
+
+When a `createValidation` instance is created inside a component that has a parent form context, it **auto-registers** with the form — no manual `form.register()` needed:
+
+```vue
+<script setup lang="ts">
+  import { createValidation } from '@vuetify/v0'
+
+  // Parent provides form context — this validation auto-registers
+  const validation = createValidation()
+
+  const email = validation.register({
+    id: 'email',
+    value: '',
+    rules: ['required', 'email'],
+  })
+</script>
+```
+
+### Disabled and Readonly
+
+The form exposes `disabled` and `readonly` as reactive refs. Components can read these to conditionally disable inputs:
+
+```ts
+const form = createForm({ disabled: true })
+
+form.disabled.value = false // Toggle at runtime
 ```
 
 ### Injecting a Form Context
 
-Use `useForm` to inject an existing form context (typically provided by a parent component):
+Use `useForm` to inject an existing form context provided by a parent component:
 
 ```ts
 import { useForm } from '@vuetify/v0'
 
-// Injects the form context provided by an ancestor
-const form = useForm()
+const form = useForm() // Returns undefined if no parent form
 ```
 
 ## Architecture
 
-`createForm` extends `createRegistry` with validation capabilities:
+`createForm` is a pure registry. Validations register with it for coordination:
 
-```mermaid "Form Validation Flow"
+```mermaid "Form Architecture"
 flowchart TD
   createRegistry --> createForm
-  createForm --> useForm
-  useForm --> validate[validate/validateAll]
-  useForm --> reset[reset/resetAll]
-  useForm --> errors[error collection]
+  createValidation -->|auto-register| createForm
+  createForm --> submit[submit / reset]
+  createForm --> aggregate[isValid / isValidating]
+  createForm --> state[disabled / readonly]
 ```
 
 ## Reactivity
 
-`createForm` adds **reactive validation state** on top of `createRegistry`. Form-level and field-level state are fully reactive.
+Form-level state is fully reactive.
 
 | Property/Method | Reactive | Notes |
 | - | :-: | - |
-| `isValid` | <AppSuccessIcon /> | Computed from all fields |
-| `isValidating` | <AppSuccessIcon /> | Computed from all fields |
-| `ticket.value` | <AppSuccessIcon /> | ShallowRef, triggers validation on change |
-| `ticket.errors` | <AppSuccessIcon /> | ShallowRef array |
-| `ticket.isValid` | <AppSuccessIcon /> | ShallowRef (null/true/false) |
-| `ticket.isPristine` | <AppSuccessIcon /> | ShallowRef boolean |
-| `ticket.isValidating` | <AppSuccessIcon /> | ShallowRef boolean |
-| `get(id)` | <AppErrorIcon /> | Returns ticket with reactive refs |
-| `values()` | <AppErrorIcon /> | Use `useProxyRegistry()` for reactive collection |
+| `isValid` | <AppSuccessIcon /> | Computed from all registered validations |
+| `isValidating` | <AppSuccessIcon /> | Computed from all registered validations |
+| `disabled` | <AppSuccessIcon /> | ShallowRef, read by components |
+| `readonly` | <AppSuccessIcon /> | ShallowRef, read by components |
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/forms/create-validation.md
+++ b/apps/docs/src/pages/composables/forms/create-validation.md
@@ -1,0 +1,171 @@
+---
+title: createValidation - Per-Field Validation for Vue 3
+meta:
+- name: description
+  content: Per-field validation lifecycle with async rule support, race-safe validation, auto-registration with parent forms, and Standard Schema support.
+- name: keywords
+  content: createValidation, validation, rules, form, composable, Vue 3, async, standard schema
+features:
+  category: Composable
+  label: 'E: createValidation'
+  github: /composables/createValidation/
+  level: 2
+related:
+  - /composables/forms/create-form
+  - /composables/plugins/use-rules
+  - /composables/registration/create-registry
+---
+
+# createValidation
+
+Per-field validation lifecycle composable. Manages validation state — errors, validity, pristine tracking — for individual fields. Works standalone or auto-registers with a parent `createForm`.
+
+<DocsPageFeatures :frontmatter />
+
+## Usage
+
+### Standalone
+
+Create a validation instance and register fields with rules:
+
+```ts collapse no-filename
+import { createValidation } from '@vuetify/v0'
+
+const validation = createValidation()
+
+const email = validation.register({
+  id: 'email',
+  value: '',
+  rules: [
+    v => !!v || 'Required',
+    v => /^.+@\S+\.\S+$/.test(String(v)) || 'Invalid email',
+  ],
+})
+
+await email.validate()
+
+console.log(email.errors.value)    // ['Required']
+console.log(email.isValid.value)   // false
+console.log(email.isPristine.value) // true
+
+email.reset()
+```
+
+### With Rule Aliases
+
+When a rules context is provided via `createRulesPlugin` or `createRulesContext`, alias strings resolve automatically:
+
+```ts
+import { createValidation } from '@vuetify/v0'
+
+const validation = createValidation()
+
+const name = validation.register({
+  id: 'name',
+  value: '',
+  rules: ['required', 'slug'],
+})
+```
+
+### With Standard Schema
+
+Pass schema objects directly — they're auto-detected and wrapped:
+
+```ts
+import { z } from 'zod'
+import { createValidation } from '@vuetify/v0'
+
+const validation = createValidation()
+
+const age = validation.register({
+  id: 'age',
+  value: '',
+  rules: [z.coerce.number().int().min(18, 'Must be 18+')],
+})
+```
+
+### Auto-Registration with Forms
+
+When created inside a component with a parent form context, `createValidation` **auto-registers** with the form. The form can then coordinate submit and reset across all registered validations. Cleanup happens automatically via `onScopeDispose`:
+
+```vue
+<script setup lang="ts">
+  import { createValidation } from '@vuetify/v0'
+
+  // Parent provides form context via createFormContext or createFormPlugin
+  // This validation auto-registers with it
+  const validation = createValidation()
+
+  const email = validation.register({
+    id: 'email',
+    value: '',
+    rules: ['required', 'email'],
+  })
+</script>
+```
+
+### Bulk Registration
+
+Use `onboard()` to register multiple fields at once:
+
+```ts
+const validation = createValidation()
+
+const fields = validation.onboard([
+  { id: 'name', value: '', rules: ['required'] },
+  { id: 'email', value: '', rules: ['required', 'email'] },
+  { id: 'bio', value: '', rules: [v => String(v).length <= 500 || 'Too long'] },
+])
+```
+
+### Silent Validation
+
+Check validity without updating the UI:
+
+```ts
+const valid = await email.validate(true) // silent = true
+// email.errors.value is unchanged
+// email.isValid.value is unchanged
+```
+
+## Architecture
+
+`createValidation` extends `createRegistry` with per-ticket validation state. When a parent form context exists, it auto-registers like a child component:
+
+```mermaid "Validation Architecture"
+flowchart TD
+  createRegistry --> createValidation
+  createValidation -->|auto-register| createForm
+  createValidation --> ticket[ValidationTicket]
+  ticket --> validate[validate / reset]
+  ticket --> state[errors / isValid / isPristine]
+  createValidation --> aggregate[isValid / isValidating]
+```
+
+### Race Safety
+
+Async validation uses a generation counter to prevent stale results. If a newer validation starts before an older one completes, the older result is discarded:
+
+```ts
+// User types fast — each keystroke triggers validation
+email.value = 'a'     // generation 1
+email.value = 'ab'    // generation 2 — generation 1 result discarded
+email.value = 'abc'   // generation 3 — generation 2 result discarded
+// Only generation 3 result is applied
+```
+
+## Reactivity
+
+Field-level and aggregate state are fully reactive.
+
+| Property/Method | Reactive | Notes |
+| - | :-: | - |
+| `isValid` | <AppSuccessIcon /> | Computed aggregate from all tickets |
+| `isValidating` | <AppSuccessIcon /> | Computed aggregate from all tickets |
+| `ticket.value` | <AppSuccessIcon /> | ShallowRef, resets isValid on change |
+| `ticket.errors` | <AppSuccessIcon /> | ShallowRef array |
+| `ticket.isValid` | <AppSuccessIcon /> | ShallowRef (null/true/false) |
+| `ticket.isPristine` | <AppSuccessIcon /> | ShallowRef boolean |
+| `ticket.isValidating` | <AppSuccessIcon /> | ShallowRef boolean |
+
+<DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-rules.md
+++ b/apps/docs/src/pages/composables/plugins/use-rules.md
@@ -1,0 +1,238 @@
+---
+title: useRules - Validation Rules for Vue 3
+meta:
+- name: description
+  content: Headless validation composable with Standard Schema support, custom aliases, and createValidation integration.
+- name: keywords
+  content: useRules, validation, rules, form, composable, Vue 3, standard schema, zod, valibot, arktype
+features:
+  category: Plugin
+  label: 'E: useRules'
+  github: /composables/useRules/
+  level: 2
+related:
+  - /composables/forms/create-validation
+  - /composables/forms/create-form
+---
+
+# useRules
+
+Headless validation composable that resolves rules from multiple sources — [Standard Schema](https://standardschema.dev/) objects, custom aliases, and raw functions — into `FormValidationRule[]` for use with `createValidation`. No built-in validators are included; bring your own via a schema library or register custom aliases at the plugin level.
+
+A validation function returns one of three values:
+- **`true`** — validation passes
+- **`string`** — validation fails, the string is the error message
+- **`false`** — validation fails, the error message is resolved from the locale plugin (`$rules.<name>`)
+
+<DocsPageFeatures :frontmatter />
+
+## Installation
+
+Register the plugin with your app-wide aliases:
+
+```ts main.ts
+import { createApp } from 'vue'
+import { createRulesPlugin } from '@vuetify/v0'
+import App from './App.vue'
+
+const app = createApp(App)
+
+app.use(
+  createRulesPlugin({
+    aliases: {
+      required: v => (v === 0 || !!v) || 'Required',
+      email: v => !v || /^.+@\S+\.\S+$/.test(String(v)) || 'Invalid email',
+      slug: v => !v || /^[a-z][a-z0-9-]*$/.test(String(v)) || 'Invalid slug',
+    },
+  })
+)
+
+app.mount('#app')
+```
+
+> [!TIP]
+> Return `false` instead of a string to defer the error message to the locale plugin. When `useLocale` is installed, `false` resolves to `locale.t('$rules.<aliasName>')`. Without locale, it falls back to the alias name.
+
+## Usage
+
+### In a Component
+
+`createValidation` resolves aliases automatically via `useRules()` — no manual wiring needed:
+
+```vue
+<script setup lang="ts">
+  import { createValidation } from '@vuetify/v0'
+
+  const validation = createValidation()
+
+  const name = validation.register({
+    id: 'name',
+    value: '',
+    rules: ['required', 'slug'],
+  })
+</script>
+```
+
+### Standalone
+
+`createRules` works without a plugin for use outside component scope:
+
+```ts
+import { createRules } from '@vuetify/v0'
+
+const rules = createRules({
+  aliases: {
+    required: v => !!v || 'Required',
+  },
+})
+
+rules.resolve(['required'])
+```
+
+### Custom Aliases
+
+An alias is a **predicate** — a `FormValidationRule` that returns `true`, a `string`, or `false`:
+
+```ts
+app.use(
+  createRulesPlugin({
+    aliases: {
+      // String return — inline error message
+      required: v => !!v || 'This field is required',
+
+      // String return — domain-specific
+      slug: v => !v || /^[a-z][a-z0-9-]*$/.test(String(v)) || 'Invalid slug',
+
+      // false return — defers to locale plugin for message
+      email: v => !v || /^.+@\S+\.\S+$/.test(String(v)) || false,
+    },
+  })
+)
+```
+
+## Adapters
+
+`useRules` supports [Standard Schema](https://standardschema.dev/) — a universal interface for validation libraries. Pass schema objects directly in `rules` arrays alongside alias strings and inline functions — `resolve()` auto-detects and wraps them.
+
+### Zod
+
+```vue
+<script setup lang="ts">
+  import { z } from 'zod'
+  import { createValidation } from '@vuetify/v0'
+
+  const validation = createValidation()
+
+  const email = validation.register({
+    id: 'email',
+    value: '',
+    rules: ['required', z.string().email('Invalid email')],
+  })
+
+  const age = validation.register({
+    id: 'age',
+    value: '',
+    rules: [z.coerce.number().int().min(18, 'Must be 18+').max(120)],
+  })
+</script>
+```
+
+### Valibot
+
+```vue
+<script setup lang="ts">
+  import * as v from 'valibot'
+  import { createValidation } from '@vuetify/v0'
+
+  const validation = createValidation()
+
+  const username = validation.register({
+    id: 'username',
+    value: '',
+    rules: ['required', v.pipe(v.string(), v.minLength(3), v.maxLength(20))],
+  })
+</script>
+```
+
+### ArkType
+
+```vue
+<script setup lang="ts">
+  import { type } from 'arktype'
+  import { createValidation } from '@vuetify/v0'
+
+  const validation = createValidation()
+
+  const score = validation.register({
+    id: 'score',
+    value: '',
+    rules: [type('1 <= number <= 100')],
+  })
+</script>
+```
+
+> [!TIP]
+> Schema objects produce async rules. `createValidation` handles this transparently — no special handling needed in components.
+
+### Compatible Libraries
+
+Any library that implements the [Standard Schema v1 spec](https://standardschema.dev/) works out of the box:
+
+| Library | Version | Import |
+| - | - | - |
+| [Zod](https://zod.dev/) | v3.24+ | `import { z } from 'zod'` |
+| [Valibot](https://valibot.dev/) | v1.0+ | `import * as v from 'valibot'` |
+| [ArkType](https://arktype.io/) | v2.0+ | `import { type } from 'arktype'` |
+
+## Examples
+
+::: example
+/composables/use-rules/context.ts 1
+/composables/use-rules/FormField.vue 2
+/composables/use-rules/dashboard.vue 3
+
+### API Key Manager
+
+This example registers 4 custom aliases (`required`, `email`, `slug`, `prefix`) as predicates with inline error strings, and wires them into `createValidation`. A rate limit field uses an inline function rule to show that aliases and functions can coexist.
+
+The controls let you trigger validation, prefill valid or invalid data, and reset. The state panel reflects each field's `isValid`, `isPristine`, and error count in real time — showing the tri-state validation lifecycle (`null` → `true`/`false`) and how reset returns everything to its initial state.
+
+| File | Role |
+|------|------|
+| `context.ts` | Defines predicate aliases via `createRulesContext` |
+| `FormField.vue` | Reusable field component — binds ticket value, errors, and border state |
+| `dashboard.vue` | Provides rules context, creates validation, registers fields, renders UI |
+
+**Key patterns:**
+
+- `createRulesContext({ aliases })` registers predicate validators
+- `true` = pass, `string` = fail with message, `false` = fail with locale lookup
+- `createValidation()` resolves aliases automatically via `useRules()`
+- Each ticket exposes `isValid`, `isPristine`, `errors` as reactive refs
+- Components decide when to call `validate()` — validation triggers are a UI concern
+
+:::
+
+## Architecture
+
+`useRules` resolves aliases, functions, and Standard Schema objects into `FormValidationRule[]` for use with `createValidation`:
+
+```mermaid "Rules Architecture"
+flowchart TD
+  aliases[Predicate Aliases] --> resolve
+  functions[Inline Functions] --> resolve
+  StandardSchema[Standard Schema] --> resolve
+  useRules --> resolve[resolve rules]
+  resolve --> createValidation
+```
+
+## Reactivity
+
+`useRules` has no reactive state. Aliases are plain predicate functions — `resolve()` wraps them with locale-aware error message lookup when they return `false`.
+
+| Property | Reactive | Notes |
+| - | :-: | - |
+| `aliases` | <AppErrorIcon /> | Static map of predicate functions |
+| `resolve()` | <AppErrorIcon /> | Pure function, returns array of rule functions |
+
+<DocsApi />

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js'
 
 // Framework
-import { createBreakpointsPlugin, createDatePlugin, createFeaturesPlugin, createHydrationPlugin, createLocalePlugin, createLoggerPlugin, createPermissionsPlugin, createRtlPlugin, createStackPlugin, createStoragePlugin, createThemePlugin, IN_BROWSER, useStorage } from '@vuetify/v0'
+import { createBreakpointsPlugin, createDatePlugin, createFeaturesPlugin, createHydrationPlugin, createLocalePlugin, createLoggerPlugin, createPermissionsPlugin, createStackPlugin, createStoragePlugin, createThemePlugin, IN_BROWSER, useStorage } from '@vuetify/v0'
 import { Vuetify0DateAdapter } from '@vuetify/v0/date'
 import { PostHogFeatureAdapter } from '@vuetify/v0/features/adapters/posthog'
 
@@ -47,7 +47,6 @@ export default function zero (app: App) {
       },
     }),
   )
-  app.use(createRtlPlugin())
   app.use(
     createLocalePlugin({
       default: 'en',


### PR DESCRIPTION
## Summary
- Add doc pages for `useRules` and `createValidation`
- Update `createForm` examples for new register object pattern
- Remove manual `useRules()` wiring from all code examples — `createValidation()` resolves aliases automatically via DI
- Remove `standalone: true` references
- Remove unused `createRulesPlugin()` from docs plugin
- Fix use-rules live example to use `createRulesContext` + component-level provide

**Depends on:** #160

## Test plan
- [ ] `pnpm vitest run apps/docs/src/composables/useDiscovery/index.test.ts` passes (66 tests)
- [ ] `pnpm dev:docs` — verify use-rules example works