### PR TITLE
docs: beta.0 launch-readiness pass

### DIFF
--- a/apps/docs/build/generate-api-whitelist.ts
+++ b/apps/docs/build/generate-api-whitelist.ts
@@ -20,7 +20,33 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '../../..')
 const COMPONENTS_DIR = resolve(ROOT, 'packages/0/src/components')
 const COMPOSABLES_DIR = resolve(ROOT, 'packages/0/src/composables')
+const COMPOSABLES_BARREL = resolve(COMPOSABLES_DIR, 'index.ts')
 const OUTPUT_FILE = resolve(__dirname, 'generated/api-whitelist.ts')
+
+/**
+ * Read the public composable surface from the barrel (index.ts).
+ *
+ * The whitelist must mirror the public API, not the filesystem. Internal-only
+ * composables (e.g., createFocusTraversal, createObserver) live in their own
+ * directories but are never re-exported, so they must not leak into the
+ * whitelist. The barrel is the single source of truth for what's public:
+ * every line is `export * from './<dirName>'`, and the directory name is the
+ * API cache key. Filtering discovery against this set keeps the whitelist in
+ * lockstep with the barrel — a new internal composable is excluded
+ * automatically, with no blocklist to maintain.
+ */
+async function getPublicComposableDirs (): Promise<Set<string>> {
+  const content = await readFile(COMPOSABLES_BARREL, 'utf8')
+  const dirs = new Set<string>()
+
+  // Matches: export * from './createSelection'
+  const reexports = content.matchAll(/export\s+\*\s+from\s+'\.\/([^']+)'/g)
+  for (const match of reexports) {
+    dirs.add(match[1])
+  }
+
+  return dirs
+}
 
 /**
  * Discover component directory names (e.g., Avatar, Popover, Dialog)
@@ -56,7 +82,10 @@ async function getComposableData (): Promise<{
 }> {
   const names = new Set<string>()
   const toDir: Record<string, string> = {}
-  const dirs = await readdir(COMPOSABLES_DIR)
+  const [dirs, publicDirs] = await Promise.all([
+    readdir(COMPOSABLES_DIR),
+    getPublicComposableDirs(),
+  ])
 
   // Pattern for composable function names we care about
   const COMPOSABLE_PATTERN = /^(use|create|to|provide)[A-Z]/
@@ -64,6 +93,10 @@ async function getComposableData (): Promise<{
   for (const dir of dirs) {
     // Composable directories start with 'use', 'create', or 'to'
     if (!dir.startsWith('use') && !dir.startsWith('create') && !dir.startsWith('to')) continue
+
+    // Only public composables (re-exported from the barrel) belong in the
+    // whitelist. Internal-only directories are skipped.
+    if (!publicDirs.has(dir)) continue
 
     const indexPath = resolve(COMPOSABLES_DIR, dir, 'index.ts')
     const content = await readFile(indexPath, 'utf8').catch(() => null)

--- a/apps/docs/src/examples/components/collapsible/controlled.vue
+++ b/apps/docs/src/examples/components/collapsible/controlled.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Collapsible } from '@vuetify/v0'
+  import { Button, Collapsible, Switch } from '@vuetify/v0'
   import { shallowRef } from 'vue'
 
   const open = shallowRef(false)
@@ -9,29 +9,41 @@
 <template>
   <div class="flex flex-col gap-4">
     <div class="flex items-center gap-2 flex-wrap">
-      <button
+      <Button.Root
         class="px-3 py-1.5 text-sm rounded-lg border border-divider hover:bg-surface-tint"
         @click="open = true"
       >
         Open
-      </button>
+      </Button.Root>
 
-      <button
+      <Button.Root
         class="px-3 py-1.5 text-sm rounded-lg border border-divider hover:bg-surface-tint"
         @click="open = false"
       >
         Close
-      </button>
+      </Button.Root>
 
-      <button
+      <Button.Root
         class="px-3 py-1.5 text-sm rounded-lg border border-divider hover:bg-surface-tint"
         @click="open = !open"
       >
         Toggle
-      </button>
+      </Button.Root>
 
-      <label class="flex items-center gap-1.5 text-sm text-on-surface-variant ml-auto">
-        <input v-model="disabled" type="checkbox">
+      <label class="flex items-center gap-1.5 text-sm text-on-surface-variant ml-auto cursor-pointer">
+        <Switch.Root
+          v-model="disabled"
+          class="inline-flex items-center border-none bg-transparent p-0 outline-none"
+        >
+          <Switch.Track
+            class="relative inline-flex items-center w-9 h-5 rounded-full bg-surface-variant transition-colors data-[state=checked]:bg-primary"
+          >
+            <Switch.Thumb
+              class="![visibility:visible] block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.75 data-[state=checked]:translate-x-4.25"
+            />
+          </Switch.Track>
+        </Switch.Root>
+
         Disabled
       </label>
     </div>

--- a/apps/docs/src/examples/components/combobox/disabled.vue
+++ b/apps/docs/src/examples/components/combobox/disabled.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Combobox } from '@vuetify/v0'
+  import { Combobox, Switch } from '@vuetify/v0'
   import { shallowRef } from 'vue'
 
   const selected = shallowRef<string>()
@@ -15,8 +15,20 @@
 
 <template>
   <div class="flex flex-col gap-4 max-w-xs mx-auto">
-    <label class="flex items-center gap-2 text-sm text-on-surface">
-      <input v-model="disabled" type="checkbox">
+    <label class="flex items-center gap-2 text-sm text-on-surface cursor-pointer">
+      <Switch.Root
+        v-model="disabled"
+        class="inline-flex items-center border-none bg-transparent p-0 outline-none"
+      >
+        <Switch.Track
+          class="relative inline-flex items-center w-11 h-6 rounded-full bg-surface-variant transition-colors data-[state=checked]:bg-primary"
+        >
+          <Switch.Thumb
+            class="![visibility:visible] block size-4 rounded-full bg-white shadow-sm transition-transform translate-x-1 data-[state=checked]:translate-x-6"
+          />
+        </Switch.Track>
+      </Switch.Root>
+
       Disable entire combobox
     </label>
 

--- a/apps/docs/src/examples/components/input/ContactForm.vue
+++ b/apps/docs/src/examples/components/input/ContactForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Input } from '@vuetify/v0'
+  import { Form, Input } from '@vuetify/v0'
 
   const {
     serverError,
@@ -7,7 +7,7 @@
     reset,
   } = defineProps<{
     serverError?: string
-    submit: () => Promise<void>
+    submit: (valid: boolean) => void
     reset: () => void
   }>()
 
@@ -16,12 +16,17 @@
   const message = defineModel<string>('message', { default: '' })
 
   const input = 'w-full px-3 py-2 rounded-lg border border-divider bg-surface text-on-surface placeholder:text-on-surface-variant/50 outline-none data-[focused]:border-primary data-[state=invalid]:border-error transition-colors'
+
+  function onSubmit (payload: { valid: boolean }) {
+    submit(payload.valid)
+  }
 </script>
 
 <template>
-  <form
+  <Form
     class="flex flex-col gap-4"
-    @submit.prevent="submit"
+    @reset="reset"
+    @submit="onSubmit"
   >
     <Input.Root
       v-model="name"
@@ -91,11 +96,10 @@
 
       <button
         class="px-4 py-2 rounded-lg border border-divider text-on-surface text-sm"
-        type="button"
-        @click="reset"
+        type="reset"
       >
         Reset
       </button>
     </div>
-  </form>
+  </Form>
 </template>

--- a/apps/docs/src/examples/components/input/contact-form.vue
+++ b/apps/docs/src/examples/components/input/contact-form.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+  import { Button } from '@vuetify/v0'
   import ContactForm from './ContactForm.vue'
   import { useContact } from './useContact'
 
-  const { name, email, message, submitted, serverError, submit, reset } = useContact()
+  const { name, email, message, submitted, serverError, onSubmit, reset } = useContact()
 </script>
 
 <template>
@@ -12,12 +13,12 @@
       <p class="text-sm">{{ submitted.name }} &lt;{{ submitted.email }}&gt;</p>
       <p class="text-sm text-on-surface-variant">{{ submitted.message }}</p>
 
-      <button
+      <Button.Root
         class="self-start mt-2 px-3 py-1 rounded-lg border border-divider text-sm"
         @click="reset"
       >
         Start over
-      </button>
+      </Button.Root>
     </div>
 
     <ContactForm
@@ -27,7 +28,7 @@
       v-model:name="name"
       :reset
       :server-error
-      :submit
+      :submit="onSubmit"
     />
 
     <p class="mt-3 text-xs text-on-surface-variant">

--- a/apps/docs/src/examples/components/input/useContact.ts
+++ b/apps/docs/src/examples/components/input/useContact.ts
@@ -1,4 +1,3 @@
-import { createForm } from '@vuetify/v0'
 import { ref, shallowRef } from 'vue'
 
 export interface ContactData {
@@ -8,16 +7,14 @@ export interface ContactData {
 }
 
 export function useContact () {
-  const form = createForm()
   const name = ref('')
   const email = ref('')
   const message = ref('')
   const submitted = shallowRef<ContactData>()
   const serverError = shallowRef<string>()
 
-  async function submit () {
+  function onSubmit (valid: boolean) {
     serverError.value = undefined
-    const valid = await form.submit()
 
     if (!valid) return
 
@@ -35,7 +32,6 @@ export function useContact () {
   }
 
   function reset () {
-    form.reset()
     name.value = ''
     email.value = ''
     message.value = ''
@@ -43,5 +39,5 @@ export function useContact () {
     serverError.value = undefined
   }
 
-  return { form, name, email, message, submitted, serverError, submit, reset }
+  return { name, email, message, submitted, serverError, onSubmit, reset }
 }

--- a/apps/docs/src/examples/components/select/disabled.vue
+++ b/apps/docs/src/examples/components/select/disabled.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Select } from '@vuetify/v0'
+  import { Select, Switch } from '@vuetify/v0'
   import { shallowRef } from 'vue'
 
   const size = shallowRef<string>()
@@ -16,8 +16,20 @@
 
 <template>
   <div class="flex flex-col gap-4 max-w-xs mx-auto">
-    <label class="flex items-center gap-2 text-sm text-on-surface">
-      <input v-model="disabled" type="checkbox">
+    <label class="flex items-center gap-2 text-sm text-on-surface cursor-pointer">
+      <Switch.Root
+        v-model="disabled"
+        class="inline-flex items-center border-none bg-transparent p-0 outline-none"
+      >
+        <Switch.Track
+          class="relative inline-flex items-center w-11 h-6 rounded-full bg-surface-variant transition-colors data-[state=checked]:bg-primary"
+        >
+          <Switch.Thumb
+            class="![visibility:visible] block size-4 rounded-full bg-white shadow-sm transition-transform translate-x-1 data-[state=checked]:translate-x-6"
+          />
+        </Switch.Track>
+      </Switch.Root>
+
       Disable entire select
     </label>
 

--- a/apps/docs/src/examples/components/step/basic.vue
+++ b/apps/docs/src/examples/components/step/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Step } from '@vuetify/v0'
+  import { Button, Step } from '@vuetify/v0'
   import { shallowRef } from 'vue'
 
   const current = shallowRef(1)
@@ -18,8 +18,8 @@
       </Step.Item>
 
       <div class="flex gap-2">
-        <button class="px-4 py-1 border border-divider rounded" @click="prev">Previous</button>
-        <button class="px-4 py-1 rounded bg-primary text-on-primary" @click="next">Next</button>
+        <Button.Root class="px-4 py-1 border border-divider rounded" @click="prev">Previous</Button.Root>
+        <Button.Root class="px-4 py-1 rounded bg-primary text-on-primary" @click="next">Next</Button.Root>
       </div>
     </template>
   </Step.Root>

--- a/apps/docs/src/examples/composables/create-plugin/DashboardConsumer.vue
+++ b/apps/docs/src/examples/composables/create-plugin/DashboardConsumer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Switch } from '@vuetify/v0'
+  import { Button, Switch } from '@vuetify/v0'
   import { toRef } from 'vue'
   import { useDashboard } from './plugin'
 
@@ -18,19 +18,19 @@
       </div>
 
       <div class="flex gap-1.5">
-        <button
+        <Button.Root
           class="px-2 py-1 text-xs rounded-md border border-divider text-on-surface-variant hover:text-on-surface hover:bg-surface-tint transition-colors"
           @click="group.selectAll()"
         >
           Enable all
-        </button>
+        </Button.Root>
 
-        <button
+        <Button.Root
           class="px-2 py-1 text-xs rounded-md border border-divider text-on-surface-variant hover:text-on-surface hover:bg-surface-tint transition-colors"
           @click="group.unselectAll()"
         >
           Disable all
-        </button>
+        </Button.Root>
       </div>
     </div>
 
@@ -39,7 +39,7 @@
       <label class="block text-xs font-medium text-on-surface-variant mb-1.5">Locale</label>
 
       <div class="flex flex-wrap gap-1.5">
-        <button
+        <Button.Root
           v-for="loc in locales"
           :key="loc.code"
           class="px-2.5 py-1 text-xs rounded-md border transition-all"
@@ -49,13 +49,13 @@
           @click="locale = loc.code"
         >
           {{ loc.label }}
-        </button>
+        </Button.Root>
       </div>
     </div>
 
     <!-- Feature toggles -->
     <div class="space-y-1">
-      <button
+      <Button.Root
         v-for="ticket in tickets"
         :key="ticket.id"
         class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-all"
@@ -80,7 +80,7 @@
             />
           </Switch.Track>
         </Switch.Root>
-      </button>
+      </Button.Root>
     </div>
 
     <!-- Live preview -->

--- a/apps/docs/src/examples/composables/create-selection/file-picker.vue
+++ b/apps/docs/src/examples/composables/create-selection/file-picker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { createSelection } from '@vuetify/v0'
+  import { Button, createSelection } from '@vuetify/v0'
   import { computed } from 'vue'
 
   const files = [
@@ -36,18 +36,18 @@
         {{ selection.selectedIds.size }} selected
       </span>
 
-      <button
+      <Button.Root
         class="text-xs px-2 py-1 rounded border border-divider text-on-surface-variant hover:bg-surface-tint transition-colors disabled:opacity-40"
         :disabled="selection.selectedIds.size === 0"
         @click="selection.reset()"
       >
         Clear
-      </button>
+      </Button.Root>
     </div>
 
     <!-- File list -->
     <div class="border border-divider rounded-lg overflow-hidden divide-y divide-divider">
-      <button
+      <Button.Root
         v-for="ticket in tickets"
         :key="ticket.id"
         class="w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors"
@@ -86,7 +86,7 @@
 
         <!-- Size -->
         <span class="text-xs text-on-surface-variant">{{ ticket.value.size }}</span>
-      </button>
+      </Button.Root>
     </div>
 
     <!-- Status -->
@@ -94,9 +94,9 @@
       Selected: {{ totalSize }}
       <span v-if="selection.selectedIds.size > 0">
         &middot;
-        <button class="text-primary hover:underline" @click="selection.reset()">
+        <Button.Root class="text-primary hover:underline" @click="selection.reset()">
           Deselect all
-        </button>
+        </Button.Root>
       </span>
     </p>
   </div>

--- a/apps/docs/src/examples/composables/create-virtual/basic.vue
+++ b/apps/docs/src/examples/composables/create-virtual/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { createVirtual } from '@vuetify/v0'
+  import { Button, createVirtual } from '@vuetify/v0'
   import { computed, shallowRef } from 'vue'
 
   const items = shallowRef(
@@ -55,13 +55,13 @@
         @keyup.enter="onJumpTo"
       >
 
-      <button class="px-3 py-1 border border-divider rounded hover:bg-surface-tint" @click="onJumpTo">
+      <Button.Root class="px-3 py-1 border border-divider rounded hover:bg-surface-tint" @click="onJumpTo">
         Jump
-      </button>
+      </Button.Root>
 
-      <button class="px-3 py-1 border border-divider rounded hover:bg-surface-tint" @click="addItems">
+      <Button.Root class="px-3 py-1 border border-divider rounded hover:bg-surface-tint" @click="addItems">
         Add 100
-      </button>
+      </Button.Root>
 
       <span class="text-on-surface opacity-60 ml-auto">
         {{ stats.rendered }} (rendered) / {{ stats.total }}

--- a/apps/docs/src/examples/composables/use-click-outside/basic.vue
+++ b/apps/docs/src/examples/composables/use-click-outside/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useClickOutside } from '@vuetify/v0'
+  import { Button, useClickOutside } from '@vuetify/v0'
   import { shallowRef, useTemplateRef } from 'vue'
 
   const isOpen = shallowRef(false)
@@ -12,28 +12,28 @@
 
 <template>
   <div ref="menu" class="inline-block relative">
-    <button
+    <Button.Root
       class="px-4 py-2 bg-primary text-on-primary rounded"
       @click="isOpen = !isOpen"
     >
       {{ isOpen ? 'Close' : 'Open' }} Menu
-    </button>
+    </Button.Root>
 
     <div
       v-if="isOpen"
       class="mt-2 w-48 py-2 bg-surface border border-divider rounded shadow-lg"
     >
-      <button class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
+      <Button.Root class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
         Profile
-      </button>
+      </Button.Root>
 
-      <button class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
+      <Button.Root class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
         Settings
-      </button>
+      </Button.Root>
 
-      <button class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
+      <Button.Root class="w-full text-left px-4 py-2 text-sm hover:bg-surface-tint">
         Sign out
-      </button>
+      </Button.Root>
     </div>
   </div>
 </template>

--- a/apps/docs/src/examples/composables/use-notifications/NotificationProvider.vue
+++ b/apps/docs/src/examples/composables/use-notifications/NotificationProvider.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { computed, shallowRef } from 'vue'
   import { mdiClose, mdiArchiveOutline, mdiClockOutline, mdiBellOutline } from '@mdi/js'
-  import { Snackbar, useProxyRegistry } from '@vuetify/v0'
+  import { Button, Snackbar, useProxyRegistry } from '@vuetify/v0'
   import { createAppNotifications, provideNotifications } from './context'
   import type { NotificationTicket } from '@vuetify/v0'
 
@@ -83,7 +83,7 @@
 
       <!-- Inbox bell -->
       <div class="relative">
-        <button
+        <Button.Root
           class="px-3 py-1.5 bg-surface border border-divider rounded text-sm flex items-center gap-1.5"
           @click="onToggle"
         >
@@ -96,7 +96,7 @@
           >
             {{ unread.length }}
           </span>
-        </button>
+        </Button.Root>
       </div>
     </div>
 
@@ -108,9 +108,9 @@
     >
       <span class="flex-1">{{ banner.subject }}</span>
 
-      <button class="p-1 -mr-1 opacity-70 hover:opacity-100" @click.stop="notifications.unregister(banner.id)">
+      <Button.Root aria-label="Dismiss" class="p-1 -mr-1 opacity-70 hover:opacity-100" @click.stop="notifications.unregister(banner.id)">
         <svg class="w-4 h-4 pointer-events-none" viewBox="0 0 24 24"><path :d="mdiClose" fill="currentColor" /></svg>
-      </button>
+      </Button.Root>
     </div>
 
     <!-- Content area -->
@@ -131,16 +131,16 @@
       >
         <span class="flex-1">{{ ticket.subject }}</span>
 
-        <button class="p-1 -mr-1 opacity-50 hover:opacity-100" @click.stop="notifications.unregister(ticket.id)">
+        <Button.Root aria-label="Dismiss" class="p-1 -mr-1 opacity-50 hover:opacity-100" @click.stop="notifications.unregister(ticket.id)">
           <svg class="w-3.5 h-3.5 pointer-events-none" viewBox="0 0 24 24"><path :d="mdiClose" fill="currentColor" /></svg>
-        </button>
+        </Button.Root>
       </div>
     </div>
 
     <!-- Inbox panel -->
     <div v-if="open" class="border border-divider rounded-lg overflow-hidden bg-surface">
       <div class="flex border-b border-divider text-sm">
-        <button
+        <Button.Root
           v-for="t in (['unread', 'all', 'archived'] as const)"
           :key="t"
           class="flex-1 px-4 py-2 capitalize"
@@ -150,7 +150,7 @@
           {{ t }}
           <span v-if="t === 'unread' && unread.length > 0" class="ml-1 opacity-60">({{ unread.length }})</span>
           <span v-if="t === 'archived' && archived.length > 0" class="ml-1 opacity-60">({{ archived.length }})</span>
-        </button>
+        </Button.Root>
       </div>
 
       <div class="max-h-64 overflow-y-auto">
@@ -178,23 +178,23 @@
             <p v-if="ticket.body" class="text-xs opacity-60 mt-0.5 truncate">{{ ticket.body }}</p>
 
             <div class="flex gap-2 mt-1.5">
-              <button class="text-xs text-primary" @click="ticket.readAt ? ticket.unread() : ticket.read()">
+              <Button.Root class="text-xs text-primary" @click="ticket.readAt ? ticket.unread() : ticket.read()">
                 {{ ticket.readAt ? 'Mark unread' : 'Mark read' }}
-              </button>
+              </Button.Root>
 
-              <button class="text-xs opacity-40 flex items-center gap-0.5" @click="ticket.archivedAt ? ticket.unarchive() : ticket.archive()">
+              <Button.Root class="text-xs opacity-40 flex items-center gap-0.5" @click="ticket.archivedAt ? ticket.unarchive() : ticket.archive()">
                 <svg class="w-3 h-3" viewBox="0 0 24 24"><path :d="mdiArchiveOutline" fill="currentColor" /></svg>
                 {{ ticket.archivedAt ? 'Unarchive' : 'Archive' }}
-              </button>
+              </Button.Root>
 
-              <button
+              <Button.Root
                 v-if="!ticket.snoozedUntil"
                 class="text-xs opacity-40 flex items-center gap-0.5"
                 @click="onSnooze(ticket)"
               >
                 <svg class="w-3 h-3" viewBox="0 0 24 24"><path :d="mdiClockOutline" fill="currentColor" /></svg>
                 Snooze
-              </button>
+              </Button.Root>
 
               <span v-else class="text-xs opacity-40">Snoozed</span>
             </div>
@@ -207,8 +207,8 @@
       </div>
 
       <div v-if="inbox.length > 0" class="flex justify-between px-4 py-2 border-t border-divider text-xs">
-        <button class="text-primary" @click="notifications.readAll()">Mark all read</button>
-        <button class="opacity-40" @click="notifications.archiveAll()">Archive all</button>
+        <Button.Root class="text-primary" @click="notifications.readAll()">Mark all read</Button.Root>
+        <Button.Root class="opacity-40" @click="notifications.archiveAll()">Archive all</Button.Root>
       </div>
     </div>
 

--- a/apps/docs/src/examples/composables/use-rtl/direction-toggle.vue
+++ b/apps/docs/src/examples/composables/use-rtl/direction-toggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useRtl } from '@vuetify/v0'
+  import { Button, useRtl } from '@vuetify/v0'
   import { toRef } from 'vue'
 
   const { isRtl, toggle } = useRtl()
@@ -10,7 +10,7 @@
 <template>
   <div class="flex flex-col gap-6">
     <div class="flex items-center gap-3">
-      <button
+      <Button.Root
         class="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium text-sm"
         @click="toggle"
       >
@@ -18,7 +18,7 @@
           <span class="i-lucide-arrow-left-right" />
           Switch to {{ isRtl ? 'LTR' : 'RTL' }}
         </span>
-      </button>
+      </Button.Root>
 
       <span class="px-3 py-1 rounded-full bg-surface-variant text-on-surface-variant text-xs font-mono uppercase">
         {{ direction }}
@@ -50,13 +50,13 @@
       </p>
 
       <div class="flex gap-2">
-        <button class="px-3 py-1.5 rounded bg-primary text-on-primary text-sm">
+        <Button.Root class="px-3 py-1.5 rounded bg-primary text-on-primary text-sm">
           {{ isRtl ? 'إرسال' : 'Send' }}
-        </button>
+        </Button.Root>
 
-        <button class="px-3 py-1.5 rounded bg-surface-variant text-on-surface-variant text-sm">
+        <Button.Root class="px-3 py-1.5 rounded bg-surface-variant text-on-surface-variant text-sm">
           {{ isRtl ? 'إلغاء' : 'Cancel' }}
-        </button>
+        </Button.Root>
       </div>
     </div>
 

--- a/apps/docs/src/pages/components/forms/combobox.md
+++ b/apps/docs/src/pages/components/forms/combobox.md
@@ -197,7 +197,7 @@ Style interactive states without slot props:
 
 ## Accessibility
 
-The Combobox implements the [WAI-ARIA Combobox](https://www.w3.org/WAI/ARIA/apd/patterns/combobox/) pattern with a listbox popup.
+The Combobox implements the [WAI-ARIA Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) pattern with a listbox popup.
 
 ### ARIA Attributes
 

--- a/apps/docs/src/pages/components/forms/select.md
+++ b/apps/docs/src/pages/components/forms/select.md
@@ -230,7 +230,7 @@ Style interactive states without slot props:
 
 ## Accessibility
 
-The Select implements the [WAI-ARIA Combobox](https://www.w3.org/WAI/ARIA/apd/patterns/combobox/) pattern with a listbox popup.
+The Select implements the [WAI-ARIA Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) pattern with a listbox popup.
 
 ### ARIA Attributes
 

--- a/apps/docs/src/pages/components/index.md
+++ b/apps/docs/src/pages/components/index.md
@@ -81,7 +81,7 @@ Components with meaningful HTML defaults. Render semantic elements by default bu
 | [Image](/components/semantic/image) | Image with placeholder, error fallback, and lazy loading |
 | [Overflow](/components/semantic/overflow) | Responsive truncation primitive |
 | [Pagination](/components/semantic/pagination) | Page navigation with semantic `<nav>` wrapper |
-| [Progress](/components/semantic/progress/) | Headless progress bar with multi-segment and buffer support |
+| [Progress](/components/semantic/progress) | Headless progress bar with multi-segment and buffer support |
 | [Snackbar](/components/semantic/snackbar) | Toast notification with queue, positioning, and auto-dismiss |
 | [Splitter](/components/semantic/splitter) | Resizable panel layout with drag handles |
 

--- a/apps/docs/src/pages/components/semantic/pagination.md
+++ b/apps/docs/src/pages/components/semantic/pagination.md
@@ -13,7 +13,7 @@ features:
   level: 2
 related:
   - /composables/data/create-pagination
-  - /composables/utilities/create-overflow
+  - /composables/semantic/create-overflow
 ---
 
 # Pagination

--- a/apps/docs/src/pages/composables/index.md
+++ b/apps/docs/src/pages/composables/index.md
@@ -245,6 +245,7 @@ Form state management and model binding utilities.
 | [createForm](/composables/forms/create-form) | Form validation coordinator |
 | [createInput](/composables/forms/create-input) | Shared form field primitive: validation, field state, ARIA IDs |
 | [createNumberField](/composables/forms/create-number-field) | Numeric input state with formatting, parsing, and validation |
+| [createNumeric](/composables/forms/create-numeric) | Pure numeric math: clamp, snap, step, percentage, and circular wrapping |
 | [createOtp](/composables/forms/create-otp) | OTP / verification code state with pattern-gated entry and decisional completion hook |
 | [createRating](/composables/forms/create-rating) | Bounded rating value with discrete items and half-step support |
 | [createSlider](/composables/forms/create-slider) | Slider state with multi-thumb support, step snapping, and value math |
@@ -325,7 +326,7 @@ Composables for presentational and semantic components.
 | - | - |
 | [createBreadcrumbs](/composables/semantic/create-breadcrumbs) | Breadcrumb navigation with path truncation |
 | [createOverflow](/composables/semantic/create-overflow) | Compute item capacity for responsive truncation |
-| [createProgress](/composables/semantic/create-progress/) | Progress tracking with multi-segment registration |
+| [createProgress](/composables/semantic/create-progress) | Progress tracking with multi-segment registration |
 
 ## Transformers
 

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -50,7 +50,7 @@ For new features:
 
 ### Prerequisites
 
-- Node.js 20.19+ or 22+
+- Node 26+ (matches .nvmrc)
 - pnpm 10.6+
 - Git
 

--- a/apps/docs/src/pages/introduction/frequently-asked.md
+++ b/apps/docs/src/pages/introduction/frequently-asked.md
@@ -24,7 +24,7 @@ Have a question that isn't answered here? Try [Ask AI](/guide/essentials/using-t
 ::: faq
 ??? What is Vuetify0?
 
-Vuetify0 is a collection of headless UI primitives and composables for Vue 3. It provides unstyled, logic-focused building blocks that handle accessibility, keyboard navigation, and state management while giving you complete control over styling. The library includes 35+ composables covering everything from selection patterns to form validation, plus ready-to-use headless components like Dialog, Tabs, and ExpansionPanel. Get started instantly with `pnpm create vuetify0`.
+Vuetify0 is a collection of headless UI primitives and composables for Vue 3. It provides unstyled, logic-focused building blocks that handle accessibility, keyboard navigation, and state management while giving you complete control over styling. The library includes 70 composables covering everything from selection patterns to form validation, plus ready-to-use headless components like Dialog, Tabs, and ExpansionPanel. Get started instantly with `pnpm create vuetify0`.
 
 ??? How is Vuetify0 different from Vuetify?
 

--- a/apps/docs/src/pages/introduction/why-vuetify0.md
+++ b/apps/docs/src/pages/introduction/why-vuetify0.md
@@ -23,7 +23,7 @@ The meta-framework for building UI libraries.
 
 <DocsPageFeatures :frontmatter />
 
-v0 provides headless composables, unstyled components, and reactive primitives — the foundation layer that UI frameworks are built on. **46 components, 63+ composables** — all unstyled, all accessible, built on standard Vue SFCs using the latest macros (`defineModel`, `defineSlots`, generics).
+v0 provides headless composables, unstyled components, and reactive primitives — the foundation layer that UI frameworks are built on. **39 components, 70 composables** — all unstyled, all accessible, built on standard Vue SFCs using the latest macros (`defineModel`, `defineSlots`, generics).
 
 No custom compiler, no proprietary patterns. Use it to build a full design system shared across projects, or import a single composable to solve one problem in your app. v0 scales to your ambition.
 

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -2,9 +2,9 @@
 title: Roadmap - Vuetify0 Development Timeline
 meta:
   - name: description
-    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 enters alpha on April 7, 2026.
+    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 is in beta following its April 7, 2026 alpha.
   - name: keywords
-    content: vuetify0, roadmap, alpha, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
+    content: vuetify0, roadmap, beta, alpha, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
 features:
   level: 1
 related:
@@ -26,27 +26,27 @@ Track the development of @vuetify/v0. Milestones are organized by time horizon:
 
 > [!NOTE] Want to help shape the future of this project? [Become a Founder Supporter](mailto:john@vuetifyjs.com?subject=Founder%20Supporter%20Inquiry) and gain a guiding voice in what we build next.
 
-## Alpha
+## Beta
 
-**Launching April 7, 2026.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
+**Now in beta.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
 
-We're opening v0 for feedback, bug reports, and contributions. Your input shapes what gets locked in for v1.
+Alpha opened on April 7, 2026 for feedback, bug reports, and contributions. With beta, the focus shifts to stability and locking in the APIs for v1.
 
 ### Road to v1
 
 <DocsTimeline :milestones="[
-  { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Open for feedback, bug reports, and contributions. APIs mostly stable, may evolve.', active: true },
-  { id: 'beta', label: 'Beta', date: 'June 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
+  { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Opened for feedback, bug reports, and contributions. APIs mostly stable, may evolve.' },
+  { id: 'beta', label: 'Beta', date: 'June 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.', active: true },
   { id: 'v1', label: 'v1.0', date: 'July 2026', description: 'Milestone-driven. Ships when the milestones are met.' },
 ]" />
 
-### What alpha means
+### What beta means
 
 This isn't a proof of concept. v0 is feature-complete enough to build with and evaluate seriously.
 
-- **APIs are mostly stable.** They may evolve based on community feedback, but the foundation is solid.
+- **APIs are freezing.** The foundation is solid and the surface is settling as we lock things in for v1.
 - **v0 is being built directly into Vuetify.** The composables and patterns here are the same ones powering Vuetify's next generation. This isn't a side project — it's the core.
-- **Your feedback matters now.** Alpha is when design decisions are still open. Once we hit beta, APIs freeze. If something feels wrong, this is the time to say so.
+- **Your feedback still matters.** Alpha was when design decisions were wide open; beta is the last window to flag anything before APIs lock for v1. If something feels wrong, this is the time to say so.
 
 ### Try v0
 
@@ -84,7 +84,7 @@ Whether you want to explore in the browser, scaffold a project, or integrate wit
 </div>
 
 > [!TIP]
-> Want a complete working reference? [DevKey](/guide/integration/devkey) is the example project shipped with Alpha — a full Vue 3 + Vite + UnoCSS app built on `@vuetify/v0`. Clone it, or run `pnpm create vuetify0` to scaffold your own copy.
+> Want a complete working reference? [DevKey](/guide/integration/devkey) is the example project that ships with v0 — a full Vue 3 + Vite + UnoCSS app built on `@vuetify/v0`. Clone it, or run `pnpm create vuetify0` to scaffold your own copy.
 
 ### Get involved
 
@@ -111,11 +111,11 @@ v0 is the foundation layer being built directly into Vuetify's next generation. 
 
 ??? Can I use v0 in production?
 
-Yes, with the understanding that APIs may evolve during alpha. The core is solid and is already being used to build Vuetify itself. If you're comfortable with occasional minor adjustments as things stabilize, v0 is ready to build with.
+Yes, with the understanding that APIs are still settling during beta. The core is solid and is already being used to build Vuetify itself. If you're comfortable with occasional minor adjustments as things stabilize, v0 is ready to build with.
 
-??? Will APIs break during alpha?
+??? Will APIs break during beta?
 
-APIs are mostly stable. Breaking changes are possible but will be documented in release notes. The goal of alpha is to gather feedback before locking APIs at beta.
+APIs are mostly stable and freezing for v1. Breaking changes are still possible but will be documented in release notes. Alpha gathered the feedback; beta is where APIs lock down.
 
 ??? What styling framework should I use with v0?
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,3 @@
-exclude = ["^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://.*\\.vuejs\\.org"]
+exclude = ["^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://.*\\.vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
 
 root_dir = "./apps/docs/dist"

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -28,7 +28,7 @@
 
 Headless Vue 3 UI primitives and composables for building modern applications and design systems. `@vuetify/v0` is the foundation of the Vuetify ecosystem, offering lightweight, unstyled building blocks with full TypeScript support and accessibility features built-in.
 
-> **Note:** This package is in early development (pre-1.0). APIs may change between minor versions.
+> **Note:** v0 is in beta — the API is stabilizing toward 1.0. Some APIs may still change before the stable release.
 
 ## Primary Sponsor
 
@@ -146,6 +146,7 @@ import { ... } from '@vuetify/v0/date'       // Date adapter and utilities
 | [Image](https://0.vuetifyjs.com/components/semantic/image) | Image with placeholder, error fallback, and lazy loading |
 | [Overflow](https://0.vuetifyjs.com/components/semantic/overflow) | Responsive truncation primitive with overflow detection and indicator |
 | [Pagination](https://0.vuetifyjs.com/components/semantic/pagination) | Page navigation with semantic `<nav>` wrapper |
+| [Progress](https://0.vuetifyjs.com/components/semantic/progress) | Headless progress indicator with multi-segment and buffer support |
 | [Snackbar](https://0.vuetifyjs.com/components/semantic/snackbar) | Toast notification with queue, positioning, and auto-dismiss |
 | [Splitter](https://0.vuetifyjs.com/components/semantic/splitter) | Resizable panel layout with drag handles |
 
@@ -193,6 +194,7 @@ Selection management composables built on `createRegistry`:
 - [`createForm`](https://0.vuetifyjs.com/composables/forms/create-form) - Form validation and state management with async rules
 - [`createInput`](https://0.vuetifyjs.com/composables/forms/create-input) - Shared form field state: validation, dirty/pristine, ARIA IDs
 - [`createNumberField`](https://0.vuetifyjs.com/composables/forms/create-number-field) - Numeric input state with formatting, stepping, and validation
+- [`createNumeric`](https://0.vuetifyjs.com/composables/forms/create-numeric) - Pure numeric math primitive: clamp, snap, step, percentage, and circular wrapping
 - [`createOtp`](https://0.vuetifyjs.com/composables/forms/create-otp) - OTP / verification code state with pattern-gated entry and decisional completion hook
 - [`createValidation`](https://0.vuetifyjs.com/composables/forms/create-validation) - Field-level validation with sync/async rules
 - [`createCombobox`](https://0.vuetifyjs.com/composables/forms/create-combobox) - Combobox state management with filtering and virtual focus
@@ -204,10 +206,11 @@ Selection management composables built on `createRegistry`:
 - [`useProxyModel`](https://0.vuetifyjs.com/composables/reactivity/use-proxy-model) - Bridge selection context to component v-model
 - [`useProxyRegistry`](https://0.vuetifyjs.com/composables/reactivity/use-proxy-registry) - Convert registry Map to reactive object
 
-#### Utilities
+#### Semantic
 
-- [`createBreadcrumbs`](https://0.vuetifyjs.com/composables/utilities/create-breadcrumbs) - Breadcrumb navigation model with depth tracking and path traversal
-- [`createOverflow`](https://0.vuetifyjs.com/composables/utilities/create-overflow) - Container overflow measurement for item capacity
+- [`createBreadcrumbs`](https://0.vuetifyjs.com/composables/semantic/create-breadcrumbs) - Breadcrumb navigation model with depth tracking and path traversal
+- [`createOverflow`](https://0.vuetifyjs.com/composables/semantic/create-overflow) - Container overflow measurement for item capacity
+- [`createProgress`](https://0.vuetifyjs.com/composables/semantic/create-progress) - Progress state with multi-segment and buffer tracking
 
 #### Transformers
 
@@ -298,7 +301,7 @@ pnpm validate
 
 ## Contributing
 
-Vuetify0 is in alpha — open for feedback, bug reports, and contributions. See the [Alpha Roadmap](https://0.vuetifyjs.com/roadmap#alpha) for what's planned and how to get involved.
+Vuetify0 is in beta — open for feedback, bug reports, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap#beta) for what's planned and how to get involved.
 
 ## License
 

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -6,8 +6,7 @@
   "types": "./dist/index.d.mts",
   "type": "module",
   "files": [
-    "dist",
-    "SKILL.md"
+    "dist"
   ],
   "repository": {
     "type": "git",

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -103,7 +103,7 @@
     },
     "createOtp": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.5",
       "category": "forms"
     },
     "createDataTable": {
@@ -118,7 +118,7 @@
     },
     "createKanban": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.4",
       "category": "data"
     },
     "createPagination": {
@@ -128,7 +128,7 @@
     },
     "createSortable": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.4",
       "category": "data"
     },
     "createProgress": {
@@ -144,12 +144,12 @@
     "createBreadcrumbs": {
       "level": "preview",
       "since": "0.1.0",
-      "category": "utilities"
+      "category": "semantic"
     },
     "createOverflow": {
       "level": "preview",
       "since": "0.1.0",
-      "category": "utilities"
+      "category": "semantic"
     },
     "useBreakpoints": {
       "level": "preview",
@@ -213,7 +213,7 @@
     },
     "useDragDrop": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.4",
       "category": "system"
     },
     "useEventListener": {
@@ -283,7 +283,7 @@
     },
     "toHighlight": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.5",
       "category": "transformers"
     },
     "toReactive": {
@@ -642,7 +642,7 @@
     },
     "isThenable": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-alpha.4",
       "category": "utilities"
     },
     "isUndefined": {


### PR DESCRIPTION
Launch-readiness pass for the `1.0.0-beta.0` cut: documentation accuracy, example correctness, and metadata hygiene. No package source behavior changes (version bump is left to the release process).

## Documentation
- Correct the inventory copy on the why-v0 and FAQ pages to the real **39 components, 70 composables** (was "46 components, 63+" / "35+")
- Add the shipped **Progress** component and **createProgress** / **createNumeric** composables to the README "What's Included" tables and the composables index
- Repoint `createBreadcrumbs` / `createOverflow` / `createProgress` and the pagination `related` link to the `semantic` category (the pages live there; the old `utilities` links 404'd)
- Align Node guidance: consumer floor `22+`, contributor floor `26` (matches `.nvmrc`)
- Transition the roadmap narrative from alpha to beta (active milestone moved, alpha preserved as completed)

## Examples
- Fix the broken contact-form validation example (Closes #219): the fields were wrapped in a native `<form>` and never registered with `createForm`, so submission was never gated by validation. Now wired through the `Form` component.
- Replace native HTML controls with v0 components (`Switch`, `Button.Root`) across examples; form submit/reset buttons stay native to match the canonical `Form` example

## Metadata
- `maturity.json`: move `createBreadcrumbs` / `createOverflow` to `semantic`; resolve the six `null` `since` values to the alpha that first shipped each
- `package.json`: declare `"sideEffects": false`; drop the stale `SKILL.md` entry from `files` (the skill ships via the docs site, not the tarball)
- Scope the api-whitelist generator to public barrel exports so internal helpers stop leaking into the whitelist
