### PR TITLE
refactor(createEnrollable): internal factory for dual-mode toggleable roots

### DIFF
--- a/packages/0/src/components/Checkbox/CheckboxRoot.vue
+++ b/packages/0/src/components/Checkbox/CheckboxRoot.vue
@@ -18,6 +18,7 @@
 
   // Composables
   import { createContext } from '#v0/composables/createContext'
+  import { createEnrollable } from '#v0/composables/createEnrollable'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
@@ -176,68 +177,29 @@
 
   const model = defineModel<boolean>()
 
-  // Dual mode: register with parent
-  const ticket = group?.register({ id, value, disabled, indeterminate })
-
-  const isChecked = toRef(() => ticket
-    ? toValue(ticket.isSelected)
-    : model.value ?? false,
-  )
-
-  const isMixed = toRef(() => ticket
-    ? toValue(ticket.isMixed)
-    : toValue(indeterminate) ?? false,
-  )
-
-  const isDisabled = toRef(() => group && ticket
-    ? toValue(ticket.disabled) || toValue(group.disabled)
-    : toValue(disabled) ?? false,
-  )
+  const {
+    ticket,
+    isChecked,
+    isMixed,
+    isDisabled,
+    select,
+    unselect,
+    toggle,
+    mix,
+    unmix,
+  } = createEnrollable<V>({
+    id,
+    value,
+    disabled: () => toValue(disabled),
+    indeterminate: () => toValue(indeterminate),
+    model,
+    group,
+  })
 
   const dataState = toRef(() => isMixed.value
     ? 'indeterminate'
     : (isChecked.value ? 'checked' : 'unchecked'),
   )
-
-  function toggle () {
-    if (isDisabled.value) return
-
-    if (ticket) {
-      ticket.toggle()
-    } else {
-      model.value = !model.value
-    }
-  }
-
-  function select () {
-    if (isDisabled.value) return
-
-    if (ticket) {
-      ticket.select()
-    } else {
-      model.value = true
-    }
-  }
-
-  function unselect () {
-    if (isDisabled.value) return
-
-    if (ticket) {
-      ticket.unselect()
-    } else {
-      model.value = false
-    }
-  }
-
-  function mix () {
-    if (isDisabled.value || !ticket) return
-    ticket.mix()
-  }
-
-  function unmix () {
-    if (isDisabled.value || !ticket) return
-    ticket.unmix()
-  }
 
   function onClick () {
     toggle()

--- a/packages/0/src/components/Switch/SwitchRoot.vue
+++ b/packages/0/src/components/Switch/SwitchRoot.vue
@@ -20,6 +20,7 @@
 
   // Composables
   import { createContext } from '#v0/composables/createContext'
+  import { createEnrollable } from '#v0/composables/createEnrollable'
 
   // Utilities
   import { useId } from '#v0/utilities'
@@ -171,64 +172,29 @@
 
   const model = defineModel<boolean>()
 
-  const ticket = group?.register({ id, value, disabled, indeterminate })
-
-  const isChecked = toRef(() => ticket
-    ? toValue(ticket.isSelected)
-    : model.value ?? false,
-  )
-
-  const isMixed = toRef(() => ticket
-    ? toValue(ticket.isMixed)
-    : toValue(indeterminate) ?? false,
-  )
-
-  const isDisabled = toRef(() => group && ticket
-    ? toValue(ticket.disabled) || toValue(group.disabled)
-    : toValue(disabled) ?? false,
-  )
+  const {
+    ticket,
+    isChecked,
+    isMixed,
+    isDisabled,
+    select,
+    unselect,
+    toggle,
+    mix,
+    unmix,
+  } = createEnrollable<V>({
+    id,
+    value,
+    disabled: () => toValue(disabled),
+    indeterminate: () => toValue(indeterminate),
+    model,
+    group,
+  })
 
   const dataState = toRef(() => isMixed.value
     ? 'indeterminate'
     : (isChecked.value ? 'checked' : 'unchecked'),
   )
-
-  function toggle () {
-    if (isDisabled.value) return
-    if (ticket) {
-      ticket.toggle()
-    } else {
-      model.value = !model.value
-    }
-  }
-
-  function select () {
-    if (isDisabled.value) return
-    if (ticket) {
-      ticket.select()
-    } else {
-      model.value = true
-    }
-  }
-
-  function unselect () {
-    if (isDisabled.value) return
-    if (ticket) {
-      ticket.unselect()
-    } else {
-      model.value = false
-    }
-  }
-
-  function mix () {
-    if (isDisabled.value || !ticket) return
-    ticket.mix()
-  }
-
-  function unmix () {
-    if (isDisabled.value || !ticket) return
-    ticket.unmix()
-  }
 
   function onClick () {
     toggle()

--- a/packages/0/src/composables/createEnrollable/index.test.ts
+++ b/packages/0/src/composables/createEnrollable/index.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest'
+
+// Composables
+import { createGroup } from '#v0/composables/createGroup'
+
+// Utilities
+import { shallowRef, toRef } from 'vue'
+
+import { createEnrollable } from './index'
+
+describe('createEnrollable', () => {
+  describe('standalone mode', () => {
+    it('should mirror model.value on isChecked', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      expect(enrollable.isChecked.value).toBe(false)
+      model.value = true
+      expect(enrollable.isChecked.value).toBe(true)
+    })
+
+    it('should flip model.value on toggle', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      enrollable.toggle()
+      expect(model.value).toBe(true)
+      enrollable.toggle()
+      expect(model.value).toBe(false)
+    })
+
+    it('should set model.value true on select', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      enrollable.select()
+      expect(model.value).toBe(true)
+    })
+
+    it('should set model.value false on unselect', () => {
+      const model = shallowRef<boolean>(true)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      enrollable.unselect()
+      expect(model.value).toBe(false)
+    })
+
+    it('should no-op mix and unmix without a group', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      enrollable.mix()
+      expect(model.value).toBe(false)
+      expect(enrollable.isMixed.value).toBe(false)
+
+      enrollable.unmix()
+      expect(model.value).toBe(false)
+    })
+
+    it('should report isMixed from the indeterminate option', () => {
+      const model = shallowRef<boolean>(false)
+      const indeterminate = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, indeterminate, group: null })
+
+      expect(enrollable.isMixed.value).toBe(false)
+      indeterminate.value = true
+      expect(enrollable.isMixed.value).toBe(true)
+    })
+
+    it('should accept indeterminate as a plain boolean', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, indeterminate: true, group: null })
+
+      expect(enrollable.isMixed.value).toBe(true)
+    })
+
+    it('should accept indeterminate as a getter', () => {
+      const model = shallowRef<boolean>(false)
+      const source = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({
+        id: 'test:a',
+        model,
+        indeterminate: () => source.value,
+        group: null,
+      })
+
+      expect(enrollable.isMixed.value).toBe(false)
+      source.value = true
+      expect(enrollable.isMixed.value).toBe(true)
+    })
+
+    it('should respect the disabled option on isDisabled', () => {
+      const model = shallowRef<boolean>(false)
+      const disabled = shallowRef<boolean>(true)
+      const enrollable = createEnrollable({ id: 'test:a', model, disabled, group: null })
+
+      expect(enrollable.isDisabled.value).toBe(true)
+    })
+
+    it('should block toggle/select/unselect when disabled', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, disabled: true, group: null })
+
+      enrollable.toggle()
+      enrollable.select()
+      expect(model.value).toBe(false)
+
+      model.value = true
+      enrollable.unselect()
+      expect(model.value).toBe(true)
+    })
+
+    it('should return a null ticket when standalone', () => {
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group: null })
+
+      expect(enrollable.ticket).toBeNull()
+    })
+  })
+
+  describe('group mode', () => {
+    it('should register with the group on construction', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+
+      const enrollable = createEnrollable({
+        id: 'test:a',
+        value: 'alpha',
+        model,
+        group,
+      })
+
+      expect(enrollable.ticket).not.toBeNull()
+      expect(group.has('test:a')).toBe(true)
+      expect(group.get('test:a')?.value).toBe('alpha')
+    })
+
+    it('should read isChecked from the ticket, not the model', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group })
+
+      expect(enrollable.isChecked.value).toBe(false)
+      group.select('test:a')
+      expect(enrollable.isChecked.value).toBe(true)
+
+      model.value = false
+      expect(enrollable.isChecked.value).toBe(true)
+    })
+
+    it('should read isMixed from the ticket', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group })
+
+      expect(enrollable.isMixed.value).toBe(false)
+      group.mix('test:a')
+      expect(enrollable.isMixed.value).toBe(true)
+    })
+
+    it('should composite isDisabled from ticket.disabled and group.disabled', () => {
+      const groupDisabled = shallowRef<boolean>(false)
+      const group = createGroup({ disabled: toRef(() => groupDisabled.value) })
+      const ticketDisabled = shallowRef<boolean>(false)
+      const model = shallowRef<boolean>(false)
+
+      const enrollable = createEnrollable({
+        id: 'test:a',
+        model,
+        disabled: toRef(() => ticketDisabled.value),
+        group,
+      })
+
+      expect(enrollable.isDisabled.value).toBe(false)
+
+      ticketDisabled.value = true
+      expect(enrollable.isDisabled.value).toBe(true)
+
+      ticketDisabled.value = false
+      groupDisabled.value = true
+      expect(enrollable.isDisabled.value).toBe(true)
+    })
+
+    it('should route toggle through the ticket', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group })
+
+      enrollable.toggle()
+      expect(group.selectedIds.has('test:a')).toBe(true)
+      expect(model.value).toBe(false)
+
+      enrollable.toggle()
+      expect(group.selectedIds.has('test:a')).toBe(false)
+    })
+
+    it('should route select and unselect through the ticket', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group })
+
+      enrollable.select()
+      expect(group.selectedIds.has('test:a')).toBe(true)
+      expect(model.value).toBe(false)
+
+      enrollable.unselect()
+      expect(group.selectedIds.has('test:a')).toBe(false)
+    })
+
+    it('should route mix and unmix through the ticket', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({ id: 'test:a', model, group })
+
+      enrollable.mix()
+      expect(group.mixedIds.has('test:a')).toBe(true)
+      expect(enrollable.isMixed.value).toBe(true)
+
+      enrollable.unmix()
+      expect(group.mixedIds.has('test:a')).toBe(false)
+      expect(enrollable.isMixed.value).toBe(false)
+    })
+
+    it('should forward indeterminate: true to group.register so ticket starts mixed', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+
+      const enrollable = createEnrollable({
+        id: 'test:a',
+        model,
+        indeterminate: true,
+        group,
+      })
+
+      expect(enrollable.isMixed.value).toBe(true)
+      expect(group.mixedIds.has('test:a')).toBe(true)
+    })
+
+    it('should block mutations when disabled via ticket.disabled', () => {
+      const group = createGroup()
+      const model = shallowRef<boolean>(false)
+      const enrollable = createEnrollable({
+        id: 'test:a',
+        model,
+        disabled: true,
+        group,
+      })
+
+      enrollable.toggle()
+      enrollable.select()
+      enrollable.mix()
+
+      expect(group.selectedIds.has('test:a')).toBe(false)
+      expect(group.mixedIds.has('test:a')).toBe(false)
+    })
+  })
+})

--- a/packages/0/src/composables/createEnrollable/index.ts
+++ b/packages/0/src/composables/createEnrollable/index.ts
@@ -1,0 +1,216 @@
+/**
+ * @module createEnrollable
+ *
+ * @internal
+ *
+ * @remarks
+ * Extracts the dual-mode (group or standalone) toggleable-root pattern shared by
+ * Checkbox, Switch, Toggle, and similar binary controls. Given a model ref and an
+ * optional parent group context, returns reactive state and mutation methods that
+ * automatically route through the group ticket when enrolled, or fall back to the
+ * model ref when standalone.
+ *
+ * Responsibilities:
+ * - Registers with the group when one is provided, yielding a ticket.
+ * - Computes `isChecked`, `isMixed`, and `isDisabled` from whichever source is active.
+ * - Routes `toggle` / `select` / `unselect` / `mix` / `unmix` to the ticket or model.
+ * - Guards every mutation with the resolved disabled state.
+ *
+ * Non-responsibilities:
+ * - No DOM, no DI, no lifecycle. Callers own `onBeforeUnmount` / `group.unregister`.
+ * - Caller resolves the optional group (typically via `useXGroup` inside a try/catch);
+ *   `createEnrollable` only accepts the resolved context or `null`.
+ *
+ * @example
+ * ```ts
+ * import { createEnrollable } from '@vuetify/v0'
+ *
+ * let group: GroupContext<GroupTicket> | null = null
+ * try { group = useCheckboxGroup(groupNamespace) } catch { }
+ *
+ * const model = defineModel<boolean>()
+ *
+ * const enrollable = createEnrollable({
+ *   id,
+ *   value,
+ *   disabled,
+ *   indeterminate,
+ *   model,
+ *   group,
+ * })
+ * ```
+ */
+
+// Utilities
+import { toRef, toValue } from 'vue'
+
+// Types
+import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
+import type { ID } from '#v0/types'
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+/**
+ * Options for {@link createEnrollable}.
+ *
+ * @template V The type of the underlying value carried by the enrollable.
+ *
+ * @example
+ * ```ts
+ * const options: EnrollableOptions<string> = {
+ *   id: 'apple',
+ *   value: 'apple',
+ *   disabled: () => props.disabled,
+ *   indeterminate: false,
+ *   model: defineModel<boolean>(),
+ *   group: null,
+ * }
+ * ```
+ */
+export interface EnrollableOptions<V = unknown> {
+  /** Unique identifier used for group registration. */
+  id: ID
+  /** Value associated with this item (only meaningful in group mode). */
+  value?: V
+  /** Reactive disabled flag. */
+  disabled?: MaybeRefOrGetter<boolean>
+  /** Reactive indeterminate flag. Standalone mode reads this directly; group mode forwards it to the ticket. */
+  indeterminate?: MaybeRefOrGetter<boolean>
+  /** Boolean ref from the consumer's `defineModel<boolean>()`. */
+  model: Ref<boolean | undefined>
+  /**
+   * Optional parent group. Pass `null` for standalone mode.
+   *
+   * @remarks The caller is responsible for resolving the group (typically via a
+   * `useXGroup(namespace)` call wrapped in try/catch). `createEnrollable` itself
+   * never injects.
+   */
+  group: GroupContext<GroupTicket> | null
+}
+
+/**
+ * Context returned by {@link createEnrollable}.
+ *
+ * @template V The type of the underlying value carried by the enrollable.
+ *
+ * @example
+ * ```ts
+ * const enrollable: EnrollableContext<string> = createEnrollable({ ... })
+ * enrollable.toggle()
+ * enrollable.isChecked.value // reactive
+ * ```
+ */
+export interface EnrollableContext<V = unknown> {
+  /** The id passed in options. */
+  id: ID
+  /** The value passed in options. */
+  value: V | undefined
+  /** The group ticket when enrolled, `null` when standalone. */
+  ticket: GroupTicket | null
+  /** Whether the item is currently selected / on. */
+  isChecked: Readonly<Ref<boolean>>
+  /** Whether the item is in a mixed (indeterminate) state. Always `false` when standalone unless `indeterminate` is truthy. */
+  isMixed: Readonly<Ref<boolean>>
+  /** Resolved disabled state. Combines own `disabled` with `group.disabled` when enrolled. */
+  isDisabled: Readonly<Ref<boolean>>
+  /** Select the item. Routes to `ticket.select()` when enrolled, else sets `model.value = true`. */
+  select: () => void
+  /** Unselect the item. Routes to `ticket.unselect()` when enrolled, else sets `model.value = false`. */
+  unselect: () => void
+  /** Toggle the item. Routes to `ticket.toggle()` when enrolled, else flips `model.value`. */
+  toggle: () => void
+  /** Set the item to mixed state. No-op in standalone mode (no mixed state without a group). */
+  mix: () => void
+  /** Clear the mixed state. No-op in standalone mode. */
+  unmix: () => void
+}
+
+/**
+ * Factory for the dual-mode (group or standalone) toggleable pattern used by
+ * Checkbox, Switch, Toggle, and similar binary controls.
+ *
+ * @param options See {@link EnrollableOptions}.
+ * @template V The underlying value type.
+ * @returns See {@link EnrollableContext}.
+ *
+ * @internal
+ *
+ * @example
+ * ```ts
+ * import { createEnrollable } from '@vuetify/v0'
+ *
+ * const model = defineModel<boolean>()
+ *
+ * const { isChecked, isDisabled, toggle } = createEnrollable({
+ *   id: useId(),
+ *   model,
+ *   group: null,
+ * })
+ * ```
+ */
+export function createEnrollable<V = unknown> (options: EnrollableOptions<V>): EnrollableContext<V> {
+  const { id, value, disabled, indeterminate, model, group } = options
+
+  const ticket = group?.register({ id, value, disabled, indeterminate }) ?? null
+
+  const isChecked = toRef(() => ticket
+    ? toValue(ticket.isSelected)
+    : model.value ?? false,
+  )
+
+  const isMixed = toRef(() => ticket
+    ? toValue(ticket.isMixed)
+    : toValue(indeterminate) ?? false,
+  )
+
+  const isDisabled = toRef(() => group && ticket
+    ? toValue(ticket.disabled) || toValue(group.disabled)
+    : toValue(disabled) ?? false,
+  )
+
+  function toggle () {
+    if (isDisabled.value) return
+
+    if (ticket) ticket.toggle()
+    else model.value = !model.value
+  }
+
+  function select () {
+    if (isDisabled.value) return
+
+    if (ticket) ticket.select()
+    else model.value = true
+  }
+
+  function unselect () {
+    if (isDisabled.value) return
+
+    if (ticket) ticket.unselect()
+    else model.value = false
+  }
+
+  function mix () {
+    if (isDisabled.value || !ticket) return
+
+    ticket.mix()
+  }
+
+  function unmix () {
+    if (isDisabled.value || !ticket) return
+
+    ticket.unmix()
+  }
+
+  return {
+    id,
+    value,
+    ticket,
+    isChecked,
+    isMixed,
+    isDisabled,
+    select,
+    unselect,
+    toggle,
+    mix,
+    unmix,
+  }
+}

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -272,6 +272,11 @@
       "category": "internal",
       "notes": "Internal factory for useRovingFocus and useVirtualFocus"
     },
+    "createEnrollable": {
+      "level": "draft",
+      "category": "internal",
+      "notes": "Internal factory for dual-mode toggleable roots (Checkbox, Switch, Toggle)"
+    },
     "createValidation": {
       "level": "preview",
       "since": "0.1.8",


### PR DESCRIPTION
## Summary

- Extracts the ~85% structural overlap between `CheckboxRoot` and `SwitchRoot` into an **internal** composable. Not a public primitive.
- Matches the existing `createObserver` / `createFocusTraversal` convention: lives under `packages/0/src/composables/createEnrollable/` but is **not** re-exported from the barrel, **not** documented, and flagged `category: "internal"` in `maturity.json`.
- Consumers import via deep path: `#v0/composables/createEnrollable`.
- Roadmap audit confirmed only 3 components fit the dual-mode binary-state + optional-parent-enrollment shape (Checkbox, Switch, Toggle); nothing on the 27-component roadmap substantially broadens the reuse pool — hence internal.

## Consumers in this PR

- `CheckboxRoot` — migrated (reference consumer)
- `SwitchRoot` — migrated (reference consumer)
- `ToggleRoot` — deferred; needs `isPressed` / `.selection` accessor aliasing to fit the shape
- `RadioRoot` — out of scope (mandatory group + roving tabindex, no v-model)

## Design notes

- Framework-neutral: no DOM, no DI, no lifecycle. Callers resolve the optional parent group via `useXGroup` + try/catch and pass `GroupContext | null` in.
- Vue 3.5 reactive-destructure quirk: consumers wrap props as getters (`disabled: () => toValue(disabled)`) at the call site to preserve prop-change reactivity across the composable boundary.