### PR TITLE
fix(createRegistry): skip values/keys/entries cache when reactive

### DIFF
--- a/apps/docs/src/pages/composables/registration/create-registry.md
+++ b/apps/docs/src/pages/composables/registration/create-registry.md
@@ -131,7 +131,7 @@ Each branch extends the base ticket pattern with domain-specific capabilities. S
 | `dispose()` | Remove all tickets and clear event listeners |
 
 > [!TIP] Need reactive collections?
-> Use `useProxyRegistry(registry)` with `events: true` for reliable template reactivity. While `reactive: true` makes the internal collection a `shallowReactive` Map, `values()` caches its result — after any re-render not triggered by a collection mutation, Vue loses the reactive dependency on the collection, and future mutations won't trigger re-renders. See [useProxyRegistry](/composables/reactivity/use-proxy-registry) for details.
+> Pass `{ reactive: true }` to make `keys()`, `values()`, `entries()`, `size`, and per-ticket field reads reactive in templates and computeds. Upserts on existing tickets propagate through the `shallowReactive` wrapping. For event-driven snapshots — or when you want `deep: true` tracking or need reactivity without wrapping the tickets themselves — use [useProxyRegistry](/composables/reactivity/use-proxy-registry) with `{ events: true }`.
 
 ## Examples
 

--- a/apps/docs/src/pages/guide/fundamentals/reactivity.md
+++ b/apps/docs/src/pages/guide/fundamentals/reactivity.md
@@ -157,6 +157,9 @@ Registry collections and computed properties are **not** reactive by default:
 
 This is intentional. Most UI patterns only need to react to *selection changes*, not *collection changes*. When the collection itself changes (items added/removed), you typically know about it—you're the one calling `register()`.
 
+> [!TIP]
+> Pass `{ reactive: true }` to `createRegistry` and the whole table above becomes reactive — `values()`, `keys()`, `entries()`, `size`, plus per-ticket field mutations via `upsert()`. See [Pattern 1](#pattern-1-reactive-option) below.
+
 ## Opting Into Reactivity
 
 When you need reactive collections, v0 provides three patterns.
@@ -170,21 +173,21 @@ import { createRegistry } from '@vuetify/v0'
 
 const registry = createRegistry({ reactive: true })
 
-// The collection Map is now shallowReactive
-registry.collection.size  // Reactive
-registry.collection.values()  // Reactive iteration
+// Public accessors are reactive
+registry.size          // Reactive
+registry.values()      // Reactive iteration
+registry.keys()        // Reactive iteration
+registry.entries()     // Reactive iteration
+
+// Tickets are shallowReactive — upsert mutations propagate
+registry.upsert('id', { value: 'updated' })
 ```
 
 ```vue playground
 <script setup>
-  import { computed } from 'vue'
   import { createRegistry } from '@vuetify/v0'
 
   const registry = createRegistry({ reactive: true })
-
-  // Use computed to access reactive collection
-  const items = computed(() => Array.from(registry.collection.values()))
-  const size = computed(() => registry.collection.size)
 
   let count = 0
   function onAdd() {
@@ -197,9 +200,9 @@ registry.collection.values()  // Reactive iteration
 
 <template>
   <button @click="onAdd">Add Item</button>
-  <p>Count: {{ size }}</p>
+  <p>Count: {{ registry.size }}</p>
   <ul>
-    <li v-for="item in items" :key="item.id">
+    <li v-for="item in registry.values()" :key="item.id">
       {{ item.value }}
     </li>
   </ul>
@@ -207,7 +210,7 @@ registry.collection.values()  // Reactive iteration
 ```
 
 > [!TIP]
-> The `reactive` option wraps the internal `collection` Map with `shallowReactive`. Access `registry.collection` directly for reactive tracking.
+> `reactive: true` wraps both the internal collection and each ticket with `shallowReactive`. Prefer this pattern when you want both reactive iteration *and* reactive per-ticket field mutations via `upsert()`. Use [useProxyRegistry](#pattern-3-useproxyregistry) instead when you want event-driven snapshot reactivity without wrapping the tickets themselves.
 
 ### Pattern 2: Events
 

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 // Utilities
-import { isReactive, nextTick, watchEffect } from 'vue'
+import { computed, isReactive, nextTick, shallowRef, watchEffect } from 'vue'
 
 import { createRegistry, createRegistryContext } from './index'
 
@@ -1151,6 +1151,74 @@ describe('createRegistry', () => {
       registry.upsert('test', { value: 'updated' })
       await nextTick()
       expect(values).toEqual(['initial', 'updated'])
+    })
+
+    it('should propagate upserts to computeds iterating values() after a non-iteration re-run', async () => {
+      const registry = createRegistry<{ value: string }>({ reactive: true })
+      const trigger = shallowRef(0)
+
+      registry.register({ id: 'a', value: 'initial-a' })
+      registry.register({ id: 'b', value: 'initial-b' })
+
+      const snapshot = computed(() => {
+        void trigger.value
+        return registry.values().map(t => t.value).join(',')
+      })
+
+      expect(snapshot.value).toBe('initial-a,initial-b')
+
+      trigger.value++
+      await nextTick()
+      expect(snapshot.value).toBe('initial-a,initial-b')
+
+      registry.upsert('b', { value: 'updated-b' })
+      await nextTick()
+      expect(snapshot.value).toBe('initial-a,updated-b')
+    })
+
+    it('should propagate registers to computeds iterating keys() after a non-iteration re-run', async () => {
+      const registry = createRegistry({ reactive: true })
+      const trigger = shallowRef(0)
+
+      registry.register({ id: 'a' })
+
+      const snapshot = computed(() => {
+        void trigger.value
+        return [...registry.keys()].join(',')
+      })
+
+      expect(snapshot.value).toBe('a')
+
+      trigger.value++
+      await nextTick()
+      expect(snapshot.value).toBe('a')
+
+      registry.register({ id: 'b' })
+      await nextTick()
+      expect(snapshot.value).toBe('a,b')
+    })
+
+    it('should propagate upserts to computeds iterating entries() after a non-iteration re-run', async () => {
+      const registry = createRegistry<{ value: string }>({ reactive: true })
+      const trigger = shallowRef(0)
+
+      registry.register({ id: 'a', value: 'initial-a' })
+      registry.register({ id: 'b', value: 'initial-b' })
+
+      const snapshot = computed(() => {
+        void trigger.value
+        return registry.entries().map(([id, t]) => `${id}=${t.value}`).join(',')
+      })
+
+      expect(snapshot.value).toBe('a=initial-a,b=initial-b')
+
+      trigger.value++
+      await nextTick()
+      expect(snapshot.value).toBe('a=initial-a,b=initial-b')
+
+      registry.upsert('a', { value: 'updated-a' })
+      await nextTick()
+      expect(snapshot.value).toBe('a=updated-a,b=initial-b')
     })
   })
 })

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -865,6 +865,8 @@ export function createRegistry<
   }
 
   function keys (): readonly ID[] {
+    if (reactive) return Array.from(collection.keys())
+
     const cached = cache.get('keys')
     if (!isUndefined(cached)) return cached as readonly ID[]
 
@@ -876,6 +878,8 @@ export function createRegistry<
   }
 
   function values (): readonly E[] {
+    if (reactive) return Array.from(collection.values())
+
     const cached = cache.get('values')
     if (!isUndefined(cached)) return cached as readonly E[]
 
@@ -887,6 +891,8 @@ export function createRegistry<
   }
 
   function entries (): readonly [ID, E][] {
+    if (reactive) return Array.from(collection.entries())
+
     const cached = cache.get('entries')
     if (!isUndefined(cached)) return cached as readonly [ID, E][]
 


### PR DESCRIPTION
## Summary

Skip the `keys()` / `values()` / `entries()` cache in `createRegistry` when the registry is created with `reactive: true`. The cache was silently dropping Vue's iteration dependency on warm re-runs, so a computed iterating a reactive registry would lose its Map-iteration dep after any re-run that hit the cache — subsequent mutations then failed to propagate.

## Background

Alternative fix for the bug in #208. That PR works around the symptom by mutating the existing ticket in \`upsert\` via \`Object.assign\` so its \`shallowReactive\` proxy fires — which happens to land on a *different* live dep path (per-ticket \`.value\`). The underlying iteration-dep hole stays open for any other consumer.

This PR fixes the hole at the source:

- \`reactive: true\` now does what its JSDoc promises — iteration reactivity included.
- \`upsert\`'s existing replace-the-object behavior is fine; no change needed there.
- Every \`reactive: true\` consumer (\`useNotifications\`, \`createInput\`, \`createForm\`, \`createBreadcrumbs\`) benefits from the same fix.

## Why the cache broke dep tracking

```ts
function values (): readonly E[] {
  const cached = cache.get('values')
  if (!isUndefined(cached)) return cached as readonly E[]  // no reactive read
  const values = Array.from(collection.values())           // reactive read
  cache.set('values', values)
  return values
}
```

Vue's computed re-tracks deps on every run. When a computed iterated \`values()\`:

- Cold cache → \`Array.from\` on the \`shallowReactive\` Map forms an iteration dep.
- Warm cache → early return, no iteration, no dep.

\`select()\` doesn't \`invalidate()\`, so any re-run triggered by a ref change after the initial render dropped the iteration dep. Subsequent \`upsert\`s then had nothing listening.

Reactive consumers tend to have small collections (UI state), so skipping the cache in that mode has negligible cost. Non-reactive registries keep the cache unchanged.

## Follow-ups (separate PRs)

- \`useTheme\` — enable \`reactive: true\` internally so consumers don't have to opt in.
- \`useLocale\` — same.
- \`useFeatures\` — same; \`variation()\` currently reads through a non-reactive registry.