### PR TITLE
fix(InputRoot): emit focused state via v-model:focused

### DIFF
--- a/packages/0/src/components/Input/InputRoot.vue
+++ b/packages/0/src/components/Input/InputRoot.vue
@@ -185,7 +185,7 @@
 
   defineEmits<{
     'update:model-value': [value: string]
-    'update:isFocused': [value: boolean]
+    'update:focused': [value: boolean]
   }>()
 
   const {
@@ -207,6 +207,7 @@
   } = defineProps<InputRootProps>()
 
   const model = defineModel<string>({ default: '' })
+  const focused = defineModel<boolean>('focused', { default: false })
 
   const input = createInput({
     value: model,
@@ -233,6 +234,7 @@
   }
 
   watch(input.isFocused, val => {
+    focused.value = val
     if (val) return
     input.isTouched.value = true
     if (shouldValidate('blur')) input.validate()


### PR DESCRIPTION
## Summary

- Closes #194 — `update:isFocused` was declared on `InputRoot` but never emitted, so parent `v-model` bindings were silent
- Renames the emit to `update:focused` for kebab-case consistency with `update:model-value`
- Wires the emit through `defineModel('focused')`, syncing internal focus state inside the existing blur watch

## Usage

```vue
<script setup lang="ts>
  import { Input } from '@vuetify/v0'
  import { shallowRef } from 'vue'

  const value = shallowRef('')
  const isFocused = shallowRef(false)
</script>

<template>
  <Input.Root v-model="value" v-model:focused="isFocused">
    <Input.Control />
  </Input.Root>
</template>
```

## Test plan

- [x] `pnpm typecheck` passes (pre-existing unrelated Snackbar TS6133 aside)
- [x] `pnpm lint:fix` clean
- [x] Manual: dev playground with `v-model:focused` toggles correctly on focus/blur