### PR TITLE
docs: SEO fixes (404 status, BreadcrumbList, og/twitter meta)

### DIFF
--- a/apps/docs/nginx.conf
+++ b/apps/docs/nginx.conf
@@ -22,7 +22,7 @@ http {
 
     location / {
       index index.html;
-      try_files $uri $uri/index.html /index.html;
+      try_files $uri $uri/index.html =404;
       add_header Cache-Control 'public, max-age=3600, s-maxage=60';
     }
 
@@ -30,7 +30,7 @@ http {
       add_header Cache-Control 'public, immutable, max-age=31536000, stale-if-error=604800';
     }
 
-    #error_page  404              /404.html;
+    error_page  404              /404/index.html;
     #error_page  500 502 503 504  /50x.html;
   }
 }

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -9,6 +9,7 @@
   import AppMeshBg from '@/components/app/AppMeshBg.vue'
 
   // Composables
+  import { useBreadcrumbItems } from './composables/useBreadcrumbItems'
   import { useScrollPersist } from './composables/useScrollPersist'
   import { useSettings } from './composables/useSettings'
 
@@ -32,6 +33,35 @@
 
   const url = toRef(() => `https://0.vuetifyjs.com${route.path}`)
 
+  const breadcrumbs = useBreadcrumbItems()
+
+  const breadcrumbScript = toRef(() => {
+    if (route.path === '/') return []
+
+    const items = breadcrumbs.value
+    if (items.length <= 1) return []
+
+    return [{
+      key: 'breadcrumb-schema',
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement': items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const name = index === 0 ? 'Vuetify0' : item.text
+          const entry: Record<string, unknown> = {
+            '@type': 'ListItem',
+            'position': index + 1,
+            name,
+          }
+          if (!isLast && item.to) entry.item = `https://0.vuetifyjs.com${item.to}`
+          return entry
+        }),
+      }),
+    }]
+  })
+
   useHead({
     title: 'Vuetify0',
     titleTemplate: '%s — Vuetify0',
@@ -44,27 +74,33 @@
     meta: [
       { key: 'description', name: 'description', content: 'Headless components and composables for building modern applications and design systems' },
       { key: 'og:type', property: 'og:type', content: 'website' },
+      { key: 'og:site_name', property: 'og:site_name', content: 'Vuetify0' },
+      { key: 'og:locale', property: 'og:locale', content: 'en_US' },
       { key: 'og:url', property: 'og:url', content: url },
       { key: 'og:image', property: 'og:image', content: 'https://cdn.vuetifyjs.com/docs/images/one/logos/vzero-logo-og.png' },
       { key: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
+      { key: 'twitter:site', name: 'twitter:site', content: '@VuetifyJS' },
     ],
-    script: [{
-      key: 'website-schema',
-      type: 'application/ld+json',
-      innerHTML: JSON.stringify({
-        '@context': 'https://schema.org',
-        '@type': 'WebSite',
-        'name': 'Vuetify0',
-        'url': 'https://0.vuetifyjs.com',
-        'description': 'Headless components and composables for building modern applications and design systems',
-        'publisher': {
-          '@type': 'Organization',
-          'name': 'Vuetify',
-          'url': 'https://vuetifyjs.com',
-          'logo': 'https://cdn.vuetifyjs.com/docs/images/one/logos/vzero-logo-og.png',
-        },
-      }),
-    }],
+    script: toRef(() => [
+      {
+        key: 'website-schema',
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'WebSite',
+          'name': 'Vuetify0',
+          'url': 'https://0.vuetifyjs.com',
+          'description': 'Headless components and composables for building modern applications and design systems',
+          'publisher': {
+            '@type': 'Organization',
+            'name': 'Vuetify',
+            'url': 'https://vuetifyjs.com',
+            'logo': 'https://cdn.vuetifyjs.com/docs/images/one/logos/vzero-logo-og.png',
+          },
+        }),
+      },
+      ...breadcrumbScript.value,
+    ]),
   })
 </script>
 

--- a/apps/docs/src/components/app/AppMain.vue
+++ b/apps/docs/src/components/app/AppMain.vue
@@ -38,17 +38,6 @@
     return `https://0.vuetifyjs.com/og${path}.png`
   })
 
-  // Build breadcrumb list from route path
-  const breadcrumbs = computed(() => {
-    const segments = route.path.split('/').filter(Boolean)
-    return segments.map((segment, index) => ({
-      '@type': 'ListItem' as const,
-      'position': index + 1,
-      'name': segment.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
-      'item': `https://0.vuetifyjs.com/${segments.slice(0, index + 1).join('/')}`,
-    }))
-  })
-
   // JSON-LD structured data
   const jsonLd = computed(() => {
     const schemas: Record<string, unknown>[] = []
@@ -63,14 +52,6 @@
         'author': { '@type': 'Organization', 'name': 'Vuetify' },
         'publisher': { '@type': 'Organization', 'name': 'Vuetify' },
         'image': ogImage.value,
-      })
-    }
-
-    if (breadcrumbs.value.length > 1) {
-      schemas.push({
-        '@context': 'https://schema.org',
-        '@type': 'BreadcrumbList',
-        'itemListElement': breadcrumbs.value,
       })
     }
 

--- a/apps/docs/src/pages/introduction/security.md
+++ b/apps/docs/src/pages/introduction/security.md
@@ -64,10 +64,16 @@ Internally, security incidents are handled according to a formal Incident Respon
 
 ### Trust Boundaries
 
-```
-Contributor ──PR──→ GitHub ──tag──→ CI ──publish──→ npm ──install──→ Consumer app ──render──→ End user
-                                   │
-                                   └──push──→ CI ──webhook──→ Deploy ──serve──→ Docs site
+```mermaid "Trust Boundaries"
+flowchart LR
+  Contributor -->|PR| GitHub
+  GitHub -->|tag| CI
+  CI -->|publish| npm
+  npm -->|install| ConsumerApp[Consumer app]
+  ConsumerApp -->|render| EndUser[End user]
+  GitHub -->|push| CIDocs[CI]
+  CIDocs -->|webhook| Deploy
+  Deploy -->|serve| DocsSite[Docs site]
 ```
 
 ### In Scope

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -52,9 +52,10 @@ export default defineConfig({
         getApiSlugs(),
         getSkillzSlugs(),
       ])
+      const filtered = paths.filter(p => !p.includes(':path'))
       const apiRoutes = apiSlugs.map(slug => `/api/${slug}`)
       const skillzRoutes = skillzSlugs.map(slug => `/skillz/${slug}`)
-      return [...paths, ...apiRoutes, ...skillzRoutes]
+      return [...filtered, ...apiRoutes, ...skillzRoutes, '/404']
     },
     async onFinished () {
       generateSitemap({
@@ -62,6 +63,7 @@ export default defineConfig({
         generateRobotsTxt: false,
         changefreq: 'daily',
         priority: 0.7,
+        exclude: ['/404'],
       })
       await generateOgImages()
     },


### PR DESCRIPTION
## Summary

- Return real HTTP 404 for unmatched routes (previously 200 via nginx fallback to /index.html)
- Emit route-derived BreadcrumbList JSON-LD from App.vue, replacing the inferior duplicate in AppMain.vue (preserves camelCase segment names, omits \`item\` on last entry per schema.org)
- Add missing \`og:site_name\`, \`og:locale\`, \`twitter:site\` meta tags

## Implementation notes (404)

apps/docs already uses vite-ssg, so no build pipeline change was needed. Changes:
- \`vite.config.ts\`: filter the catch-all's literal path from \`includedRoutes\`, append \`/404\`, exclude \`/404\` from the sitemap
- \`nginx.conf\`: \`try_files … =404\` + \`error_page 404 /404/index.html\`
