### PR TITLE
docs(useCustomThemes): remove theme reactivity workarounds

### DIFF
--- a/apps/docs/src/composables/useCustomThemes.ts
+++ b/apps/docs/src/composables/useCustomThemes.ts
@@ -4,10 +4,12 @@ import { IN_BROWSER, useStorage, useTheme } from '@vuetify/v0'
 // Utilities
 import { computed, shallowRef, watch } from 'vue'
 
+// Types
+import type { ComputedRef } from 'vue'
+
 // Themes
 import { themes, type ThemeDefinition, type ThemeId } from '@/themes'
 
-// Types
 export interface CustomTheme extends ThemeDefinition {
   custom: true
   baseTheme?: ThemeId
@@ -15,7 +17,7 @@ export interface CustomTheme extends ThemeDefinition {
 
 export interface UseCustomThemesReturn {
   customThemes: typeof customThemes
-  allThemes: ReturnType<typeof computed<Record<string, ThemeDefinition>>>
+  allThemes: ComputedRef<Record<string, ThemeDefinition>>
   editing: typeof isEditing
   create: (theme: Omit<CustomTheme, 'custom'>) => CustomTheme
   update: (id: string, theme: Partial<Omit<CustomTheme, 'id' | 'custom'>>) => void
@@ -26,7 +28,6 @@ export interface UseCustomThemesReturn {
 }
 
 const STORAGE_KEY = 'v0:custom-themes'
-const STYLESHEET_ID = 'v0-theme-stylesheet'
 
 // Shared singleton state
 const customThemes = shallowRef<CustomTheme[]>([])
@@ -38,66 +39,6 @@ let initialized = false
  */
 function generateId (): string {
   return `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
-}
-
-/**
- * Generate CSS for a theme
- */
-function generateThemeCSS (id: string, colors: Record<string, string>): string {
-  const vars = Object.entries(colors)
-    .map(([key, val]) => `  --v0-${key}: ${val};`)
-    .join('\n')
-  return `[data-theme="${id}"] {\n${vars}\n}`
-}
-
-/**
- * Inject or update a custom theme's CSS in the stylesheet
- */
-function injectThemeCSS (id: string, colors: Record<string, string>): void {
-  if (!IN_BROWSER) return
-  const styleEl = document.querySelector(`#${STYLESHEET_ID}`) as HTMLStyleElement | null
-  if (!styleEl) return
-
-  const css = generateThemeCSS(id, colors)
-  const marker = `/* custom:${id} */`
-  const endMarker = `/* /custom:${id} */`
-
-  // Check if this theme's CSS already exists
-  const content = styleEl.textContent || ''
-  const startIdx = content.indexOf(marker)
-
-  if (startIdx === -1) {
-    // Append new (before the :root rule if it exists)
-    const rootIdx = content.indexOf(':root {')
-    styleEl.textContent = rootIdx === -1 ? content + '\n' + marker + '\n' + css + '\n' + endMarker : content.slice(0, rootIdx) + marker + '\n' + css + '\n' + endMarker + '\n' + content.slice(rootIdx)
-  } else {
-    // Update existing
-    const endIdx = content.indexOf(endMarker)
-    if (endIdx !== -1) {
-      styleEl.textContent = content.slice(0, startIdx) + marker + '\n' + css + '\n' + endMarker + content.slice(endIdx + endMarker.length)
-    }
-  }
-}
-
-/**
- * Remove a custom theme's CSS from the stylesheet
- */
-function removeThemeCSS (id: string): void {
-  if (!IN_BROWSER) return
-  const styleEl = document.querySelector(`#${STYLESHEET_ID}`) as HTMLStyleElement | null
-  if (!styleEl) return
-
-  const marker = `/* custom:${id} */`
-  const endMarker = `/* /custom:${id} */`
-  const content = styleEl.textContent || ''
-  const startIdx = content.indexOf(marker)
-
-  if (startIdx !== -1) {
-    const endIdx = content.indexOf(endMarker)
-    if (endIdx !== -1) {
-      styleEl.textContent = content.slice(0, startIdx) + content.slice(endIdx + endMarker.length)
-    }
-  }
 }
 
 /**
@@ -119,28 +60,14 @@ export function useCustomThemes (): UseCustomThemesReturn {
     }
 
     // Persist changes to storage
-    watch(
-      customThemes,
-      value => {
-        storage.set(STORAGE_KEY, value)
-        // Sync custom themes with the theme system
-        for (const custom of value) {
-          theme.upsert(custom.id, {
-            value: custom.colors,
-            dark: custom.dark,
-          })
-        }
-      },
-      { deep: true },
-    )
+    watch(customThemes, value => storage.set(STORAGE_KEY, value))
 
-    // Register existing custom themes on init and inject their CSS
+    // Register existing custom themes on init
     for (const custom of customThemes.value) {
       theme.upsert(custom.id, {
         value: custom.colors,
         dark: custom.dark,
       })
-      injectThemeCSS(custom.id, custom.colors)
     }
   }
 
@@ -163,19 +90,12 @@ export function useCustomThemes (): UseCustomThemesReturn {
       custom: true,
     }
 
-    // Register with theme system
     theme.upsert(newTheme.id, {
       value: newTheme.colors,
       dark: newTheme.dark,
     })
 
-    // Inject CSS immediately (workaround for theme system reactivity)
-    injectThemeCSS(newTheme.id, newTheme.colors)
-
-    // Update state and persist immediately
-    const updated = [...customThemes.value, newTheme]
-    customThemes.value = updated
-    storage.set(STORAGE_KEY, updated)
+    customThemes.value = [...customThemes.value, newTheme]
 
     return newTheme
   }
@@ -191,30 +111,20 @@ export function useCustomThemes (): UseCustomThemesReturn {
     const newThemes = [...customThemes.value]
     newThemes[index] = updated
 
-    // Re-register with theme system
     theme.upsert(id, {
       value: updated.colors,
       dark: updated.dark,
     })
 
-    // Update CSS immediately (workaround for theme system reactivity)
-    injectThemeCSS(id, updated.colors)
-
-    // Update state and persist immediately
     customThemes.value = newThemes
-    storage.set(STORAGE_KEY, newThemes)
   }
 
   /**
    * Remove a custom theme
    */
   function remove (id: string): void {
-    // Remove CSS from stylesheet
-    removeThemeCSS(id)
-
-    const updated = customThemes.value.filter(t => t.id !== id)
-    customThemes.value = updated
-    storage.set(STORAGE_KEY, updated)
+    theme.unregister(id)
+    customThemes.value = customThemes.value.filter(t => t.id !== id)
   }
 
   /**


### PR DESCRIPTION
## Summary

Clean up the docs site's `useCustomThemes` composable now that the theme reactivity gap it worked around is fixed upstream.

## Background

`useCustomThemes` accumulated manual DOM-patching helpers (`generateThemeCSS`, `injectThemeCSS`, `removeThemeCSS`) plus `// workaround for theme system reactivity` comments because calling \`theme.upsert()\` on an existing theme didn't trigger the adapter to regenerate its stylesheet. With #209 (createRegistry cache fix) and #210 (useTheme reactive by default), the adapter's \`watch([context.colors, context.isDark])\` now fires on every upsert and regenerates \`document.adoptedStyleSheets\` automatically.

## Changes

- Remove \`generateThemeCSS\`, \`injectThemeCSS\`, \`removeThemeCSS\` and the \`STYLESHEET_ID\` constant — replaced by the adapter's own pipeline.
- Remove the three inline workaround calls (post-upsert in \`create\`/\`update\`, post-splice in \`remove\`).
- Remove the \`{ deep: true }\` watch that re-ran \`theme.upsert()\` for every custom theme on every change — redundant with the direct upserts. Kept the storage-persistence side.
- **Fix the latent \`remove()\` gap** — it now calls \`theme.unregister(id)\`. Previously the deleted theme stayed in the registry and the adapter kept emitting CSS for it. Wasn't visible before because the CSS helpers were the real source of truth; now that the adapter is, the leak would show up as lingering themes in the cascade.

\`preview()\` and \`clearPreview()\` stay untouched — they bypass the registry intentionally for ~60fps color-picker drag.

## Diff

| Delta | Lines |
|---|---|
| Workaround removal | -99 |
| \`theme.unregister\` fix | +1 |
| Net | **~-90** (about a third of the file) |

## Verification

- \`pnpm typecheck\` — clean.
- \`pnpm lint:fix\` — clean.
- Manual: create/update/delete custom themes in the docs site settings; verify preview drag, save, switching, and deletion all still work.