### PR TITLE
docs: convert in-table parentheticals to footnotes

### DIFF
--- a/apps/docs/src/pages/composables/index.md
+++ b/apps/docs/src/pages/composables/index.md
@@ -195,9 +195,11 @@ Composables consume existing context or wrap browser APIs. They're called inside
 
 | Pattern | Example | When to Use |
 | - | - | - |
-| Plugin consumers | `useTheme`, `useLocale`, `useStorage` | Reading app-level plugin state (requires plugin installation) |
+| Plugin consumers | `useTheme`, `useLocale`, `useStorage` | Reading app-level plugin state[^plugin-install] |
 | Browser wrappers | `useEventListener`, `useResizeObserver` | Safe, lifecycle-managed browser API access |
 | Behavior composables | `useHotkey`, `useClickOutside` | Adding interactive behavior to elements |
+
+[^plugin-install]: Requires the corresponding plugin installed at app level — e.g. `app.use(createThemePlugin())` for `useTheme`. See each plugin composable's page for the exact factory.
 
 ## Foundation
 

--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -84,7 +84,9 @@ Adapters let you swap the underlying date library without changing your applicat
 
 | Adapter | Import | Description |
 |---------|--------|-------------|
-| `Vuetify0DateAdapter` | `@vuetify/v0/date` | [Temporal API](https://tc39.es/proposal-temporal/docs/) adapter (requires `@js-temporal/polyfill`) |
+| `Vuetify0DateAdapter` | `@vuetify/v0/date` | [Temporal API](https://tc39.es/proposal-temporal/docs/) adapter[^temporal] |
+
+[^temporal]: Requires the [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) package until native Temporal ships in all evergreen browsers. Install with `pnpm add @js-temporal/polyfill`.
 
 ### DateAdapter Interface
 

--- a/apps/docs/src/pages/composables/selection/create-selection.md
+++ b/apps/docs/src/pages/composables/selection/create-selection.md
@@ -80,7 +80,9 @@ flowchart TD
 | - | - | - | - |
 | `mandatory` | `MaybeRefOrGetter<boolean>` | `false` | Prevent deselecting the last selected item |
 | `multiple` | `MaybeRefOrGetter<boolean>` | `false` | Allow multiple IDs to be selected simultaneously |
-| `enroll` | `MaybeRefOrGetter<boolean>` | `false` | Auto-select tickets on registration (note: `createModel` defaults to `true`) |
+| `enroll` | `MaybeRefOrGetter<boolean>` | `false` | Auto-select tickets on registration[^enroll-createmodel] |
+
+[^enroll-createmodel]: [createModel](/composables/selection/create-model) flips this default to `true` since two-way-bound items are typically expected to start enrolled.
 
 ## Reactivity
 

--- a/apps/docs/src/pages/guide/features/accessibility.md
+++ b/apps/docs/src/pages/guide/features/accessibility.md
@@ -49,8 +49,12 @@ Every v0 component exposes an `attrs` object containing all accessibility attrib
 | Selection.Item | `aria-selected`, `aria-disabled`, `data-selected`, `data-disabled` |
 | Group.Item | `role="checkbox"`, `aria-checked`, `aria-disabled`, `data-selected`, `data-disabled`, `data-mixed` |
 | ExpansionPanel.Activator | `id`, `role`, `tabindex`, `aria-expanded`, `aria-controls`, `aria-disabled` |
-| Pagination.Root | `aria-label`, `role="navigation"` (when not using `<nav>`) |
-| Popover.Activator | `popovertarget`, `data-open` (uses native popover API) |
+| Pagination.Root | `aria-label`, `role="navigation"`[^pagination-nav] |
+| Popover.Activator | `popovertarget`, `data-open`[^popover-native] |
+
+[^pagination-nav]: `role="navigation"` is only added when the root element isn't already a `<nav>`. If you render `Pagination.Root as="nav"`, the role is omitted to avoid redundant landmark roles.
+
+[^popover-native]: `Popover.Activator` wires the [native Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) via the `popovertarget` attribute. See the [Browser Support](/introduction/browser-support) page for fallback behavior in older browsers.
 
 > [!TIP]
 > Always spread the `attrs` object from slot props onto your interactive elements. Missing ARIA attributes break screen reader support.

--- a/apps/docs/src/pages/guide/features/utilities.md
+++ b/apps/docs/src/pages/guide/features/utilities.md
@@ -398,10 +398,12 @@ if (!isNullOrUndefined(x)) {
 | `isNullOrUndefined(x)` | `null \| undefined` |
 | `isPrimitive(x)` | `string \| number \| boolean` |
 | `isSymbol(x)` | `symbol` |
-| `isNaN(x)` | `number` (only the NaN value) |
+| `isNaN(x)` | `number` (only the NaN value)[^isnan-vs-global] |
+
+[^isnan-vs-global]: `isNaN` here uses `Number.isNaN()` internally — it does not coerce strings like the global `isNaN()`. `isNaN("foo")` returns `false`, not `true`.
 
 > [!TIP]
-> Prefer these over raw comparisons. `isNaN` uses `Number.isNaN()` internally—it won't coerce strings like the global `isNaN()`.
+> Prefer these over raw comparisons.
 
 ## Helpers
 

--- a/apps/docs/src/pages/introduction/browser-support.md
+++ b/apps/docs/src/pages/introduction/browser-support.md
@@ -45,12 +45,11 @@ These features require the latest browser versions and may not work in all brows
 
 | Feature | <AppBrowserIcon browser="chrome" /> | <AppBrowserIcon browser="firefox" /> | <AppBrowserIcon browser="safari" /> | <AppBrowserIcon browser="edge" /> | Fallback |
 |---------|---:|---:|---:|---:|----------|
-| [CSS Anchor Positioning](https://caniuse.com/css-anchor-positioning) | 125+ | 147+ | — | 125+ | Properties ignored |
+| [CSS Anchor Positioning](https://caniuse.com/css-anchor-positioning) | 125+ | 147+ | —[^safari-anchor] | 125+ | Properties ignored |
 | [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) | 114+ | 125+ | 17+ | 114+ | Optional chaining |
 | [Scrollend Event](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) | 112+ | 109+ | 18+ | 112+ | Falls back to scroll |
 
-> [!TIP]
-> CSS Anchor Positioning is currently only available in <AppBrowserIcon browser="chrome" /> Chrome 125+, <AppBrowserIcon browser="edge" /> Edge 125+, and <AppBrowserIcon browser="firefox" /> Firefox 147 beta. Safari support is not yet available.
+[^safari-anchor]: Safari support for CSS Anchor Positioning is not yet available; track at [WebKit Bug 286106](https://bugs.webkit.org/show_bug.cgi?id=286106). Firefox 147+ requires the beta channel.
 
 ### Well-Supported Features
 


### PR DESCRIPTION
## Summary

Apply the same footnote pattern from the Claude Desktop addition (#227) across six tables where parenthetical caveats were wedged into cells or where a \`> [!TIP]\` block immediately under a table was doing footnote work.

Footnotes keep table rows aligned and let the caveat carry more context (links, install commands, related docs) without bloating the cell.

## Changes

| File | What |
|------|------|
| \`introduction/browser-support.md\` | Footnote on Safari's missing CSS Anchor Positioning support, replacing the redundant TIP below. |
| \`composables/index.md\` | Footnote on Plugin consumers requiring plugin installation, with example factory call. |
| \`composables/plugins/use-date.md\` | Footnote on \`Vuetify0DateAdapter\`'s \`@js-temporal/polyfill\` requirement, with install command. |
| \`composables/selection/create-selection.md\` | Footnote on \`enroll\` vs \`createModel\`'s flipped default. |
| \`guide/features/utilities.md\` | Footnote on \`isNaN\`'s \`Number.isNaN\` semantics, splitting the prior TIP into a row-scoped footnote and remaining general guidance. |
| \`guide/features/accessibility.md\` | Footnotes on \`Pagination.Root\`'s conditional \`role=\"navigation\"\` and \`Popover.Activator\`'s native Popover API integration. |
