### PR TITLE
docs: fix mobile AppNav being covered by Scrim

### DIFF
--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -162,11 +162,11 @@
       <div :inert="isModalOpen || undefined">
         <router-view />
       </div>
+
+      <Scrim class="fixed inset-0 bg-black/30 transition-opacity" :teleport="false" />
     </div>
 
     <DocsSearch />
-
-    <Scrim class="fixed inset-0 bg-black/30 transition-opacity" :teleport="false" />
 
     <Transition :name="slideTransition">
       <AppSettingsSheet v-if="settings.isOpen.value" />


### PR DESCRIPTION
## Summary

The dot-grid layout fix in 9d3be68f promoted `.app-shell-content` to a stacking context (`position: relative; z-index: 1`), which inadvertently trapped the mobile AppNav inside it. The Scrim — sitting outside `.app-shell-content` — outranked the entire subtree at z=1999, covering the nav (which thinks it has z=2000 but is bounded by its parent stacking context).

Settings panel was unaffected because `<AppSettingsSheet>` is a sibling of `.app-shell-content`, not a descendant.

## Fix

Move the `<Scrim>` inside `.app-shell-content` so it shares the stacking context with AppNav. Inside that context, the relative ordering wins — nav z=2000 above scrim z=1999. AppSettingsSheet remains a sibling at z=2000, still above the scrim globally.

## Test plan

- [x] Mobile (≤768px) viewport on `/components/disclosure/dialog` → open nav from hamburger → AppNav drawer renders cleanly above the scrim
- [x] AppBar / AppBanner / page content remain dimmed under the scrim (expected behavior)
- [x] AppSettingsSheet (cog icon) still opens above the scrim with no visual regression
- [x] Desktop layout unaffected — nav doesn't register/select on desktop, so scrim doesn't render