### PR TITLE
chore(security): raise dependency cooldown to 14 days and document it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=3d

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 The Vuetify team takes security seriously. We appreciate your efforts to responsibly disclose vulnerabilities and will make every effort to acknowledge your contributions.
 
-For the full threat model, security properties, and CSP guidance, see the [Security documentation](https://0.vuetifyjs.com/introduction/security).
+For the full threat model, security properties, supply-chain hardening, and CSP guidance, see the [Security documentation](https://0.vuetifyjs.com/introduction/security).
 
 ## Reporting a Vulnerability
 
@@ -36,6 +36,16 @@ When we receive a security report, we will:
 - Release fixes to npm as quickly as possible
 
 Internally, security incidents are handled according to a formal Incident Response Plan that defines severity classification, response timelines, and escalation procedures.
+
+## Supply Chain
+
+We harden the path from source to published package:
+
+- **Dependency cooldown** — a newly published dependency version must age **14 days** before it can be installed (first-party and dev/build toolchain packages are exempt), giving time for a compromised release to be detected and pulled.
+- **Committed lockfile** — `pnpm-lock.yaml` is version-controlled for reproducible installs.
+- **Pinned CI actions** — Vuetify-owned GitHub Actions are pinned to commit SHAs, not mutable branch refs.
+
+See the [Security documentation](https://0.vuetifyjs.com/introduction/security#supply-chain-hardening) for the full breakdown.
 
 ## Scope
 

--- a/apps/docs/src/pages/introduction/security.md
+++ b/apps/docs/src/pages/introduction/security.md
@@ -100,10 +100,13 @@ flowchart LR
 These measures protect the integrity of `@vuetify/v0` from source to consumer:
 
 - **Lockfile committed** — `pnpm-lock.yaml` is version-controlled, ensuring reproducible installs
-- **Dependency cooldown** — pnpm `minimum-release-age` enforces a waiting period before newly published dependency versions can be installed, giving time for compromised packages to be detected
+- **Dependency cooldown** — pnpm's `minimumReleaseAge` (set in `pnpm-workspace.yaml`) enforces a release-age waiting period before a newly published dependency version can be installed, giving time for a compromised release to be detected and pulled. First-party Vuetify packages and the dev/build toolchain (linters, the bundler, CI preview tooling) are exempt via `minimumReleaseAgeExclude`, as they are either published by us or never ship in a consumer's runtime bundle
 - **Pinned CI actions** — Vuetify-owned GitHub Actions are pinned to commit SHAs, not mutable branch refs, preventing silent changes via force-push
 - **Scoped package** — published under the `@vuetify` npm org, reducing typosquatting risk
 - **No lifecycle scripts** — no `postinstall` or `preinstall` scripts that could execute arbitrary code at install time
+
+> [!IMPORTANT]
+> The current dependency release-age cooldown is **14 days** — a newly published version of any non-exempt dependency must be at least 14 days old before it can be installed.
 
 ### Security Properties
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,7 +87,7 @@ catalog:
 
 catalogMode: strict
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 20160
 
 minimumReleaseAgeExclude:
   - '@vuetify/auth'


### PR DESCRIPTION
## Summary

Raises the supply-chain dependency cooldown and makes the policy discoverable.

- **Cooldown 3 → 14 days** — `minimumReleaseAge` in `pnpm-workspace.yaml` goes from `4320` to `20160` minutes. A newly published, non-exempt dependency version must age 14 days before it can be installed, widening the window for a compromised release to be reported and yanked.
- **Documented + indicated** — the docs security page now states the value, where it's configured, and the `minimumReleaseAgeExclude` carve-out (first-party + dev/build toolchain), with an `[!IMPORTANT]` callout indicating the current 14-day min release age.
- **Single source of truth** — removed the redundant `.npmrc` `minimum-release-age=3d`; `pnpm config get minimumReleaseAge` confirms the value now resolves solely from `pnpm-workspace.yaml`.

## Why 14 days

Real-world malicious npm releases are typically detected and pulled within hours-to-days, so 14 days clears essentially all of that detection window while keeping legitimate security-patch latency bounded to two weeks. 30 days was considered but buys little additional catch rate for roughly double the patch delay.

## Operational note

At 14 days, more Renovate/Dependabot bumps will sit blocked until they age out, and freshly published packages added via `pnpm add` will resolve to an older version until the window passes. The committed lockfile is unaffected — this only governs future resolutions. If a specific dependency causes friction, add it to `minimumReleaseAgeExclude` rather than lowering the global window.