### PR TITLE
fix(Overflow): guard element measurement against non-finite width

### DIFF
--- a/packages/0/src/components/Avatar/AvatarIndicator.vue
+++ b/packages/0/src/components/Avatar/AvatarIndicator.vue
@@ -79,8 +79,8 @@
       return
     }
     const style = getComputedStyle(el.value)
-    const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
-    group.indicatorWidth.value = (el.value as HTMLElement).offsetWidth + marginX
+    const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
+    group.indicatorWidth.value = ((el.value as HTMLElement).offsetWidth || 0) + marginX
   }
 
   useToggleScope(() => !!group && group.responsive.value, () => {

--- a/packages/0/src/components/Avatar/index.test.ts
+++ b/packages/0/src/components/Avatar/index.test.ts
@@ -48,6 +48,11 @@ describe('avatar', () => {
       })
 
       it('should support renderless mode', () => {
+        // The Root's `v-show` is a no-op on a renderless Atom (the consumer
+        // owns the rendered element), so Vue warns about a runtime directive
+        // on a non-element root. Silence the expected, benign warning.
+        using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
         const wrapper = mount(Avatar.Root, {
           props: {
             renderless: true,
@@ -58,6 +63,7 @@ describe('avatar', () => {
         })
 
         expect(wrapper.find('.custom-root').exists()).toBe(true)
+        expect(warn).toHaveBeenCalled()
       })
     })
 

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsEllipsis.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsEllipsis.vue
@@ -84,8 +84,8 @@
 
       const el = element as HTMLElement
       const style = getComputedStyle(el)
-      const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
-      context.ellipsisWidth.value = el.offsetWidth + marginX
+      const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
+      context.ellipsisWidth.value = (el.offsetWidth || 0) + marginX
     },
     { immediate: true },
   )

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
@@ -137,8 +137,8 @@
     }
     const htmlEl = el as HTMLElement
     const style = getComputedStyle(htmlEl)
-    const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
-    target.value = htmlEl.offsetWidth + marginX
+    const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
+    target.value = (htmlEl.offsetWidth || 0) + marginX
   }
 
   function measureElement (index: number, type: 'item' | 'divider', el: Element | undefined) {

--- a/packages/0/src/components/Combobox/index.test.ts
+++ b/packages/0/src/components/Combobox/index.test.ts
@@ -1441,6 +1441,10 @@ describe('combobox', () => {
       const value = { foo: 'bar' }
       let ctx: { open: () => void } | undefined
 
+      // modelValue is typed String | Number | Array; passing an object to
+      // exercise JSON serialization makes Vue warn on the prop type. Silence it.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const wrapper = mount(
         defineComponent({
           render () {
@@ -1473,6 +1477,7 @@ describe('combobox', () => {
       expect(hidden.exists()).toBe(true)
       // Object values should be serialized to JSON
       expect((hidden.element as HTMLInputElement).value).toBe(JSON.stringify(value))
+      expect(warn).toHaveBeenCalled()
     })
 
     it('should render empty string for null selection values', async () => {

--- a/packages/0/src/components/Overflow/OverflowIndicator.vue
+++ b/packages/0/src/components/Overflow/OverflowIndicator.vue
@@ -75,8 +75,8 @@
       return
     }
     const style = getComputedStyle(el.value)
-    const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
-    root.indicatorWidth.value = (el.value as HTMLElement).offsetWidth + marginX
+    const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
+    root.indicatorWidth.value = ((el.value as HTMLElement).offsetWidth || 0) + marginX
   }
 
   watch(el, () => measure(), { immediate: true })

--- a/packages/0/src/components/Pagination/PaginationRoot.vue
+++ b/packages/0/src/components/Pagination/PaginationRoot.vue
@@ -151,10 +151,10 @@
     requestAnimationFrame(() => {
       const rootStyle = getComputedStyle(root)
       const style = getComputedStyle(el)
-      const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
+      const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
       const gapX = Number.parseFloat(rootStyle.gap) || 0
 
-      itemWidth.value = el.offsetWidth + marginX
+      itemWidth.value = (el.offsetWidth || 0) + marginX
       itemGap.value = gapX
     })
   }, { flush: 'post' })

--- a/packages/0/src/components/Select/index.test.ts
+++ b/packages/0/src/components/Select/index.test.ts
@@ -689,6 +689,10 @@ describe('select', () => {
       const value = { id: 1 }
       let ctx: { open: () => void } | undefined
 
+      // modelValue is typed String | Number | Array; passing an object to
+      // exercise JSON serialization makes Vue warn on the prop type. Silence it.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const wrapper = mount(
         defineComponent({
           render () {
@@ -719,6 +723,7 @@ describe('select', () => {
       const hidden = wrapper.find('input[type="hidden"]')
       expect(hidden.exists()).toBe(true)
       expect((hidden.element as HTMLInputElement).value).toBe(JSON.stringify(value))
+      expect(warn).toHaveBeenCalled()
     })
 
     it('should render empty string for null values in hidden input', async () => {

--- a/packages/0/src/composables/createOverflow/index.ts
+++ b/packages/0/src/composables/createOverflow/index.ts
@@ -183,8 +183,8 @@ export function createOverflow<
     if (!IN_BROWSER) return
 
     const style = getComputedStyle(el)
-    const marginX = Number.parseFloat(style.marginLeft) + Number.parseFloat(style.marginRight)
-    const w = (el as HTMLElement).offsetWidth + marginX
+    const marginX = (Number.parseFloat(style.marginLeft) || 0) + (Number.parseFloat(style.marginRight) || 0)
+    const w = ((el as HTMLElement).offsetWidth || 0) + marginX
 
     if (widths.value.get(index) !== w) {
       widths.value = new Map(widths.value).set(index, w)

--- a/packages/0/src/composables/createPlugin/index.test.ts
+++ b/packages/0/src/composables/createPlugin/index.test.ts
@@ -243,9 +243,13 @@ describe('createPluginContext', () => {
       () => ({ value: 1 }),
     )
 
+    // Calling the consumer outside a component setup makes Vue's inject()
+    // warn; the throw is what we assert. Silence the incidental warning.
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(() => useX()).toThrow(
       'Context "v0:no-fallback" not found. Ensure it\'s provided by an ancestor.',
     )
+    expect(warn).toHaveBeenCalled()
   })
 
   describe('persist/restore', () => {

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -1216,9 +1216,13 @@ describe('createRegistry', () => {
 
   describe('useRegistry', () => {
     it('should throw when no registry context is provided', () => {
+      // Calling the consumer outside a component setup makes Vue's inject()
+      // warn; the throw is what we assert. Silence the incidental warning.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       expect(() => useRegistry('v0:missing-registry')).toThrow(
         'Context "v0:missing-registry" not found. Ensure it\'s provided by an ancestor.',
       )
+      expect(warn).toHaveBeenCalled()
     })
   })
 

--- a/packages/0/src/palettes/leonardo/generate/index.test.ts
+++ b/packages/0/src/palettes/leonardo/generate/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { leonardo } from './index'
 
@@ -15,6 +15,22 @@ function expectAllHex (record: Record<string, string>) {
 }
 
 describe('leonardo palette generator', () => {
+  // @adobe/leonardo-contrast-colors@1.1.0 emits a `colorspace` deprecation from
+  // its own internals (Color._generateColorScale) even when callers pass the
+  // current `colorSpace` key. Drop only that third-party noise; let any other
+  // warning through so a real regression still surfaces.
+  beforeEach(() => {
+    const original = console.warn
+    vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('Leonardo:')) return
+      original(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   describe('shape', () => {
     it('should return palette and themes keys', () => {
       const result = leonardo('#0ea5e9')


### PR DESCRIPTION
## Summary

Fixes the flaky `Maximum recursive updates exceeded in <OverflowRoot>` failures in `Overflow/index.test.ts` that intermittently broke CI (`test:run --coverage`).

## Root cause

In happy-dom (and for detached/transient elements), `(el as HTMLElement).offsetWidth` can return `undefined`, and `getComputedStyle` margins can be empty/`auto`, so the indicator's width measurement evaluates to `NaN`. A `NaN` `reserved` width makes `isOverflowing` (`total > width - reserved`) evaluate `false`, which unmounts the indicator via its `v-if`; `onBeforeUnmount` then resets `indicatorWidth` to `0`, flipping `isOverflowing` back to `true` and remounting it — an infinite mount/unmount loop. It only manifests under full-suite concurrent load (timing-dependent), which is why it was flaky.

## Fix

Coerce both the parsed margins and `offsetWidth` to `0` when non-finite, so the measurement is always a finite number — a no-op in real browsers, where `offsetWidth` is always numeric. Applied to every measurement site in the `createOverflow` family (`createOverflow`, `OverflowIndicator`, `BreadcrumbsRoot`, `BreadcrumbsEllipsis`, `PaginationRoot`, `AvatarIndicator`) since they share the same pattern and latent fragility.

## Test log cleanup

The second commit brings the suite to zero stderr, per the zero-warnings policy:

- Expected Vue warnings (inject outside setup, object `modelValue` prop-type, renderless directive) in `createRegistry`, `createPlugin`, `Select`, `Combobox`, and `Avatar` tests are now captured with `using` `console.warn` spies and asserted.
- The `Leonardo: colorspace is deprecated` spam originates inside `@adobe/leonardo-contrast-colors@1.1.0` (its own internals read the deprecated key even when callers pass `colorSpace`); filtered only that line in the leonardo test, letting all other warnings through.

## Verification

- `vitest run --coverage` × 15: 0 failures (was ~33% flaky).
- Suite stderr: 0 warnings.
- `packages/0` typecheck + eslint clean.
