### PR TITLE
chore: enforce V0Error over bare Error in packages/0/src via no-restricted-syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,6 +127,22 @@ export default vuetify({
   ignores: ['**/export-templates/package.json'],
 },
 {
+  // Enforce V0Error over bare Error for throw sites in the core package.
+  // This prevents contributors from accidentally bypassing the typed error
+  // registry (V0ErrorDetails) that gives consumers a stable code discriminant.
+  name: 'vuetify/no-bare-error-throw',
+  files: ['packages/0/src/**/*.ts'],
+  ignores: ['packages/0/src/**/*.test.ts', 'packages/0/src/**/*.bench.ts'],
+  rules: {
+    'no-restricted-syntax': ['error',
+      {
+        selector: 'ThrowStatement > NewExpression[callee.name="Error"]',
+        message: 'Use V0Error with a code from V0ErrorDetails instead of bare Error. See packages/0/src/utilities/errors.ts.',
+      },
+    ],
+  },
+},
+{
   name: 'vuetify/no-v0-imports',
   files: ['packages/paper/**/*.{ts,js,vue}', 'app/**/*.{ts,js,vue}'],
   rules: {


### PR DESCRIPTION
## Problem

Closes #248.

PR #247 converted all 8 existing `throw new Error(...)` sites in `packages/0/src` to use `V0Error` with a typed code from `V0ErrorDetails`. The convention was described in the philosophy but enforced only by author discipline — nothing in CI would catch a future PR landing a bare `throw new Error(...)`.

## Fix

Add a `no-restricted-syntax` block in `eslint.config.js` scoped to `packages/0/src/**/*.ts` (with carve-outs for `*.test.ts` and `*.bench.ts`):

```js
{
  name: 'vuetify/no-bare-error-throw',
  files: ['packages/0/src/**/*.ts'],
  ignores: ['packages/0/src/**/*.test.ts', 'packages/0/src/**/*.bench.ts'],
  rules: {
    'no-restricted-syntax': ['error',
      {
        selector: 'ThrowStatement > NewExpression[callee.name="Error"]',
        message: 'Use V0Error with a code from V0ErrorDetails instead of bare Error. See packages/0/src/utilities/errors.ts.',
      },
    ],
  },
},
```

## Notes

- Uses `no-restricted-syntax` — no custom plugin, no new dependency, mirrors the existing `withDefaults` guard on line 29.
- Re-throws (`throw err` where `err` is a caught binding) are not flagged — the selector only matches `new Error(...)` constructor calls.
- Test and bench files are excluded per the issue spec.
- The rule fires at `error` severity so it blocks CI on a violation.