### PR TITLE
docs(GnDocsExampleDescription): always collapse behind an expand toggle

### DIFF
--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -156,8 +156,9 @@
 </template>
 
 <style scoped>
-  /* Match the AppBar's glass treatment on sticky toolbars so they read as a
-     continuous surface with the page chrome while scrolling. */
+  /* Skin the example surfaces with the AppBar's glass treatment so the
+     description and the sticky toolbars read as continuous page chrome. */
+  :deep(.genesis-docs-example-description),
   :deep(.genesis-docs-example__toggle-bar),
   :deep(.genesis-docs-example__code-bar),
   :deep(.genesis-docs-example-tabs__bar) {

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -110,7 +110,7 @@
   }
 
   .genesis-docs-example-description__body {
-    margin-top: 0.25rem;
+    margin-top: 0;
     font-size: 0.875rem;
     line-height: 1.5;
     transition: max-height 0.3s ease-out;

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -116,6 +116,25 @@
     transition: max-height 0.3s ease-out;
   }
 
+  /* The body renders forwarded markdown prose. Match the legacy
+     DocsExampleDescription's compact heading scale so a `### Title` inside the
+     description reads as a heading, not body text. */
+  .genesis-docs-example-description__body :deep(h3) {
+    margin: 0 0 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--v0-on-surface, #1a1c1e);
+  }
+
+  .genesis-docs-example-description__body :deep(h4),
+  .genesis-docs-example-description__body :deep(h5),
+  .genesis-docs-example-description__body :deep(h6) {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--v0-on-surface, #1a1c1e);
+  }
+
   .genesis-docs-example-description__fade {
     position: absolute;
     inset-inline: 0;

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -87,7 +87,7 @@
 <style scoped>
   .genesis-docs-example-description {
     position: relative;
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.25rem 0;
     border-bottom: 1px solid color-mix(in srgb, var(--v0-on-surface, currentcolor) 14%, transparent);
     background: var(--v0-surface-tint, var(--v0-surface, #f5f5f8));
     color: var(--v0-on-surface-variant, rgb(0 0 0 / 0.6));

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -4,7 +4,7 @@
     title?: string
     /** Anchor id rendered on the heading for deep-linking */
     anchorId?: string
-    /** Collapse the description with an expand toggle */
+    /** Accepted for API compatibility; the description always collapses behind an expand toggle */
     collapse?: boolean
   }
 </script>
@@ -18,7 +18,6 @@
   const {
     title,
     anchorId,
-    collapse = false,
   } = defineProps<GnDocsExampleDescriptionProps>()
 
   defineEmits<{
@@ -29,7 +28,10 @@
   const expanded = defineModel<boolean>('expanded', { default: false })
 
   const hasContent = toRef(() => !!slots.default)
-  const truncated = toRef(() => collapse && !expanded.value && hasContent.value)
+  // Truncate by default with an always-available toggle, matching the legacy
+  // DocsExampleDescription. `collapse` is a boolean prop, so it casts to false
+  // when absent — gating truncation on it would make long prose never collapse.
+  const truncated = toRef(() => !expanded.value && hasContent.value)
   const maxHeight = shallowRef('4.5rem')
 
   function onToggle () {
@@ -70,7 +72,7 @@
     <div v-if="truncated" aria-hidden="true" class="genesis-docs-example-description__fade" />
 
     <button
-      v-if="hasContent && collapse"
+      v-if="hasContent"
       :aria-expanded="expanded ? 'true' : 'false'"
       :aria-label="expanded ? 'Collapse description' : 'Expand description'"
       class="genesis-docs-example-description__toggle"


### PR DESCRIPTION
## Summary

Follow-up to #266. Rendering the forwarded `#description` slot exposed that `GnDocsExampleDescription` gated truncation **and** the expand toggle on the `collapse` prop. `collapse` is a boolean prop, so Vue casts it to `false` when absent — meaning the markdown path (`::: gn-example` with no `collapse` flag) rendered the entire description in full with no header/expand affordance.

The legacy `DocsExampleDescription` avoids this by truncating **unconditionally** — `collapse` there only switches button presentation. This change matches that: truncate by default with an always-available toggle.

## Change

```diff
-  const truncated = toRef(() => collapse && !expanded.value && hasContent.value)
+  const truncated = toRef(() => !expanded.value && hasContent.value)
```
```diff
-      v-if="hasContent && collapse"
+      v-if="hasContent"
```

`collapse` is dropped from the destructure (no longer gates behavior) but kept on the props interface for API compatibility.

## Verification

On a live docs server (`aspect-ratio.md`, the long-prose `gn-example`): the description now renders collapsed (body clipped to 4.5rem with a fade and an "Expand" toggle); clicking expands to full prose with a "Collapse" toggle. `vue-tsc` and `eslint` on `@paper/genesis` pass clean.