### PR TITLE
feat(useLocale,useFeatures): enable reactive registry by default

### DIFF
--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -126,7 +126,7 @@ export function createFeatures (_options: FeatureOptions = {}): FeatureContext {
   const { features, ...options } = _options
 
   const tokens = createTokens(features, { flat: true })
-  const registry = createGroup({ ...options, events: true })
+  const registry = createGroup({ ...options, events: true, reactive: true })
 
   for (const [id, { value }] of tokens.entries()) {
     register({ id, value } as Partial<FeatureTicketInput>)

--- a/packages/0/src/composables/useLocale/index.ts
+++ b/packages/0/src/composables/useLocale/index.ts
@@ -128,7 +128,7 @@ export interface LocalePluginOptions extends LocaleContextOptions {
 export function createLocale (_options: LocaleOptions = {}): LocaleContext {
   const { adapter: externalAdapter, messages = {}, fallback: fallbackLocale, ...options } = _options
   const tokens = createTokens(messages)
-  const registry = createSingle(options)
+  const registry = createSingle({ ...options, reactive: true })
 
   for (const id in messages) {
     registry.register({ id })


### PR DESCRIPTION
## Summary

Pass `reactive: true` to the internal registries in `useLocale` and `useFeatures` so consumers get reactive collection reads and per-ticket mutation propagation without having to opt in.

## Rationale

Same audit, same shape as #210:

- **`useLocale`** — exposes `size`, `keys()`, `values()`, `entries()` over a plain `Map`. Most real-world usage is through `t()` and `selectedId` (already reactive), but a template listing registered locales would silently miss `register()` / `unregister()`.
- **`useFeatures`** — the higher-priority case. Its headline API, `variation(id)`, reads `registry.get(id)` on a plain `Map`. Templates using `v-if="features.variation('new-checkout')"` don't react when `sync()` updates flag values from a remote adapter. Since `sync()` is called on every remote-flag update, this is the primary way the composable is meant to be used.

Both are product composables (users expect a Vue-reactive service from the name) with tiny collections (a handful of locales, a handful of flags), so the `shallowReactive` overhead is negligible.

## Verification

- `pnpm typecheck` — clean.
- `pnpm vitest run useLocale useFeatures` — 136 tests passing.
- `pnpm lint:fix` — clean.