### PR TITLE
docs(AppChevron): reusable rotating disclosure chevron

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     AppBreadcrumbs: typeof import('./components/app/AppBreadcrumbs.vue')['default']
     AppBrowserIcon: typeof import('./components/app/AppBrowserIcon.vue')['default']
     AppBurst: typeof import('./components/app/AppBurst.vue')['default']
+    AppChevron: typeof import('./components/app/AppChevron.vue')['default']
     AppChip: typeof import('./components/app/AppChip.vue')['default']
     AppCloseButton: typeof import('./components/app/AppCloseButton.vue')['default']
     AppCopyright: typeof import('./components/app/AppCopyright.vue')['default']

--- a/apps/docs/src/components/app/AppChevron.vue
+++ b/apps/docs/src/components/app/AppChevron.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+  // Composables
+  import { useSettings } from '@/composables/useSettings'
+
+  // Utilities
+  import { toRef } from 'vue'
+
+  export interface AppChevronProps {
+    /** Rotated (expanded) state */
+    open?: boolean
+    /** Dropdown idiom (▼→▲) instead of the tree idiom (▶→▼) */
+    vertical?: boolean
+    size?: string | number
+  }
+
+  const {
+    open = false,
+    vertical = false,
+    size = 14,
+  } = defineProps<AppChevronProps>()
+
+  const settings = useSettings()
+
+  const animate = toRef(() => !settings.prefersReducedMotion.value)
+  const rotation = toRef(() => open && (vertical ? 'rotate-180' : 'rotate-90'))
+</script>
+
+<template>
+  <AppIcon
+    aria-hidden="true"
+    :class="[
+      rotation,
+      animate && 'transition-transform duration-200 ease-in-out',
+    ]"
+    :icon="vertical ? 'chevron-down' : 'chevron-right'"
+    :size
+  />
+</template>

--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -143,11 +143,7 @@
         type="button"
         @click.stop="onToggle"
       >
-        <AppIcon
-          aria-hidden="true"
-          :icon="isOpen ? 'chevron-down' : 'chevron-right'"
-          size="14"
-        />
+        <AppChevron :open="isOpen" />
 
         <span class="sr-only">
           {{ isOpen ? 'Collapse' : 'Expand' }} {{ name }}

--- a/apps/docs/src/components/docs/DocsExample.vue
+++ b/apps/docs/src/components/docs/DocsExample.vue
@@ -399,7 +399,10 @@
               >
                 <Select.Value v-slot="{ selectedValue }">{{ selectedValue }}</Select.Value>
                 <Select.Placeholder>+{{ hiddenFiles.length }} more</Select.Placeholder>
-                <Select.Cue v-slot="{ isOpen }" class="text-[10px] opacity-50">{{ isOpen ? '&#x25B4;' : '&#x25BE;' }}</Select.Cue>
+
+                <Select.Cue v-slot="{ isOpen }" class="opacity-50">
+                  <AppChevron :open="isOpen" :size="12" vertical />
+                </Select.Cue>
               </Select.Activator>
 
               <Select.Content class="p-1 rounded-lg border border-divider bg-surface shadow-lg" :style="{ minWidth: 'anchor-size(width)' }">
@@ -517,7 +520,7 @@
       @click="peekExpanded = !peekExpanded"
     >
       <span>{{ peekExpanded ? 'Collapse' : 'Expand' }}</span>
-      <AppIcon :icon="peekExpanded ? 'up' : 'down'" :size="14" />
+      <AppChevron :open="peekExpanded" :size="14" vertical />
     </button>
   </div>
 </template>

--- a/apps/docs/src/components/docs/DocsFreshnessTable.vue
+++ b/apps/docs/src/components/docs/DocsFreshnessTable.vue
@@ -94,12 +94,7 @@
           </Select.Value>
 
           <Select.Cue v-slot="{ isOpen }" class="inline-flex items-center opacity-60">
-            <AppIcon
-              class="transition-transform"
-              :class="isOpen ? '-rotate-90' : 'rotate-90'"
-              icon="chevron-right"
-              :size="14"
-            />
+            <AppChevron :open="isOpen" :size="14" vertical />
           </Select.Cue>
         </Select.Activator>
 

--- a/apps/docs/src/components/docs/DocsPaletteBrowse.vue
+++ b/apps/docs/src/components/docs/DocsPaletteBrowse.vue
@@ -112,7 +112,10 @@
       >
         <Select.Activator class="h-[30px] px-2 text-xs font-medium bg-surface-tint border border-divider rounded inline-flex items-center gap-1 cursor-pointer">
           <Select.Value v-slot="{ selectedValue }">{{ PALETTES[String(selectedValue)]?.label }}</Select.Value>
-          <Select.Cue v-slot="{ isOpen }" class="text-[10px] opacity-50">{{ isOpen ? '&#x25B4;' : '&#x25BE;' }}</Select.Cue>
+
+          <Select.Cue v-slot="{ isOpen }" class="opacity-50">
+            <AppChevron :open="isOpen" :size="12" vertical />
+          </Select.Cue>
         </Select.Activator>
 
         <Select.Content class="p-1 rounded-lg border border-divider bg-surface shadow-lg" :style="{ minWidth: 'anchor-size(width)' }">

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -187,11 +187,7 @@
 
         <span v-else class="opacity-50">Select a release...</span>
 
-        <AppIcon
-          class="ml-auto opacity-50"
-          :icon="open ? 'chevron-up' : 'chevron-down'"
-          :size="20"
-        />
+        <AppChevron class="ml-auto opacity-50" :open :size="20" vertical />
 
         <div
           v-if="store.isLoading"


### PR DESCRIPTION
## Summary

The docs reach for a rotating-chevron disclosure indicator all over the place, implemented three inconsistent ways — and two of them didn't animate at all (they swapped between two glyphs, which CSS can't tween).

This adds a single `AppChevron` component that rotates **one** glyph via `transition-transform` (gated on `prefers-reduced-motion`) and adopts it across the docs.

## `AppChevron`

`apps/docs/src/components/app/AppChevron.vue` — auto-imported, no call-site imports needed.

| Prop | Default | Behavior |
|------|---------|----------|
| `open` | `false` | rotated (expanded) state |
| `vertical` | `false` | dropdown idiom (chevron-down → `rotate-180`, ▼→▲) instead of the tree idiom (chevron-right → `rotate-90`, ▶→▼) |
| `size` | `14` | forwarded to the underlying icon |

The two idioms exist because tree disclosures (▶→▼) and dropdown activators (▼→▲) are genuinely different affordances; one rigid glyph can't serve both.

## Adopted at

- `AppNavLink` — sidebar section toggle (was a non-animating glyph swap)
- `DocsReleases` — release-picker activator (`vertical`)
- `DocsExample` — peek expand/collapse button + multi-file picker cue
- `DocsPaletteBrowse` — palette select cue
- `DocsFreshnessTable` — page-size select cue (unified; zero visual change)

Four of these previously didn't animate; all now do, and respect reduced-motion.

## Intentionally left alone

- chevron↔`code` swaps in `DocsApiCard` / `DocsExample` code toggles — those are *semantic* icon changes, not direction indicators.
- Sort-direction indicators (`DocsMaturity`, `DocsFreshnessTable` headers) — tri-state asc/desc/none; would warrant a separate `AppSortIcon`.
- The already-animating group expanders (`DocsMaturity`, `BenchmarkGroup`, `DocsRoadmap`) — a consistency-only sweep, deferred.
- `examples/**` — teaching code that must stay self-contained.

`pnpm build:docs` passes.