### PR TITLE
docs(GnDocsExample): render forwarded description slot

### DIFF
--- a/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
@@ -119,11 +119,13 @@
     :data-peek="peek || undefined"
   >
     <GnDocsExampleDescription
-      v-if="title"
+      v-if="title || $slots.description"
       :anchor-id="id"
       :collapse
       :title
-    />
+    >
+      <slot name="description" />
+    </GnDocsExampleDescription>
 
     <GnDocsExamplePreview
       ref="preview"


### PR DESCRIPTION
## Summary

`GnDocsExample` rendered `GnDocsExampleDescription` self-closing and gated it on the `title` prop, so the `#description` slot forwarded from `DocsGenesisExample` was never rendered. That slot carries the prose the markdown plugin (`apps/docs/build/markdown.ts`) places after example file declarations in a `::: gn-example` block — heading, paragraphs, mermaid, file tables — and the markdown path never sets a `title` prop (the title is a heading *inside* the slot). Result: all prose after the file list was silently dropped.

## Fix

Forward the slot and gate on `title || $slots.description`, matching the working legacy `DocsExample`:

```diff
     <GnDocsExampleDescription
-      v-if="title"
+      v-if="title || $slots.description"
       :anchor-id="id"
       :collapse
       :title
-    />
+    >
+      <slot name="description" />
+    </GnDocsExampleDescription>
```

## Verification

- Live docs server: the `### Compose with Image` prose block on `aspect-ratio.md` was absent before, renders inside `.genesis-docs-example-description__body` after.
- `vue-tsc --noEmit` on `@paper/genesis` passes.