### PR TITLE
fix(Carousel): intercept shift+wheel for discrete slide navigation

### DIFF
--- a/packages/0/src/components/Carousel/CarouselViewport.vue
+++ b/packages/0/src/components/Carousel/CarouselViewport.vue
@@ -118,6 +118,23 @@
       }
     })
 
+    let lastShiftWheel = 0
+
+    useEventListener(el, 'wheel', (e: WheelEvent) => {
+      if (!e.shiftKey) return
+      const delta = e.deltaY || e.deltaX
+      if (delta === 0) return
+
+      e.preventDefault()
+
+      const now = performance.now()
+      if (now - lastShiftWheel < 300) return
+      lastShiftWheel = now
+
+      if (delta > 0) carousel.next()
+      else carousel.prev()
+    }, { passive: false })
+
     let dragStart = 0
     let scrollStart = 0
 


### PR DESCRIPTION
## Summary

- Intercept `wheel` events on `CarouselViewport` only when `Shift` is held, call `preventDefault`, and step `next()`/`prev()` with a 300ms throttle.
- Regular page scrolling over the carousel is untouched — the handler no-ops when `shiftKey` is false.

## Context

Chrome's `scroll-snap-type: x mandatory` resists fast, continuous shift+wheel input: each tick gets absorbed by the snap, so rapid or direction-changing scrolls feel sluggish or get swallowed entirely. The same behavior is reproducible on MDN's reference scroll-snap carousel. Firefox is mostly fluid.

By bypassing the native wheel→scroll→snap pipeline for shift+wheel specifically and driving slide selection imperatively, one wheel tick = one slide, reliably.

Closes #193