### PR TITLE
feat(useLogger): scoped key for per-caller message prefix

### DIFF
--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -258,6 +258,8 @@ export const [createLoggerContext, createLoggerPlugin, useLogger] =
   )
 ```
 
+> `useLogger` additionally wraps the generated consumer in a hand-written function to support an optional scope key (see its source); the snippet above shows the fallback wiring it still uses, not its literal export shape.
+
 When the fallback is in place, `useLogger()` returns synthesized defaults instead of throwing. Sibling plugins that follow the same convention: `useLocale` (`createLocaleFallback`), `useHydration` (`createFallbackHydration`). If a plugin **must** be installed (e.g., it depends on caller-provided adapters with no defensible default — `useDate`), omit the fallback and let injection throw; document that explicitly on the docs page so the failure is loud, not silent.
 
 ### 4. Adapter (pluggable implementation)

--- a/apps/docs/src/pages/composables/plugins/use-logger.md
+++ b/apps/docs/src/pages/composables/plugins/use-logger.md
@@ -65,6 +65,21 @@ Once the plugin is installed, use the `useLogger` composable in any component:
 </template>
 ```
 
+## Scoped logging
+
+When several composables share the app-level logger, their output blends together with no easy way to tell which one emitted what. Pass a scope key to `useLogger` to tag every message from that caller with a `[scope]` segment, layered after the plugin prefix:
+
+```ts no-filename
+import { useLogger } from '@vuetify/v0'
+
+const logger = useLogger('createKanban')
+
+logger.warn('drop rejected')
+// → [v0 warn] [createKanban] drop rejected
+```
+
+`useLogger()` with no argument is unchanged — it returns the plugin-configured logger as-is. A scoped logger shares the plugin's level, enabled state, and adapter; only the message prefix differs, so re-leveling or disabling the shared logger affects every scope. A blank scope key is treated as no scope. Without a plugin installed, `useLogger` falls back to a console logger and still appends the `[scope]` segment, so output stays attributable.
+
 ## Adapters
 
 Adapters let you swap the underlying logging implementation without changing your application code.

--- a/packages/0/src/composables/useLogger/index.test.ts
+++ b/packages/0/src/composables/useLogger/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createLogger, createLoggerContext, createLoggerPlugin, useLogger } from './index'
+import { createLogger, createLoggerContext, createLoggerPlugin, useLogger, V0LoggerAdapter } from './index'
 
 // Utilities
 import { createApp, defineComponent } from 'vue'
@@ -221,13 +221,13 @@ describe('createLogger', () => {
         expect(logger.error).toBeTypeOf('function')
       })
 
-      it('should return fallback logger with custom namespace', () => {
+      it('should append the scope to fallback output outside a component', () => {
         const logger = useLogger('my:logger')
 
         logger.info('test message')
 
         expect(console.info).toHaveBeenCalledWith(
-          expect.stringContaining('[my:logger info]'),
+          expect.stringContaining('[my:logger] test message'),
         )
       })
 
@@ -277,6 +277,100 @@ describe('createLogger', () => {
 
         expect(logger.current()).toBe('info')
         expect(logger.enabled()).toBe(true)
+      })
+    })
+
+    describe('useLogger scope', () => {
+      function withLogger (
+        scope: string | undefined,
+        run: (logger: ReturnType<typeof useLogger>) => void,
+        options: Record<string, unknown> = {},
+      ) {
+        const plugin = createLoggerPlugin({
+          level: 'debug',
+          adapter: new V0LoggerAdapter({ colors: false, timestamps: false }),
+          ...options,
+        })
+
+        const Comp = defineComponent({
+          setup () {
+            run(useLogger(scope))
+            return () => null
+          },
+        })
+
+        const app = createApp(Comp)
+        app.use(plugin)
+        app.mount(document.createElement('div'))
+        app.unmount()
+      }
+
+      it('should prefix messages with the scope segment after the plugin prefix', () => {
+        withLogger('createKanban', logger => logger.warn('drop rejected'))
+
+        expect(console.warn).toHaveBeenCalledTimes(1)
+        expect(console.warn).toHaveBeenCalledWith('[v0 warn] [createKanban] drop rejected')
+      })
+
+      it('should leave the plugin logger untouched when no scope is passed', () => {
+        withLogger(undefined, logger => logger.info('mounted'))
+
+        expect(console.info).toHaveBeenCalledTimes(1)
+        expect(console.info).toHaveBeenCalledWith('[v0 info] mounted')
+      })
+
+      it('should delegate level gating to the shared plugin logger', () => {
+        withLogger('createKanban', logger => {
+          logger.info('filtered out')
+          logger.warn('passes through')
+        }, { level: 'warn' })
+
+        expect(console.info).not.toHaveBeenCalled()
+        expect(console.warn).toHaveBeenCalledTimes(1)
+        expect(console.warn).toHaveBeenCalledWith('[v0 warn] [createKanban] passes through')
+      })
+
+      it('should prefix every level through the scoped wrapper', () => {
+        withLogger('createKanban', logger => {
+          logger.debug('d')
+          logger.info('i')
+          logger.warn('w')
+          logger.error('e')
+          logger.trace('t')
+          logger.fatal('f')
+        }, { level: 'trace' })
+
+        expect(console.debug).toHaveBeenCalledWith('[v0 debug] [createKanban] d')
+        expect(console.info).toHaveBeenCalledWith('[v0 info] [createKanban] i')
+        expect(console.warn).toHaveBeenCalledWith('[v0 warn] [createKanban] w')
+        expect(console.error).toHaveBeenCalledWith('[v0 error] [createKanban] e')
+        expect(console.trace).toHaveBeenCalledWith('[v0 trace] [createKanban] t')
+        expect(console.error).toHaveBeenCalledWith('[v0 fatal] [createKanban] f')
+      })
+
+      it('should silence scoped output when the shared logger is disabled', () => {
+        withLogger('createKanban', logger => {
+          logger.disable()
+          logger.warn('suppressed')
+        })
+
+        expect(console.warn).not.toHaveBeenCalled()
+      })
+
+      it('should treat a blank scope as no scope', () => {
+        withLogger('', logger => logger.info('mounted'))
+
+        expect(console.info).toHaveBeenCalledWith('[v0 info] mounted')
+      })
+
+      it('should still append the scope when no plugin is installed', () => {
+        const logger = useLogger('createKanban')
+
+        logger.error('boom')
+
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining('[v0:logger error] [createKanban] boom'),
+        )
       })
     })
 

--- a/packages/0/src/composables/useLogger/index.ts
+++ b/packages/0/src/composables/useLogger/index.ts
@@ -34,6 +34,9 @@ import { V0LoggerAdapter } from '#v0/composables/useLogger/adapters'
 // Globals
 import { __LOGGER_ENABLED__, IN_BROWSER } from '#v0/constants/globals'
 
+// Utilities
+import { isUndefined } from '#v0/utilities'
+
 // Types
 import type { LoggerAdapter } from '#v0/composables/useLogger/adapters'
 import type { LogLevel } from '#v0/composables/useLogger/types'
@@ -191,9 +194,11 @@ export function createLogger (options: LoggerOptions = {}): LoggerContext {
   } as LoggerContext
 }
 
+const NAMESPACE = 'v0:logger'
+
 // PHILOSOPHY §9.2 Layer-0 exception: this IS the logger bootstrap —
 // useLogger() here would be infinite recursion.
-function createFallbackLogger (namespace = 'v0:logger'): LoggerContext {
+function createFallbackLogger (namespace = NAMESPACE): LoggerContext {
   function format (message: string, type: string): string {
     return `[${namespace} ${type}] ${message}`
   }
@@ -232,9 +237,9 @@ function createFallbackLogger (namespace = 'v0:logger'): LoggerContext {
  * })
  * ```
  */
-export const [createLoggerContext, createLoggerPlugin, useLogger] =
+const [createLoggerContext, createLoggerPlugin, useLoggerContext] =
   createPluginContext<LoggerContextOptions, LoggerContext>(
-    'v0:logger',
+    NAMESPACE,
     options => createLogger(options),
     {
       fallback: ns => createFallbackLogger(ns),
@@ -245,3 +250,56 @@ export const [createLoggerContext, createLoggerPlugin, useLogger] =
       },
     },
   )
+
+export { createLoggerContext, createLoggerPlugin }
+
+// Wraps a resolved logger so every message carries a `[scope]` segment after the
+// plugin prefix. Level gating, enable/disable, and the adapter are delegated to the
+// shared instance via spread, so a scoped logger never diverges from its parent.
+function createScopedLogger (logger: LoggerContext, scope: string): LoggerContext {
+  const tag = `[${scope}]`
+
+  function wrap (method: (message: string, ...args: unknown[]) => void) {
+    return (message: string, ...args: unknown[]) => method(`${tag} ${message}`, ...args)
+  }
+
+  return {
+    ...logger,
+    debug: wrap(logger.debug),
+    info: wrap(logger.info),
+    warn: wrap(logger.warn),
+    error: wrap(logger.error),
+    trace: wrap(logger.trace),
+    fatal: wrap(logger.fatal),
+  }
+}
+
+/**
+ * Consumes the application logger provided by `createLoggerPlugin`.
+ *
+ * Call with no argument to use the configured logger as-is. Pass a scope key to get a
+ * logger that prefixes every message with a `[scope]` segment after the plugin prefix —
+ * useful for telling apart output from composables that share the app-level logger. A
+ * scoped logger shares the underlying logger's level, enabled state, and adapter; only
+ * the message prefix differs. A blank scope is treated as no scope.
+ *
+ * @param scope Optional per-caller scope key prefixed onto every message.
+ * @returns The application logger, or a scoped wrapper around it.
+ *
+ * @see https://0.vuetifyjs.com/composables/plugins/use-logger
+ *
+ * @example
+ * ```ts
+ * import { useLogger } from '@vuetify/v0'
+ *
+ * const logger = useLogger('createKanban')
+ *
+ * logger.warn('drop rejected')
+ * // → [v0 warn] [createKanban] drop rejected
+ * ```
+ */
+export function useLogger (scope?: string): LoggerContext {
+  const logger = useLoggerContext()
+
+  return isUndefined(scope) || !scope.trim() ? logger : createScopedLogger(logger, scope)
+}


### PR DESCRIPTION
Closes #235.

## Problem

`useLogger()` returns the plugin-configured logger as-is. To scope output to a single composable, callers had to thread the scope into every message string or spin up a fresh `createLogger()` with a different prefix — throwing away the plugin-level options. When multiple composables share the app-level logger (the v0 default), all output blends together with no way to tell which one emitted what.

## Solution

`useLogger()` now accepts an optional scope key:

```ts
// Plugin installed with the default prefix
const logger = useLogger('createKanban')

logger.warn('drop rejected')
// → [v0 warn] [createKanban] drop rejected
```

- `useLogger()` (no arg) — unchanged; returns the configured logger as-is.
- `useLogger('scope')` — wraps the resolved logger so every message gets a `[scope]` segment after the plugin prefix. Level gating, enable/disable, and the adapter are delegated to the shared instance via spread, so a scoped logger never diverges from its parent.
- A blank scope is treated as no scope.

It resolves through the generated consumer and wraps the result uniformly, so the same `[scope]` segment is appended whether or not a plugin is installed (the no-plugin fallback prefixes with the default namespace, e.g. `[v0:logger warn] [createKanban] …`).

Picked the bracket form `[prefix][scope]` suggested in the issue for visual consistency with the existing prefix style.

## Notes

- The single string argument changes meaning from a DI-namespace override to a scope key. Every internal `useLogger(...)` callsite uses the no-arg form, so nothing downstream moves.
- No new adapter API, and no raw `inject` — the consumer routes through the existing plugin context, keeping the PHILOSOPHY §6.5 "no raw inject/provide outside foundation" invariant intact.