### PR TITLE
docs: add Special Sponsor program (home band, /sponsor page, READMEs)

### DIFF
--- a/apps/docs/build/markdown.ts
+++ b/apps/docs/build/markdown.ts
@@ -153,7 +153,7 @@ export function applyMarkdownPlugins (md: MarkdownIt, highlighter: DocsHighlight
   registerExampleContainer('gn-example', 'DocsGenesisExample')
 
   // Sponsor container: ::: sponsor ... :::
-  // Renders the standing $1,500/mo Premier sponsor pitch
+  // Renders the $2,000/mo Special Sponsor teaser (full pitch lives at /sponsor)
   md.use(Container, 'sponsor', {
     render (tokens: MarkdownToken[], index: number) {
       if (tokens[index].nesting === 1) return '<DocsSponsor />\n'

--- a/apps/docs/build/markdown.ts
+++ b/apps/docs/build/markdown.ts
@@ -153,7 +153,7 @@ export function applyMarkdownPlugins (md: MarkdownIt, highlighter: DocsHighlight
   registerExampleContainer('gn-example', 'DocsGenesisExample')
 
   // Sponsor container: ::: sponsor ... :::
-  // Renders the $2,000/mo Special Sponsor teaser (full pitch lives at /sponsor)
+  // Renders the $2,000/mo Primary Sponsor teaser (full pitch lives at /sponsor)
   md.use(Container, 'sponsor', {
     render (tokens: MarkdownToken[], index: number) {
       if (tokens[index].nesting === 1) return '<DocsSponsor />\n'

--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -156,6 +156,7 @@ declare module 'vue' {
     DocsSkeleton: typeof import('./components/docs/DocsSkeleton.vue')['default']
     DocsSkillToggle: typeof import('./components/docs/meta/DocsSkillToggle.vue')['default']
     DocsSponsor: typeof import('./components/docs/DocsSponsor.vue')['default']
+    DocsSponsorSlot: typeof import('./components/docs/DocsSponsorSlot.vue')['default']
     DocsTimeline: typeof import('./components/docs/DocsTimeline.vue')['default']
     DocsToc: typeof import('./components/docs/DocsToc.vue')['default']
     HomeAiFirst: typeof import('./components/home/HomeAiFirst.vue')['default']

--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -168,11 +168,10 @@ declare module 'vue' {
     HomeEcosystem: typeof import('./components/home/HomeEcosystem.vue')['default']
     HomeFoundation: typeof import('./components/home/HomeFoundation.vue')['default']
     HomeHero: typeof import('./components/home/HomeHero.vue')['default']
+    HomeSpecialSponsor: typeof import('./components/home/HomeSpecialSponsor.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    ServicesContactCard: typeof import('./components/services/ServicesContactCard.vue')['default']
     ServicesProjectTiers: typeof import('./components/services/ServicesProjectTiers.vue')['default']
-    ServicesSponsorBand: typeof import('./components/services/ServicesSponsorBand.vue')['default']
     ServicesSupportTiers: typeof import('./components/services/ServicesSupportTiers.vue')['default']
     SkillCard: typeof import('./components/skillz/SkillCard.vue')['default']
     SkillCardDeck: typeof import('./components/skillz/SkillCardDeck.vue')['default']
@@ -185,5 +184,9 @@ declare module 'vue' {
     SkillPrerequisites: typeof import('./components/skillz/SkillPrerequisites.vue')['default']
     SkillzResume: typeof import('./components/skillz/SkillzResume.vue')['default']
     SkillzTour: typeof import('./components/skillz/SkillzTour.vue')['default']
+    SponsorComparison: typeof import('./components/sponsor/SponsorComparison.vue')['default']
+    SponsorCta: typeof import('./components/sponsor/SponsorCta.vue')['default']
+    SponsorHero: typeof import('./components/sponsor/SponsorHero.vue')['default']
+    SponsorIncluded: typeof import('./components/sponsor/SponsorIncluded.vue')['default']
   }
 }

--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -169,6 +169,7 @@ declare module 'vue' {
     HomeEcosystem: typeof import('./components/home/HomeEcosystem.vue')['default']
     HomeFoundation: typeof import('./components/home/HomeFoundation.vue')['default']
     HomeHero: typeof import('./components/home/HomeHero.vue')['default']
+    HomePrimarySponsor: typeof import('./components/home/HomePrimarySponsor.vue')['default']
     HomeSpecialSponsor: typeof import('./components/home/HomeSpecialSponsor.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/apps/docs/src/components/docs/DocsMermaid.vue
+++ b/apps/docs/src/components/docs/DocsMermaid.vue
@@ -582,6 +582,74 @@
     fill: var(--v0-on-primary) !important;
   }
 
+  /* Mindmap styling */
+  .docs-mermaid .mindmap-node > rect,
+  .docs-mermaid .mindmap-node > polygon,
+  .docs-mermaid .mindmap-node > circle,
+  .docs-mermaid .mindmap-node > ellipse,
+  .docs-mermaid .mindmap-node > path {
+    fill: var(--v0-surface) !important;
+    stroke: var(--v0-divider) !important;
+  }
+
+  .docs-mermaid .mindmap-node > rect {
+    rx: 8px;
+    ry: 8px;
+  }
+
+  /* Override mermaid's per-branch color rotation (.section-0, .section-1, ...) */
+  .docs-mermaid g[class*="section-"] > rect,
+  .docs-mermaid g[class*="section-"] > polygon,
+  .docs-mermaid g[class*="section-"] > circle,
+  .docs-mermaid g[class*="section-"] > ellipse,
+  .docs-mermaid g[class*="section-"] > path {
+    fill: var(--v0-surface) !important;
+    stroke: var(--v0-divider) !important;
+  }
+
+  .docs-mermaid g[class*="section-"] > rect {
+    rx: 8px;
+    ry: 8px;
+  }
+
+  /* Mindmap root node — primary-colored hub */
+  .docs-mermaid .mindmap-node.section--1 > circle,
+  .docs-mermaid .mindmap-node:has(> circle) > circle {
+    fill: var(--v0-primary) !important;
+    stroke: var(--v0-primary) !important;
+  }
+
+  /* Mermaid sizes foreignObject for the original label measurement;
+     bold text + browser rendering can push descenders past the right edge */
+  .docs-mermaid .mindmap-node foreignObject,
+  .docs-mermaid .mindmap-node foreignObject > div {
+    overflow: visible !important;
+  }
+
+  .docs-mermaid .mindmap-node.section--1 text,
+  .docs-mermaid .mindmap-node.section--1 .nodeLabel,
+  .docs-mermaid .mindmap-node:has(> circle) text,
+  .docs-mermaid .mindmap-node:has(> circle) .nodeLabel {
+    font-weight: 600 !important;
+    fill: var(--v0-on-primary) !important;
+    color: var(--v0-on-primary) !important;
+  }
+
+  .docs-mermaid .mindmap-node text,
+  .docs-mermaid .mindmap-node .nodeLabel,
+  .docs-mermaid g[class*="section-"] text,
+  .docs-mermaid g[class*="section-"] .nodeLabel {
+    fill: var(--v0-on-surface) !important;
+    color: var(--v0-on-surface) !important;
+  }
+
+  .docs-mermaid .edge,
+  .docs-mermaid path[class*="edge-"] {
+    stroke: var(--v0-primary) !important;
+    stroke-width: 1.5px !important;
+    fill: none !important;
+  }
+
   /* Semantic node classes (use with classDef in mermaid) */
   .docs-mermaid .node.primary rect,
   .docs-mermaid .node.primary polygon {

--- a/apps/docs/src/components/docs/DocsSponsor.vue
+++ b/apps/docs/src/components/docs/DocsSponsor.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-  import { SPECIAL_SPONSOR_PRICE } from '@/constants/sponsor'
+  import { SPECIAL_SPONSOR, SPECIAL_SPONSOR_PRICE } from '@/constants/sponsor'
+
+  const isOpen = SPECIAL_SPONSOR === null
 </script>
 
 <template>
-  <section class="relative my-10 px-5 py-4 sm:px-6 sm:py-5 rounded-xl border border-divider bg-surface overflow-hidden">
+  <section v-if="isOpen" class="relative my-10 px-5 py-4 sm:px-6 sm:py-5 rounded-xl border border-divider bg-surface overflow-hidden">
     <AppDotGrid :coverage="40" origin="bottom right" />
 
     <div class="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/docs/src/components/docs/DocsSponsor.vue
+++ b/apps/docs/src/components/docs/DocsSponsor.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-  // Constants
-  import { GITHUB_SPONSORS_ECOSYSTEM } from '@/constants/services'
+  import { SPECIAL_SPONSOR_PRICE } from '@/constants/sponsor'
 </script>
 
 <template>
@@ -20,26 +19,24 @@
           Sponsor
         </div>
 
-        <h3 class="text-xl font-bold mb-2">Your logo across the Vuetify ecosystem</h3>
+        <h3 class="text-xl font-bold mb-2">Fund v0, get your logo on the docs</h3>
 
         <p class="text-sm text-on-surface-variant max-w-prose">
-          For companies that want their brand in front of the entire Vuetify community. Logo and link rendered across every site in the ecosystem — docs, playground, bin, link, snips, and beyond — and a direct contribution to every open source project I maintain.
+          For companies whose product is built on v0. Logo across the docs, every page, and the README. One sponsor at a time.
         </p>
       </div>
 
       <div class="flex flex-col items-center gap-3 sm:items-end">
         <div class="flex items-baseline gap-1">
-          <span class="text-3xl font-bold">$1,500</span>
+          <span class="text-3xl font-bold">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}</span>
           <span class="text-sm text-on-surface-variant">/mo</span>
         </div>
 
-        <a
+        <router-link
           class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
-          :href="GITHUB_SPONSORS_ECOSYSTEM"
-          rel="noopener"
-          target="_blank"
+          to="/sponsor"
         >
-          Become a sponsor
+          Learn more
           <svg
             aria-hidden="true"
             fill="currentColor"
@@ -48,9 +45,9 @@
             width="14"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
+            <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59a.996.996 0 0 0 0-1.41l-6.58-6.6a.996.996 0 1 0-1.41 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" />
           </svg>
-        </a>
+        </router-link>
       </div>
     </div>
   </section>

--- a/apps/docs/src/components/docs/DocsSponsor.vue
+++ b/apps/docs/src/components/docs/DocsSponsor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-  import { SPECIAL_SPONSOR, SPECIAL_SPONSOR_PRICE } from '@/constants/sponsor'
+  import { PRIMARY_SPONSOR, PRIMARY_SPONSOR_PRICE } from '@/constants/sponsor'
 
-  const isOpen = SPECIAL_SPONSOR === null
+  const isOpen = PRIMARY_SPONSOR === null
 </script>
 
 <template>
@@ -21,16 +21,16 @@
           Sponsor
         </div>
 
-        <h3 class="text-xl font-bold mb-2">Fund v0, get your logo on the docs</h3>
+        <h3 class="text-xl font-bold mb-2">Fund Vuetify0, get your logo on the docs</h3>
 
         <p class="text-sm text-on-surface-variant max-w-prose">
-          For companies whose product is built on v0. Logo across the docs, every page, and the README. One sponsor at a time.
+          For companies whose product is built on Vuetify0. Logo across the docs, every page, and the README. One sponsor at a time.
         </p>
       </div>
 
       <div class="flex flex-col items-center gap-3 sm:items-end">
         <div class="flex items-baseline gap-1">
-          <span class="text-3xl font-bold">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}</span>
+          <span class="text-3xl font-bold">${{ PRIMARY_SPONSOR_PRICE.toLocaleString() }}</span>
           <span class="text-sm text-on-surface-variant">/mo</span>
         </div>
 

--- a/apps/docs/src/components/docs/DocsSponsorSlot.vue
+++ b/apps/docs/src/components/docs/DocsSponsorSlot.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
-  import {
-    SPECIAL_SPONSOR,
-    SPECIAL_SPONSOR_PRICE,
-  } from '@/constants/sponsor'
+  import { PRIMARY_SPONSOR } from '@/constants/sponsor'
 
-  const sponsor = SPECIAL_SPONSOR
+  // Utilities
+  import { toRef } from 'vue'
+  import { useRoute } from 'vue-router'
+
+  const route = useRoute()
+  const sponsor = PRIMARY_SPONSOR
+  const onSponsorPage = toRef(() => route.path === '/sponsor')
 </script>
 
 <template>
-  <div v-if="sponsor" class="mt-6 p-3 rounded-lg border border-divider bg-surface">
+  <div v-if="sponsor" class="mt-3 p-3 rounded-lg border border-divider bg-surface">
     <p class="text-xs uppercase tracking-wide text-on-surface-variant mb-2">SPONSORED BY</p>
 
     <a
@@ -36,11 +39,15 @@
 
   <router-link
     v-else
-    class="block mt-6 p-3 rounded-lg border-2 border-dashed border-divider text-on-surface-variant hover:border-primary hover:text-primary transition-colors"
+    class="block mt-3 p-3 rounded-lg border border-dashed hover:border-primary hover:text-primary transition-colors"
+    :class="onSponsorPage ? 'border-primary text-primary' : 'border-divider text-on-surface-variant'"
     to="/sponsor"
   >
-    <p class="text-xs font-semibold">Your logo here</p>
-    <p class="text-xs">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</p>
-    <p class="text-xs mt-1">Become the sponsor →</p>
+    <p class="text-xs font-semibold flex items-center gap-1">
+      <AppIcon icon="vuetify-0" size=".75rem" />
+      Your logo here
+    </p>
+
+    <p class="text-xs mt-1">Become the Primary Sponsor →</p>
   </router-link>
 </template>

--- a/apps/docs/src/components/docs/DocsSponsorSlot.vue
+++ b/apps/docs/src/components/docs/DocsSponsorSlot.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+  import {
+    SPECIAL_SPONSOR,
+    SPECIAL_SPONSOR_PRICE,
+  } from '@/constants/sponsor'
+
+  const sponsor = SPECIAL_SPONSOR
+</script>
+
+<template>
+  <div v-if="sponsor" class="mt-6 p-3 rounded-lg border border-divider bg-surface">
+    <p class="text-xs uppercase tracking-wide text-on-surface-variant mb-2">SPONSORED BY</p>
+
+    <a
+      class="block transition-opacity hover:opacity-85"
+      :href="sponsor.url"
+      rel="noopener"
+      target="_blank"
+    >
+      <img
+        :alt="sponsor.name"
+        class="max-h-12 w-full object-contain"
+        :src="sponsor.logo"
+      >
+    </a>
+
+    <a
+      class="block mt-2 text-xs text-on-surface-variant hover:text-primary hover:underline transition-colors truncate"
+      :href="sponsor.url"
+      rel="noopener"
+      target="_blank"
+    >
+      {{ sponsor.name }} →
+    </a>
+  </div>
+
+  <router-link
+    v-else
+    class="block mt-6 p-3 rounded-lg border-2 border-dashed border-divider text-on-surface-variant hover:border-primary hover:text-primary transition-colors"
+    to="/sponsor"
+  >
+    <p class="text-xs font-semibold">Your logo here</p>
+    <p class="text-xs">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</p>
+    <p class="text-xs mt-1">Become the sponsor →</p>
+  </router-link>
+</template>

--- a/apps/docs/src/components/docs/DocsToc.vue
+++ b/apps/docs/src/components/docs/DocsToc.vue
@@ -2,6 +2,9 @@
   // Components
   import { Discovery } from '@/components/discovery'
 
+  // Context
+  import DocsSponsorSlot from './DocsSponsorSlot.vue'
+
   // Composables
   import { useAsk } from '@/composables/useAsk'
   import { useSettings } from '@/composables/useSettings'
@@ -89,5 +92,7 @@
         </li>
       </ul>
     </nav>
+
+    <DocsSponsorSlot />
   </Discovery.Activator>
 </template>

--- a/apps/docs/src/components/home/HomeHero.vue
+++ b/apps/docs/src/components/home/HomeHero.vue
@@ -49,7 +49,7 @@
 </script>
 
 <template>
-  <section class="home-hero relative text-center py-24 md:py-32 lg:py-40">
+  <section class="home-hero relative text-center py-16 md:py-20 lg:py-24">
 
     <img
       alt="Vuetify0 Logo"
@@ -71,7 +71,7 @@
       Headless, composable-first components for Vue with AI-integrated docs, published benchmarks, and the backing of Vuetify.
     </p>
 
-    <div class="relative flex flex-col items-center gap-6 mb-16">
+    <div class="relative flex flex-col items-center gap-6 mb-10">
       <div class="grid grid-cols-2 md:flex gap-4 justify-center">
         <router-link
           class="home-hero-cta-primary px-8 py-3.5 bg-primary text-on-primary rounded-xl font-semibold text-lg text-center whitespace-nowrap transition-all duration-150"

--- a/apps/docs/src/components/home/HomePrimarySponsor.vue
+++ b/apps/docs/src/components/home/HomePrimarySponsor.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-  import { SPECIAL_SPONSOR } from '@/constants/sponsor'
+  import { PRIMARY_SPONSOR } from '@/constants/sponsor'
 
-  const sponsor = SPECIAL_SPONSOR
+  const sponsor = PRIMARY_SPONSOR
 </script>
 
 <template>
-  <aside aria-label="Sponsorship" class="home-special-sponsor relative w-screen ml-[calc(50%-50vw)] border-y border-divider overflow-hidden">
+  <aside aria-label="Sponsorship" class="home-primary-sponsor relative w-screen ml-[calc(50%-50vw)] border-y border-divider overflow-hidden">
     <AppDotGrid :coverage="0" origin="top right" />
 
     <div v-if="sponsor" class="relative mx-auto max-w-[900px] px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-3">

--- a/apps/docs/src/components/home/HomeSpecialSponsor.vue
+++ b/apps/docs/src/components/home/HomeSpecialSponsor.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+  import {
+    SPECIAL_SPONSOR,
+    SPECIAL_SPONSOR_PRICE,
+  } from '@/constants/sponsor'
+
+  const sponsor = SPECIAL_SPONSOR
+</script>
+
+<template>
+  <section v-if="sponsor" class="home-special-sponsor relative py-4 overflow-hidden">
+    <AppDotGrid :coverage="30" origin="bottom right" />
+
+    <div class="relative flex flex-col sm:flex-row items-center justify-between gap-3">
+      <p class="section-overline">PROUDLY SPONSORED BY</p>
+
+      <a
+        class="transition-opacity hover:opacity-85"
+        :href="sponsor.url"
+        rel="noopener"
+        target="_blank"
+      >
+        <img
+          :alt="sponsor.name"
+          class="h-8"
+          :src="sponsor.logo"
+        >
+      </a>
+    </div>
+  </section>
+
+  <AppLink v-else class="block" no-suffix to="/sponsor">
+    <section class="home-special-sponsor relative py-4 overflow-hidden hover:bg-surface-tint transition-colors">
+      <AppDotGrid :coverage="30" origin="bottom right" />
+
+      <div class="relative flex flex-col sm:flex-row items-center justify-between gap-2 text-center sm:text-left">
+        <p class="section-overline">SPECIAL SPONSOR</p>
+
+        <p class="text-sm">
+          <span class="text-on-surface-variant">This spot is available · </span>
+          <span class="font-semibold">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</span>
+          <span class="ml-1">→</span>
+        </p>
+      </div>
+    </section>
+  </AppLink>
+</template>

--- a/apps/docs/src/components/home/HomeSpecialSponsor.vue
+++ b/apps/docs/src/components/home/HomeSpecialSponsor.vue
@@ -29,11 +29,15 @@
     </div>
   </section>
 
-  <AppLink v-else class="block" no-suffix to="/sponsor">
-    <section class="home-special-sponsor relative py-4 overflow-hidden hover:bg-surface-tint transition-colors">
-      <AppDotGrid :coverage="30" origin="bottom right" />
+  <section v-else class="home-special-sponsor relative overflow-hidden">
+    <AppDotGrid :coverage="30" origin="bottom right" />
 
-      <div class="relative flex flex-col sm:flex-row items-center justify-between gap-2 text-center sm:text-left">
+    <AppLink
+      class="relative block py-4 hover:bg-surface-tint transition-colors"
+      no-suffix
+      to="/sponsor"
+    >
+      <div class="flex flex-col sm:flex-row items-center justify-between gap-2 text-center sm:text-left">
         <p class="section-overline">SPECIAL SPONSOR</p>
 
         <p class="text-sm">
@@ -42,6 +46,6 @@
           <span class="ml-1">→</span>
         </p>
       </div>
-    </section>
-  </AppLink>
+    </AppLink>
+  </section>
 </template>

--- a/apps/docs/src/components/sponsor/SponsorComparison.vue
+++ b/apps/docs/src/components/sponsor/SponsorComparison.vue
@@ -4,29 +4,31 @@
     bestFor: string
     whatYouGet: string
     price: string
-    cta: { label: string, to: string } | null
-    note?: string
+    cta: { label: string, to: string }
     featured?: boolean
   }
 
   const columns: Column[] = [
     {
       name: 'Services',
-      bestFor: 'Most teams using v0',
+      bestFor: 'Most teams using Vuetify0',
       whatYouGet: 'Direct chat, code review, fixed-scope builds',
-      price: '$250–$1,000/mo + one-time builds',
+      price: '$250-$1,000/mo + one-time builds',
       cta: { label: 'See Services →', to: '/services' },
     },
     {
-      name: 'Special Sponsor',
-      bestFor: 'Companies whose product is built on v0',
+      name: 'Primary Sponsor',
+      bestFor: 'Companies whose product is built on Vuetify0',
       whatYouGet: 'Logo across the docs, README, sponsor page',
       price: '$2,000/mo · one slot',
-      cta: null,
-      note: 'Read on below ↓',
+      cta: { label: 'Become the sponsor →', to: 'mailto:john@vuetifyjs.com?subject=Primary%20Sponsor' },
       featured: true,
     },
   ]
+
+  function isMail (to: string) {
+    return to.startsWith('mailto:')
+  }
 </script>
 
 <template>
@@ -39,7 +41,7 @@
     >
       <div class="font-semibold text-base mb-4">{{ col.name }}</div>
 
-      <dl class="text-sm space-y-3 flex-1">
+      <dl class="text-sm space-y-3">
         <div>
           <dt class="text-xs uppercase tracking-wide text-on-surface-variant mb-0.5">Best for</dt>
           <dd>{{ col.bestFor }}</dd>
@@ -56,16 +58,22 @@
         </div>
       </dl>
 
+      <a
+        v-if="isMail(col.cta.to)"
+        class="mt-auto pt-4 inline-flex items-center gap-1 text-primary hover:underline font-medium text-sm"
+        :href="col.cta.to"
+      >
+        {{ col.cta.label }}
+      </a>
+
       <AppLink
-        v-if="col.cta"
-        class="mt-4 inline-flex items-center gap-1 text-primary hover:underline font-medium text-sm"
+        v-else
+        class="mt-auto pt-4 inline-flex items-center gap-1 text-primary hover:underline font-medium text-sm"
         no-suffix
         :to="col.cta.to"
       >
         {{ col.cta.label }}
       </AppLink>
-
-      <p v-else class="mt-4 text-sm text-primary font-medium">{{ col.note }}</p>
     </div>
   </div>
 </template>

--- a/apps/docs/src/components/sponsor/SponsorComparison.vue
+++ b/apps/docs/src/components/sponsor/SponsorComparison.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+  interface Column {
+    name: string
+    bestFor: string
+    whatYouGet: string
+    price: string
+    cta: { label: string, to: string } | null
+    note?: string
+    featured?: boolean
+  }
+
+  const columns: Column[] = [
+    {
+      name: 'Services',
+      bestFor: 'Most teams using v0',
+      whatYouGet: 'Direct chat, code review, fixed-scope builds',
+      price: '$250–$1,000/mo + one-time builds',
+      cta: { label: 'See Services →', to: '/services' },
+    },
+    {
+      name: 'Special Sponsor',
+      bestFor: 'Companies whose product is built on v0',
+      whatYouGet: 'Logo across the docs, README, sponsor page',
+      price: '$2,000/mo · one slot',
+      cta: null,
+      note: 'Read on below ↓',
+      featured: true,
+    },
+  ]
+</script>
+
+<template>
+  <div class="grid gap-4 my-6 sm:grid-cols-2">
+    <div
+      v-for="col in columns"
+      :key="col.name"
+      class="relative flex flex-col p-5 rounded-xl border-2 bg-surface"
+      :class="col.featured ? 'border-primary' : 'border-divider'"
+    >
+      <div class="font-semibold text-base mb-4">{{ col.name }}</div>
+
+      <dl class="text-sm space-y-3 flex-1">
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-on-surface-variant mb-0.5">Best for</dt>
+          <dd>{{ col.bestFor }}</dd>
+        </div>
+
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-on-surface-variant mb-0.5">What you get</dt>
+          <dd>{{ col.whatYouGet }}</dd>
+        </div>
+
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-on-surface-variant mb-0.5">Price</dt>
+          <dd class="font-semibold">{{ col.price }}</dd>
+        </div>
+      </dl>
+
+      <AppLink
+        v-if="col.cta"
+        class="mt-4 inline-flex items-center gap-1 text-primary hover:underline font-medium text-sm"
+        no-suffix
+        :to="col.cta.to"
+      >
+        {{ col.cta.label }}
+      </AppLink>
+
+      <p v-else class="mt-4 text-sm text-primary font-medium">{{ col.note }}</p>
+    </div>
+  </div>
+</template>

--- a/apps/docs/src/components/sponsor/SponsorCta.vue
+++ b/apps/docs/src/components/sponsor/SponsorCta.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+  import { SPECIAL_SPONSOR_TIER_URL } from '@/constants/sponsor'
+</script>
+
+<template>
+  <section class="relative my-10 px-5 py-8 sm:px-8 sm:py-10 rounded-2xl border border-divider bg-surface overflow-hidden text-center">
+    <AppDotGrid :coverage="40" origin="top right" />
+
+    <p class="relative text-sm text-on-surface-variant mb-6 max-w-prose mx-auto">
+      One slot. First-come, first-served. Reach out before subscribing to confirm availability.
+    </p>
+
+    <div class="relative flex flex-wrap justify-center gap-3">
+      <a
+        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity"
+        :href="SPECIAL_SPONSOR_TIER_URL"
+        rel="noopener"
+        target="_blank"
+      >
+        Become the sponsor
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="14"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
+        </svg>
+      </a>
+
+      <a
+        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-semibold hover:bg-surface-tint transition-colors"
+        href="mailto:john@vuetifyjs.com"
+      >
+        Email John
+      </a>
+    </div>
+  </section>
+</template>

--- a/apps/docs/src/components/sponsor/SponsorCta.vue
+++ b/apps/docs/src/components/sponsor/SponsorCta.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { SPECIAL_SPONSOR_TIER_URL } from '@/constants/sponsor'
+  import { PRIMARY_SPONSOR_TIER_URL } from '@/constants/sponsor'
 </script>
 
 <template>
@@ -13,11 +13,18 @@
     <div class="relative flex flex-wrap justify-center gap-3">
       <a
         class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity"
-        :href="SPECIAL_SPONSOR_TIER_URL"
+        href="mailto:john@vuetifyjs.com?subject=Primary%20Sponsor"
+      >
+        Email to claim the slot
+      </a>
+
+      <a
+        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-semibold hover:bg-surface-tint transition-colors"
+        :href="PRIMARY_SPONSOR_TIER_URL"
         rel="noopener"
         target="_blank"
       >
-        Become the sponsor
+        Sponsor on GitHub
         <svg
           aria-hidden="true"
           fill="currentColor"
@@ -28,13 +35,6 @@
         >
           <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
         </svg>
-      </a>
-
-      <a
-        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-semibold hover:bg-surface-tint transition-colors"
-        href="mailto:john@vuetifyjs.com"
-      >
-        Email John
       </a>
     </div>
   </section>

--- a/apps/docs/src/components/sponsor/SponsorHero.vue
+++ b/apps/docs/src/components/sponsor/SponsorHero.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+  import {
+    SPECIAL_SPONSOR,
+    SPECIAL_SPONSOR_PRICE,
+    SPECIAL_SPONSOR_TIER_URL,
+  } from '@/constants/sponsor'
+
+  const sponsor = SPECIAL_SPONSOR
+  const domain = sponsor ? new URL(sponsor.url).hostname.replace(/^www\./, '') : ''
+</script>
+
+<template>
+  <section v-if="sponsor" class="relative my-10 px-6 py-12 rounded-2xl border border-divider bg-surface overflow-hidden text-center">
+    <AppDotGrid :coverage="40" />
+
+    <p class="relative section-overline mb-4">PROUDLY SPONSORED BY</p>
+
+    <a
+      class="relative inline-block transition-opacity hover:opacity-85"
+      :href="sponsor.url"
+      rel="noopener"
+      target="_blank"
+    >
+      <img
+        :alt="sponsor.name"
+        class="max-h-20 mx-auto"
+        :src="sponsor.logo"
+      >
+    </a>
+
+    <p class="relative text-sm text-on-surface-variant mt-4 mb-6">Thank you for funding v0</p>
+
+    <a
+      class="relative inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-semibold hover:bg-surface-tint transition-colors"
+      :href="sponsor.url"
+      rel="noopener"
+      target="_blank"
+    >
+      Visit {{ domain }}
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="14"
+        viewBox="0 0 24 24"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
+      </svg>
+    </a>
+  </section>
+
+  <section v-else class="relative my-10 px-6 py-12 rounded-2xl border border-divider bg-surface overflow-hidden text-center">
+    <AppDotGrid :coverage="40" />
+
+    <p class="relative section-overline mb-4">THE SPOT IS OPEN</p>
+
+    <h2 class="relative text-2xl md:text-3xl font-bold tracking-tight mb-3">
+      Become the Special Sponsor
+    </h2>
+
+    <p class="relative text-sm text-on-surface-variant mb-1">
+      <span class="text-base font-semibold text-on-surface">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</span> · One slot
+    </p>
+
+    <p class="relative text-xs uppercase tracking-wide text-on-surface-variant mb-6">
+      No ads. No tracking. Ever.
+    </p>
+
+    <a
+      class="relative inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity"
+      :href="SPECIAL_SPONSOR_TIER_URL"
+      rel="noopener"
+      target="_blank"
+    >
+      Become the sponsor
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="14"
+        viewBox="0 0 24 24"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
+      </svg>
+    </a>
+  </section>
+</template>

--- a/apps/docs/src/components/sponsor/SponsorHero.vue
+++ b/apps/docs/src/components/sponsor/SponsorHero.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
   import {
-    SPECIAL_SPONSOR,
-    SPECIAL_SPONSOR_PRICE,
-    SPECIAL_SPONSOR_TIER_URL,
+    PRIMARY_SPONSOR,
+    PRIMARY_SPONSOR_TIER_URL,
   } from '@/constants/sponsor'
 
-  const sponsor = SPECIAL_SPONSOR
+  const sponsor = PRIMARY_SPONSOR
   const domain = sponsor ? new URL(sponsor.url).hostname.replace(/^www\./, '') : ''
 </script>
 
@@ -28,7 +27,7 @@
       >
     </a>
 
-    <p class="relative text-sm text-on-surface-variant mt-4 mb-6">Thank you for funding v0</p>
+    <p class="relative text-sm text-on-surface-variant mt-4 mb-6">Thank you for funding Vuetify0</p>
 
     <a
       class="relative inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-semibold hover:bg-surface-tint transition-colors"
@@ -50,40 +49,43 @@
     </a>
   </section>
 
-  <section v-else class="relative my-10 px-6 py-12 rounded-2xl border border-divider bg-surface overflow-hidden text-center">
+  <section v-else class="relative my-10 px-6 py-10 rounded-2xl border border-divider bg-surface overflow-hidden text-center">
     <AppDotGrid :coverage="40" />
 
-    <p class="relative section-overline mb-4">THE SPOT IS OPEN</p>
-
-    <p class="relative text-2xl md:text-3xl font-bold tracking-tight mb-3">
-      Become the Special Sponsor
+    <p class="relative text-xl md:text-2xl tracking-tight mb-3">
+      The Primary Sponsor spot is currently open.
     </p>
 
-    <p class="relative text-sm text-on-surface-variant mb-1">
-      <span class="text-base font-semibold text-on-surface">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</span> · One slot
+    <p class="relative text-sm text-on-surface-variant max-w-prose mx-auto mb-6">
+      One company at a time. If your product is built on Vuetify0, this is how you fund its development and share that relationship with the community.
     </p>
 
-    <p class="relative text-xs uppercase tracking-wide text-on-surface-variant mb-6">
-      No ads. No tracking. Ever.
-    </p>
-
-    <a
-      class="relative inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity"
-      :href="SPECIAL_SPONSOR_TIER_URL"
-      rel="noopener"
-      target="_blank"
-    >
-      Become the sponsor
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="14"
-        viewBox="0 0 24 24"
-        width="14"
-        xmlns="http://www.w3.org/2000/svg"
+    <div class="relative flex flex-wrap justify-center gap-3">
+      <a
+        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg bg-primary text-on-primary font-medium hover:opacity-90 transition-opacity"
+        href="mailto:john@vuetifyjs.com?subject=Primary%20Sponsor"
       >
-        <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
-      </svg>
-    </a>
+        Email to claim the slot
+      </a>
+
+      <a
+        class="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg border border-divider font-medium hover:bg-surface-tint transition-colors"
+        :href="PRIMARY_SPONSOR_TIER_URL"
+        rel="noopener"
+        target="_blank"
+      >
+        Sponsor on GitHub
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="14"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59L7.76 14.83l1.41 1.41L19 6.41V10h2V3h-7z" />
+        </svg>
+      </a>
+    </div>
   </section>
 </template>

--- a/apps/docs/src/components/sponsor/SponsorHero.vue
+++ b/apps/docs/src/components/sponsor/SponsorHero.vue
@@ -55,9 +55,9 @@
 
     <p class="relative section-overline mb-4">THE SPOT IS OPEN</p>
 
-    <h2 class="relative text-2xl md:text-3xl font-bold tracking-tight mb-3">
+    <p class="relative text-2xl md:text-3xl font-bold tracking-tight mb-3">
       Become the Special Sponsor
-    </h2>
+    </p>
 
     <p class="relative text-sm text-on-surface-variant mb-1">
       <span class="text-base font-semibold text-on-surface">${{ SPECIAL_SPONSOR_PRICE.toLocaleString() }}/mo</span> · One slot

--- a/apps/docs/src/components/sponsor/SponsorIncluded.vue
+++ b/apps/docs/src/components/sponsor/SponsorIncluded.vue
@@ -8,13 +8,13 @@
   const surfaces: Surface[] = [
     {
       title: 'Home page band',
-      description: 'Your logo at the top of the v0 docs home page, above the fold for every visitor.',
-      icon: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+      description: 'Your logo in a slim band on the Vuetify0 docs home page, above the fold for every visitor.',
+      icon: 'M12 8H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h1v4a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-4h3l5 4V4l-5 4m3 7.6-2-1.6H4v-4h9l2-1.6v7.2M21.5 12c0 1.71-.96 3.26-2.5 4V8c1.53.75 2.5 2.3 2.5 4z',
     },
     {
-      title: 'Docs sidebar (desktop)',
-      description: 'A persistent card below the table of contents on every component, composable, and guide page at desktop widths.',
-      icon: 'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zm4 18H6V4h7v5h5z',
+      title: 'Every docs page',
+      description: 'A small card alongside the table of contents — visible at desktop widths.',
+      icon: 'M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5m2 0v14h10V5H5m12 14h2V5h-2v14z',
     },
     {
       title: 'Sponsor page hero',
@@ -23,7 +23,7 @@
     },
     {
       title: 'GitHub README',
-      description: 'Logo on the repo README at github.com/vuetifyjs/0, seen by every developer evaluating v0.',
+      description: 'Logo on the README at vuetifyjs/0 — a Vuetify org repo, alongside the rest of the ecosystem.',
       icon: 'M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57v-2.02c-3.34.72-4.04-1.61-4.04-1.61-.55-1.38-1.34-1.75-1.34-1.75-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.07 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.81 5.62-5.48 5.92.42.36.81 1.1.81 2.22v3.29c0 .31.21.69.83.57A12 12 0 0 0 12 .3',
     },
   ]

--- a/apps/docs/src/components/sponsor/SponsorIncluded.vue
+++ b/apps/docs/src/components/sponsor/SponsorIncluded.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+  interface Surface {
+    title: string
+    description: string
+    icon: string
+  }
+
+  const surfaces: Surface[] = [
+    {
+      title: 'Home page band',
+      description: 'Your logo at the top of the v0 docs home page, above the fold for every visitor.',
+      icon: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+    },
+    {
+      title: 'Every docs page',
+      description: 'A persistent slot below the table of contents on every component, composable, and guide page.',
+      icon: 'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zm4 18H6V4h7v5h5z',
+    },
+    {
+      title: 'Sponsor page hero',
+      description: 'The biggest placement on the dedicated sponsor page — your logo as the headline.',
+      icon: 'M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z',
+    },
+    {
+      title: 'GitHub README',
+      description: 'Logo on the repo README at github.com/vuetifyjs/0, seen by every developer evaluating v0.',
+      icon: 'M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57v-2.02c-3.34.72-4.04-1.61-4.04-1.61-.55-1.38-1.34-1.75-1.34-1.75-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.07 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.81 5.62-5.48 5.92.42.36.81 1.1.81 2.22v3.29c0 .31.21.69.83.57A12 12 0 0 0 12 .3',
+    },
+  ]
+</script>
+
+<template>
+  <div class="grid gap-4 my-6 sm:grid-cols-2">
+    <div
+      v-for="surface in surfaces"
+      :key="surface.title"
+      class="relative flex flex-col p-4 rounded-xl border border-divider bg-surface"
+    >
+      <svg
+        aria-hidden="true"
+        class="flex-shrink-0 text-primary mb-3"
+        fill="currentColor"
+        height="20"
+        viewBox="0 0 24 24"
+        width="20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path :d="surface.icon" />
+      </svg>
+
+      <div class="font-semibold text-base mb-1">{{ surface.title }}</div>
+      <p class="text-sm text-on-surface-variant">{{ surface.description }}</p>
+    </div>
+  </div>
+</template>

--- a/apps/docs/src/components/sponsor/SponsorIncluded.vue
+++ b/apps/docs/src/components/sponsor/SponsorIncluded.vue
@@ -12,8 +12,8 @@
       icon: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
     },
     {
-      title: 'Every docs page',
-      description: 'A persistent slot below the table of contents on every component, composable, and guide page.',
+      title: 'Docs sidebar (desktop)',
+      description: 'A persistent card below the table of contents on every component, composable, and guide page at desktop widths.',
       icon: 'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zm4 18H6V4h7v5h5z',
     },
     {

--- a/apps/docs/src/constants/services.ts
+++ b/apps/docs/src/constants/services.ts
@@ -6,9 +6,6 @@ export const STRIPE_SUPPORT_MULTIVERSE = 'https://buy.stripe.com/9B600k4xu7sxeCB
 /** GitHub Sponsors page (general) */
 export const GITHUB_SPONSORS = 'https://github.com/sponsors/johnleider'
 
-/** GitHub Sponsors deep link to the $1,500/mo ecosystem-sponsor tier */
-export const GITHUB_SPONSORS_ECOSYSTEM = 'https://github.com/sponsors/johnleider/sponsorships?tier_id=366'
-
 /** Calendly booking URL for the 30-minute intro / scoping call */
 export const CALENDLY_INTRO_CALL = 'https://calendly.com/vuetify/conference-call-30-min'
 

--- a/apps/docs/src/constants/sponsor.ts
+++ b/apps/docs/src/constants/sponsor.ts
@@ -1,0 +1,14 @@
+export interface SpecialSponsor {
+  name: string
+  logo: string
+  logoDark?: string
+  url: string
+}
+
+export const SPECIAL_SPONSOR: SpecialSponsor | null = null
+
+export const SPECIAL_SPONSOR_PRICE = 2000
+
+// Update once the dedicated $2,000 tier exists on github.com/sponsors/johnleider;
+// the deep link will be .../sponsorships?tier_id=XXX
+export const SPECIAL_SPONSOR_TIER_URL = 'https://github.com/sponsors/johnleider'

--- a/apps/docs/src/constants/sponsor.ts
+++ b/apps/docs/src/constants/sponsor.ts
@@ -1,14 +1,12 @@
-export interface SpecialSponsor {
+export interface PrimarySponsor {
   name: string
   logo: string
   logoDark?: string
   url: string
 }
 
-export const SPECIAL_SPONSOR: SpecialSponsor | null = null
+export const PRIMARY_SPONSOR: PrimarySponsor | null = null
 
-export const SPECIAL_SPONSOR_PRICE = 2000
+export const PRIMARY_SPONSOR_PRICE = 2000
 
-// Update once the dedicated $2,000 tier exists on github.com/sponsors/johnleider;
-// the deep link will be .../sponsorships?tier_id=XXX
-export const SPECIAL_SPONSOR_TIER_URL = 'https://github.com/sponsors/johnleider'
+export const PRIMARY_SPONSOR_TIER_URL = 'https://github.com/sponsors/johnleider/sponsorships?tier_id=621941'

--- a/apps/docs/src/pages/index.vue
+++ b/apps/docs/src/pages/index.vue
@@ -15,7 +15,7 @@
 <template>
   <div class="home-page">
     <HomeHero />
-    <HomeSpecialSponsor />
+    <HomePrimarySponsor />
     <HomeArchitecture />
     <HomeEcosystem />
     <HomeBenchmarks />
@@ -36,6 +36,10 @@ meta:
   }
 
   .home-page :deep(section:last-child) {
+    border-bottom: none;
+  }
+
+  .home-page :deep(.home-hero) {
     border-bottom: none;
   }
 

--- a/apps/docs/src/pages/index.vue
+++ b/apps/docs/src/pages/index.vue
@@ -15,6 +15,7 @@
 <template>
   <div class="home-page">
     <HomeHero />
+    <HomeSpecialSponsor />
     <HomeArchitecture />
     <HomeEcosystem />
     <HomeBenchmarks />

--- a/apps/docs/src/pages/services.md
+++ b/apps/docs/src/pages/services.md
@@ -1,10 +1,10 @@
 ---
-title: Vuetify Services - Hire the creator of v0
+title: Vuetify Services - Hire the creator of Vuetify0
 meta:
   - name: description
-    content: Hire the creator of v0. Subscribe for direct support, or hire him for a fixed-scope custom framework, app, or monorepo on Vuetify0.
+    content: Hire the creator of Vuetify0. Subscribe for direct support, or hire him for a fixed-scope custom framework, app, or monorepo on Vuetify0.
   - name: keywords
-    content: vuetify services, v0 services, hire vuetify, custom framework, custom app, vuetify monorepo, discord support
+    content: vuetify services, Vuetify0 services, hire vuetify, custom framework, custom app, vuetify monorepo, discord support
 features:
   level: 1
 related:
@@ -15,7 +15,7 @@ related:
 
 # Vuetify Services
 
-Hire the creator of v0. Subscribe for direct support, or hire me for a fixed-scope project — just one person, building software to keep v0 going.
+Hire the creator of Vuetify0. Subscribe for direct support, or hire me for a fixed-scope project — just one person, building software to keep Vuetify0 going.
 
 <DocsPageFeatures :frontmatter />
 
@@ -24,7 +24,7 @@ Hire the creator of v0. Subscribe for direct support, or hire me for a fixed-sco
 
 ## Direct Support {#support}
 
-Subscribe to a monthly support plan and get direct chat access. Same plans Vuetify sells for enterprise support — v0 questions land in the same channels.
+Subscribe to a monthly support plan and get direct chat access. Same plans Vuetify sells for enterprise support — Vuetify0 questions land in the same channels.
 
 <ServicesSupportTiers />
 
@@ -48,7 +48,7 @@ Fixed price, fixed scope. Three flavors covering most of what people ask for. AI
 
 ## Sponsor {#sponsor}
 
-Already built on v0 and want to fund the project directly? The Special Sponsor slot is for companies whose product depends on v0 as part of their infrastructure — one company at a time gets their logo across the docs, every page, and the README. Full details on the [sponsor page](/sponsor).
+Already built on Vuetify0 and want to fund the project directly? The Primary Sponsor slot is for companies whose product depends on Vuetify0 as part of their infrastructure — one company at a time gets their logo across the docs, every page, and the README. Full details on the [sponsor page](/sponsor).
 
 ::: sponsor
 :::

--- a/apps/docs/src/pages/services.md
+++ b/apps/docs/src/pages/services.md
@@ -48,7 +48,7 @@ Fixed price, fixed scope. Three flavors covering most of what people ask for. AI
 
 ## Sponsor {#sponsor}
 
-If you'd rather support v0 than buy from it, this is the highest-impact way to do it — direct brand visibility in exchange for funding the project.
+Already built on v0 and want to fund the project directly? The Special Sponsor slot is for companies whose product depends on v0 as part of their infrastructure — one company at a time gets their logo across the docs, every page, and the README. Full details on the [sponsor page](/sponsor).
 
 ::: sponsor
 :::

--- a/apps/docs/src/pages/sponsor.md
+++ b/apps/docs/src/pages/sponsor.md
@@ -1,0 +1,44 @@
+---
+title: Sponsor v0 - Become the Special Sponsor
+meta:
+- name: description
+  content: One sponsor at a time. $2,000/mo. Your logo across the v0 docs site and README, funding development of the AI-native headless framework for Vue.
+- name: keywords
+  content: vuetify sponsor, v0 sponsor, special sponsor, vue framework sponsor, open source funding
+features:
+  level: 1
+related:
+  - /services
+  - /introduction/why-vuetify0
+  - /roadmap
+---
+
+# Sponsor v0
+
+One special sponsor at a time. $2,000/mo gets your brand in front of every visitor to the v0 docs and every developer who reads the README.
+
+<DocsPageFeatures :frontmatter />
+
+<SponsorHero />
+
+## What you get
+
+<SponsorIncluded />
+
+## Why sponsor v0
+
+**For the company that's already built on v0.**
+
+The Special Sponsor slot isn't for companies looking for ad placement — v0 doesn't run ads, and there are no plans to. It's for the company whose product depends on v0 as part of its infrastructure: the team that ships against `@vuetify/v0` in production, files issues, and has a vested interest in the framework staying healthy and actively maintained.
+
+If that's you, sponsoring funds the OSS work directly and makes that dependency visible — to your engineering org, to prospective hires, and to other teams evaluating v0 for the same reasons you did.
+
+One slot at a time. Most teams using v0 don't need this; they need [Services](/services). The Special Sponsor slot is for the rare case where v0 is core to your product, and "we sponsor this" is a more accurate description of the relationship than "we use it."
+
+## Sponsorship vs. Services
+
+<SponsorComparison />
+
+## Become the sponsor
+
+<SponsorCta />

--- a/apps/docs/src/pages/sponsor.md
+++ b/apps/docs/src/pages/sponsor.md
@@ -1,10 +1,10 @@
 ---
-title: Sponsor v0 - Become the Special Sponsor
+title: Sponsor Vuetify0 - Become the Primary Sponsor
 meta:
 - name: description
-  content: One sponsor at a time. $2,000/mo. Your logo across the v0 docs site and README, funding development of the AI-native headless framework for Vue.
+  content: One sponsor at a time. $2,000/mo. Your logo across the Vuetify0 docs site and README, funding development of the AI-native headless framework for Vue.
 - name: keywords
-  content: vuetify sponsor, v0 sponsor, special sponsor, vue framework sponsor, open source funding
+  content: vuetify sponsor, Vuetify0 sponsor, primary sponsor, vue framework sponsor, open source funding
 features:
   level: 1
 related:
@@ -13,9 +13,9 @@ related:
   - /roadmap
 ---
 
-# Sponsor v0
+# Sponsor Vuetify0
 
-One special sponsor at a time. $2,000/mo gets your brand in front of every visitor to the v0 docs and every developer who reads the README.
+One primary sponsor at a time. A way for the company whose product depends on Vuetify0 to fund the project directly and have that relationship visible across the docs and the repo.
 
 <DocsPageFeatures :frontmatter />
 
@@ -25,20 +25,70 @@ One special sponsor at a time. $2,000/mo gets your brand in front of every visit
 
 <SponsorIncluded />
 
-## Why sponsor v0
+## Why sponsor Vuetify0
 
-**For the company that's already built on v0.**
+**For the company that's already built on Vuetify0.**
 
-The Special Sponsor slot isn't for companies looking for ad placement — v0 doesn't run ads, and there are no plans to. It's for the company whose product depends on v0 as part of its infrastructure: the team that ships against `@vuetify/v0` in production, files issues, and has a vested interest in the framework staying healthy and actively maintained.
+The Primary Sponsor slot isn't for companies looking for ad placement — Vuetify0 doesn't run ads, and there are no plans to. It's for the company whose product depends on Vuetify0 as part of its infrastructure: the team that ships against `@vuetify/v0` in production, files issues, and has a vested interest in the framework staying healthy and actively maintained.
 
-If that's you, sponsoring funds the OSS work directly and makes that dependency visible — to your engineering org, to prospective hires, and to other teams evaluating v0 for the same reasons you did.
+> [!NOTE]
+> Vuetify0 is the foundation for Vuetify 5 and the Paper design system family. Sponsoring Vuetify0 directly funds work that touches the entire ecosystem — not just the piece you're using today.
 
-One slot at a time. Most teams using v0 don't need this; they need [Services](/services). The Special Sponsor slot is for the rare case where v0 is core to your product, and "we sponsor this" is a more accurate description of the relationship than "we use it."
+If that's you, sponsoring funds the OSS work directly and makes that dependency visible — to your engineering org, to prospective hires, and to other teams evaluating Vuetify0 for the same reasons you did.
+
+One slot at a time. Most teams using Vuetify0 don't need this; they need [Services](/services). The Primary Sponsor slot is for the rare case where Vuetify0 is core to your product, and "we sponsor this" is a more accurate description of the relationship than "we use it."
+
+### For your management
+
+Forward this page to whoever signs the budget. The case in plain terms:
+
+- **Continuity.** You already depend on Vuetify0. A recurring sponsorship insulates your team from the common open-source failure modes — maintainer burnout, project stagnation, abrupt direction changes.
+- **Visibility.** Logo placement on the Vuetify0 docs reaches every engineer evaluating Vue infrastructure — the same audience as your recruiting pipeline.
+- **Simple accounting.** Single recurring charge through GitHub Sponsors. No procurement, no vendor onboarding. Books as a sponsorship line, not a software license.
+- **No lock-in.** Cancel anytime; the relationship reverts to standard MIT use of the framework, no contract obligation.
+
+## Where this fits
+
+Primary Sponsor is one piece of how Vuetify gets funded — not the only one. The project is MIT-licensed and free to use; the revenue streams below cover continued development, each targeting a different audience and budget.
 
 ## Sponsorship vs. Services
 
 <SponsorComparison />
 
-## Become the sponsor
+## FAQ
+
+::: faq single
+
+??? Is the slot exclusive?
+
+Yes — only one Primary Sponsor at a time. Your logo isn't competing with others, and competitor logos won't appear in the same surface area. If the slot is taken, ask to be next in line.
+
+??? When does my logo go live?
+
+Within 48 hours of subscribing, assuming you've already sent the logo and destination URL to john@vuetifyjs.com. If you want it timed to a launch or announcement, email first to coordinate.
+
+??? Can I update the logo or link later?
+
+Yes. Email john@vuetifyjs.com any time with a new logo file or destination URL — the change goes live within 48 hours.
+
+??? Do I get direct support too?
+
+No — the Primary Sponsor slot is visibility only. If you also want direct chat, code review, or fixed-scope builds, those are sold separately on the [Services](/services) page. You can stack a Services subscription with Primary Sponsor.
+
+??? How is this different from being a backer on GitHub Sponsors?
+
+GitHub Sponsors lets anyone contribute at any amount; backers appear in the supporter list on John's GitHub profile but get no surface placement. Primary Sponsor is the curated slot — one company at a time with prominent placement across the Vuetify0 docs and README.
+
+??? What happens if I cancel?
+
+Your logo comes down within 48 hours and the slot reopens for the next sponsor. No notice period, no contract obligation; the relationship reverts to standard MIT use of the framework.
+
+??? Do I get an invoice or receipt?
+
+GitHub Sponsors handles billing and issues monthly receipts under your GitHub organization. The line item appears on your GitHub Sponsors invoice — no separate vendor onboarding required.
+
+:::
+
+## Become the Primary Sponsor
 
 <SponsorCta />

--- a/apps/docs/src/typed-router.d.ts
+++ b/apps/docs/src/typed-router.d.ts
@@ -821,13 +821,6 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
-    '/genesis-sandbox': RouteRecordInfo<
-      '/genesis-sandbox',
-      '/genesis-sandbox',
-      Record<never, never>,
-      Record<never, never>,
-      | never
-    >,
     '/guide/': RouteRecordInfo<
       '/guide/',
       '/guide',
@@ -1092,6 +1085,13 @@ declare module 'vue-router/auto-routes' {
       '/skillz/:id',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
+      | never
+    >,
+    '/sponsor': RouteRecordInfo<
+      '/sponsor',
+      '/sponsor',
+      Record<never, never>,
+      Record<never, never>,
       | never
     >,
   }
@@ -1785,12 +1785,6 @@ declare module 'vue-router/auto-routes' {
       views:
         | never
     }
-    'src/pages/genesis-sandbox.vue': {
-      routes:
-        | '/genesis-sandbox'
-      views:
-        | never
-    }
     'src/pages/guide/index.md': {
       routes:
         | '/guide/'
@@ -2016,6 +2010,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/skillz.[id].vue': {
       routes:
         | '/skillz.[id]'
+      views:
+        | never
+    }
+    'src/pages/sponsor.md': {
+      routes:
+        | '/sponsor'
       views:
         | never
     }

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -30,9 +30,9 @@ Headless Vue 3 UI primitives and composables for building modern applications an
 
 > **Note:** This package is in early development (pre-1.0). APIs may change between minor versions.
 
-## Special Sponsor
+## Primary Sponsor
 
-This spot is open. v0 accepts one Special Sponsor at a time — $2,000/mo gets your logo on the v0 docs site (home page + desktop sidebar on every docs page) and this README. [Become the sponsor →](https://0.vuetifyjs.com/sponsor)
+This spot is open. Vuetify0 accepts one Primary Sponsor at a time — $2,000/mo gets your logo on the Vuetify0 docs site (home page + desktop sidebar on every docs page) and this README. [Become the Primary Sponsor →](https://0.vuetifyjs.com/sponsor)
 
 ## Repository Structure
 
@@ -298,7 +298,7 @@ pnpm validate
 
 ## Contributing
 
-v0 is in alpha — open for feedback, bug reports, and contributions. See the [Alpha Roadmap](https://0.vuetifyjs.com/roadmap#alpha) for what's planned and how to get involved.
+Vuetify0 is in alpha — open for feedback, bug reports, and contributions. See the [Alpha Roadmap](https://0.vuetifyjs.com/roadmap#alpha) for what's planned and how to get involved.
 
 ## License
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -32,7 +32,7 @@ Headless Vue 3 UI primitives and composables for building modern applications an
 
 ## Special Sponsor
 
-This spot is open. v0 accepts one Special Sponsor at a time — $2,000/mo gets your logo on the docs home page, every docs page, this README, and the dedicated sponsor page. [Become the sponsor →](https://0.vuetifyjs.com/sponsor)
+This spot is open. v0 accepts one Special Sponsor at a time — $2,000/mo gets your logo on the v0 docs site (home page + desktop sidebar on every docs page) and this README. [Become the sponsor →](https://0.vuetifyjs.com/sponsor)
 
 ## Repository Structure
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -30,6 +30,10 @@ Headless Vue 3 UI primitives and composables for building modern applications an
 
 > **Note:** This package is in early development (pre-1.0). APIs may change between minor versions.
 
+## Special Sponsor
+
+This spot is open. v0 accepts one Special Sponsor at a time — $2,000/mo gets your logo on the docs home page, every docs page, this README, and the dedicated sponsor page. [Become the sponsor →](https://0.vuetifyjs.com/sponsor)
+
 ## Repository Structure
 
 This is a **pnpm monorepo** containing:


### PR DESCRIPTION
## Summary

- Adds Special Sponsor program: home page band, every-page TOC slot, dedicated `/sponsor` page, README entries on root and `packages/0`
- All surfaces driven by single typed constant `SPECIAL_SPONSOR` in `apps/docs/src/constants/sponsor.ts` — flipping to a signed sponsor is a one-line edit
- Rewrites `DocsSponsor.vue` from the $1,500 ecosystem-sponsor pitch into a $2,000 Special Sponsor teaser routing to `/sponsor` (the directive is reused on `services.md`, `roadmap.md`, `introduction/why-vuetify0.md`, `introduction/frequently-asked.md`)
- Reframes `/services` sponsor intro around infra-dependency targeting

## Positioning

The Special Sponsor slot is intentionally narrow: one sponsor at a time, $2,000/mo, for the company whose product is **built on v0 as core infrastructure**. Most teams using v0 are steered to [Services](https://0.vuetifyjs.com/services) instead (Galaxy/Cosmic/Multiverse subscriptions + project builds). The slot is brand visibility only — no support perks bleed into Services territory. v0 docs do not, and will not, run ads.

## Follow-up

Once the dedicated $2,000 tier is created on github.com/sponsors/johnleider, swap `SPECIAL_SPONSOR_TIER_URL` in `apps/docs/src/constants/sponsor.ts` to the deep link (`.../sponsorships?tier_id=XXX`).