### PR TITLE
feat(useTheme): enable reactive registry by default

### DIFF
--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -280,7 +280,7 @@ export interface ThemePluginOptions extends ThemeContextOptions {
 export function createTheme (_options: ThemeOptions = {}): ThemeContext {
   const { themes = {}, palette = {}, foreground: genForeground, ...options } = _options
   const tokens = createTokens({ palette, ...themes }, { flat: true })
-  const registry = createSingle<SingleTicketInput<ThemeColors>, SingleTicket<SingleTicketInput<ThemeColors>>>(options)
+  const registry = createSingle<SingleTicketInput<ThemeColors>, SingleTicket<SingleTicketInput<ThemeColors>>>({ ...options, reactive: true })
 
   for (const id in themes) {
     const { colors: value, ...theme } = themes[id]!


### PR DESCRIPTION
## Summary

Pass `reactive: true` to the internal `createSingle` so `useTheme` consumers get reactive collection reads and per-ticket mutation propagation without having to opt in at plugin configuration time.

## Background

#209 fixed the underlying `values()` cache bug at the primitive level, which means `reactive: true` on the theme registry now does what users intuitively expect:

- `theme.colors` re-runs on `upsert`
- `v-for` over `theme.keys()` updates when themes register/unregister
- `theme.size`, `theme.values()`, `theme.entries()` all track
- Mutating a ticket's fields via `upsert()` propagates to consumers

Before this change, that behavior required passing `reactive: true` to the theme plugin at config time — a knob most users don't know exists. #208 is the upstream report of this gap.

## Why it should be the default

- `useTheme` is a product composable, not a registry primitive. Consumers expect a Vue-reactive service — the name implies it.
- The docs site's own `useCustomThemes` composable accumulated `// workaround for theme system reactivity` comments and a parallel DOM-patching pipeline because the opt-in wasn't discoverable. That's evidence that even the most informed consumer (the author) hit the gap.
- Theme registries hold a handful of entries; `shallowReactive` overhead is negligible.
- Existing precedent: `useNotifications`, `createInput`, `createForm`, `createBreadcrumbs` all enable `reactive: true` internally.

## Interaction with #208

With this merged, #208 collapses to just the `dark: true` fix on the dev dark theme. The `Object.assign` in `createRegistry` was made redundant by #209; the `reactive: true` plugin-config additions become redundant with this change.

## Follow-ups (separate)

- Clean up `apps/docs/src/composables/useCustomThemes.ts` — remove `injectThemeCSS` / `removeThemeCSS` / `generateThemeCSS` and the `// workaround` comments now that the adapter path works.
- Audit other product composables for the same shape: `useLocale`, `useFeatures` both flagged in prior audit.