### PR TITLE
chore(playground): add project export ZIP download

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -13,6 +13,7 @@
     "@vue/repl": "catalog:",
     "@vuetify/auth": "catalog:",
     "@vuetify/v0": "workspace:*",
+    "client-zip": "catalog:",
     "fflate": "catalog:",
     "pinia": "catalog:",
     "vue": "catalog:"

--- a/apps/playground/src/components/playground/settings/PlaygroundSettings.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettings.vue
@@ -2,6 +2,7 @@
   // Components
   import AppCloseButton from '@/components/app/AppCloseButton.vue'
   import AppIcon from '@/components/app/AppIcon.vue'
+  import PlaygroundSettingsExport from './PlaygroundSettingsExport.vue'
   import PlaygroundSettingsPresets from './PlaygroundSettingsPresets.vue'
   import PlaygroundSettingsVersions from './PlaygroundSettingsVersions.vue'
 
@@ -23,7 +24,7 @@
   const sections: Section[] = [
     { id: 'versions', label: 'Versions', icon: 'tags', component: PlaygroundSettingsVersions, available: true },
     { id: 'presets', label: 'Presets', icon: 'layers', component: PlaygroundSettingsPresets, available: true },
-    { id: 'export', label: 'Export', icon: 'download', component: null, available: false },
+    { id: 'export', label: 'Export', icon: 'download', component: PlaygroundSettingsExport, available: true },
   ]
 
   const current = toRef(() => sections.find(s => s.id === active.value))

--- a/apps/playground/src/components/playground/settings/PlaygroundSettingsExport.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettingsExport.vue
@@ -15,7 +15,7 @@
 
     <div>
       <button
-        class="px-3 py-1.5 text-xs font-medium rounded bg-primary text-on-primary hover:opacity-90 transition-opacity cursor-pointer"
+        class="px-3 py-1.5 rounded text-xs font-medium bg-primary text-on-primary"
         type="button"
         @click="downloadProject"
       >

--- a/apps/playground/src/components/playground/settings/PlaygroundSettingsExport.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettingsExport.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+  // Composables
+  import { useExport } from '@/composables/useExport'
+
+  const { downloadProject } = useExport()
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <p class="text-sm text-on-surface-variant">
+      Download your playground as a Vite project. The ZIP includes a runnable scaffold
+      (<code>package.json</code>, <code>vite.config.ts</code>, <code>index.html</code>,
+      <code>src/uno.config.ts</code>) alongside your editor files.
+    </p>
+
+    <div>
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded bg-primary text-on-primary hover:opacity-90 transition-opacity cursor-pointer"
+        type="button"
+        @click="downloadProject"
+      >
+        Download ZIP
+      </button>
+    </div>
+  </div>
+</template>

--- a/apps/playground/src/composables/useExport.ts
+++ b/apps/playground/src/composables/useExport.ts
@@ -1,0 +1,48 @@
+import { downloadZip } from 'client-zip'
+
+// Components
+import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
+
+import { generateProjectFiles } from '@/util/export'
+
+export function useExport () {
+  const playground = usePlayground()
+
+  async function downloadProject () {
+    const store = playground.store
+    const files: Record<string, string> = {}
+    for (const [path, file] of Object.entries(store.files)) {
+      files[path] = file.code
+    }
+
+    const exportFiles = generateProjectFiles({
+      files,
+      importMap: store.getImportMap(),
+    })
+
+    try {
+      const entries = Object.entries(exportFiles).map(([path, content]) => ({
+        name: path,
+        input: new Blob([content], { type: 'text/plain' }),
+      }))
+
+      saveBlob(await downloadZip(entries).blob(), 'v0play.zip')
+    } catch (error) {
+      throw new Error('Error when creating Zip', { cause: error })
+    }
+  }
+
+  return { downloadProject }
+}
+
+function saveBlob (blob: Blob, fileName: string) {
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.setAttribute('download', fileName)
+  document.body.append(link)
+
+  link.click()
+  link.remove()
+  window.URL.revokeObjectURL(url)
+}

--- a/apps/playground/src/composables/useExport.ts
+++ b/apps/playground/src/composables/useExport.ts
@@ -11,8 +11,8 @@ export function useExport () {
   async function downloadProject () {
     const store = playground.store
     const files: Record<string, string> = {}
-    for (const [path, file] of Object.entries(store.files)) {
-      files[path] = file.code
+    for (const path of Object.keys(store.files)) {
+      files[path] = store.files[path]!.code
     }
 
     const exportFiles = generateProjectFiles({

--- a/apps/playground/src/util/export-templates/index.html
+++ b/apps/playground/src/util/export-templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>v0play</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/playground/src/util/export-templates/index.ts
+++ b/apps/playground/src/util/export-templates/index.ts
@@ -1,5 +1,5 @@
 export { default as indexHtmlTemplate } from './index.html?raw'
-export { default as unoConfigTemplate } from './uno.config.ts?raw'
 export { default as packageJsonTemplate } from './package.json?raw'
-
+export { default as tsconfigTemplate } from './tsconfig.json?raw'
+export { default as unoConfigTemplate } from './uno.config.ts?raw'
 export { default as viteConfigTemplate } from './vite.config.ts?raw'

--- a/apps/playground/src/util/export-templates/index.ts
+++ b/apps/playground/src/util/export-templates/index.ts
@@ -1,0 +1,5 @@
+export { default as indexHtmlTemplate } from './index.html?raw'
+export { default as unoConfigTemplate } from './uno.config.ts?raw'
+export { default as packageJsonTemplate } from './package.json?raw'
+
+export { default as viteConfigTemplate } from './vite.config.ts?raw'

--- a/apps/playground/src/util/export-templates/package.json
+++ b/apps/playground/src/util/export-templates/package.json
@@ -5,18 +5,17 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc -b && vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.5.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.0",
-    "@unocss/vite": "^0.65.0",
-    "typescript": "~5.6.0",
-    "unocss": "^0.65.0",
-    "vite": "^6.0.0",
-    "vue-tsc": "^2.1.0"
+    "@vitejs/plugin-vue": "^6.0.0",
+    "typescript": "^6.0.0",
+    "unocss": "^66.0.0",
+    "vite": "^8.0.0",
+    "vue-tsc": "^3.0.0"
   }
 }

--- a/apps/playground/src/util/export-templates/package.json
+++ b/apps/playground/src/util/export-templates/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "v0play-export",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.0",
+    "@unocss/vite": "^0.65.0",
+    "typescript": "~5.6.0",
+    "unocss": "^0.65.0",
+    "vite": "^6.0.0",
+    "vue-tsc": "^2.1.0"
+  }
+}

--- a/apps/playground/src/util/export-templates/tsconfig.json
+++ b/apps/playground/src/util/export-templates/tsconfig.json
@@ -13,5 +13,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.vue"],
+  "exclude": ["src/uno.config.ts"]
 }

--- a/apps/playground/src/util/export-templates/tsconfig.json
+++ b/apps/playground/src/util/export-templates/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/apps/playground/src/util/export-templates/uno.config.ts
+++ b/apps/playground/src/util/export-templates/uno.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, presetWind4 } from 'unocss'
+
+export default defineConfig({
+  presets: [presetWind4()],
+  theme: {
+    colors: {
+      'primary': 'var(--v0-primary)',
+      'secondary': 'var(--v0-secondary)',
+      'accent': 'var(--v0-accent)',
+      'error': 'var(--v0-error)',
+      'info': 'var(--v0-info)',
+      'success': 'var(--v0-success)',
+      'warning': 'var(--v0-warning)',
+      'background': 'var(--v0-background)',
+      'surface': 'var(--v0-surface)',
+      'surface-tint': 'var(--v0-surface-tint)',
+      'surface-variant': 'var(--v0-surface-variant)',
+      'divider': 'var(--v0-divider)',
+      'on-primary': 'var(--v0-on-primary)',
+      'on-secondary': 'var(--v0-on-secondary)',
+      'on-accent': 'var(--v0-on-accent)',
+      'on-error': 'var(--v0-on-error)',
+      'on-info': 'var(--v0-on-info)',
+      'on-success': 'var(--v0-on-success)',
+      'on-warning': 'var(--v0-on-warning)',
+      'on-background': 'var(--v0-on-background)',
+      'on-surface': 'var(--v0-on-surface)',
+      'on-surface-variant': 'var(--v0-on-surface-variant)',
+    },
+    borderColor: {
+      DEFAULT: 'var(--v0-divider)',
+    },
+  },
+})

--- a/apps/playground/src/util/export-templates/vite.config.ts
+++ b/apps/playground/src/util/export-templates/vite.config.ts
@@ -5,7 +5,7 @@ import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  plugins: [Vue(), UnoCSS()],
+  plugins: [Vue(), UnoCSS({ configFile: './src/uno.config.ts' })],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('src', import.meta.url)),

--- a/apps/playground/src/util/export-templates/vite.config.ts
+++ b/apps/playground/src/util/export-templates/vite.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url'
+
+import Vue from '@vitejs/plugin-vue'
+import UnoCSS from 'unocss/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [Vue(), UnoCSS()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('src', import.meta.url)),
+    },
+  },
+})

--- a/apps/playground/src/util/export.ts
+++ b/apps/playground/src/util/export.ts
@@ -1,0 +1,88 @@
+import { indexHtmlTemplate, packageJsonTemplate, unoConfigTemplate, viteConfigTemplate } from '@/util/export-templates'
+
+const EXCLUDED_FILES = new Set(['src/uno.config.ts'])
+
+interface GenerateProjectFilesOptions {
+  files: Record<string, string>
+  importMap: { imports: Record<string, string> }
+}
+
+function generateProjectFiles ({ files, importMap }: GenerateProjectFilesOptions): Record<string, string> {
+  const packageJson = importMapToPackageJson(importMap)
+
+  const templates: Record<string, string> = {
+    'index.html': indexHtmlTemplate,
+    'package.json': JSON.stringify(packageJson, null, 2),
+    'src/uno.config.ts': unoConfigTemplate,
+    'vite.config.ts': viteConfigTemplate,
+  }
+
+  const projectFiles: Record<string, string> = {}
+
+  for (const [path, content] of Object.entries(files)) {
+    if (!EXCLUDED_FILES.has(path)) {
+      projectFiles[replaceExtension(path)] = content
+    }
+  }
+
+  for (const [path, content] of Object.entries(templates)) {
+    if (!projectFiles[path]) {
+      projectFiles[replaceExtension(path)] = content
+    }
+  }
+
+  return projectFiles
+}
+
+function importMapToPackageJson (importMap: { imports: Record<string, string> }): Record<string, unknown> {
+  const deps = extractDependenciesFromImportMap(importMap)
+
+  const packageJson = JSON.parse(packageJsonTemplate)
+
+  for (const [name, version] of Object.entries(deps)) {
+    packageJson.dependencies[name] = version === 'latest' ? version : `^${version}`
+  }
+
+  return packageJson
+}
+
+function extractDependenciesFromImportMap (importMap: { imports: Record<string, string> }): Record<string, string> {
+  const deps: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(importMap.imports)) {
+    const dep = extractPackageInfoFromUrl(value)
+    if (key === 'vue') {
+      deps[key] = dep?.version ?? 'latest'
+    } else {
+      deps[dep?.name ?? key] = dep?.version ?? 'latest'
+    }
+  }
+
+  return deps
+}
+
+function extractPackageInfoFromUrl (url: string): { name: string, version: string } | null {
+  const cdnPatterns = [
+    { regex: /\/npm\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
+    { regex: /unpkg\.com\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
+    { regex: /esm\.sh\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
+  ]
+
+  for (const { regex, nameIdx, versionIdx } of cdnPatterns) {
+    const match = url.match(regex)
+    if (match) {
+      return { name: match[nameIdx], version: match[versionIdx] }
+    }
+  }
+
+  return null
+}
+
+function replaceExtension (path: string): string {
+  if (path.endsWith('.js')) {
+    return path.replace(/\.js$/, '.ts')
+  }
+  return path
+}
+
+export { generateProjectFiles }

--- a/apps/playground/src/util/export.ts
+++ b/apps/playground/src/util/export.ts
@@ -37,6 +37,11 @@ function generateProjectFiles ({ files, importMap }: GenerateProjectFilesOptions
     }
   }
 
+  const mainTs = projectFiles['src/main.ts']
+  if (mainTs) {
+    projectFiles['src/main.ts'] = adaptMainTs(mainTs)
+  }
+
   return projectFiles
 }
 
@@ -89,6 +94,16 @@ function replaceExtension (path: string): string {
     return path.replace(/\.js$/, '.ts')
   }
   return path
+}
+
+function adaptMainTs (source: string): string {
+  // Strip the playground's sandbox-only `./uno.config.ts` side-effect import; in a
+  // real Vite project the UnoCSS plugin emits CSS via the virtual module instead.
+  let updated = source.replace(/^import\s+['"]\.\/uno\.config\.ts['"]\n?/m, '')
+  if (!updated.includes('\'virtual:uno.css\'') && !updated.includes('"virtual:uno.css"')) {
+    updated = `import 'virtual:uno.css'\n${updated}`
+  }
+  return updated
 }
 
 export { generateProjectFiles }

--- a/apps/playground/src/util/export.ts
+++ b/apps/playground/src/util/export.ts
@@ -1,5 +1,6 @@
 import { indexHtmlTemplate, packageJsonTemplate, unoConfigTemplate, viteConfigTemplate } from '@/util/export-templates'
 
+// Excluded so the template version below wins over the playground's runtime sandbox config.
 const EXCLUDED_FILES = new Set(['src/uno.config.ts'])
 
 interface GenerateProjectFilesOptions {
@@ -26,7 +27,7 @@ function generateProjectFiles ({ files, importMap }: GenerateProjectFilesOptions
   }
 
   for (const [path, content] of Object.entries(templates)) {
-    if (!projectFiles[path]) {
+    if (!(path in projectFiles)) {
       projectFiles[replaceExtension(path)] = content
     }
   }

--- a/apps/playground/src/util/export.ts
+++ b/apps/playground/src/util/export.ts
@@ -1,7 +1,11 @@
-import { indexHtmlTemplate, packageJsonTemplate, unoConfigTemplate, viteConfigTemplate } from '@/util/export-templates'
+import { indexHtmlTemplate, packageJsonTemplate, tsconfigTemplate, unoConfigTemplate, viteConfigTemplate } from '@/util/export-templates'
 
-// Excluded so the template version below wins over the playground's runtime sandbox config.
-const EXCLUDED_FILES = new Set(['src/uno.config.ts'])
+// REPL infrastructure files; the template versions (or no version at all) win.
+const EXCLUDED_FILES = new Set([
+  'import-map.json',
+  'src/uno.config.ts',
+  'tsconfig.json',
+])
 
 interface GenerateProjectFilesOptions {
   files: Record<string, string>
@@ -15,6 +19,7 @@ function generateProjectFiles ({ files, importMap }: GenerateProjectFilesOptions
     'index.html': indexHtmlTemplate,
     'package.json': JSON.stringify(packageJson, null, 2),
     'src/uno.config.ts': unoConfigTemplate,
+    'tsconfig.json': tsconfigTemplate,
     'vite.config.ts': viteConfigTemplate,
   }
 

--- a/apps/playground/src/util/export.ts
+++ b/apps/playground/src/util/export.ts
@@ -74,15 +74,15 @@ function extractDependenciesFromImportMap (importMap: { imports: Record<string, 
 
 function extractPackageInfoFromUrl (url: string): { name: string, version: string } | null {
   const cdnPatterns = [
-    { regex: /\/npm\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
-    { regex: /unpkg\.com\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
-    { regex: /esm\.sh\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, nameIdx: 1, versionIdx: 2 },
+    { regex: /\/npm\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, name: 1, version: 2 },
+    { regex: /unpkg\.com\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, name: 1, version: 2 },
+    { regex: /esm\.sh\/((?:@[^/]+\/)?[^@/]+)@([^/]+)\//, name: 1, version: 2 },
   ]
 
-  for (const { regex, nameIdx, versionIdx } of cdnPatterns) {
+  for (const { regex, name, version } of cdnPatterns) {
     const match = url.match(regex)
     if (match) {
-      return { name: match[nameIdx], version: match[versionIdx] }
+      return { name: match[name], version: match[version] }
     }
   }
 

--- a/apps/playground/tsconfig.app.json
+++ b/apps/playground/tsconfig.app.json
@@ -28,7 +28,8 @@
     "src/**/*.vue"
   ],
   "exclude": [
-    "src/**/__tests__/*"
+    "src/**/__tests__/*",
+    "src/util/export-templates/**"
   ],
   "references": [
     { "path": "../../packages/0" }

--- a/apps/playground/tsconfig.app.json
+++ b/apps/playground/tsconfig.app.json
@@ -29,7 +29,8 @@
   ],
   "exclude": [
     "src/**/__tests__/*",
-    "src/util/export-templates/**"
+    "src/util/export-templates/uno.config.ts",
+    "src/util/export-templates/vite.config.ts"
   ],
   "references": [
     { "path": "../../packages/0" }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,9 @@ export default vuetify({
   },
 },
 {
+  ignores: ['**/export-templates/package.json'],
+},
+{
   name: 'vuetify/no-v0-imports',
   files: ['packages/paper/**/*.{ts,js,vue}', 'app/**/*.{ts,js,vue}'],
   rules: {

--- a/knip.json
+++ b/knip.json
@@ -94,7 +94,8 @@
         "vite.config.*"
       ],
       "ignore": [
-        "src/typed-router.d.ts"
+        "src/typed-router.d.ts",
+        "src/util/export-templates/**"
       ],
       "paths": {
         "@/*": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     bumpp:
       specifier: ^11.0.1
       version: 11.0.1
+    client-zip:
+      specifier: ^2.5.0
+      version: 2.5.0
     concurrently:
       specifier: ^9.2.1
       version: 9.2.1
@@ -149,7 +152,7 @@ catalogs:
       version: 0.0.70
     posthog-js:
       specifier: ^1.372.6
-      version: 1.372.6
+      version: 1.372.8
     rollup-plugin-sass:
       specifier: ^1.15.3
       version: 1.15.3
@@ -357,7 +360,7 @@ importers:
         version: 3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.372.6
+        version: 1.372.8
       svg-pan-zoom:
         specifier: 'catalog:'
         version: 3.6.2
@@ -467,6 +470,9 @@ importers:
       '@vuetify/v0':
         specifier: workspace:*
         version: link:../../packages/0
+      client-zip:
+        specifier: 'catalog:'
+        version: 2.5.0
       fflate:
         specifier: 'catalog:'
         version: 0.8.2
@@ -585,7 +591,7 @@ importers:
         version: 3.9.1
       posthog-js:
         specifier: 'catalog:'
-        version: 1.372.6
+        version: 1.372.8
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@tsdown/css@0.21.10)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
@@ -623,7 +629,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: 'catalog:'
-        version: 0.21.10(jiti@2.6.1)(postcss@8.5.13)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.21.10(jiti@2.6.1)(postcss@8.5.14)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)
       rollup-plugin-sass:
         specifier: 'catalog:'
         version: 1.15.3(rollup@4.59.0)
@@ -2300,11 +2306,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.28.0':
-    resolution: {integrity: sha512-753giUMWuk602UtS101tDZuNcwiKkr+3UEhLgfOwHAk2W32n53knOxAjyWT0JwMq5/+0uSQ2y4uaZXQAxwvBSw==}
+  '@posthog/core@1.28.2':
+    resolution: {integrity: sha512-Dii3pxDheG1WioztvV/MqHQMnb16jSFrl2HkDR1T5yf5/R7lPqJCFYt+eXkEdp/oAv/PD+1joyG6Ap/2quFmtQ==}
 
-  '@posthog/types@1.372.6':
-    resolution: {integrity: sha512-sqI36LBvuo8xcYsXIlVa0q3IXJJjqtatM2LrXlyOM7kgHrldBwS4ldzaTXrTdpe/TiIl1b4ZHxtSHMzPig+DnQ==}
+  '@posthog/types@1.372.8':
+    resolution: {integrity: sha512-ALpfCnWsMSM9Cw/6kyLPVpd81ZReEdZwmDxOi+DTJuIo7wDxBiu2cAsjOuA6D/AL22v7HOJrHsmBAPAWqS5X7Q==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3622,6 +3628,9 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
+
+  client-zip@2.5.0:
+    resolution: {integrity: sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -5623,16 +5632,16 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.13:
-    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.372.6:
-    resolution: {integrity: sha512-+Fy9fwWni5WDKQXiUBIzFvdmnZSR6OBxGC/4wj09JvvK5JE4dhI9ZlKO1+b887PowjeAx0sx1Tf+S1eAjDvzqg==}
+  posthog-js@1.372.8:
+    resolution: {integrity: sha512-NAFWVScFGnU5jgGNLkrY/UnGH82uULs9RsJ/f26LkLn1l0MOZfq+/z+2RaOOQQX4NHruIVuxqz3J/50bgRG68A==}
 
   preact@10.29.0:
     resolution: {integrity: sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==}
@@ -6849,8 +6858,8 @@ packages:
       typescript:
         optional: true
 
-  vue-component-type-helpers@3.2.7:
-    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
+  vue-component-type-helpers@3.2.8:
+    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
@@ -7130,7 +7139,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.4
+      tinyexec: 1.1.1
 
   '@apideck/better-ajv-errors@0.3.7(ajv@8.18.0)':
     dependencies:
@@ -8679,11 +8688,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.28.0':
+  '@posthog/core@1.28.2':
     dependencies:
-      '@posthog/types': 1.372.6
+      '@posthog/types': 1.372.8
 
-  '@posthog/types@1.372.6': {}
+  '@posthog/types@1.372.8': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -9036,14 +9045,14 @@ snapshots:
 
   '@tsconfig/node24@24.0.4': {}
 
-  '@tsdown/css@0.21.10(jiti@2.6.1)(postcss@8.5.13)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)':
+  '@tsdown/css@0.21.10(jiti@2.6.1)(postcss@8.5.14)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
       lightningcss: 1.32.0
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3)
       rolldown: 1.0.0-rc.17
       tsdown: 0.21.10(@tsdown/css@0.21.10)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.13
+      postcss: 8.5.14
       sass: 1.99.0
       sass-embedded: 1.99.0
     transitivePeerDependencies:
@@ -9643,7 +9652,7 @@ snapshots:
       '@vue/shared': 3.5.33
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.13
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.31':
@@ -9761,7 +9770,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.33
       js-beautify: 1.15.4
       vue: 3.5.33(typescript@6.0.3)
-      vue-component-type-helpers: 3.2.7
+      vue-component-type-helpers: 3.2.8
     optionalDependencies:
       '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
 
@@ -9940,7 +9949,7 @@ snapshots:
       domhandler: 5.0.3
       htmlparser2: 10.1.0
       picocolors: 1.1.1
-      postcss: 8.5.13
+      postcss: 8.5.8
       postcss-media-query-parser: 0.2.3
     optional: true
 
@@ -10104,6 +10113,8 @@ snapshots:
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  client-zip@2.5.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -12348,12 +12359,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.13
+      postcss: 8.5.14
       tsx: 4.21.0
       yaml: 2.8.3
 
@@ -12367,7 +12378,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.13:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -12379,15 +12390,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.372.6:
+  posthog-js@1.372.8:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@posthog/core': 1.28.0
-      '@posthog/types': 1.372.6
+      '@posthog/core': 1.28.2
+      '@posthog/types': 1.372.8
       core-js: 3.49.0
       dompurify: 3.3.3
       fflate: 0.4.8
@@ -13207,7 +13218,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37(synckit@0.11.12)
     optionalDependencies:
-      '@tsdown/css': 0.21.10(jiti@2.6.1)(postcss@8.5.13)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)
+      '@tsdown/css': 0.21.10(jiti@2.6.1)(postcss@8.5.14)(sass-embedded@1.99.0)(sass@1.99.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.8.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -13324,7 +13335,7 @@ snapshots:
 
   unhead@2.1.12:
     dependencies:
-      hookable: 6.1.1
+      hookable: 6.1.0
 
   unhead@2.1.13:
     dependencies:
@@ -13610,7 +13621,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.13
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -13680,7 +13691,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vue-component-type-helpers@3.2.7: {}
+  vue-component-type-helpers@3.2.8: {}
 
   vue-eslint-parser@10.4.0(eslint@10.3.0(jiti@2.6.1)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   '@vuetify/auth': 0.1.8
   '@vuetify/github-releaser': ^4.0.3
   bumpp: ^11.0.1
+  client-zip: ^2.5.0
   concurrently: ^9.2.1
   conventional-changelog-vuetify: ^2.0.2
   eslint: ^10.3.0


### PR DESCRIPTION
## Summary

- Adds a Settings → Export tab in v0play that downloads the current REPL session as a runnable Vite + UnoCSS starter ZIP (`v0play.zip`). Wires up the existing placeholder in `PlaygroundSettings.vue` (was `available: false`, `component: null`) — the "soon" badge is gone and the tab now renders a tiny explainer + "Download ZIP" button.
- Ports Vuetify Play's [`useExport` flow](https://github.com/vuetifyjs/play/blob/main/src/composables/useExport.ts) to the v0 stack: thin composable orchestrator (`apps/playground/src/composables/useExport.ts`) reads `ReplStore` files + import map, hands them to a pure-logic generator (`apps/playground/src/util/export.ts`), and pipes the result through `client-zip` into a hidden `<a download>`.
- Ships six static raw-string templates under `apps/playground/src/util/export-templates/`: `index.html`, `package.json`, `tsconfig.json`, `vite.config.ts`, `uno.config.ts`, plus an `index.ts` barrel. Runtime deps for the exported `package.json` are extracted from the playground's live import map (CDN URL → `^version`); dev deps are pinned to the workspace catalog versions (vite 8, vue-tsc 3, typescript 6, unocss 66, `@vitejs/plugin-vue` 6).
- `generateProjectFiles` adapts the user's `src/main.ts` on the way out: strips the playground's sandbox-only `import './uno.config.ts'` side-effect import and prepends `import 'virtual:uno.css'` so the exported project actually emits CSS via `@unocss/vite`. Also strips REPL-only infrastructure files (`import-map.json`, `tsconfig.json` from `REPL_BUILTIN_FILES`) so they don't pollute the exported scaffold.

## Notes

- The exported `tsconfig.json` excludes `src/uno.config.ts` from `vue-tsc --noEmit` because UnoCSS's `Theme` type doesn't include `borderColor` despite `presetWind4` supporting it at runtime. The vite plugin loads the config independently, so the v0 color tokens still apply.
- `tsconfig.app.json` excludes `src/util/export-templates/uno.config.ts` and `vite.config.ts` from the playground's own typecheck for the same reason — those templates reference modules the playground itself doesn't install (`@vitejs/plugin-vue`).
- `eslint.config.js` ignores `**/export-templates/package.json` for `pnpm/json-enforce-catalog` so the rule doesn't rewrite the template's pinned versions to `catalog:` references on lint.
- `knip.json` ignores `apps/playground/src/util/export-templates/**` so knip doesn't flag the templates' imports as unlisted dependencies.
- Smoke-tested end-to-end against the default preset: extracted scaffold installs cleanly, `pnpm build` runs `vue-tsc --noEmit && vite build` successfully, emits a 4.47 kB CSS bundle containing the v0 color tokens.
- Filename is hard-coded `v0play.zip` — no input field, no manifest preview, no progress UI per the minimal-Export-tab decision.

## Out of scope

- Round-trip import (uploading an exported ZIP back).
- "Open in StackBlitz" / "Open in CodeSandbox" links.
- Per-preset scaffold templates — single static set; runtime deps via import-map extraction handle preset variation. Vuetify-preset exports won't include `vite-plugin-vuetify` for auto-import; users add it themselves.