### PR TITLE
docs(discovery): center final tour step on the viewport

### DIFF
--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -68,13 +68,26 @@
       positionArea: 'right',
       alignSelf: 'anchor-center',
     },
-    center: {
-      positionArea: 'center',
-    },
   }
 
   const style = toRef(() => {
     const currentPlacement = activePlacement.value
+
+    // The last step has no activator, so no element carries the anchor-name.
+    // position-area: center silently no-ops without a resolvable anchor and the
+    // inset collapses the box to the top-left corner, so center on the viewport.
+    if (currentPlacement === 'center') {
+      return {
+        position: 'fixed' as const,
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: 'max-content',
+        height: 'max-content',
+        maxHeight: `calc(100vh - ${offset * 2}px)`,
+        overflow: noOverflow ? 'visible' : 'auto',
+      }
+    }
 
     if (supportsAnchor) {
       return {
@@ -98,7 +111,6 @@
       top: { top: `${offset}px`, left: '50%', transform: 'translateX(-50%)' },
       left: { top: '50%', left: `${offset}px`, transform: 'translateY(-50%)' },
       right: { top: '50%', right: `${offset}px`, transform: 'translateY(-50%)' },
-      center: { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' },
     }
     return {
       ...base,


### PR DESCRIPTION
## Problem

The "Tour complete" popover (the final step of any Skillz tour) rendered in the **top-left corner** instead of centered — but only in anchor-positioning browsers (Chrome/Edge). Safari centered it correctly.

## Root cause

The last step has no activator, so no element in the DOM carries `anchor-name: --discovery-{step}`. `DiscoveryContent` still set `position-anchor` to that non-existent anchor and relied on `position-area: center` to center the box. With no resolvable anchor, `position-area` silently no-ops, so the `inset: 16px` + `max-content` size collapsed the popover to the top-left corner. The Safari/no-anchor fallback path already centered via `top/left: 50%` + translate, which is why the bug was Chrome/Edge-only.

## Fix

Handle `center` placement with explicit viewport-centering *before* the anchor and fallback branches — it has no anchor to position against in either browser. Removed the now-dead `center` entries from both style maps. `center` is only ever produced by the `isLast` short-circuit; no tour uses it as a real anchored placement, so this is safe.

## Verification

Drove the "Using the Docs" guided tour through all 12 steps in Chromium. The final popover now renders at viewport center (box center 845,641 vs viewport center 853,641 — the ~7px horizontal delta is half the scrollbar gutter). Intermediate anchored steps still position next to their targets (step 1 beside the search box), confirming anchored placement is intact.
