### PR TITLE
fix(playground): replace calc(100% + 1px) with height: 100% on .editor-container

### DIFF
--- a/apps/playground/src/components/playground/editor/PlaygroundEditor.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditor.vue
@@ -93,8 +93,10 @@
     --color-branding-dark: #89ddff;
   }
 
+  /* .file-selector is hidden above, but @vue/repl still sizes .editor-container as
+     calc(100% - var(--header-height)). Override so Monaco fills the full panel. */
   .playground-repl :deep(.editor-container) {
-    height: calc(100% + 1px) !important;
+    height: 100% !important;
     width: 100% !important;
   }
 </style>


### PR DESCRIPTION
## Problem

`PlaygroundEditor.vue:97` had:
```css
.playground-repl :deep(.editor-container) {
  height: calc(100% + 1px) !important;
  width: 100% !important;
}
```

The `+1px` was a historic workaround (the trigger for the infinite-grow loop fixed in #217). The real layout problem is that `@vue/repl` sizes `.editor-container` as `calc(100% - var(--header-height))` — subtracting 38px for the file-selector. Since we hide `.file-selector` with `display: none !important` higher in this same file, that 38px is never consumed but still deducted, leaving the Monaco editor 38px short.

`calc(100% + 1px)` happened to "fix" this by overriding the library value, but the `+1px` overshoot was arbitrary and the cause was never documented. The same result is achieved correctly with `height: 100%`.

Closes #218

## Change

- `height: calc(100% + 1px) !important` → `height: 100% !important`
- Added a comment explaining why the override is needed (so it cannot be reflexively cleaned up)