### PR TITLE
perf(data-table): drop reactive row registry to eliminate per-row proxy cost

### DIFF
--- a/packages/0/src/composables/createDataTable/index.ts
+++ b/packages/0/src/composables/createDataTable/index.ts
@@ -548,11 +548,21 @@ export function createDataTable<T extends Record<string, unknown>> (
   // Using an event-driven counter rather than registry reactive mode avoids
   // allocating a shallowReactive proxy for every row ticket.
   const _rowVersion = shallowRef(0)
-  registry.on('register:ticket', () => { _rowVersion.value++ })
-  registry.on('unregister:ticket', () => { _rowVersion.value++ })
-  registry.on('update:ticket', () => { _rowVersion.value++ })
-  registry.on('clear:registry', () => { _rowVersion.value++ })
-  registry.on('reindex:registry', () => { _rowVersion.value++ })
+  registry.on('register:ticket', () => {
+    _rowVersion.value++
+  })
+  registry.on('unregister:ticket', () => {
+    _rowVersion.value++
+  })
+  registry.on('update:ticket', () => {
+    _rowVersion.value++
+  })
+  registry.on('clear:registry', () => {
+    _rowVersion.value++
+  })
+  registry.on('reindex:registry', () => {
+    _rowVersion.value++
+  })
 
   // Row values projected from registry tickets in registration order — the
   // adapter consumes this as its `items` input and runs the filter → sort →

--- a/packages/0/src/composables/createDataTable/index.ts
+++ b/packages/0/src/composables/createDataTable/index.ts
@@ -372,9 +372,13 @@ export function createDataTable<T extends Record<string, unknown>> (
     adapter = new ClientDataTableAdapter<T>(),
   } = options
 
+  // Row registry is intentionally non-reactive: the adapter pipeline reads rows
+  // through the `source` computed (see below), so per-row shallowReactive proxies
+  // buy nothing and add ~10k allocations for large tables.  Registry events keep
+  // `source` up-to-date instead.
   const registry = createRegistry<DataTableTicketInput<T>, DataTableTicket<T>>({
     events: true,
-    reactive: true,
+    reactive: false,
   })
 
   const columns = createRegistry<DataTableColumnTicketInput<T>, DataTableColumnTicket<T>>({
@@ -540,10 +544,23 @@ export function createDataTable<T extends Record<string, unknown>> (
     return filters
   })
 
+  // Bump whenever the row set changes (add / remove / reorder / update).
+  // Using an event-driven counter rather than registry reactive mode avoids
+  // allocating a shallowReactive proxy for every row ticket.
+  const _rowVersion = shallowRef(0)
+  registry.on('register:ticket', () => { _rowVersion.value++ })
+  registry.on('unregister:ticket', () => { _rowVersion.value++ })
+  registry.on('update:ticket', () => { _rowVersion.value++ })
+  registry.on('clear:registry', () => { _rowVersion.value++ })
+  registry.on('reindex:registry', () => { _rowVersion.value++ })
+
   // Row values projected from registry tickets in registration order — the
   // adapter consumes this as its `items` input and runs the filter → sort →
   // paginate pipeline against it.
-  const source = computed(() => registry.values().map(t => t.value as T))
+  const source = computed(() => {
+    void _rowVersion.value
+    return registry.values().map(t => t.value as T)
+  })
 
   const {
     allItems,
@@ -808,6 +825,7 @@ export function createDataTable<T extends Record<string, unknown>> (
     loading,
     error,
     get size () {
+      void _rowVersion.value
       return registry.size
     },
   }


### PR DESCRIPTION
## Summary

Fixes #257.

`createDataTable` was constructing the row registry with `reactive: true`, wrapping each row ticket in a `shallowReactive()` Proxy at registration time. For a 10 000-row table that meant 10 000 Proxy allocations at construction — the dominant cost in the ~25 ms creation regression reported in #257.

Per-row template reactivity provides no benefit to the adapter pipeline: the pipeline reads rows through the `source` computed (`registry.values()`), not through individual ticket bindings in component templates.

### Changes

- Row registry: `reactive: false` — no per-row `shallowReactive` allocation
- Added `_rowVersion: shallowRef<number>` that increments on every registry mutation via registry events (`register:ticket`, `unregister:ticket`, `update:ticket`, `clear:registry`, `reindex:registry`)
- `source` computed tracks `_rowVersion` so it re-evaluates whenever the row set changes
- `table.size` getter also tracks `_rowVersion` so reactivity-dependent code (e.g. `computed(() => table.size)`) still works
- Columns registry stays `reactive: true` (column tickets are read from template bindings via `leaves` / `headers` computeds)

### Test plan

- [x] All 6 101 existing tests pass
- [x] `packages/0 typecheck` clean
- [x] ESLint clean