### PR TITLE
chore(playground): relocate side preview to bottom on drag-collapse

### DIFF
--- a/apps/playground/src/components/playground/workspace/PlaygroundWorkspaceSide.vue
+++ b/apps/playground/src/components/playground/workspace/PlaygroundWorkspaceSide.vue
@@ -11,10 +11,14 @@
   const playground = usePlayground()
   const { isMobile } = useBreakpoints()
 
+  // Drag-to-collapse must flip placement, not just hide the side preview.
+  // side/bottom are mutually exclusive (see onSide/onIntro) — collapsing the
+  // side panel without setting bottom leaves the preview mounted nowhere.
   const collapsed = computed({
     get: () => !playground.side.value,
     set: v => {
       playground.side.value = !v
+      playground.bottom.value = v
     },
   })
 </script>


### PR DESCRIPTION
## Problem

In the playground's **Preview Right** (side) layout, dragging the editor/preview splitter handle far enough to collapse the side preview leaves a permanently blank pane: the preview region reappears at the bottom but never renders.

## Root cause

`PlaygroundWorkspaceSide.vue`'s `collapsed` computed setter set only `side.value = !v`. `side` and `bottom` are mutually exclusive — the menu toggle (`onSide`) and intro toggle (`onIntro`) always flip the pair together. The Splitter's drag-to-collapse routed through this setter and left **both** `side=false` and `bottom=false`, so `WorkspaceBottom` opened its region (`v-if="!isMobile && !side"`) but never mounted the preview (`v-if="bottom"` was false). No `<Sandbox>` iframe existed in either placement.

## Fix

Flip `bottom` in lockstep with `side` so the preview actually relocates:

```js
set: v => {
  playground.side.value = !v
  playground.bottom.value = v
},
```

The symmetric `PlaygroundWorkspaceBottom.vue` setter is intentionally left as-is — collapsing the bottom preview is "hide it," not "relocate it."

## Verification

Drag-to-collapse of the side handle:

- **Before:** 0 preview iframes — blank bottom region.
- **After:** preview mounts full-width at the bottom and renders.