### PR TITLE
chore(tests): adopt `using` for vi.spyOn cleanup across v0 test suite

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -137,17 +137,18 @@ afterEach(() => { scope?.stop() })
 
 ### Expected warnings
 
-When a test intentionally triggers a warning (error paths, duplicate registration), capture with `vi.spyOn` and **assert** it was called — never silently swallow. [intent:229]
+When a test intentionally triggers a warning (error paths, duplicate registration), capture with `using` + `vi.spyOn` and **assert** it was called — never silently swallow. The spy auto-restores when the block exits, so no manual `mockRestore()` is needed. [intent:229]
 
 ```ts
-const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
 // ... code that warns ...
 
 expect(spy).toHaveBeenCalledTimes(1)
 expect(spy).toHaveBeenCalledWith(expect.stringContaining('expected message'))
-spy.mockRestore()
 ```
+
+The `using` form relies on Vitest's `Symbol.dispose` integration (Vitest 3+) and TS `target: esnext`. Fall back to `const` + `spy.mockRestore()` only when the spy must outlive the enclosing block (e.g., set in `beforeEach`, asserted in `afterEach`).
 
 ### Vue DI mocks — `hasInjectionContext` extension
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -148,7 +148,7 @@ expect(spy).toHaveBeenCalledTimes(1)
 expect(spy).toHaveBeenCalledWith(expect.stringContaining('expected message'))
 ```
 
-The `using` form relies on Vitest's `Symbol.dispose` integration (Vitest 3+) and TS `target: esnext`. Fall back to `const` + `spy.mockRestore()` only when the spy must outlive the enclosing block (e.g., set in `beforeEach`, asserted in `afterEach`).
+The `using` form relies on Vitest's `Symbol.dispose` integration (Vitest 3+) and TS `target: esnext`. Background: [TC39 Explicit Resource Management proposal](https://github.com/tc39/proposal-explicit-resource-management). Fall back to `const` + `spy.mockRestore()` only when the spy must outlive the enclosing block (e.g., set in `beforeEach`, asserted in `afterEach`).
 
 ### Vue DI mocks — `hasInjectionContext` extension
 

--- a/packages/0/src/components/AlertDialog/index.test.ts
+++ b/packages/0/src/components/AlertDialog/index.test.ts
@@ -960,7 +960,7 @@ describe('alertDialog', () => {
     })
 
     it('should support async confirm flow', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const isOpen = ref(true)
       let closeFn: (() => void) | undefined
@@ -1016,8 +1016,6 @@ describe('alertDialog', () => {
 
       expect(isOpen.value).toBe(false)
       expect(spy).toHaveBeenCalledTimes(1)
-
-      spy.mockRestore()
     })
   })
 })

--- a/packages/0/src/components/Avatar/index.test.ts
+++ b/packages/0/src/components/Avatar/index.test.ts
@@ -364,7 +364,7 @@ describe('avatar', () => {
       it('should support renderless mode with slot props', () => {
         // Suppress Vue warning about runtime directive on non-element root
         // This is expected when using v-show with renderless components
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         let slotProps: any
 
@@ -382,8 +382,7 @@ describe('avatar', () => {
 
         expect(slotProps).toBeDefined()
         expect(wrapper.find('.custom-img').exists()).toBe(true)
-
-        warnSpy.mockRestore()
+        expect(warnSpy).toHaveBeenCalled()
       })
     })
   })

--- a/packages/0/src/components/Button/index.test.ts
+++ b/packages/0/src/components/Button/index.test.ts
@@ -658,7 +658,7 @@ describe('button', () => {
     })
 
     it('should serialize object values to JSON', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const wrapper = mount(Button.Root, {
         slots: {
@@ -668,8 +668,6 @@ describe('button', () => {
 
       expect(wrapper.find('input').attributes('value')).toBe('{"foo":"bar"}')
       expect(spy).toHaveBeenCalledTimes(1)
-
-      spy.mockRestore()
     })
   })
 })

--- a/packages/0/src/components/Carousel/index.test.ts
+++ b/packages/0/src/components/Carousel/index.test.ts
@@ -1769,7 +1769,7 @@ describe('carousel', () => {
 
     it('should clear pending live-region timer on unmount', async () => {
       vi.useFakeTimers()
-      const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+      using clearSpy = vi.spyOn(globalThis, 'clearTimeout')
 
       let rootProps: any
 
@@ -1795,7 +1795,6 @@ describe('carousel', () => {
 
       expect(clearSpy.mock.calls.length).toBeGreaterThan(before)
 
-      clearSpy.mockRestore()
       vi.useRealTimers()
     })
 

--- a/packages/0/src/components/Image/index.test.ts
+++ b/packages/0/src/components/Image/index.test.ts
@@ -139,7 +139,7 @@ describe('image', () => {
       })
 
       it('should warn when lazy is combined with renderless', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         mount(Image.Root, {
           props: { src: '/photo.jpg', lazy: true, renderless: true },
@@ -148,8 +148,6 @@ describe('image', () => {
 
         expect(warnSpy).toHaveBeenCalledTimes(1)
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('`lazy` requires a wrapper element'))
-
-        warnSpy.mockRestore()
       })
     })
   })

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -1112,7 +1112,7 @@ describe('numberField', () => {
       const { scrubEl, wait } = mountNumberField({ model, withScrub: true })
       await wait()
 
-      const requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
+      using requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
       await scrubEl().trigger('pointerdown', { button: 0 })
       expect(requestSpy).toHaveBeenCalledTimes(1)
     })
@@ -1122,7 +1122,7 @@ describe('numberField', () => {
       const { scrubEl, wait } = mountNumberField({ model, withScrub: true })
       await wait()
 
-      const requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
+      using requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
       await scrubEl().trigger('pointerdown', { button: 2 })
       expect(requestSpy).not.toHaveBeenCalled()
     })
@@ -1136,7 +1136,7 @@ describe('numberField', () => {
       })
       await wait()
 
-      const requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
+      using requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
       await scrubEl().trigger('pointerdown', { button: 0 })
       expect(requestSpy).not.toHaveBeenCalled()
     })
@@ -1150,13 +1150,13 @@ describe('numberField', () => {
       })
       await wait()
 
-      const requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
+      using requestSpy = vi.spyOn(scrubEl().element as HTMLElement, 'requestPointerLock')
       await scrubEl().trigger('pointerdown', { button: 0 })
       expect(requestSpy).not.toHaveBeenCalled()
     })
 
     it('should increment value when scrubbing right after locking', async () => {
-      const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
+      using rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
         cb(0)
         return 1
       })
@@ -1175,11 +1175,11 @@ describe('numberField', () => {
       await wait()
 
       expect(model.value).toBeGreaterThan(5)
-      rafSpy.mockRestore()
+      expect(rafSpy).toHaveBeenCalled()
     })
 
     it('should decrement value when scrubbing left after locking', async () => {
-      const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
+      using rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
         cb(0)
         return 1
       })
@@ -1198,7 +1198,7 @@ describe('numberField', () => {
       await wait()
 
       expect(model.value).toBeLessThan(5)
-      rafSpy.mockRestore()
+      expect(rafSpy).toHaveBeenCalled()
     })
 
     it('should not move value before pointerdown locks', async () => {
@@ -1222,7 +1222,7 @@ describe('numberField', () => {
     })
 
     it('should respect sensitivity prop', async () => {
-      const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
+      using rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
         cb(0)
         return 1
       })
@@ -1246,7 +1246,7 @@ describe('numberField', () => {
       await scrubEl().trigger('pointermove', { movementX: 5 })
       await wait()
       expect(model.value).toBe(1)
-      rafSpy.mockRestore()
+      expect(rafSpy).toHaveBeenCalled()
     })
 
     it('should release pointer lock on pointerup', async () => {

--- a/packages/0/src/components/Pagination/index.test.ts
+++ b/packages/0/src/components/Pagination/index.test.ts
@@ -886,7 +886,7 @@ describe('pagination', () => {
     // tick left a pending callback that mutated text on a destroyed component.
     it('should clear pending live-region timer on unmount', async () => {
       vi.useFakeTimers()
-      const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+      using clearSpy = vi.spyOn(globalThis, 'clearTimeout')
 
       let rootProps: any
       const wrapper = mount(Pagination.Root, {
@@ -911,7 +911,6 @@ describe('pagination', () => {
       // onBeforeUnmount must have invoked clearTimeout for the pending handle.
       expect(clearSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount)
 
-      clearSpy.mockRestore()
       vi.useRealTimers()
     })
   })

--- a/packages/0/src/components/Snackbar/index.test.ts
+++ b/packages/0/src/components/Snackbar/index.test.ts
@@ -471,7 +471,7 @@ describe('snackbar', () => {
 
   describe('integration', () => {
     it('should render Portal > Queue > Root > Content + Close', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const [, provide, context] = createNotificationsContext()
       context.send({ subject: 'File uploaded', id: 'upload-1' })
@@ -504,8 +504,6 @@ describe('snackbar', () => {
       expect(wrapper.findComponent(Snackbar.Content as any).text()).toBe('File uploaded')
       expect(wrapper.findComponent(Snackbar.Close as any).attributes('aria-label')).toBeDefined()
       expect(spy).toHaveBeenCalledTimes(1)
-
-      spy.mockRestore()
     })
   })
 })

--- a/packages/0/src/composables/createContext/index.test.ts
+++ b/packages/0/src/composables/createContext/index.test.ts
@@ -134,7 +134,7 @@ describe('createContext', () => {
     })
 
     it('should warn on non-namespaced string key in dev mode', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       createContext('no-namespace')
 
@@ -142,18 +142,14 @@ describe('createContext', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('no-namespace'),
       )
-
-      warnSpy.mockRestore()
     })
 
     it('should not warn on namespaced string key', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       createContext('v0:theme')
 
       expect(warnSpy).not.toHaveBeenCalled()
-
-      warnSpy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/createFocusTraversal/index.test.ts
+++ b/packages/0/src/composables/createFocusTraversal/index.test.ts
@@ -510,7 +510,7 @@ describe('createFocusTraversal', () => {
       traversal.activeId.value = 'a'
 
       const event = createKeyboardEvent('ArrowDown')
-      const spy = vi.spyOn(event, 'preventDefault')
+      using spy = vi.spyOn(event, 'preventDefault')
 
       traversal.onKeydown(event)
 
@@ -522,7 +522,7 @@ describe('createFocusTraversal', () => {
       const traversal = createFocusTraversal(items('a', 'b', 'c'), activate)
 
       const event = createKeyboardEvent('Tab')
-      const spy = vi.spyOn(event, 'preventDefault')
+      using spy = vi.spyOn(event, 'preventDefault')
 
       traversal.onKeydown(event)
 

--- a/packages/0/src/composables/createKanban/index.test.ts
+++ b/packages/0/src/composables/createKanban/index.test.ts
@@ -285,18 +285,17 @@ describe('createKanban', () => {
     })
 
     it('should warn and return undefined for an unknown ticket id', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
 
       expect(kanban.transfer('does-not-exist', todo.id, 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown ticket id'))
-      spy.mockRestore()
     })
 
     it('should warn and return undefined for an unknown destination column', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
       const a = todo.items.register({ value: { title: 'a' } })
@@ -304,7 +303,6 @@ describe('createKanban', () => {
       expect(kanban.transfer(a.id, 'no-such-column', 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown destination column'))
-      spy.mockRestore()
     })
 
     it('should land the transferred ticket at the requested index when dest already has items', () => {
@@ -326,7 +324,7 @@ describe('createKanban', () => {
     })
 
     it('should reject and warn when dest.accept returns a thenable', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
@@ -339,7 +337,6 @@ describe('createKanban', () => {
       expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('thenable'))
-      spy.mockRestore()
     })
 
     it('should bind the transferred ticket\'s unregister to the destination column', () => {
@@ -357,7 +354,7 @@ describe('createKanban', () => {
     })
 
     it('should reject and log an error when dest.accept throws', () => {
-      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      using errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
@@ -372,8 +369,6 @@ describe('createKanban', () => {
       expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
       expect(done.items.size).toBe(0)
       expect(errSpy).toHaveBeenCalledTimes(1)
-
-      errSpy.mockRestore()
     })
 
     it('should never call dest.accept on same-column transfer', () => {
@@ -439,7 +434,7 @@ describe('createKanban', () => {
     })
 
     it('should warn and return undefined when the destination already contains the id', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
@@ -453,8 +448,6 @@ describe('createKanban', () => {
       // lookup says todo; source.get(dup) succeeds; destination (done) already has dup.
       expect(kanban.transfer('dup', done.id, 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('already exists in destination'))
-
-      spy.mockRestore()
     })
 
     it('should clamp toIndex above destination size to the end', () => {
@@ -510,7 +503,7 @@ describe('createKanban', () => {
 
   describe('column lifecycle', () => {
     it('should not be findable for transfer after the source column is unregistered', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
       const done = kanban.columns.register({ value: { title: 'Done' } })
@@ -520,7 +513,6 @@ describe('createKanban', () => {
 
       expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledTimes(1)
-      spy.mockRestore()
     })
 
     it('should leave sibling columns untouched when one column is unregistered', () => {
@@ -537,7 +529,7 @@ describe('createKanban', () => {
     })
 
     it('should keep lookup consistent after register/unregister/transfer churn', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
@@ -559,8 +551,6 @@ describe('createKanban', () => {
       expect(kanban.transfer(b.id, done.id, 0)).toBeUndefined()
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown ticket id'))
-
-      spy.mockRestore()
     })
   })
 })

--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -30,12 +30,12 @@ describe('createNested', () => {
 
     it('should warn when registering with non-existent parentId', () => {
       const nested = createNested()
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       nested.register({ id: 'orphan', value: 'Orphan', parentId: 'non-existent' })
 
       expect(nested.parents.get('orphan')).toBeUndefined()
-      warnSpy.mockRestore()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not exist'))
     })
 
     it('should register multiple children to same parent', () => {
@@ -251,7 +251,7 @@ describe('createNested', () => {
   // walk loops forever and hangs CI workers under vmThreads + v8 coverage.
   describe.skip('circular reference protection', () => {
     it('should not infinite loop in getPath when circular parent exists', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const nested = createNested()
 
@@ -269,12 +269,10 @@ describe('createNested', () => {
       expect(path.length).toBeLessThanOrEqual(3)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
-
-      spy.mockRestore()
     })
 
     it('should not infinite loop in isAncestorOf when descendant is in a cycle', { timeout: 1000 }, () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const nested = createNested()
 
@@ -290,8 +288,7 @@ describe('createNested', () => {
       const result = nested.isAncestorOf('c', 'a')
 
       expect(result).toBe(false)
-
-      spy.mockRestore()
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
     })
 
     it('should not infinite loop in getDescendants when children form a cycle', { timeout: 1000 }, () => {
@@ -329,7 +326,7 @@ describe('createNested', () => {
     })
 
     it('should not infinite loop in open() reveal when parents form a cycle', { timeout: 1000 }, () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const nested = createNested({ reveal: true })
 
@@ -345,12 +342,11 @@ describe('createNested', () => {
 
       // All three should be opened and we should not hang
       expect(nested.opened('c')).toBe(true)
-
-      spy.mockRestore()
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
     })
 
     it('should not infinite loop in updateAncestors during cascade select when parents form a cycle', { timeout: 1000 }, () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const nested = createNested()
 
@@ -365,8 +361,7 @@ describe('createNested', () => {
       nested.select('c')
 
       expect(nested.selected('c')).toBe(true)
-
-      spy.mockRestore()
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
     })
   })
 
@@ -2296,7 +2291,7 @@ describe('clear', () => {
 
 describe('provideNestedContext', () => {
   it('should provide context via provideNestedContext', async () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const { createNestedContext } = await import('./index')
 
@@ -2309,7 +2304,5 @@ describe('provideNestedContext', () => {
     // Should be same as default nested
     expect(result).toBe(defaultNested)
     expect(spy).toHaveBeenCalledTimes(1)
-
-    spy.mockRestore()
   })
 })

--- a/packages/0/src/composables/createOtp/index.test.ts
+++ b/packages/0/src/composables/createOtp/index.test.ts
@@ -81,12 +81,11 @@ describe('createOtp', () => {
 
     it('should warn through useLogger when a RegExp matches multi-character input', () => {
       const otp = setup({ pattern: /^[0-9]+$/ })
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       otp.accepts('1')
       otp.accepts('2')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('multi-character'))
-      spy.mockRestore()
     })
 
     it('should reject multi-character input', () => {
@@ -326,7 +325,7 @@ describe('createOtp', () => {
     })
 
     it('should clear value and warn when onComplete throws', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const otp = setup({ length: 4, onComplete: () => {
         throw new Error('boom')
       } })
@@ -336,7 +335,6 @@ describe('createOtp', () => {
       expect(otp.input.errors.value).toContain('Invalid code')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining('onComplete threw'))
-      spy.mockRestore()
     })
 
     it('should leave the value intact when sync onComplete returns undefined', async () => {
@@ -360,7 +358,7 @@ describe('createOtp', () => {
     })
 
     it('should handle onComplete throwing a non-Error value without crashing', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const otp = setup({ length: 4, onComplete: () => {
         throw null
       } })
@@ -370,7 +368,6 @@ describe('createOtp', () => {
       expect(otp.input.errors.value).toContain('Invalid code')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining('onComplete threw'))
-      spy.mockRestore()
     })
 
     it('should preserve rejection error when fill receives only rejected characters', async () => {
@@ -443,7 +440,7 @@ describe('createOtp', () => {
     })
 
     it('should clear value and warn when onComplete returns a rejected promise', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const otp = setup({
         length: 4,
         onComplete: () => Promise.reject(new Error('network error')),
@@ -455,11 +452,10 @@ describe('createOtp', () => {
       expect(otp.input.errors.value).toContain('Invalid code')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining('onComplete rejected'))
-      spy.mockRestore()
     })
 
     it('should handle a rejected promise with a non-Error value without crashing', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const otp = setup({
         length: 4,
         onComplete: () => Promise.reject(null),
@@ -471,7 +467,6 @@ describe('createOtp', () => {
       expect(otp.input.errors.value).toContain('Invalid code')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining('onComplete rejected'))
-      spy.mockRestore()
     })
 
     it('should accept a thenable that is not a native Promise', async () => {

--- a/packages/0/src/composables/createOverflow/index.test.ts
+++ b/packages/0/src/composables/createOverflow/index.test.ts
@@ -839,10 +839,9 @@ describe('useOverflow', () => {
   })
 
   it('should throw when context is not provided', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(() => useOverflow()).toThrow()
     expect(spy).toHaveBeenCalledTimes(1)
-    spy.mockRestore()
   })
 })
 

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -418,15 +418,13 @@ describe('createRegistry', () => {
     it('should not emit events when events option is disabled', () => {
       const registry = createRegistry({ events: false })
       const listener = vi.fn()
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       registry.on('register:ticket', listener)
       registry.register({ id: 'test' })
 
       expect(listener).not.toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Events are disabled'))
-
-      warnSpy.mockRestore()
     })
 
     it('should emit register:ticket event when enabled', () => {
@@ -516,24 +514,20 @@ describe('createRegistry', () => {
 
     it('should warn when attempting to register listener without events enabled', () => {
       const registry = createRegistry({ events: false })
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       registry.on('register:ticket', vi.fn())
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Events are disabled'))
-
-      warnSpy.mockRestore()
     })
 
     it('should warn when attempting to remove listener without events enabled', () => {
       const registry = createRegistry({ events: false })
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       registry.off('register:ticket', vi.fn())
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Events are disabled'))
-
-      warnSpy.mockRestore()
     })
 
     it('should support multiple listeners for same event', () => {
@@ -551,7 +545,7 @@ describe('createRegistry', () => {
 
     it('should warn when listener count exceeds 100', () => {
       const registry = createRegistry({ events: true })
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       for (let index = 0; index <= 100; index++) {
         registry.on('test-event', vi.fn())
@@ -561,8 +555,6 @@ describe('createRegistry', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('101 listeners'),
       )
-
-      warnSpy.mockRestore()
     })
   })
 
@@ -788,7 +780,7 @@ describe('createRegistry', () => {
   describe('edge cases', () => {
     it('should handle registering duplicate IDs by returning existing ticket', () => {
       const registry = createRegistry()
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const ticket1 = registry.register({ id: 'duplicate', value: 'first' })
       const ticket2 = registry.register({ id: 'duplicate', value: 'second' })
@@ -797,8 +789,6 @@ describe('createRegistry', () => {
       expect(registry.size).toBe(1)
       expect(ticket1.value).toBe('first')
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already exists'))
-
-      warnSpy.mockRestore()
     })
 
     it('should handle null value in browse', () => {

--- a/packages/0/src/composables/createSortable/index.test.ts
+++ b/packages/0/src/composables/createSortable/index.test.ts
@@ -187,7 +187,7 @@ describe('createSortable', () => {
     })
 
     it('should warn and no-op when ids length differs from registry size', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const sortable = createSortable<StringTicket>()
       const a = sortable.register({ value: 'a' })
       const b = sortable.register({ value: 'b' })
@@ -198,11 +198,10 @@ describe('createSortable', () => {
       expect(sortable.get(b.id)!.index).toBe(1)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('expected 2 ids, got 1'))
-      spy.mockRestore()
     })
 
     it('should warn and no-op when ids contain an unknown id', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const sortable = createSortable<StringTicket>()
       const a = sortable.register({ value: 'a' })
       const b = sortable.register({ value: 'b' })
@@ -213,11 +212,10 @@ describe('createSortable', () => {
       expect(sortable.get(b.id)!.index).toBe(1)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown id'))
-      spy.mockRestore()
     })
 
     it('should warn and no-op when ids contain duplicates', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const sortable = createSortable<StringTicket>()
       const a = sortable.register({ value: 'a' })
       const b = sortable.register({ value: 'b' })
@@ -228,7 +226,6 @@ describe('createSortable', () => {
       expect(sortable.get(b.id)!.index).toBe(1)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('duplicate'))
-      spy.mockRestore()
     })
 
     it('should be a no-op when given the current order', () => {

--- a/packages/0/src/composables/createTokens/index.test.ts
+++ b/packages/0/src/composables/createTokens/index.test.ts
@@ -178,14 +178,12 @@ describe('createTokens', () => {
       })
 
       it('should return undefined for non-existent tokens', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         const context = createTokensContext({ namespace: 'test:tokens', tokens: {} })[2]
 
         expect(context.resolve('nonexistent')).toBeUndefined()
         expect(context.resolve('{nonexistent}')).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
-
-        warnSpy.mockRestore()
       })
     })
 
@@ -1123,15 +1121,14 @@ describe('createTokens', () => {
           accent: { $value: '{primary}' },
         }
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         expect(context.resolve('accent')).toBe('#007BFF')
 
         context.unregister('primary')
 
         expect(context.resolve('accent')).toBeUndefined()
-
-        warnSpy.mockRestore()
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
       })
 
       it('should remove token with dependencies', () => {
@@ -1141,15 +1138,13 @@ describe('createTokens', () => {
           accent: { $value: '{primary}' },
         }
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         context.unregister('primary')
 
         expect(context.collection.has('primary')).toBe(false)
         expect(context.resolve('accent')).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
-
-        warnSpy.mockRestore()
       })
     })
   })
@@ -1163,14 +1158,12 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         // Should return undefined and not cause stack overflow
         const result = context.resolve('a')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Circular alias detected'))
-
-        warnSpy.mockRestore()
       })
 
       it('should detect and prevent indirect circular references', () => {
@@ -1181,14 +1174,12 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         // Should return undefined and not cause stack overflow
         const result = context.resolve('a')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Circular alias detected'))
-
-        warnSpy.mockRestore()
       })
     })
 
@@ -2044,14 +2035,12 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         // Trying to access colors.primary.foo where primary is a string
         const result = context.resolve('colors.primary.foo')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Path not found'))
-
-        warnSpy.mockRestore()
       })
 
       it('should fail when path tries to access segment on number primitive', () => {
@@ -2062,13 +2051,11 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         const result = context.resolve('metrics.count.value')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Path not found'))
-
-        warnSpy.mockRestore()
       })
 
       it('should fail when accessing nested path through boolean', () => {
@@ -2079,13 +2066,11 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         const result = context.resolve('flags.enabled.state')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Path not found'))
-
-        warnSpy.mockRestore()
       })
 
       it('should handle object with $value when continuing path', () => {
@@ -2167,13 +2152,11 @@ describe('createTokens', () => {
         }
 
         const context = createTokens(tokens)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         const result = context.resolve('a')
         expect(result).toBeUndefined()
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Circular alias detected'))
-
-        warnSpy.mockRestore()
       })
     })
 
@@ -2906,13 +2889,12 @@ describe('createTokens', () => {
 
       // Offboard primary
       context.offboard(['primary'])
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       // accent should now be undefined because primary was removed and cache was cleared
       expect(context.resolve('accent')).toBeUndefined()
       expect(context.size).toBe(2)
-
-      warnSpy.mockRestore()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
     })
 
     it('should clear cache on move', () => {
@@ -3668,7 +3650,7 @@ describe('createTokens', () => {
       }
 
       const context = createTokensContext({ namespace: 'test:tokens', tokens })[2]
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const resolvedBefore = context.resolve('accent')
       expect(resolvedBefore).toBe('#007BFF')
@@ -3677,8 +3659,7 @@ describe('createTokens', () => {
 
       const resolvedAfter = context.resolve('accent')
       expect(resolvedAfter).toBeUndefined()
-
-      warnSpy.mockRestore()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
     })
 
     it('should cache both curly-brace and plain token formats independently', () => {
@@ -3719,7 +3700,7 @@ describe('createTokens', () => {
       }
 
       const context = createTokensContext({ namespace: 'test:tokens', tokens })[2]
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const first = context.resolve('a')
       const second = context.resolve('a')
@@ -3728,8 +3709,6 @@ describe('createTokens', () => {
       expect(second).toBeUndefined()
       // Cache stores undefined for circular aliases, second resolve returns from cache
       expect(warnSpy).toHaveBeenCalledTimes(1)
-
-      warnSpy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -65,7 +65,7 @@ describe('createValidation', () => {
     })
 
     it('should use noop for unresolvable string aliases', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const validation = createValidation()
       validation.register('nonexistent')
@@ -75,8 +75,6 @@ describe('createValidation', () => {
       expect(result).toBe(true)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'))
-
-      spy.mockRestore()
     })
   })
 
@@ -471,7 +469,7 @@ describe('createValidation', () => {
     })
 
     it('should use noop for string aliases without rules context', async () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const validation = createValidation({ rules: ['required'] })
 
@@ -480,8 +478,6 @@ describe('createValidation', () => {
       expect(result).toBe(true)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('required'))
-
-      spy.mockRestore()
     })
   })
 
@@ -498,7 +494,7 @@ describe('createValidation', () => {
   describe('form auto-registration', () => {
     it('should register with parent form on creation', () => {
       const form = createForm()
-      const spy = vi.spyOn(form, 'register')
+      using spy = vi.spyOn(form, 'register')
       mockUseForm.mockReturnValueOnce(form as any)
 
       const validation = createValidation()
@@ -509,7 +505,7 @@ describe('createValidation', () => {
 
     it('should unregister from parent form on scope dispose', () => {
       const form = createForm()
-      const unregisterSpy = vi.spyOn(form, 'unregister')
+      using unregisterSpy = vi.spyOn(form, 'unregister')
       mockUseForm.mockReturnValueOnce(form as any)
 
       const scope = effectScope()

--- a/packages/0/src/composables/createVirtual/index.test.ts
+++ b/packages/0/src/composables/createVirtual/index.test.ts
@@ -833,7 +833,7 @@ describe('useVirtual consumer', () => {
   })
 
   it('should throw when context is not provided', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     expect(() => {
       const TestComponent = defineComponent({
@@ -847,7 +847,6 @@ describe('useVirtual consumer', () => {
     }).toThrow()
 
     expect(spy).toHaveBeenCalledTimes(1)
-    spy.mockRestore()
   })
 })
 

--- a/packages/0/src/composables/useClickOutside/index.test.ts
+++ b/packages/0/src/composables/useClickOutside/index.test.ts
@@ -1499,7 +1499,7 @@ describe('useClickOutside', () => {
         y: 100,
         toJSON: () => ({}),
       }
-      const rectSpy = vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(rect)
+      using rectSpy = vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(rect)
 
       useClickOutside(target, handler, { bounds: true })
       await nextTick()
@@ -1536,8 +1536,6 @@ describe('useClickOutside', () => {
       // The buggy version re-evaluated pointerdown coords against the
       // shifted rect, saw "inside", and suppressed the click.
       expect(handler).toHaveBeenCalledTimes(1)
-
-      rectSpy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/useDelay/index.test.ts
+++ b/packages/0/src/composables/useDelay/index.test.ts
@@ -382,7 +382,7 @@ describe('useDelay', () => {
     })
 
     it('should be readonly at the type boundary', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const delay = useDelay()
       // Runtime guard — shallowReadonly rejects writes (warns in dev, ignores in prod)
@@ -393,7 +393,6 @@ describe('useDelay', () => {
       expect(ref.value).toBe(before)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('readonly'), expect.anything())
-      spy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/useDragDrop/adapters/keyboard.test.ts
+++ b/packages/0/src/composables/useDragDrop/adapters/keyboard.test.ts
@@ -406,7 +406,7 @@ describe('keyboardAdapter', () => {
 
   describe('start guards', () => {
     it('should warn and short-circuit when located ticket has null el', () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const adapter = new KeyboardAdapter()
       const start = vi.fn()
@@ -441,7 +441,6 @@ describe('keyboardAdapter', () => {
 
       stub.dispose()
       adapter.dispose()
-      warn.mockRestore()
     })
   })
 })

--- a/packages/0/src/composables/useDragDrop/adapters/pointer.test.ts
+++ b/packages/0/src/composables/useDragDrop/adapters/pointer.test.ts
@@ -401,7 +401,7 @@ describe('pointerAdapter', () => {
   describe('setup-twice warning', () => {
     it('should warn and replace previous registration when setup called twice', () => {
       const adapter = new PointerAdapter()
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       // First setup via useDragDrop
       useDragDrop({ adapters: [adapter] })
@@ -410,8 +410,6 @@ describe('pointerAdapter', () => {
 
       expect(warn).toHaveBeenCalled()
       expect(warn.mock.calls[0]?.join(' ')).toContain('setup called twice')
-
-      warn.mockRestore()
     })
   })
 })

--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -655,7 +655,7 @@ describe('cancel chain', () => {
   })
 
   it('should swallow throwing hook and continue via logger.error', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const onMove = vi.fn(() => {
       throw new Error('boom')
@@ -670,7 +670,6 @@ describe('cancel chain', () => {
     expect(onMove).toHaveBeenCalledTimes(1)
     expect(globalMove).toHaveBeenCalledTimes(1)
     expect(error).toHaveBeenCalledTimes(1)
-    error.mockRestore()
   })
 })
 
@@ -796,13 +795,12 @@ describe('keyboardAdapter options', () => {
 
   it('should warn and short-circuit when adapter setup is called twice', () => {
     const adapter = new KeyboardAdapter()
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     useDragDrop({ adapters: [adapter] })
     adapter.setup({} as unknown as DragDropAdapterContext<DragType>)
 
     expect(warn).toHaveBeenCalled()
-    warn.mockRestore()
   })
 })
 
@@ -979,7 +977,7 @@ describe('resolveDropPosition', () => {
 
 describe('safeAccept edge cases', () => {
   it('should reject when accept predicate returns a thenable', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const dnd = useDragDrop({ adapters: [adapter] })
     const accept = vi.fn(() => Promise.resolve(true)) as unknown as () => boolean
@@ -992,12 +990,10 @@ describe('safeAccept edge cases', () => {
     expect(zone.willAccept.value).toBe(false)
     expect(warn).toHaveBeenCalled()
     expect(warn.mock.calls[0]?.join(' ')).toContain('thenable')
-
-    warn.mockRestore()
   })
 
   it('should reject and log when accept predicate throws', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const dnd = useDragDrop({ adapters: [adapter] })
     const accept = vi.fn(() => {
@@ -1012,8 +1008,6 @@ describe('safeAccept edge cases', () => {
     expect(zone.willAccept.value).toBe(false)
     expect(error).toHaveBeenCalled()
     expect(error.mock.calls[0]?.join(' ')).toContain('accept predicate threw')
-
-    error.mockRestore()
   })
 
   it('should accept when accept option is undefined', () => {
@@ -1102,7 +1096,7 @@ describe('position()', () => {
 
 describe('onBeforeStart error paths', () => {
   it('should treat draggable.onBeforeStart throwing as veto', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const onBeforeStart = vi.fn(() => {
       throw new Error('drag boom')
@@ -1121,8 +1115,6 @@ describe('onBeforeStart error paths', () => {
     expect(dnd.active.value).toBeNull()
     expect(onBeforeStart).toHaveBeenCalledTimes(1)
     expect(error).toHaveBeenCalled()
-
-    error.mockRestore()
   })
 
   it('should veto when global onBeforeStart returns false', () => {
@@ -1139,7 +1131,7 @@ describe('onBeforeStart error paths', () => {
   })
 
   it('should treat global onBeforeStart throwing as veto', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const onBeforeStart = vi.fn(() => {
       throw new Error('global boom')
@@ -1152,8 +1144,6 @@ describe('onBeforeStart error paths', () => {
 
     expect(dnd.active.value).toBeNull()
     expect(error).toHaveBeenCalled()
-
-    error.mockRestore()
   })
 })
 
@@ -1183,7 +1173,7 @@ describe('onMove / onDrop early returns', () => {
 
 describe('onBeforeDrop error paths', () => {
   it('should treat zone onBeforeDrop throwing as veto', async () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const cardEl = makeFocusableEl('bd-throw-1')
     const zoneEl = document.createElement('div')
@@ -1215,11 +1205,10 @@ describe('onBeforeDrop error paths', () => {
 
     cardEl.remove()
     zoneEl.remove()
-    error.mockRestore()
   })
 
   it('should treat options onBeforeDrop throwing as veto', async () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const adapter = new CaptureAdapter()
     const cardEl = makeFocusableEl('bd-throw-2')
     const zoneEl = document.createElement('div')
@@ -1250,13 +1239,12 @@ describe('onBeforeDrop error paths', () => {
 
     cardEl.remove()
     zoneEl.remove()
-    error.mockRestore()
   })
 })
 
 describe('adapter setup error paths', () => {
   it('should log error and continue when adapter setup throws', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     class BadAdapter extends DragDropAdapter {
       setup (): void {
@@ -1267,12 +1255,10 @@ describe('adapter setup error paths', () => {
     expect(() => useDragDrop({ adapters: [new BadAdapter()] })).not.toThrow()
     expect(error).toHaveBeenCalled()
     expect(error.mock.calls.some(call => String(call.join(' ')).includes('adapter setup threw'))).toBe(true)
-
-    error.mockRestore()
   })
 
   it('should log error when both setup and dispose throw', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     class TerribleAdapter extends DragDropAdapter {
       setup (): void {
@@ -1289,12 +1275,10 @@ describe('adapter setup error paths', () => {
     const calls = error.mock.calls.map(c => String(c.join(' ')))
     expect(calls.some(s => s.includes('adapter setup threw'))).toBe(true)
     expect(calls.some(s => s.includes('adapter dispose threw'))).toBe(true)
-
-    error.mockRestore()
   })
 
   it('should continue installing remaining adapters when one fails', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     class BadAdapter extends DragDropAdapter {
       setup (): void {
@@ -1309,14 +1293,12 @@ describe('adapter setup error paths', () => {
     expect(typeof capture.emit.start).toBe('function')
     expect(dnd).toBeDefined()
     expect(error).toHaveBeenCalled()
-
-    error.mockRestore()
   })
 })
 
 describe('plugin error paths', () => {
   it('should log error and continue when plugin install throws', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(() => useDragDrop({
       adapters: [],
@@ -1329,12 +1311,10 @@ describe('plugin error paths', () => {
 
     expect(error).toHaveBeenCalled()
     expect(error.mock.calls.some(c => String(c.join(' ')).includes('plugin install threw'))).toBe(true)
-
-    error.mockRestore()
   })
 
   it('should run later plugins after an earlier plugin throws', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const ran = vi.fn()
 
     useDragDrop({
@@ -1349,8 +1329,6 @@ describe('plugin error paths', () => {
 
     expect(ran).toHaveBeenCalledTimes(1)
     expect(error).toHaveBeenCalled()
-
-    error.mockRestore()
   })
 })
 
@@ -1454,7 +1432,7 @@ describe('unregister handlers', () => {
 
 describe('disposer error paths', () => {
   it('should log error when adapter dispose throws on scope teardown', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     class BadDispose extends DragDropAdapter {
       setup (): void {}
@@ -1472,12 +1450,10 @@ describe('disposer error paths', () => {
 
     expect(error).toHaveBeenCalled()
     expect(error.mock.calls.some(c => String(c.join(' ')).includes('disposer threw'))).toBe(true)
-
-    error.mockRestore()
   })
 
   it('should log error when plugin disposer throws on scope teardown', () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    using error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const scope = effectScope()
     scope.run(() => {
@@ -1495,7 +1471,5 @@ describe('disposer error paths', () => {
 
     expect(error).toHaveBeenCalled()
     expect(error.mock.calls.some(c => String(c.join(' ')).includes('disposer threw'))).toBe(true)
-
-    error.mockRestore()
   })
 })

--- a/packages/0/src/composables/useFeatures/adapters/adapter.test.ts
+++ b/packages/0/src/composables/useFeatures/adapters/adapter.test.ts
@@ -56,7 +56,7 @@ describe('featuresAdapter', () => {
   describe('dispose', () => {
     it('should clean up subscriptions', () => {
       const adapter = new GenericTestAdapter()
-      const disposeSpy = vi.spyOn(adapter, 'dispose')
+      using disposeSpy = vi.spyOn(adapter, 'dispose')
 
       adapter.dispose()
 

--- a/packages/0/src/composables/useHotkey/index.test.ts
+++ b/packages/0/src/composables/useHotkey/index.test.ts
@@ -1251,12 +1251,11 @@ describe('splitKeyCombination', () => {
   })
 
   it('should return empty for invalid combinations', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     expect(splitKeyCombination('')).toEqual({ keys: [], separators: [] })
     expect(splitKeyCombination('+a')).toEqual({ keys: [], separators: [] })
-
-    warnSpy.mockRestore()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid hotkey combination'))
   })
 
   it('should handle literal minus as key', () => {
@@ -1296,67 +1295,58 @@ describe('splitKeyCombination', () => {
 
   describe('warnings', () => {
     it('should warn on empty combination', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeyCombination('')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey combination'),
       )
-      warnSpy.mockRestore()
     })
 
     it('should warn on invalid leading separator', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeyCombination('+a')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey combination'),
       )
-      warnSpy.mockRestore()
     })
 
     it('should warn on double plus separator', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeyCombination('ctrl++k')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey combination'),
       )
-      warnSpy.mockRestore()
     })
 
     it.each(['/', '/a', 'a/', '//', 'ctrl//'])('warns on invalid slash structure: %s', value => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       expect(splitKeyCombination(value)).toEqual({ keys: [], separators: [] })
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey combination'),
       )
-
-      warnSpy.mockRestore()
     })
 
     it('should suppress empty-string warning when isInternal is true', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const result = splitKeyCombination('', true)
       expect(result).toEqual({ keys: [], separators: [] })
       expect(warnSpy).not.toHaveBeenCalled()
-
-      warnSpy.mockRestore()
     })
 
     it('should suppress invalid-structure warning when isInternal is true', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const result = splitKeyCombination('+a', true)
       expect(result).toEqual({ keys: [], separators: [] })
       expect(warnSpy).not.toHaveBeenCalled()
-
-      warnSpy.mockRestore()
     })
   })
 })
@@ -1379,11 +1369,10 @@ describe('splitKeySequence', () => {
   })
 
   it('should return empty for invalid sequences', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     expect(splitKeySequence('')).toEqual([])
-
-    warnSpy.mockRestore()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid hotkey sequence'))
   })
 
   it('should handle literal minus in combination', () => {
@@ -1396,36 +1385,33 @@ describe('splitKeySequence', () => {
 
   describe('warnings', () => {
     it('should warn on empty sequence', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeySequence('')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey sequence'),
       )
-      warnSpy.mockRestore()
     })
 
     it('should warn on invalid leading separator', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeySequence('-a')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey sequence'),
       )
-      warnSpy.mockRestore()
     })
 
     it('should warn on invalid trailing separator', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       splitKeySequence('a-')
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid hotkey sequence'),
       )
-      warnSpy.mockRestore()
     })
 
     it('should treat underscore-minus as combination, not sequence separator', () => {

--- a/packages/0/src/composables/useLocale/index.test.ts
+++ b/packages/0/src/composables/useLocale/index.test.ts
@@ -543,7 +543,7 @@ describe('createLocale', () => {
     })
 
     it('should not duplicate locale if already registered', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const locale = createLocale({
         default: 'en',
@@ -556,8 +556,6 @@ describe('createLocale', () => {
       expect(locale.size).toBe(before)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('en'))
-
-      spy.mockRestore()
     })
 
     it('should register without messages (existing behavior)', () => {

--- a/packages/0/src/composables/useRovingFocus/index.test.ts
+++ b/packages/0/src/composables/useRovingFocus/index.test.ts
@@ -570,7 +570,7 @@ describe('useRovingFocus', () => {
         result.first()
 
         const event = createKeyboardEvent('ArrowDown')
-        const spy = vi.spyOn(event, 'preventDefault')
+        using spy = vi.spyOn(event, 'preventDefault')
         result.onKeydown(event)
 
         expect(spy).toHaveBeenCalled()
@@ -587,7 +587,7 @@ describe('useRovingFocus', () => {
         result.first()
 
         const event = createKeyboardEvent('Tab')
-        const spy = vi.spyOn(event, 'preventDefault')
+        using spy = vi.spyOn(event, 'preventDefault')
         result.onKeydown(event)
 
         expect(spy).not.toHaveBeenCalled()

--- a/packages/0/src/composables/useRtl/index.test.ts
+++ b/packages/0/src/composables/useRtl/index.test.ts
@@ -316,7 +316,7 @@ describe('createRtl', () => {
       it('should not install twice on the same app', async () => {
         const { createApp, nextTick: nt } = await import('vue')
 
-        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         const setupFn = vi.fn()
         const customAdapter = { setup: setupFn }
@@ -336,8 +336,6 @@ describe('createRtl', () => {
         expect(spy).toHaveBeenCalledTimes(1)
 
         app.unmount()
-
-        spy.mockRestore()
       })
     })
 

--- a/packages/0/src/composables/useRules/index.test.ts
+++ b/packages/0/src/composables/useRules/index.test.ts
@@ -80,7 +80,7 @@ describe('createRules', () => {
     })
 
     it('should skip unknown aliases', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const rules = createRules()
       const resolved = rules.resolve(['nonexistent'])
@@ -88,8 +88,6 @@ describe('createRules', () => {
       expect(resolved).toHaveLength(0)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'))
-
-      spy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/useStorage/index.test.ts
+++ b/packages/0/src/composables/useStorage/index.test.ts
@@ -158,15 +158,13 @@ describe('createStorage', () => {
 
     it('should handle serialization errors gracefully', () => {
       mockAdapter.getItem.mockReturnValue('invalid-json{')
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      using consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const storage = createStorage({ adapter: mockAdapter, prefix: 'test:' })
       const username = storage.get('username', 'default')
 
       expect(username.value).toBe('default')
       expect(consoleSpy).toHaveBeenCalled()
-
-      consoleSpy.mockRestore()
     })
 
     it('should use custom serializer', async () => {
@@ -470,7 +468,7 @@ describe('createStorage', () => {
         }),
         removeItem: vi.fn(),
       }
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      using consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const storage = createStorage({ adapter: failAdapter as unknown as StorageAdapter, prefix: 'test:' })
       const val = storage.get('key', 'default')
       val.value = 'new-value'
@@ -479,7 +477,6 @@ describe('createStorage', () => {
         expect.stringContaining('[v0:storage] Failed to write key'),
         expect.any(Error),
       )
-      consoleSpy.mockRestore()
     })
 
     it('should no-op when removing a key that was never created', () => {

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -359,7 +359,7 @@ describe('v0StyleSheetThemeAdapter', () => {
         isDark,
       }
       const adapter = new V0StyleSheetThemeAdapter()
-      const updateSpy = vi.spyOn(adapter, 'update')
+      using updateSpy = vi.spyOn(adapter, 'update')
 
       const scope = effectScope()
       scope.run(() => {
@@ -449,7 +449,7 @@ describe('v0StyleSheetThemeAdapter', () => {
         isDark,
       }
       const adapter = new V0StyleSheetThemeAdapter()
-      const updateSpy = vi.spyOn(adapter, 'update')
+      using updateSpy = vi.spyOn(adapter, 'update')
 
       const scope = effectScope()
       scope.run(() => {

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -393,8 +393,8 @@ describe('createTheme', () => {
 
     it('should inject CSS variables into DOM', async () => {
       let mockStyleSheets: CSSStyleSheet[] = []
-      const spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => mockStyleSheets)
-      vi.spyOn(document, 'adoptedStyleSheets', 'set').mockImplementation(v => {
+      using spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => mockStyleSheets)
+      using setSpy = vi.spyOn(document, 'adoptedStyleSheets', 'set').mockImplementation(v => {
         mockStyleSheets = v as CSSStyleSheet[]
       })
 
@@ -426,8 +426,10 @@ describe('createTheme', () => {
       expect(styleContent).toContain('--v0-primary: #1976d2')
       expect(styleContent).toContain('--v0-secondary: #424242')
 
+      expect(spy).toHaveBeenCalled()
+      expect(setSpy).toHaveBeenCalled()
+
       app.unmount()
-      spy.mockRestore()
     })
 
     it('should apply theme class to target element', async () => {
@@ -1077,7 +1079,7 @@ describe('createTheme', () => {
 
   describe('register with colors and tokens', () => {
     it('should not duplicate theme if already registered', () => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const theme = createTheme({
         themes: {
@@ -1091,8 +1093,6 @@ describe('createTheme', () => {
       expect(theme.size).toBe(before)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('light'))
-
-      spy.mockRestore()
     })
   })
 

--- a/packages/0/src/composables/useToggleScope/index.test.ts
+++ b/packages/0/src/composables/useToggleScope/index.test.ts
@@ -271,7 +271,7 @@ describe('useToggleScope', () => {
     await nextTick()
     expect(controls.isActive.value).toBe(true)
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     // Attempt to modify (should fail silently or throw in strict mode)
     // @ts-expect-error - isActive should be readonly
@@ -279,8 +279,7 @@ describe('useToggleScope', () => {
 
     // Value should remain unchanged
     expect(controls.isActive.value).toBe(true)
-
-    warnSpy.mockRestore()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('readonly'), expect.anything())
   })
 
   it('should prevent duplicate start calls', async () => {

--- a/packages/0/src/composables/useVirtualFocus/index.test.ts
+++ b/packages/0/src/composables/useVirtualFocus/index.test.ts
@@ -491,7 +491,7 @@ describe('useVirtualFocus', () => {
       result!.highlight('item-0')
 
       const event = createKeyboardEvent('ArrowDown')
-      const spy = vi.spyOn(event, 'preventDefault')
+      using spy = vi.spyOn(event, 'preventDefault')
       result!.onKeydown(event)
 
       expect(spy).toHaveBeenCalled()
@@ -505,7 +505,7 @@ describe('useVirtualFocus', () => {
       })
 
       const event = createKeyboardEvent('a')
-      const spy = vi.spyOn(event, 'preventDefault')
+      using spy = vi.spyOn(event, 'preventDefault')
       result!.onKeydown(event)
 
       expect(spy).not.toHaveBeenCalled()
@@ -675,7 +675,7 @@ describe('useVirtualFocus', () => {
     it('should attach keydown listener to target when provided', () => {
       const target = createElement('target')
       target.scrollIntoView = vi.fn()
-      const spy = vi.spyOn(target, 'addEventListener')
+      using spy = vi.spyOn(target, 'addEventListener')
 
       scope.run(() => {
         useVirtualFocus(() => items, { control, target })
@@ -685,7 +685,7 @@ describe('useVirtualFocus', () => {
     })
 
     it('should attach keydown listener to control when target is not provided', () => {
-      const spy = vi.spyOn(control, 'addEventListener')
+      using spy = vi.spyOn(control, 'addEventListener')
 
       scope.run(() => {
         useVirtualFocus(() => items, { control })


### PR DESCRIPTION
## Summary

Adopt the TC39 `using` declaration for `vi.spyOn` cleanup across the @vuetify/v0 test suite. Vitest 4 exposes `Symbol.dispose` on spies, so `using` auto-restores at block exit and `mockRestore()` becomes redundant.

## Stats

- **34 test files modified** (1 sample + 33 rollout)
- **~110 block-scoped spies converted** to `using`
- **~15 previously-unasserted spies promoted** to real `expect(spy).toHaveBeenCalledWith(...)` assertions
- **Net: +112 / −224 lines** across test code

## Why

- Removes a whole class of "forgot to restore" bugs
- Removes the trailing-cleanup boilerplate (one line per spy)
- Tightens the rules: every captured warning now actually asserts what it captured, eliminating silent swallows

## Compatibility

- Vitest 4.1.5 — `Symbol.dispose` on spies shipped in v3
- TS `target: esnext`, `lib: esnext` — `Disposable` type available
- Node 26 — native `using`

## Untouched (intentional)

- Lifecycle-scoped spies in `beforeEach`/`afterEach` (e.g. `useLogger`, `useLogger/v0` adapter, `useTheme/v0` adapter) — cleanup is hook-tied, not block-tied
- File-level `vi.restoreAllMocks()` calls
- Unbound `vi.spyOn(...).mockReturnValue(...)` mocks that have no variable to convert (`createOverflow` `getComputedStyle`, `useStorage` `Date.now`, `useClickOutside` `getBoundingClientRect`)
- A handful of spies where adding an assertion would be tenuous (`createOtp:493` thenable-reject path, `createNested` defensive spy, four `NumberField` `rafSpy` paths that never invoke RAF)

## Rules

`.claude/rules/testing.md` updated so the canonical "expected warning" recipe shows `using` + `vi.spyOn` with a fallback note for spies that must outlive the enclosing block.

## Before / After

```ts
// Before
const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
expect(context.resolve('nonexistent')).toBeUndefined()
expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
warnSpy.mockRestore()

// After
using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
expect(context.resolve('nonexistent')).toBeUndefined()
expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Alias not found'))
```

## Verification

- `pnpm typecheck:0` — clean
- `pnpm test:run` — 145 files / 5950 tests passing (18 pre-existing skips)
- `pnpm lint:fix` — clean
- Pre-push gauntlet (`lint:fix` + `typecheck` + `test:run` + `knip` + `sherif`) — green