### PR TITLE
docs: highlight the open primary-sponsor slot with animated rainbow text

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     AppPaletteRadixButton: typeof import('./components/app/theme/palette/AppPaletteRadixButton.vue')['default']
     AppPaletteTailwindButton: typeof import('./components/app/theme/palette/AppPaletteTailwindButton.vue')['default']
     AppPaletteVuetify0Button: typeof import('./components/app/theme/palette/AppPaletteVuetify0Button.vue')['default']
+    AppRainbowText: typeof import('./components/app/AppRainbowText.vue')['default']
     AppSearchInline: typeof import('./components/app/AppSearchInline.vue')['default']
     AppSettings: typeof import('./components/app/AppSettings.vue')['default']
     AppSettingsColorInput: typeof import('./components/app/settings/AppSettingsColorInput.vue')['default']

--- a/apps/docs/src/components/app/AppRainbowText.vue
+++ b/apps/docs/src/components/app/AppRainbowText.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+  // Utilities
+  import { toRef } from 'vue'
+
+  export interface AppRainbowTextProps {
+    /** Color stops spread across the text — each letter lands on a different hue. */
+    colors?: string[]
+    /** Seconds for one full cycle (a quick sheen sweep, then a pause before the next). */
+    duration?: number
+  }
+
+  const {
+    colors = ['#ff2d55', '#ff9500', '#ffcc00', '#34c759', '#5ac8fa', '#af52de'],
+    duration = 4,
+  } = defineProps<AppRainbowTextProps>()
+
+  // A soft-edged white glint that travels across; sits above the static rainbow.
+  const SHEEN = 'linear-gradient(120deg, transparent 40%, rgba(255, 255, 255, 0.85) 50%, transparent 60%)'
+
+  // Layer order: sheen on top, static rainbow underneath. Both clipped to the text.
+  const layers = toRef(() => `${SHEEN}, linear-gradient(90deg, ${colors.join(', ')})`)
+</script>
+
+<template>
+  <span
+    class="app-rainbow-text"
+    :style="{ backgroundImage: layers, animationDuration: `${duration}s` }"
+  >
+    <slot />
+  </span>
+</template>
+
+<style scoped>
+  .app-rainbow-text {
+    background-repeat: no-repeat;
+    /* sheen layer is double-width so it can travel; rainbow fills exactly. */
+    background-size: 200% 100%, 100% 100%;
+    background-position: 120% 0, 0 0;
+    background-clip: text;
+    -webkit-background-clip: text;
+    /* duration is the single source of truth via the inline binding (the `duration` prop). */
+    animation-name: app-rainbow-sheen;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  /* Only drop the real fill where the clip is supported, so unsupported engines keep legible text. */
+  @supports (background-clip: text) or (-webkit-background-clip: text) {
+    .app-rainbow-text {
+      color: transparent;
+      -webkit-text-fill-color: transparent;
+    }
+  }
+
+  /* Sweep the glint across quickly, then hold it off-screen for the rest of the cycle. */
+  @keyframes app-rainbow-sheen {
+    0% { background-position: 120% 0, 0 0; }
+    12% { background-position: -20% 0, 0 0; }
+    100% { background-position: -20% 0, 0 0; }
+  }
+
+  /* Reduced motion: static per-letter rainbow, no sheen. */
+  @media (prefers-reduced-motion: reduce) {
+    .app-rainbow-text {
+      animation: none;
+      background-position: 120% 0, 0 0;
+    }
+  }
+</style>

--- a/apps/docs/src/components/home/HomePrimarySponsor.vue
+++ b/apps/docs/src/components/home/HomePrimarySponsor.vue
@@ -30,7 +30,7 @@
         <p>
           <span class="section-overline">PRIMARY SPONSOR</span>
           <span class="ml-2 text-on-surface-variant">·</span>
-          <span class="ml-2 text-sm">This spot is available</span>
+          <span class="ml-2 text-sm"><AppRainbowText>This spot is available</AppRainbowText></span>
         </p>
       </div>
     </AppLink>


### PR DESCRIPTION
## Summary

Adds `AppRainbowText`, a small presentational component that fills its text with a static per-letter rainbow gradient plus a soft white sheen that sweeps left→right and then pauses. Applies it to the "This spot is available" link in the empty **primary-sponsor slot** on the home page, to draw the eye to the open slot.

## How it works

- Pure CSS: two stacked background layers (static rainbow + a moving white glint) clipped to the glyphs via `background-clip: text`. No JS animation.
- `duration` controls the cycle (one quick sweep, then a hold); `colors` is overridable for a brand-leaning palette.
- Honors `prefers-reduced-motion`: the sweep is dropped, a static gradient remains.
- Falls back to legible inherited text where `background-clip: text` is unsupported (`@supports` guard).

## Accessibility — known tradeoff

The rainbow palette is theme-blind and does **not** meet WCAG AA contrast on the light band (e.g. yellow ≈1.6:1 against ~4.5:1 needed for 12px text). It's used here as decorative emphasis on a sponsor CTA — the label is real, screen-reader-readable text, and the adjacent "PRIMARY SPONSOR" label (token color, AA-compliant) carries the meaning.

If we want the label itself to clear AA: a darker/contrast-safe palette, theme-aware stops, or keeping the base text in a token color with the rainbow as a hover accent. Flagging so it's a conscious call — happy to follow up.

Preview: pull the branch, `pnpm dev:docs`, scroll to the band near the bottom of the home page.