### PR TITLE
fix(overflow): isolate ResizeObserver mock per-instance

### DIFF
--- a/packages/0/src/components/Overflow/index.test.ts
+++ b/packages/0/src/components/Overflow/index.test.ts
@@ -14,16 +14,22 @@ import type {
   OverflowRootSlotProps,
 } from './index'
 
-let resizeObserverCallback: ResizeObserverCallback | null = null
-let resizeObserverTarget: Element | null = null
+// Track every ResizeObserver created during a test. Multiple observers may
+// exist per test (container + indicator), so we cannot use a single module-level
+// slot — the indicator's observer would overwrite the container's and triggerResize
+// would fire the wrong callback, preventing width.value from being set.
+const resizeObservers: Array<{ cb: ResizeObserverCallback, target: Element | null }> = []
 
 class TestResizeObserver {
+  private entry: { cb: ResizeObserverCallback, target: Element | null }
+
   constructor (cb: ResizeObserverCallback) {
-    resizeObserverCallback = cb
+    this.entry = { cb, target: null }
+    resizeObservers.push(this.entry)
   }
 
   observe (el: Element) {
-    resizeObserverTarget = el
+    this.entry.target = el
   }
 
   unobserve () {}
@@ -31,17 +37,20 @@ class TestResizeObserver {
 }
 
 beforeEach(() => {
+  resizeObservers.length = 0
   vi.stubGlobal('ResizeObserver', TestResizeObserver)
-  resizeObserverCallback = null
-  resizeObserverTarget = null
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+// Always fire the FIRST registered observer (the container's). Later observers
+// belong to the indicator or other children and should not receive container
+// resize events.
 function triggerResize (width: number, height = 0): void {
-  if (!resizeObserverCallback || !resizeObserverTarget) return
+  const first = resizeObservers[0]
+  if (!first?.cb || !first.target) return
   const rect = {
     width,
     height,
@@ -53,10 +62,10 @@ function triggerResize (width: number, height = 0): void {
     y: 0,
     toJSON: () => ({}),
   } as DOMRectReadOnly
-  resizeObserverCallback(
+  first.cb(
     [{
       contentRect: rect,
-      target: resizeObserverTarget,
+      target: first.target,
       borderBoxSize: [],
       contentBoxSize: [],
       devicePixelContentBoxSize: [],


### PR DESCRIPTION
## Summary

- Track every `TestResizeObserver` in an array instead of a single module-level slot
- `triggerResize()` now always fires the **first** registered observer (the container's), not the latest one
- `beforeEach` resets the array to an empty state, giving each test full isolation

## Root cause

`OverflowRoot` creates a `ResizeObserver` for the container (cb1). When `isOverflowing` flips true the `OverflowIndicator` mounts and creates a second `ResizeObserver` for its own element (cb2). The old code stored only the most-recently-constructed callback in a single module-level slot, so after the indicator appeared `resizeObserverCallback` pointed to cb2.

Any subsequent `triggerResize(120)` call then fired cb2 (the indicator's measurement callback) instead of cb1 (the container's width update). `width.value` was never set to 120, `capacity` stayed at `Infinity`, `isOverflowing` never stabilised, and under CI's coverage-instrumented scheduler the reactive chain kept re-queuing renders until Vue threw "Maximum recursive updates exceeded in component `<OverflowRoot>`".

## Test plan

- [x] `pnpm vitest run packages/0/src/components/Overflow` — 16/16 pass
- [x] All 16 tests pass consistently across 20 consecutive local runs
- Existing tests are structurally unchanged; only the observer infrastructure is replaced

Fixes #250