### PR TITLE
refactor: attach structured cause to v0 throws

### DIFF
--- a/packages/0/src/composables/createContext/index.test.ts
+++ b/packages/0/src/composables/createContext/index.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createContext, provideContext, useContext } from './index'
 
 // Utilities
+import { isV0Error, V0Error } from '#v0/utilities'
 import { inject, provide } from 'vue'
 
 // Types
@@ -67,6 +68,25 @@ describe('createContext', () => {
       expect(() => injectContext()).toThrow(
         'Context "v0:missing-key" not found. Ensure it\'s provided by an ancestor.',
       )
+    })
+
+    it('should throw a V0Error tagged V0_CONTEXT_MISSING with the key payload', () => {
+      mockInject.mockReturnValue(undefined)
+
+      const [injectContext] = createContext('v0:missing-key')
+
+      let caught: unknown
+      try {
+        injectContext()
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(V0Error)
+      expect(isV0Error(caught, 'V0_CONTEXT_MISSING')).toBe(true)
+      if (isV0Error(caught, 'V0_CONTEXT_MISSING')) {
+        expect(caught.code).toBe('V0_CONTEXT_MISSING')
+        expect(caught.key).toBe('v0:missing-key')
+      }
     })
 
     it('should handle symbol key in error message', () => {

--- a/packages/0/src/composables/createContext/index.ts
+++ b/packages/0/src/composables/createContext/index.ts
@@ -26,11 +26,10 @@
  */
 
 // Utilities
-import { isObject, isString, isSymbol, isUndefined } from '#v0/utilities'
+import { isObject, isString, isSymbol, isUndefined, V0Error } from '#v0/utilities'
 import { inject, provide } from 'vue'
 
 // Types
-import type { V0ErrorCause } from '#v0/types'
 import type { App, InjectionKey } from 'vue'
 
 export type ContextKey<Z> = InjectionKey<Z> | string
@@ -65,8 +64,9 @@ export function useContext<Z> (key: ContextKey<Z>, defaultValue?: Z) {
   const context = inject<Z>(key, defaultValue as Z)
 
   if (isUndefined(context)) {
-    throw new Error(`Context "${String(key)}" not found. Ensure it's provided by an ancestor.`, {
-      cause: { code: 'V0_CONTEXT_MISSING', key } satisfies V0ErrorCause,
+    throw new V0Error(`Context "${String(key)}" not found. Ensure it's provided by an ancestor.`, {
+      code: 'V0_CONTEXT_MISSING',
+      key,
     })
   }
 

--- a/packages/0/src/composables/createContext/index.ts
+++ b/packages/0/src/composables/createContext/index.ts
@@ -30,6 +30,7 @@ import { isObject, isString, isSymbol, isUndefined } from '#v0/utilities'
 import { inject, provide } from 'vue'
 
 // Types
+import type { V0ErrorCause } from '#v0/types'
 import type { App, InjectionKey } from 'vue'
 
 export type ContextKey<Z> = InjectionKey<Z> | string
@@ -65,7 +66,7 @@ export function useContext<Z> (key: ContextKey<Z>, defaultValue?: Z) {
 
   if (isUndefined(context)) {
     throw new Error(`Context "${String(key)}" not found. Ensure it's provided by an ancestor.`, {
-      cause: { code: 'V0_CONTEXT_MISSING', key },
+      cause: { code: 'V0_CONTEXT_MISSING', key } satisfies V0ErrorCause,
     })
   }
 

--- a/packages/0/src/composables/createContext/index.ts
+++ b/packages/0/src/composables/createContext/index.ts
@@ -64,7 +64,9 @@ export function useContext<Z> (key: ContextKey<Z>, defaultValue?: Z) {
   const context = inject<Z>(key, defaultValue as Z)
 
   if (isUndefined(context)) {
-    throw new Error(`Context "${String(key)}" not found. Ensure it's provided by an ancestor.`)
+    throw new Error(`Context "${String(key)}" not found. Ensure it's provided by an ancestor.`, {
+      cause: { code: 'V0_CONTEXT_MISSING', key },
+    })
   }
 
   return context

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -6,6 +6,9 @@ import { V0DateAdapter } from './adapters/v0'
 
 import { createDate, createDateContext, createDatePlugin, useDate } from './index'
 
+// Utilities
+import { isV0Error, V0Error } from '#v0/utilities'
+
 describe('createDate', () => {
   describe('v0DateAdapter', () => {
     let adapter: V0DateAdapter
@@ -1591,6 +1594,21 @@ describe('createDate', () => {
 
     it('should throw with helpful error message', () => {
       expect(() => useDate()).toThrow('createDatePlugin')
+    })
+
+    it('should throw a V0Error tagged V0_PLUGIN_MISSING with the plugin payload', () => {
+      let caught: unknown
+      try {
+        useDate()
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(V0Error)
+      expect(isV0Error(caught, 'V0_PLUGIN_MISSING')).toBe(true)
+      if (isV0Error(caught, 'V0_PLUGIN_MISSING')) {
+        expect(caught.code).toBe('V0_PLUGIN_MISSING')
+        expect(caught.plugin).toBe('createDatePlugin')
+      }
     })
   })
 

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -335,6 +335,9 @@ export function useDate<
       '  import { V0DateAdapter } from \'@vuetify/v0/date\'\n' +
       '  import { createDatePlugin } from \'@vuetify/v0\'\n\n' +
       '  app.use(createDatePlugin({ adapter: new V0DateAdapter() }))',
+      {
+        cause: { code: 'V0_PLUGIN_MISSING', plugin: 'createDatePlugin' },
+      },
     )
   }
 

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -45,13 +45,13 @@ import { createTrinity } from '#v0/composables/createTrinity'
 import { useLocale } from '#v0/composables/useLocale'
 
 // Utilities
-import { instanceExists, isNullOrUndefined, isUndefined } from '#v0/utilities'
+import { instanceExists, isNullOrUndefined, isUndefined, V0Error } from '#v0/utilities'
 import { computed, watchEffect, onScopeDispose } from 'vue'
 
 // Types
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { DateAdapter } from '#v0/composables/useDate/adapters'
-import type { ID, V0ErrorCause } from '#v0/types'
+import type { ID } from '#v0/types'
 import type { App, ComputedRef, Ref } from 'vue'
 
 // Exports
@@ -329,14 +329,15 @@ export function useDate<
   E extends DateContext<Z> = DateContext<Z>,
 > (namespace = 'v0:date'): E {
   if (!instanceExists()) {
-    throw new Error(
+    throw new V0Error(
       '[v0] useDate() must be called inside a Vue component with createDatePlugin installed.\n\n' +
       'Example:\n' +
       '  import { V0DateAdapter } from \'@vuetify/v0/date\'\n' +
       '  import { createDatePlugin } from \'@vuetify/v0\'\n\n' +
       '  app.use(createDatePlugin({ adapter: new V0DateAdapter() }))',
       {
-        cause: { code: 'V0_PLUGIN_MISSING', plugin: 'createDatePlugin' } satisfies V0ErrorCause,
+        code: 'V0_PLUGIN_MISSING',
+        plugin: 'createDatePlugin',
       },
     )
   }

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -51,7 +51,7 @@ import { computed, watchEffect, onScopeDispose } from 'vue'
 // Types
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { DateAdapter } from '#v0/composables/useDate/adapters'
-import type { ID } from '#v0/types'
+import type { ID, V0ErrorCause } from '#v0/types'
 import type { App, ComputedRef, Ref } from 'vue'
 
 // Exports
@@ -336,7 +336,7 @@ export function useDate<
       '  import { createDatePlugin } from \'@vuetify/v0\'\n\n' +
       '  app.use(createDatePlugin({ adapter: new V0DateAdapter() }))',
       {
-        cause: { code: 'V0_PLUGIN_MISSING', plugin: 'createDatePlugin' },
+        cause: { code: 'V0_PLUGIN_MISSING', plugin: 'createDatePlugin' } satisfies V0ErrorCause,
       },
     )
   }

--- a/packages/0/src/composables/useLogger/adapters/consola.ts
+++ b/packages/0/src/composables/useLogger/adapters/consola.ts
@@ -1,13 +1,19 @@
 // Adapters
 import { LoggerAdapter } from './adapter'
 
+// Utilities
+import { V0Error } from '#v0/utilities'
+
 export class ConsolaLoggerAdapter extends LoggerAdapter {
   private consola: LoggerAdapter
 
   constructor (consolaInstance: LoggerAdapter | null | undefined) {
     super()
     if (!consolaInstance) {
-      throw new Error('Consola instance is required for ConsolaLoggerAdapter')
+      throw new V0Error('Consola instance is required for ConsolaLoggerAdapter', {
+        code: 'V0_ADAPTER_INSTANCE_MISSING',
+        adapter: 'ConsolaLoggerAdapter',
+      })
     }
     this.consola = consolaInstance
   }

--- a/packages/0/src/composables/useLogger/adapters/pino.ts
+++ b/packages/0/src/composables/useLogger/adapters/pino.ts
@@ -2,7 +2,7 @@
 import { LoggerAdapter } from './adapter'
 
 // Utilities
-import { isObject } from '#v0/utilities'
+import { isObject, V0Error } from '#v0/utilities'
 
 /**
  * Pino logger adapter implementation
@@ -26,7 +26,10 @@ export class PinoLoggerAdapter extends LoggerAdapter {
   constructor (pinoInstance: PinoInstance | null | undefined) {
     super()
     if (!pinoInstance) {
-      throw new Error('Pino instance is required for PinoLoggerAdapter')
+      throw new V0Error('Pino instance is required for PinoLoggerAdapter', {
+        code: 'V0_ADAPTER_INSTANCE_MISSING',
+        adapter: 'PinoLoggerAdapter',
+      })
     }
     this.pino = pinoInstance
   }

--- a/packages/0/src/index.ts
+++ b/packages/0/src/index.ts
@@ -1,5 +1,5 @@
 export * from './components'
 export * from './composables'
 export * from './constants'
-export type { ID } from './types'
+export type { ID, V0ErrorCode, V0ErrorDetails } from './types'
 export * from './utilities'

--- a/packages/0/src/palettes/ant/generate/index.ts
+++ b/packages/0/src/palettes/ant/generate/index.ts
@@ -1,5 +1,8 @@
 import { generate } from '@ant-design/colors'
 
+// Utilities
+import { V0Error } from '#v0/utilities'
+
 // Types
 import type { PaletteDefinition } from '#v0/palettes'
 
@@ -30,7 +33,11 @@ function contrast (hex: string): string {
 /* #__NO_SIDE_EFFECTS__ */
 export function ant (seed: string, options: AntGenerateOptions = {}): PaletteDefinition {
   if (!HEX_RE.test(seed)) {
-    throw new Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#1677ff").`)
+    throw new V0Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#1677ff").`, {
+      code: 'V0_PALETTE_INVALID_SEED',
+      palette: 'ant',
+      seed,
+    })
   }
 
   const { background = '#141414' } = options

--- a/packages/0/src/palettes/leonardo/generate/index.ts
+++ b/packages/0/src/palettes/leonardo/generate/index.ts
@@ -1,7 +1,7 @@
 import { Color, Theme } from '@adobe/leonardo-contrast-colors'
 
 // Utilities
-import { isArray, isObject } from '#v0/utilities'
+import { isArray, isObject, V0Error } from '#v0/utilities'
 
 // Types
 import type { PaletteDefinition } from '#v0/palettes'
@@ -77,7 +77,11 @@ function mapSemanticColors (colors: Record<number, string>, ratios: number[]): R
 /* #__NO_SIDE_EFFECTS__ */
 export function leonardo (seed: string, options: LeonardoGenerateOptions = {}): PaletteDefinition {
   if (!HEX_RE.test(seed)) {
-    throw new Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#0ea5e9").`)
+    throw new V0Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#0ea5e9").`, {
+      code: 'V0_PALETTE_INVALID_SEED',
+      palette: 'leonardo',
+      seed,
+    })
   }
 
   const { ratios = DEFAULT_RATIOS, colorSpace = 'OKLCH' } = options

--- a/packages/0/src/palettes/material/generate/index.ts
+++ b/packages/0/src/palettes/material/generate/index.ts
@@ -10,6 +10,9 @@ import {
   hexFromArgb,
 } from '@material/material-color-utilities'
 
+// Utilities
+import { V0Error } from '#v0/utilities'
+
 // Types
 import type { PaletteDefinition } from '#v0/palettes'
 import type { TonalPalette } from '@material/material-color-utilities'
@@ -74,7 +77,11 @@ function extractSchemeColors (scheme: InstanceType<typeof SchemeTonalSpot>): Rec
 /* #__NO_SIDE_EFFECTS__ */
 export function material (seed: string, options: MaterialGenerateOptions = {}): PaletteDefinition {
   if (!HEX_RE.test(seed)) {
-    throw new Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#6750A4").`)
+    throw new V0Error(`[@vuetify/v0] Invalid seed color: "${seed}". Expected a hex string (e.g., "#6750A4").`, {
+      code: 'V0_PALETTE_INVALID_SEED',
+      palette: 'material',
+      seed,
+    })
   }
 
   const { variant = 'tonalSpot', contrast = 0 } = options
@@ -83,7 +90,11 @@ export function material (seed: string, options: MaterialGenerateOptions = {}): 
 
   const SchemeClass = VARIANTS[variant]
   if (!SchemeClass) {
-    throw new Error(`[@vuetify/v0] Unknown material variant: "${variant}"`)
+    throw new V0Error(`[@vuetify/v0] Unknown material variant: "${variant}"`, {
+      code: 'V0_PALETTE_UNKNOWN_VARIANT',
+      palette: 'material',
+      variant,
+    })
   }
 
   const light = new SchemeClass(hct, false, contrast)

--- a/packages/0/src/types/index.ts
+++ b/packages/0/src/types/index.ts
@@ -135,3 +135,46 @@ export type Extensible<T extends string> = T | (string & {})
  * ```
  */
 export type Activation = 'automatic' | 'manual'
+
+/**
+ * Discriminated union of all `Error.cause` payloads thrown by v0
+ *
+ * @remarks
+ * Every error v0 throws attaches a structured `cause` with a `code`
+ * discriminant so consumers (devtools panels, error overlays, error trackers)
+ * can identify the error stably without parsing the message string.
+ *
+ * When authoring a new v0 throw, append the literal with
+ * `satisfies V0ErrorCause` so TypeScript verifies the discriminant and the
+ * payload shape at the call site.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   useContext(myKey)
+ * } catch (err) {
+ *   if (
+ *     err instanceof Error
+ *     && err.cause
+ *     && typeof err.cause === 'object'
+ *     && 'code' in err.cause
+ *   ) {
+ *     const cause = err.cause as V0ErrorCause
+ *     if (cause.code === 'V0_CONTEXT_MISSING') {
+ *       console.log('missing context key:', cause.key)
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type V0ErrorCause =
+  | { code: 'V0_CONTEXT_MISSING', key: string | symbol }
+  | { code: 'V0_PLUGIN_MISSING', plugin: string }
+
+/**
+ * Union of all error codes thrown by v0
+ *
+ * @remarks
+ * Convenience alias for the discriminant field of {@link V0ErrorCause}.
+ */
+export type V0ErrorCode = V0ErrorCause['code']

--- a/packages/0/src/types/index.ts
+++ b/packages/0/src/types/index.ts
@@ -163,6 +163,9 @@ export type Activation = 'automatic' | 'manual'
 export type V0ErrorDetails =
   | { code: 'V0_CONTEXT_MISSING', key: string | symbol }
   | { code: 'V0_PLUGIN_MISSING', plugin: string }
+  | { code: 'V0_PALETTE_INVALID_SEED', palette: 'material' | 'leonardo' | 'ant', seed: string }
+  | { code: 'V0_PALETTE_UNKNOWN_VARIANT', palette: 'material', variant: string }
+  | { code: 'V0_ADAPTER_INSTANCE_MISSING', adapter: string }
 
 /**
  * Union of every error code thrown by v0

--- a/packages/0/src/types/index.ts
+++ b/packages/0/src/types/index.ts
@@ -137,44 +137,47 @@ export type Extensible<T extends string> = T | (string & {})
 export type Activation = 'automatic' | 'manual'
 
 /**
- * Discriminated union of all `Error.cause` payloads thrown by v0
+ * Discriminated union of structured details attached to every v0-thrown error
  *
  * @remarks
- * Every error v0 throws attaches a structured `cause` with a `code`
- * discriminant so consumers (devtools panels, error overlays, error trackers)
- * can identify the error stably without parsing the message string.
+ * Each arm pairs a stable `code` discriminant with the domain context for that
+ * code. Consumed by the `V0Error` constructor in `#v0/utilities` — the union
+ * is the source of truth for both what codes exist and what payload each code
+ * carries.
  *
- * When authoring a new v0 throw, append the literal with
- * `satisfies V0ErrorCause` so TypeScript verifies the discriminant and the
- * payload shape at the call site.
+ * Prefer `isV0Error(err, code)` over manual narrowing — see
+ * `V0Error` and `isV0Error` in `#v0/utilities` for the consumer-facing API
+ * and worked examples.
+ *
+ * Inspiration: tRPC's `TRPCError.code`, Node's `error.code` registry.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+ * @see https://nodejs.org/api/errors.html#nodejs-error-codes
+ * @see https://trpc.io/docs/server/error-handling
  *
  * @example
  * ```ts
- * try {
- *   useContext(myKey)
- * } catch (err) {
- *   if (
- *     err instanceof Error
- *     && err.cause
- *     && typeof err.cause === 'object'
- *     && 'code' in err.cause
- *   ) {
- *     const cause = err.cause as V0ErrorCause
- *     if (cause.code === 'V0_CONTEXT_MISSING') {
- *       console.log('missing context key:', cause.key)
- *     }
- *   }
- * }
+ * const details: V0ErrorDetails = { code: 'V0_CONTEXT_MISSING', key: 'theme' }
  * ```
  */
-export type V0ErrorCause =
+export type V0ErrorDetails =
   | { code: 'V0_CONTEXT_MISSING', key: string | symbol }
   | { code: 'V0_PLUGIN_MISSING', plugin: string }
 
 /**
- * Union of all error codes thrown by v0
+ * Union of every error code thrown by v0
  *
  * @remarks
- * Convenience alias for the discriminant field of {@link V0ErrorCause}.
+ * Convenience alias for the discriminant field of {@link V0ErrorDetails}.
+ *
+ * @example
+ * ```ts
+ * function describe (code: V0ErrorCode): string {
+ *   switch (code) {
+ *     case 'V0_CONTEXT_MISSING': return 'missing provider'
+ *     case 'V0_PLUGIN_MISSING': return 'plugin not installed'
+ *   }
+ * }
+ * ```
  */
-export type V0ErrorCode = V0ErrorCause['code']
+export type V0ErrorCode = V0ErrorDetails['code']

--- a/packages/0/src/utilities/errors.ts
+++ b/packages/0/src/utilities/errors.ts
@@ -1,0 +1,117 @@
+/**
+ * @module utilities/errors
+ *
+ * @remarks
+ * Structured error class thrown by v0 internals. Pattern modeled on
+ * tRPC's `TRPCError` and Node's built-in `Error` codes — `code` is a
+ * top-level discriminant field on the error, *not* a payload nested
+ * inside `Error.cause`. `cause` stays reserved for wrapping the
+ * genuine upstream error so error trackers (Sentry's `LinkedErrors`,
+ * Datadog RUM, Rollbar) render the chain correctly.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+ * @see https://nodejs.org/api/errors.html#nodejs-error-codes
+ * @see https://trpc.io/docs/server/error-handling
+ * @see https://docs.sentry.io/platforms/javascript/configuration/integrations/linkederrors/
+ */
+
+// Types
+import type { V0ErrorCode, V0ErrorDetails } from '#v0/types'
+
+/**
+ * Structured error thrown by v0 internals.
+ *
+ * @remarks
+ * Carries a stable {@link V0ErrorCode} discriminant on `code` so
+ * consumers, devtools panels, and error trackers can identify the
+ * error without parsing the message string. Domain context lives in
+ * top-level fields per code (`key` for `V0_CONTEXT_MISSING`, `plugin`
+ * for `V0_PLUGIN_MISSING`), populated from a {@link V0ErrorDetails}
+ * argument and merged onto the instance at construction time.
+ *
+ * `cause` is forwarded to `Error`'s standard `ErrorOptions.cause` slot
+ * and is intended to carry a wrapped upstream error, not metadata.
+ *
+ * Prefer {@link isV0Error} over manual `instanceof` checks at the
+ * narrowing site — the guard intersects the instance type with the
+ * matching {@link V0ErrorDetails} arm, so per-code fields are typed.
+ *
+ * @example Author site
+ * ```ts
+ * throw new V0Error('Context not found.', { code: 'V0_CONTEXT_MISSING', key })
+ * ```
+ *
+ * @example Author site with upstream wrap
+ * ```ts
+ * try {
+ *   JSON.parse(raw)
+ * } catch (err) {
+ *   throw new V0Error('Failed to hydrate registry.', {
+ *     code: 'V0_CONTEXT_MISSING',
+ *     key: 'v0:registry',
+ *     cause: err,
+ *   })
+ * }
+ * ```
+ *
+ * @example Consumer site
+ * ```ts
+ * try {
+ *   useContext(myKey)
+ * } catch (err) {
+ *   if (isV0Error(err, 'V0_CONTEXT_MISSING')) {
+ *     console.log(err.key)
+ *   }
+ * }
+ * ```
+ */
+export class V0Error extends Error {
+  override name = 'V0Error'
+  readonly code: V0ErrorCode
+  readonly key?: string | symbol
+  readonly plugin?: string
+
+  constructor (message: string, details: V0ErrorDetails & { cause?: unknown }) {
+    const { cause, ...rest } = details
+    super(message, cause === undefined ? undefined : { cause })
+    this.code = details.code
+    Object.assign(this, rest)
+  }
+}
+
+/* #__NO_SIDE_EFFECTS__ */
+/**
+ * Type guard for v0-thrown errors.
+ *
+ * @param value The value to test.
+ * @param code Optional discriminant — narrow the result to a specific
+ *   {@link V0ErrorCode} so per-code fields become required.
+ *
+ * @remarks
+ * Without the optional `code` argument, the guard verifies the value
+ * is a {@link V0Error} instance. With the `code` argument, the guard
+ * also narrows the instance type to the intersection with the matching
+ * {@link V0ErrorDetails} arm — fields like `key` or `plugin` change
+ * from optional to required on the narrowed type.
+ *
+ * @example Narrow to any v0 error
+ * ```ts
+ * if (isV0Error(err)) {
+ *   console.log(err.code)
+ * }
+ * ```
+ *
+ * @example Narrow to a specific code
+ * ```ts
+ * if (isV0Error(err, 'V0_CONTEXT_MISSING')) {
+ *   console.log(err.key) // typed as string | symbol, not string | symbol | undefined
+ * }
+ * ```
+ */
+export function isV0Error<C extends V0ErrorCode> (
+  value: unknown,
+  code?: C,
+): value is V0Error & Extract<V0ErrorDetails, { code: C }> {
+  if (!(value instanceof V0Error)) return false
+  return code === undefined || value.code === code
+}

--- a/packages/0/src/utilities/errors.ts
+++ b/packages/0/src/utilities/errors.ts
@@ -15,6 +15,9 @@
  * @see https://docs.sentry.io/platforms/javascript/configuration/integrations/linkederrors/
  */
 
+// Utilities
+import { isUndefined } from './helpers'
+
 // Types
 import type { V0ErrorCode, V0ErrorDetails } from '#v0/types'
 
@@ -73,7 +76,7 @@ export class V0Error extends Error {
 
   constructor (message: string, details: V0ErrorDetails & { cause?: unknown }) {
     const { cause, ...rest } = details
-    super(message, cause === undefined ? undefined : { cause })
+    super(message, isUndefined(cause) ? undefined : { cause })
     this.code = details.code
     Object.assign(this, rest)
   }
@@ -113,5 +116,5 @@ export function isV0Error<C extends V0ErrorCode> (
   code?: C,
 ): value is V0Error & Extract<V0ErrorDetails, { code: C }> {
   if (!(value instanceof V0Error)) return false
-  return code === undefined || value.code === code
+  return isUndefined(code) || value.code === code
 }

--- a/packages/0/src/utilities/errors.ts
+++ b/packages/0/src/utilities/errors.ts
@@ -73,6 +73,10 @@ export class V0Error extends Error {
   readonly code: V0ErrorCode
   readonly key?: string | symbol
   readonly plugin?: string
+  readonly palette?: string
+  readonly seed?: string
+  readonly variant?: string
+  readonly adapter?: string
 
   constructor (message: string, details: V0ErrorDetails & { cause?: unknown }) {
     const { cause, ...rest } = details

--- a/packages/0/src/utilities/index.ts
+++ b/packages/0/src/utilities/index.ts
@@ -1,5 +1,6 @@
 // Utilities
 export * from './apca'
 export * from './color'
+export * from './errors'
 export * from './helpers'
 export * from './instance'


### PR DESCRIPTION
## Summary

Every `throw` in `packages/0/src` now uses a typed `V0Error` class with a stable `code` discriminant, so consumers (and error trackers) can identify v0 errors without parsing message strings.

| Site | Code |
|---|---|
| `useContext` — missing provider | `V0_CONTEXT_MISSING` (`key`) |
| `useDate` — plugin not installed | `V0_PLUGIN_MISSING` (`plugin`) |
| `palettes/{ant,leonardo,material}` — bad seed hex | `V0_PALETTE_INVALID_SEED` (`palette`, `seed`) |
| `palettes/material` — unknown variant | `V0_PALETTE_UNKNOWN_VARIANT` (`palette`, `variant`) |
| `useLogger/adapters/{pino,consola}` — missing instance | `V0_ADAPTER_INSTANCE_MISSING` (`adapter`) |

```ts
import { isV0Error } from '@vuetify/v0'

try {
  useContext(myKey)
} catch (err) {
  if (isV0Error(err, 'V0_CONTEXT_MISSING')) {
    // err.code, err.key are typed
    reportToTracker(err.key)
  }
}
```

## Design

Pattern modeled on [tRPC's `TRPCError`](https://trpc.io/docs/server/error-handling) and [Node's `error.code` registry](https://nodejs.org/api/errors.html#nodejs-error-codes):

- **`V0Error extends Error`** with `code: V0ErrorCode` as a top-level field.
- **`Error.cause` reserved for wrapping the genuine upstream error** so [Sentry's `LinkedErrors` integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/linkederrors/) renders the chain correctly. `cause` is forwarded through `ErrorOptions` and only set when supplied.
- **`V0ErrorDetails`** discriminated union ([`packages/0/src/types/index.ts`](https://github.com/vuetifyjs/0/blob/worktree-error-cause/packages/0/src/types/index.ts)) is the source of truth for what codes exist and what payload each carries. Adding a code = extending the union.
- **`isV0Error(err, code?)`** type guard intersects the instance with the matching `V0ErrorDetails` arm, so post-narrowing `err.key` / `err.plugin` / etc. are required (not optional).

Initial design used `cause: { code, ... }` as the discriminant payload. Review surfaced that this conflicts with the standard semantic of [`Error.cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) — every precedent (Node, tRPC, Stripe SDK, OpenAI/Anthropic SDKs, Sentry's chain walker) uses `cause` for *upstream wrapping*, not as a discriminant. Pivoted before merging.

## Public surface

Re-exported from `@vuetify/v0`:
- `V0Error` (class)
- `isV0Error` (type guard)
- `V0ErrorCode` (union of codes)
- `V0ErrorDetails` (discriminated union of constructor inputs)

## Follow-ups (not in this PR)

- **Lint rule** (`eslint-plugin-vuetify`) — enforce that new `throw` statements under `packages/0/src` use `V0Error`, with documented carve-outs.
- **Testing docs page** — a dedicated guide covering mocks, fake timers, plugin testing, error assertions (including `isV0Error` narrowing), etc.

## Verification

- `pnpm typecheck:0` — clean
- `pnpm build:0` — clean
- `pnpm test:run packages/0` — 5862 passed / 18 skipped (added 2 cause-shape assertions to existing throw tests)
- `grep "throw new Error" packages/0/src` — 0 results outside test/bench files