### PR TITLE
fix: harden composables against prototype pollution, CSS injection, and unbounded allocation

### DIFF
--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -58,6 +58,21 @@ Before writing a new helper, check `#v0/utilities`. Available today:
 
 All helpers carry `/* #__NO_SIDE_EFFECTS__ */` and are tree-shakeable. Module-level allocating constants (e.g., a top-level `new Set([...])`) carry `/* @__PURE__ */` instead — see `utilities/helpers.ts` (the `UNSAFE_KEYS` set) and `utilities/instance.ts` (the `INSTANCE_KEY` literal) for the placement convention. Never add a new utility that introduces a top-level side effect — the barrel cannot absorb it. [PHILOSOPHY §2.7]
 
+## Security primitives — reuse, never reinvent
+
+A headless lib exposes a small, fixed set of injection / DoS sinks, and v0 already ships the guard for each. When you write code in one of these shapes, reach for the existing primitive. Every gap found in the 2026-06-04 security audit was a sibling that missed the guard its twin already had. [user-feedback:2026-06-04]
+
+| When you… | Guard | Has it / missed it |
+|-----------|-------|--------------------|
+| Build a plain object keyed by caller- or registry-supplied strings | Skip keys in `UNSAFE_KEYS` (`#v0/utilities`) — `__proto__` / `constructor` / `prototype` | `mergeDeep` has it; `usePermissions` didn't |
+| Interpolate a value into a CSS string or `<style>` text | Mirror `ThemeAdapter` — validate keys with `SAFE_IDENT`, reject values matching `UNSAFE_CSS` (`useTheme/adapters/adapter.ts`) | v0 `ThemeAdapter` has it; paper `useTheme` didn't |
+| Build a `querySelector` string from a runtime id or value | Wrap the dynamic part in `CSS.escape()` | `createCombobox`, `Select` have it |
+| Allocate an array from a caller-controlled count (`range(n)`, …) | Bound it — `clamp(Math.floor(n), 0, CAP)`, or the `n > Number.MAX_SAFE_INTEGER → []` guard | `createPagination` has it; `createRating` didn't |
+
+`UNSAFE_KEYS` is importable from `#v0/utilities`; the `ThemeAdapter` CSS sanitizer is a `private static` pattern to mirror, not import. Registry / selection / nested / tokens keyed state is `Map`-based and prototype-pollution-immune by construction — keep it that way; never swap a keyed `Map` for a plain `{}` index.
+
+This is the proactive half. `feedback_bug_family_audit` is the reactive half: after fixing one of these, grep the sibling family for the same shape before calling it done.
+
 ## Ticket Pattern (PHILOSOPHY §6.2)
 
 "Tickets" are the currency of every registry. The hierarchy:

--- a/packages/0/src/composables/createRating/index.ts
+++ b/packages/0/src/composables/createRating/index.ts
@@ -39,6 +39,9 @@ import { computed, isRef, shallowRef, toRef, toValue } from 'vue'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { ComputedRef, MaybeRefOrGetter, Ref, ShallowRef, WritableComputedRef } from 'vue'
 
+// Upper bound on generated items; guards against an unbounded allocation from a hostile `size`
+const MAX_SIZE = 1000
+
 export type RatingItemState = 'full' | 'half' | 'empty'
 
 export interface RatingItemDescriptor {
@@ -162,8 +165,9 @@ export function createRating<
 
   const items = computed<RatingItemDescriptor[]>(() => {
     const current = value.value
+    const count = clamp(Math.floor(toValue(_size)), 0, MAX_SIZE)
 
-    return range(toValue(_size), 1).map(i => ({
+    return range(count, 1).map(i => ({
       value: i,
       state: getState(i, current),
     }))

--- a/packages/0/src/composables/usePermissions/index.ts
+++ b/packages/0/src/composables/usePermissions/index.ts
@@ -34,6 +34,9 @@ import { V0PermissionsAdapter } from '#v0/composables/usePermissions/adapters'
 // Transformers
 import { toArray } from '#v0/composables/toArray'
 
+// Utilities
+import { UNSAFE_KEYS } from '#v0/utilities'
+
 // Types
 import type { TokenContext, TokenOptions, TokenTicket } from '#v0/composables/createTokens'
 import type { PermissionsAdapter } from '#v0/composables/usePermissions/adapters'
@@ -87,10 +90,13 @@ export function createPermissions (_options: PermissionOptions = {}): Permission
 
   const record: Record<string, Record<string, Record<string, boolean | ((context: Record<string, unknown>) => boolean)>>> = {}
   for (const role in permissions) {
+    if (UNSAFE_KEYS.has(role)) continue
     if (!record[role]) record[role] = {}
     for (const [actions, subjects, condition = true] of permissions[role]!) {
       for (const action of toArray(actions)) {
+        if (UNSAFE_KEYS.has(action)) continue
         for (const subject of toArray(subjects)) {
+          if (UNSAFE_KEYS.has(subject)) continue
           if (!record[role][action]) record[role][action] = {}
 
           record[role][action][subject] = condition

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -13,7 +13,7 @@ export interface ThemeAdapterSetupContext {
 }
 
 export abstract class ThemeAdapter {
-  private static UNSAFE_CSS = /url\s*\(|@import|expression\s*\(|[{}]/i
+  private static UNSAFE_CSS = /url\s*\(|@import|expression\s*\(|[{}<>]/i
   private static SAFE_IDENT = /^[a-zA-Z0-9_-]+$/
 
   public stylesheetId = 'v0-theme-stylesheet'

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -308,7 +308,7 @@ export function isNaN (item: unknown): item is number {
 }
 
 // Keys that could lead to prototype pollution
-const UNSAFE_KEYS = /* @__PURE__ */ new Set(['__proto__', 'constructor', 'prototype'])
+export const UNSAFE_KEYS = /* @__PURE__ */ new Set(['__proto__', 'constructor', 'prototype'])
 
 function isPlainObject (value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false


### PR DESCRIPTION
Security hardening pass over the v0 composables — three independent fixes plus a rule documenting the convention.

- **usePermissions** — `createPermissions` built a nested plain object keyed by caller-supplied `role`/`action`/`subject` names with no guard, so a `__proto__` key in a permissions config (e.g. one fetched from a backend) could pollute `Object.prototype`. It now skips keys in the shared `UNSAFE_KEYS` blocklist at all three levels; `UNSAFE_KEYS` is exported from `#v0/utilities` so it is reused rather than duplicated.
- **createRating** — `range(toValue(size))` allocated an unbounded array, so a large or non-finite `size` could exhaust memory. The count is now clamped to a finite upper bound before allocating, mirroring the existing guard in `createPagination`.
- **useTheme** — `ThemeAdapter`'s `UNSAFE_CSS` pattern now also rejects `<` and `>`, closing a `</style>` breakout on the SSR/unhead `innerHTML` path. Theme color values never legitimately contain angle brackets.

Also adds a `## Security primitives` section to `.claude/rules/implementation.md` mapping each sink shape to its existing guard, so new code reaches for the primitive instead of reinventing it.

For context: `mergeDeep` was already guarded, and registry/selection/nested/tokens keyed state is `Map`-based and pollution-immune by construction. `packages/0` typecheck, lint, and the affected test suites are green.
