### PR TITLE
docs: alias prerelease versions in the maturity matrix

### DIFF
--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -3,6 +3,7 @@
   import { createDataTable, createGroup, createSingle } from '@vuetify/v0'
 
   import maturityData from '#v0/maturity.json'
+  import { releaseAlias } from '@/constants/releases'
 
   // Utilities
   import { toRef, watch } from 'vue'
@@ -345,7 +346,7 @@
                 >{{ item.type }}</span>
 
                 <span v-if="item.since" class="text-[10px] text-on-surface-variant font-mono">
-                  v{{ item.since }}
+                  {{ releaseAlias(item.since) }}
                 </span>
               </div>
             </div>
@@ -526,7 +527,7 @@
                   class="text-primary no-underline hover:underline whitespace-nowrap"
                   :href="`/releases/?version=v${item.since}`"
                   target="_blank"
-                >v{{ item.since }} ↗</a>
+                >{{ releaseAlias(item.since) }} ↗</a>
 
                 <span v-else class="text-on-surface-variant/50">—</span>
               </td>

--- a/apps/docs/src/constants/releases.ts
+++ b/apps/docs/src/constants/releases.ts
@@ -1,0 +1,21 @@
+/**
+ * Maps a canonical release version (the maturity `since` value, no `v` prefix)
+ * to a short display alias. The full version still drives the release deep-link,
+ * so only the rendered label changes — not the underlying data.
+ */
+export const RELEASE_ALIASES: Record<string, string> = {
+  '1.0.0-alpha.0': 'alpha.0',
+  '1.0.0-alpha.1': 'alpha.1',
+  '1.0.0-alpha.2': 'alpha.2',
+  '1.0.0-alpha.3': 'alpha.3',
+  '1.0.0-alpha.4': 'alpha.4',
+  '1.0.0-alpha.5': 'alpha.5',
+  '1.0.0-beta.0': 'beta.0',
+}
+
+/** Display label for a release version: its alias, or `v{version}` when unmapped. */
+export function releaseAlias (version: string | undefined): string {
+  if (!version) return ''
+
+  return RELEASE_ALIASES[version] ?? `v${version}`
+}

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -108,7 +108,7 @@
     },
     "createDataGrid": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-beta.0",
       "category": "data"
     },
     "createDataTable": {
@@ -208,7 +208,7 @@
     },
     "useTooltip": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-beta.0",
       "category": "plugins"
     },
     "useClickOutside": {
@@ -521,7 +521,7 @@
     },
     "Tooltip": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-beta.0",
       "category": "disclosure"
     },
     "Alert": {


### PR DESCRIPTION
Renders short release labels (`alpha.N`, `beta.0`) in the roadmap maturity matrix via a display-only alias map (`RELEASE_ALIASES` + `releaseAlias` in `apps/docs/src/constants/releases.ts`). The `since` field stays canonical semver, so the `/releases` deep-link and downstream semver consumers (MCP/CLI) keep working — only the rendered label changes.

Also backfills `since: "1.0.0-beta.0"` for `createDataGrid`, `useTooltip`, and `Tooltip` — they shipped in `v1.0.0-beta.0` but the release commit left their `since` as `null`.