### PR TITLE
docs: fix custom themes ref access in theme popover

### DIFF
--- a/apps/docs/src/components/app/AppThemeSelector.vue
+++ b/apps/docs/src/components/app/AppThemeSelector.vue
@@ -14,7 +14,7 @@
   const router = useRouter()
 
   const toggle = useThemeToggle()
-  const { customThemes: themes, editor } = useCustomThemes()
+  const customThemes = useCustomThemes()
   const settings = useSettings()
 
   const isOpen = shallowRef(false)
@@ -27,13 +27,13 @@
   function onCreate () {
     isOpen.value = false
     settings.open()
-    editor.open()
+    customThemes.editor.open()
   }
 
   function onEdit (id: string) {
     isOpen.value = false
     settings.open()
-    editor.edit(id)
+    customThemes.editor.edit(id)
   }
 </script>
 
@@ -114,12 +114,12 @@
       </button>
 
       <!-- Custom Themes -->
-      <div v-if="themes.value.length > 0" class="mt-3">
+      <div v-if="customThemes.customThemes.value.length > 0" class="mt-3">
         <div class="text-xs font-medium text-on-surface-variant mb-2 px-1">Custom Themes</div>
 
         <div class="grid grid-cols-2 gap-2">
           <AppThemeCustomButton
-            v-for="theme in themes.value"
+            v-for="theme in customThemes.customThemes.value"
             :key="theme.id"
             editable
             :theme-id="theme.id"


### PR DESCRIPTION
## Summary

- Vue templates auto-unwrap top-level ref bindings exposed from `<script setup>`. The destructured form `const { customThemes: themes } = useCustomThemes()` made `themes` a top-level ref binding, so the template's `themes.value.length` resolved `themes` to the array first, then tried to read `.value` on it — undefined. Runtime: `Cannot read properties of undefined (reading 'length')` at `AppThemeSelector.vue:117`.
- Reverted to the qualified form `customThemes.customThemes.value` for consistency with `AppSettingsTheme.vue` and the project convention of explicit `.value` reads on composable refs.