### PR TITLE
perf(createRegistry): replace Map-rebuild move with order-array splice + windowed reindex

### DIFF
--- a/apps/docs/src/pages/composables/registration/create-registry.md
+++ b/apps/docs/src/pages/composables/registration/create-registry.md
@@ -115,7 +115,7 @@ Each branch extends the base ticket pattern with domain-specific capabilities. S
 | `register(ticket)` | Add a ticket to the registry |
 | `unregister(id)` | Remove a ticket by ID |
 | `upsert(id, partial)` | Register or update a ticket |
-| `move(id, index)` | Reorder a ticket to a new index position |
+| `move(id, index)` | Move a ticket to a new index position; reindexes only the affected `[from..to]` span |
 | `reorder(ids)` | Reorder the registry to match a canonical permutation in one O(n) pass |
 | `onboard(tickets)` | Batch-register an array of tickets |
 | `offboard(ids)` | Batch-unregister an array of IDs |

--- a/packages/0/src/composables/createRegistry/index.bench.ts
+++ b/packages/0/src/composables/createRegistry/index.bench.ts
@@ -43,6 +43,15 @@ function createPopulatedRegistry (count: number): RegistryContext<RegistryTicket
   return registry
 }
 
+// Reactive variant: keys()/values()/entries() skip the read cache and recompute
+// on every call, so these fixtures isolate the uncached O(n) read cost.
+function createReactiveRegistry (count: number): RegistryContext<RegistryTicket> {
+  const registry = createRegistry({ reactive: true })
+  const items = count === 1000 ? ITEMS_1K : ITEMS_10K
+  registry.onboard(items.slice(0, count))
+  return registry
+}
+
 // Lookup targets (middle of registry for realistic access pattern)
 const LOOKUP_ID_1K = 'item-500'
 const LOOKUP_ID_10K = 'item-5000'
@@ -249,6 +258,72 @@ describe('createRegistry benchmarks', () => {
     bench('Access entries 100 times (10,000 items, cached)', () => {
       for (let i = 0; i < 100; i++) {
         registry10k.entries()
+      }
+    })
+  })
+
+  // ===========================================================================
+  // REACTIVE ACCESS - Uncached recompute path (reactive: true bypasses the cache)
+  // Shared fixture (safe - read-only operations, no state changes)
+  // Measures: full O(n) recompute of keys/values/entries on every call (the
+  // `computed access` group above measures the cached path), plus the combined
+  // snapshot rebuild useProxyRegistry performs (keys + values + entries together)
+  // on each version bump (#280) — the read shape that dominates once a reactive
+  // registry is consumed from a template or computed.
+  // ===========================================================================
+  describe('reactive access', () => {
+    const reactive1k = createReactiveRegistry(1000)
+    const reactive10k = createReactiveRegistry(10_000)
+
+    bench('Access keys 100 times (1,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive1k.keys()
+      }
+    })
+
+    bench('Access keys 100 times (10,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive10k.keys()
+      }
+    })
+
+    bench('Access values 100 times (1,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive1k.values()
+      }
+    })
+
+    bench('Access values 100 times (10,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive10k.values()
+      }
+    })
+
+    bench('Access entries 100 times (1,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive1k.entries()
+      }
+    })
+
+    bench('Access entries 100 times (10,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive10k.entries()
+      }
+    })
+
+    bench('Rebuild snapshot 100 times (1,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive1k.keys()
+        reactive1k.values()
+        reactive1k.entries()
+      }
+    })
+
+    bench('Rebuild snapshot 100 times (10,000 items, reactive)', () => {
+      for (let i = 0; i < 100; i++) {
+        reactive10k.keys()
+        reactive10k.values()
+        reactive10k.entries()
       }
     })
   })

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -1334,6 +1334,138 @@ describe('createRegistry', () => {
     })
   })
 
+  describe('move functionality — windowed (issue #258)', () => {
+    function fixture () {
+      const registry = createRegistry()
+      registry.onboard([
+        { id: 'a', value: 'alpha' },
+        { id: 'b', value: 'beta' },
+        { id: 'c', value: 'gamma' },
+        { id: 'd', value: 'delta' },
+        { id: 'e', value: 'epsilon' },
+      ])
+      return registry
+    }
+
+    it('should not corrupt directory or catalog on a mid-list move', () => {
+      const registry = fixture()
+
+      registry.move('b', 3)
+
+      expect(registry.keys()).toEqual(['a', 'c', 'd', 'b', 'e'])
+
+      expect(registry.get('a')?.index).toBe(0)
+      expect(registry.get('c')?.index).toBe(1)
+      expect(registry.get('d')?.index).toBe(2)
+      expect(registry.get('b')?.index).toBe(3)
+      expect(registry.get('e')?.index).toBe(4)
+
+      expect(registry.lookup(0)).toBe('a')
+      expect(registry.lookup(1)).toBe('c')
+      expect(registry.lookup(2)).toBe('d')
+      expect(registry.lookup(3)).toBe('b')
+      expect(registry.lookup(4)).toBe('e')
+
+      expect(registry.browse('alpha')).toEqual(['a'])
+      expect(registry.browse('beta')).toEqual(['b'])
+      expect(registry.browse('gamma')).toEqual(['c'])
+    })
+
+    it('should keep lookup and index consistent on a mid-list move by 1 upward', () => {
+      const registry = fixture()
+
+      registry.move('c', 3)
+
+      expect(registry.keys()).toEqual(['a', 'b', 'd', 'c', 'e'])
+
+      const keys = registry.keys()
+      for (const [i, key] of keys.entries()) {
+        expect(registry.lookup(i)).toBe(key)
+        expect(registry.get(key!)?.index).toBe(i)
+      }
+    })
+
+    it('should keep lookup and index consistent on a mid-list move downward', () => {
+      const registry = fixture()
+
+      registry.move('d', 1)
+
+      expect(registry.keys()).toEqual(['a', 'd', 'b', 'c', 'e'])
+
+      const keys = registry.keys()
+      for (const [i, key] of keys.entries()) {
+        expect(registry.lookup(i)).toBe(key)
+        expect(registry.get(key!)?.index).toBe(i)
+      }
+    })
+
+    it('should track valueIsIndex values after a mid-list move', () => {
+      const registry = createRegistry()
+      registry.onboard([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }])
+
+      registry.move('b', 2)
+
+      expect(registry.keys()).toEqual(['a', 'c', 'b', 'd'])
+
+      expect(registry.get('a')?.value).toBe(0)
+      expect(registry.get('c')?.value).toBe(1)
+      expect(registry.get('b')?.value).toBe(2)
+      expect(registry.get('d')?.value).toBe(3)
+
+      expect(registry.browse(2)).toContain('b')
+      expect(registry.lookup(2)).toBe('b')
+    })
+
+    it('should hold the lookup/index invariant across a sequence of moves', () => {
+      const registry = createRegistry()
+      registry.onboard([
+        { id: 'a', value: 'v0' },
+        { id: 'b', value: 'v1' },
+        { id: 'c', value: 'v2' },
+        { id: 'd', value: 'v3' },
+        { id: 'e', value: 'v4' },
+        { id: 'f', value: 'v5' },
+      ])
+
+      function assertInvariant () {
+        const keys = registry.keys()
+        for (const [i, key] of keys.entries()) {
+          expect(registry.lookup(i)).toBe(key)
+          expect(registry.get(key!)?.index).toBe(i)
+        }
+      }
+
+      registry.move('a', 5)
+      assertInvariant()
+      registry.move('f', 0)
+      assertInvariant()
+      registry.move('c', 4)
+      assertInvariant()
+      registry.move('e', 1)
+      assertInvariant()
+    })
+
+    it('should trigger keys() reactivity on a move in reactive mode', async () => {
+      const registry = createRegistry({ reactive: true })
+      registry.onboard([
+        { id: 'a', value: 'alpha' },
+        { id: 'b', value: 'beta' },
+        { id: 'c', value: 'gamma' },
+      ])
+
+      const snapshots: string[] = []
+      watchEffect(() => snapshots.push(registry.keys().join(',')))
+
+      await nextTick()
+      expect(snapshots.at(-1)).toBe('a,b,c')
+
+      registry.move('a', 2)
+      await nextTick()
+
+      expect(snapshots.at(-1)).toBe('b,c,a')
+    })
+  })
+
   describe('reorder functionality', () => {
     it('should reorder tickets to match a canonical permutation', () => {
       const registry = createRegistry()

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -141,6 +141,30 @@ describe('createRegistry', () => {
       expect(listener).toHaveBeenCalledTimes(2)
     })
 
+    it('should dedupe repeated ids within a single offboard call', () => {
+      const registry = createRegistry({ events: true })
+      const listener = vi.fn()
+
+      // No explicit value → valueIsIndex true, so removal touches indexDependentCount.
+      registry.onboard([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+
+      registry.on('unregister:ticket', listener)
+      const removed = registry.offboard(['a', 'a'])
+
+      // The repeated id is removed once — not double-counted into a second
+      // indexDependentCount decrement or a second unregister emit.
+      expect(removed).toHaveLength(1)
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(registry.size).toBe(2)
+      expect(registry.keys()).toEqual(['b', 'c'])
+
+      // lookup() drains the deferred reindex; survivors renumber cleanly.
+      expect(registry.lookup(0)).toBe('b')
+      expect(registry.lookup(1)).toBe('c')
+      expect(registry.get('b')?.index).toBe(0)
+      expect(registry.get('c')?.index).toBe(1)
+    })
+
     it('should return removed inputs preserving id when valueIsIndex is false', () => {
       const registry = createRegistry()
 

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -769,18 +769,9 @@ export function createRegistry<
   const directory = new Map<number, ID>()
   const cache = new Map<'keys' | 'values' | 'entries', unknown[]>()
   const listeners = new Map<string, Set<InternalEventCallback>>()
-  // Ordered list of IDs – the canonical position sequence.  Splicing this
-  // array is all that move() needs; Map insertion order is no longer load-bearing.
-  // Made reactive when the registry is reactive so that keys()/values()/entries()
-  // re-evaluate whenever the order changes (register, move, reorder, etc.).
-  //
-  // Invariant: every id in `order` is also a key in `collection` at every
-  // observable point — each mutation updates the two in lockstep (collection.set
-  // before order.push on register; order spliced before collection.delete on
-  // unregister/offboard), so even a flush:'sync' watcher never sees an order id
-  // missing from the Map. This is what lets values()/entries() assert
-  // `collection.get(id)!` below.
-  const order = (reactive ? shallowReactive([] as ID[]) : []) as ID[]
+  // Canonical position sequence, kept in lockstep with `collection`. Holds
+  // ticket refs so values()/entries()/reindex() read them without a Map lookup.
+  const order = (reactive ? shallowReactive([] as E[]) : []) as E[]
 
   let indexDependentCount = 0
   let needsReindex = false
@@ -918,13 +909,13 @@ export function createRegistry<
     if (reactive) {
       // `order` is shallowReactive, so reading it here registers the dependency.
       // Effects re-evaluate when order is mutated (register, unregister, move, …).
-      return order.slice()
+      return order.map(ticket => ticket.id)
     }
 
     const cached = cache.get('keys')
     if (!isUndefined(cached)) return cached as readonly ID[]
 
-    const out = order.slice()
+    const out = order.map(ticket => ticket.id)
 
     cache.set('keys', out)
 
@@ -933,13 +924,13 @@ export function createRegistry<
 
   function values (): readonly E[] {
     if (reactive) {
-      return order.map(id => collection.get(id)!)
+      return order.slice()
     }
 
     const cached = cache.get('values')
     if (!isUndefined(cached)) return cached as readonly E[]
 
-    const out = order.map(id => collection.get(id)!)
+    const out = order.slice()
 
     cache.set('values', out)
 
@@ -948,13 +939,13 @@ export function createRegistry<
 
   function entries (): readonly [ID, E][] {
     if (reactive) {
-      return order.map(id => [id, collection.get(id)!] as [ID, E])
+      return order.map(ticket => [ticket.id, ticket] as [ID, E])
     }
 
     const cached = cache.get('entries')
     if (!isUndefined(cached)) return cached as readonly [ID, E][]
 
-    const out = order.map(id => [id, collection.get(id)!] as [ID, E])
+    const out = order.map(ticket => [ticket.id, ticket] as [ID, E])
 
     cache.set('entries', out)
 
@@ -1021,14 +1012,14 @@ export function createRegistry<
       // because a single delete-then-set pass would clobber a freshly-set slot
       // when the dirty window is a non-monotonic permutation (e.g. a mid-list move).
       for (let i = start; i <= end; i++) {
-        const ticket = collection.get(order[i]!)!
+        const ticket = order[i]
         directory.delete(ticket.index)
         if (ticket.valueIsIndex) unassign(ticket.value, ticket.id)
       }
     }
 
     for (let i = start; i <= end; i++) {
-      const ticket = collection.get(order[i]!)!
+      const ticket = order[i]
 
       if (ticket.valueIsIndex) {
         ticket.value = i
@@ -1080,7 +1071,7 @@ export function createRegistry<
     const ticket = reactive ? shallowReactive(input) : input
 
     collection.set(ticket.id, ticket)
-    order.push(ticket.id)
+    order.push(ticket)
     directory.set(ticket.index, ticket.id)
 
     assign(ticket.value, ticket.id)
@@ -1103,7 +1094,7 @@ export function createRegistry<
     // method defers reindex (lazy contract), so the index may be stale. Single
     // removals are cheap; bulk removal should go through offboard(), which
     // compacts order in one O(n) pass instead of N indexOf scans.
-    const orderPos = order.indexOf(ticket.id)
+    const orderPos = order.indexOf(ticket)
     if (orderPos !== -1) order.splice(orderPos, 1)
     collection.delete(ticket.id)
     directory.delete(ticket.index)
@@ -1164,8 +1155,8 @@ export function createRegistry<
       // Compact order FIRST so that Vue sync effects triggered by the subsequent
       // Map mutations see a consistent snapshot (no dangling IDs in order).
       let w = 0
-      for (let r = 0; r < order.length; r++) {
-        if (!removedIds.has(order[r]!)) order[w++] = order[r]!
+      for (const ticket of order) {
+        if (!removedIds.has(ticket.id)) order[w++] = ticket
       }
       order.length = w
 
@@ -1206,7 +1197,7 @@ export function createRegistry<
 
     return batch(() => {
       order.splice(from, 1)
-      order.splice(target, 0, id)
+      order.splice(target, 0, ticket)
 
       // Bound the reindex to the [from..target] window: only those indices
       // changed, so reindex() touches O(distance) tickets instead of the tail.
@@ -1225,15 +1216,18 @@ export function createRegistry<
     if (ids.length !== collection.size) return
 
     const seen = new Set<ID>()
+    const next: E[] = []
     for (const id of ids) {
       if (seen.has(id)) return
-      if (!collection.has(id)) return
+      const ticket = collection.get(id)
+      if (!ticket) return
       seen.add(id)
+      next.push(ticket)
     }
 
     batch(() => {
-      for (const [i, id] of ids.entries()) {
-        order[i] = id!
+      for (const [i, ticket] of next.entries()) {
+        order[i] = ticket
       }
       minDirtyIndex = 0
       maxDirtyIndex = -Infinity

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -773,6 +773,13 @@ export function createRegistry<
   // array is all that move() needs; Map insertion order is no longer load-bearing.
   // Made reactive when the registry is reactive so that keys()/values()/entries()
   // re-evaluate whenever the order changes (register, move, reorder, etc.).
+  //
+  // Invariant: every id in `order` is also a key in `collection` at every
+  // observable point — each mutation updates the two in lockstep (collection.set
+  // before order.push on register; order spliced before collection.delete on
+  // unregister/offboard), so even a flush:'sync' watcher never sees an order id
+  // missing from the Map. This is what lets values()/entries() assert
+  // `collection.get(id)!` below.
   const order = (reactive ? shallowReactive([] as ID[]) : []) as ID[]
 
   let indexDependentCount = 0
@@ -1092,6 +1099,10 @@ export function createRegistry<
       indexDependentCount--
     }
 
+    // O(n) locate + splice. ticket.index can't be used as the position — this
+    // method defers reindex (lazy contract), so the index may be stale. Single
+    // removals are cheap; bulk removal should go through offboard(), which
+    // compacts order in one O(n) pass instead of N indexOf scans.
     const orderPos = order.indexOf(ticket.id)
     if (orderPos !== -1) order.splice(orderPos, 1)
     collection.delete(ticket.id)
@@ -1133,9 +1144,13 @@ export function createRegistry<
 
   function offboard (ids: ID[]): Partial<Z>[] {
     // Collect valid tickets before any mutations so we know what to remove.
+    // Dedupe up front: a repeated id must not double-decrement indexDependentCount
+    // or emit `unregister:ticket` twice. The old delete-then-get loop was
+    // incidentally dedupe-safe; reading all tickets first is not.
     const removed: E[] = []
     const removedIds = new Set<ID>()
     for (const id of ids) {
+      if (removedIds.has(id)) continue
       const ticket = collection.get(id)
       if (ticket) {
         removed.push(ticket)

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -1201,8 +1201,8 @@ export function createRegistry<
     }
 
     batch(() => {
-      for (let i = 0; i < ids.length; i++) {
-        order[i] = ids[i]!
+      for (const [i, id] of ids.entries()) {
+        order[i] = id!
       }
       minDirtyIndex = 0
       reindex()

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -769,6 +769,11 @@ export function createRegistry<
   const directory = new Map<number, ID>()
   const cache = new Map<'keys' | 'values' | 'entries', unknown[]>()
   const listeners = new Map<string, Set<InternalEventCallback>>()
+  // Ordered list of IDs – the canonical position sequence.  Splicing this
+  // array is all that move() needs; Map insertion order is no longer load-bearing.
+  // Made reactive when the registry is reactive so that keys()/values()/entries()
+  // re-evaluate whenever the order changes (register, move, reorder, etc.).
+  const order = (reactive ? shallowReactive([] as ID[]) : []) as ID[]
 
   let indexDependentCount = 0
   let needsReindex = false
@@ -902,12 +907,16 @@ export function createRegistry<
   }
 
   function keys (): readonly ID[] {
-    if (reactive) return Array.from(collection.keys())
+    if (reactive) {
+      // `order` is shallowReactive, so reading it here registers the dependency.
+      // Effects re-evaluate when order is mutated (register, unregister, move, …).
+      return order.slice()
+    }
 
     const cached = cache.get('keys')
     if (!isUndefined(cached)) return cached as readonly ID[]
 
-    const out = Array.from(collection.keys())
+    const out = order.slice()
 
     cache.set('keys', out)
 
@@ -915,12 +924,14 @@ export function createRegistry<
   }
 
   function values (): readonly E[] {
-    if (reactive) return Array.from(collection.values())
+    if (reactive) {
+      return order.map(id => collection.get(id)!)
+    }
 
     const cached = cache.get('values')
     if (!isUndefined(cached)) return cached as readonly E[]
 
-    const out = Array.from(collection.values())
+    const out = order.map(id => collection.get(id)!)
 
     cache.set('values', out)
 
@@ -928,12 +939,14 @@ export function createRegistry<
   }
 
   function entries (): readonly [ID, E][] {
-    if (reactive) return Array.from(collection.entries())
+    if (reactive) {
+      return order.map(id => [id, collection.get(id)!] as [ID, E])
+    }
 
     const cached = cache.get('entries')
     if (!isUndefined(cached)) return cached as readonly [ID, E][]
 
-    const out = Array.from(collection.entries())
+    const out = order.map(id => [id, collection.get(id)!] as [ID, E])
 
     cache.set('entries', out)
 
@@ -941,6 +954,7 @@ export function createRegistry<
   }
 
   function clear () {
+    order.length = 0
     collection.clear()
     catalog.clear()
     directory.clear()
@@ -988,13 +1002,8 @@ export function createRegistry<
 
     invalidate()
 
-    let index = 0
-
-    for (const ticket of collection.values()) {
-      if (index < startIndex) {
-        index++
-        continue
-      }
+    for (let i = startIndex; i < order.length; i++) {
+      const ticket = collection.get(order[i]!)!
 
       if (startIndex > 0) {
         directory.delete(ticket.index)
@@ -1004,16 +1013,14 @@ export function createRegistry<
         if (startIndex > 0) {
           unassign(ticket.value, ticket.id)
         }
-        ticket.value = index
+        ticket.value = i
         assign(ticket.value, ticket.id)
       } else if (startIndex === 0) {
         assign(ticket.value, ticket.id)
       }
 
-      ticket.index = index
-      directory.set(index, ticket.id)
-
-      index++
+      ticket.index = i
+      directory.set(i, ticket.id)
     }
 
     needsReindex = false
@@ -1054,6 +1061,7 @@ export function createRegistry<
     const ticket = reactive ? shallowReactive(input) : input
 
     collection.set(ticket.id, ticket)
+    order.push(ticket.id)
     directory.set(ticket.index, ticket.id)
 
     assign(ticket.value, ticket.id)
@@ -1072,6 +1080,8 @@ export function createRegistry<
       indexDependentCount--
     }
 
+    const orderPos = order.indexOf(ticket.id)
+    if (orderPos !== -1) order.splice(orderPos, 1)
     collection.delete(ticket.id)
     directory.delete(ticket.index)
     unassign(ticket.value, ticket.id)
@@ -1110,25 +1120,37 @@ export function createRegistry<
   }
 
   function offboard (ids: ID[]): Partial<Z>[] {
+    // Collect valid tickets before any mutations so we know what to remove.
     const removed: E[] = []
+    const removedIds = new Set<ID>()
+    for (const id of ids) {
+      const ticket = collection.get(id)
+      if (ticket) {
+        removed.push(ticket)
+        removedIds.add(id)
+      }
+    }
+
+    if (removed.length === 0) return []
 
     batch(() => {
-      for (const id of ids) {
-        const ticket = collection.get(id)
-        if (!ticket) continue
+      // Compact order FIRST so that Vue sync effects triggered by the subsequent
+      // Map mutations see a consistent snapshot (no dangling IDs in order).
+      let w = 0
+      for (let r = 0; r < order.length; r++) {
+        if (!removedIds.has(order[r]!)) order[w++] = order[r]!
+      }
+      order.length = w
 
+      for (const ticket of removed) {
         if (ticket.valueIsIndex) {
           indexDependentCount--
         }
-
         minDirtyIndex = Math.min(minDirtyIndex, ticket.index)
         collection.delete(ticket.id)
         directory.delete(ticket.index)
         unassign(ticket.value, ticket.id)
-        removed.push(ticket)
       }
-
-      if (removed.length === 0) return
 
       for (const ticket of removed) {
         emit('unregister:ticket', ticket)
@@ -1151,22 +1173,14 @@ export function createRegistry<
 
     const size = collection.size
     const target = clamp(toIndex, 0, size - 1)
+    const from = ticket.index
 
-    if (ticket.index === target) return ticket
+    if (from === target) return ticket
 
     return batch(() => {
-      const items = Array.from(collection.entries())
-      const fromIndex = items.findIndex(([key]) => key === id)
-      const [entry] = items.splice(fromIndex, 1)
-
-      items.splice(target, 0, entry!)
-
-      collection.clear()
-      for (const [key, value] of items) {
-        collection.set(key, value)
-      }
-
-      minDirtyIndex = Math.min(ticket.index, target)
+      order.splice(from, 1)
+      order.splice(target, 0, id)
+      minDirtyIndex = Math.min(from, target)
       reindex()
       emit('update:ticket', ticket)
 
@@ -1180,19 +1194,15 @@ export function createRegistry<
     if (ids.length !== collection.size) return
 
     const seen = new Set<ID>()
-    const entries: [ID, E][] = []
     for (const id of ids) {
       if (seen.has(id)) return
-      const ticket = collection.get(id)
-      if (!ticket) return
+      if (!collection.has(id)) return
       seen.add(id)
-      entries.push([id, ticket])
     }
 
     batch(() => {
-      collection.clear()
-      for (const [id, ticket] of entries) {
-        collection.set(id, ticket)
+      for (let i = 0; i < ids.length; i++) {
+        order[i] = ids[i]!
       }
       minDirtyIndex = 0
       reindex()

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -778,6 +778,7 @@ export function createRegistry<
   let indexDependentCount = 0
   let needsReindex = false
   let minDirtyIndex = Infinity
+  let maxDirtyIndex = -Infinity
   let isBatching = false
   let batched: Array<{ event: string, data: unknown }> = []
 
@@ -962,6 +963,7 @@ export function createRegistry<
     indexDependentCount = 0
     needsReindex = false
     minDirtyIndex = Infinity
+    maxDirtyIndex = -Infinity
     emit('clear:registry')
   }
 
@@ -993,29 +995,38 @@ export function createRegistry<
   }
 
   function reindex () {
-    const startIndex = minDirtyIndex === Infinity ? 0 : minDirtyIndex
-
-    if (startIndex === 0) {
-      catalog.clear()
-      directory.clear()
-    }
+    // The dirty window is [start..end]. `minDirtyIndex === Infinity` means "no
+    // lower bound recorded" (renumber from 0); `maxDirtyIndex === -Infinity`
+    // means "no upper bound recorded" (renumber to the end) — the case for
+    // removals and full reorders, where every trailing index shifts.
+    const size = order.length
+    const start = minDirtyIndex === Infinity ? 0 : minDirtyIndex
+    const end = maxDirtyIndex === -Infinity ? size - 1 : Math.min(maxDirtyIndex, size - 1)
+    const full = start === 0 && end === size - 1
 
     invalidate()
 
-    for (let i = startIndex; i < order.length; i++) {
+    if (full) {
+      catalog.clear()
+      directory.clear()
+    } else {
+      // Clear stale window entries before reassigning. Two passes are required
+      // because a single delete-then-set pass would clobber a freshly-set slot
+      // when the dirty window is a non-monotonic permutation (e.g. a mid-list move).
+      for (let i = start; i <= end; i++) {
+        const ticket = collection.get(order[i]!)!
+        directory.delete(ticket.index)
+        if (ticket.valueIsIndex) unassign(ticket.value, ticket.id)
+      }
+    }
+
+    for (let i = start; i <= end; i++) {
       const ticket = collection.get(order[i]!)!
 
-      if (startIndex > 0) {
-        directory.delete(ticket.index)
-      }
-
       if (ticket.valueIsIndex) {
-        if (startIndex > 0) {
-          unassign(ticket.value, ticket.id)
-        }
         ticket.value = i
         assign(ticket.value, ticket.id)
-      } else if (startIndex === 0) {
+      } else if (full) {
         assign(ticket.value, ticket.id)
       }
 
@@ -1025,6 +1036,7 @@ export function createRegistry<
 
     needsReindex = false
     minDirtyIndex = Infinity
+    maxDirtyIndex = -Infinity
     emit('reindex:registry')
   }
 
@@ -1180,7 +1192,11 @@ export function createRegistry<
     return batch(() => {
       order.splice(from, 1)
       order.splice(target, 0, id)
+
+      // Bound the reindex to the [from..target] window: only those indices
+      // changed, so reindex() touches O(distance) tickets instead of the tail.
       minDirtyIndex = Math.min(from, target)
+      maxDirtyIndex = Math.max(from, target)
       reindex()
       emit('update:ticket', ticket)
 
@@ -1205,6 +1221,7 @@ export function createRegistry<
         order[i] = id!
       }
       minDirtyIndex = 0
+      maxDirtyIndex = -Infinity
       reindex()
     })
   }


### PR DESCRIPTION
## Summary

Fixes #258.

`createRegistry.move()` previously rebuilt the entire `collection` Map on every call — three O(n) passes: snapshot (`Array.from(entries())`), `clear()`, and re-insert loop. For a 10 000-item list, moving one slot near the end iterated all 10 000 entries three times.

### Changes

**New `order: ID[]` array** (shallowReactive when the registry is reactive) tracks the canonical position sequence alongside the Map:

- **`move()`** — two `Array.splice` calls on `order` + `reindex()` from `minDirtyIndex`. The Map is never rebuilt. Cost: O(distance) for the splice shift + O(n − min(from, to)) for reindex, versus O(n) unconditionally before.
- **`reorder()`** — overwrites `order` in-place and calls `reindex(0)`. No `Map.clear()` + rebuild.
- **`reindex()`** — iterates `order` from `minDirtyIndex` (index loop, not a `collection.values()` scan from 0). The O(minDirtyIndex) skip-loop is gone.
- **`keys()` / `values()` / `entries()`** — derive output from `order`, so iteration order always reflects the logical position sequence rather than Map insertion order.
- **Reactive mode** — `order` is `shallowReactive` so Vue effects re-evaluate automatically on `push` / `splice` / `length = 0`. Mutation ordering is arranged so effects always observe a consistent `(order, collection)` snapshot (relevant for `flush: 'sync'` watchers in consuming composables like `createDataTable`).
- **`offboard()`** — compacts `order` before the `collection.delete()` loop for the same snapshot-consistency reason.

### Test plan

- [x] All 6 101 existing tests pass
- [x] `packages/0 typecheck` clean
- [x] ESLint clean