### PR TITLE
perf(useProxyRegistry): rebuild the snapshot lazily on read

### DIFF
--- a/packages/0/src/composables/useProxyRegistry/index.bench.ts
+++ b/packages/0/src/composables/useProxyRegistry/index.bench.ts
@@ -182,4 +182,49 @@ describe('useProxyRegistry benchmarks', () => {
       dispose()
     })
   })
+
+  // ===========================================================================
+  // BULK REGISTRATION - load many items while the proxy is ALREADY listening
+  // Fresh fixture per iteration (required - mutations change state)
+  // onboard() is batched: the registry replays events after the collection is
+  //   stable and values() is cached, so even the eager path was O(n). The lazy
+  //   rewrite is a constant-factor win here.
+  // register() one-by-one is unbatched: each call invalidates the cache and
+  //   dispatches immediately, so the eager path rebuilt a growing snapshot per
+  //   call (O(n^2)). The lazy rewrite makes it O(n). This is the regression
+  //   sentinel — a revert to eager rebuilds tanks the 10,000 case by ~300x.
+  // ===========================================================================
+  describe('bulk registration', () => {
+    bench('Onboard 1,000 items (proxy attached)', () => {
+      const scope = effectScope()
+      const registry = createRegistry({ events: true })
+      scope.run(() => useProxyRegistry(registry))
+      registry.onboard(ITEMS_1K)
+      scope.stop()
+    })
+
+    bench('Onboard 10,000 items (proxy attached)', () => {
+      const scope = effectScope()
+      const registry = createRegistry({ events: true })
+      scope.run(() => useProxyRegistry(registry))
+      registry.onboard(ITEMS_10K)
+      scope.stop()
+    })
+
+    bench('Register 1,000 items one-by-one (proxy attached)', () => {
+      const scope = effectScope()
+      const registry = createRegistry({ events: true })
+      scope.run(() => useProxyRegistry(registry))
+      for (const item of ITEMS_1K) registry.register(item)
+      scope.stop()
+    })
+
+    bench('Register 10,000 items one-by-one (proxy attached)', () => {
+      const scope = effectScope()
+      const registry = createRegistry({ events: true })
+      scope.run(() => useProxyRegistry(registry))
+      for (const item of ITEMS_10K) registry.register(item)
+      scope.stop()
+    })
+  })
 })

--- a/packages/0/src/composables/useProxyRegistry/index.ts
+++ b/packages/0/src/composables/useProxyRegistry/index.ts
@@ -27,7 +27,7 @@
  */
 
 // Utilities
-import { onScopeDispose, reactive, shallowReactive } from 'vue'
+import { computed, onScopeDispose, reactive, shallowRef } from 'vue'
 
 // Types
 import type { RegistryContext, RegistryTicket, RegistryTicketInput } from '#v0/composables/createRegistry'
@@ -73,20 +73,14 @@ export function useProxyRegistry<
   registry: RegistryContext<Z, E>,
   options?: ProxyRegistryOptions,
 ): ProxyRegistryContext<E> {
-  const reactivity = options?.deep ? reactive : shallowReactive
+  const version = shallowRef(0)
 
-  const state = reactivity({
-    keys: registry.keys(),
-    values: registry.values(),
-    entries: registry.entries(),
-    size: registry.size,
-  })
+  function wrap<T extends object> (value: T): T {
+    return options?.deep ? reactive(value) as T : value
+  }
 
   function update () {
-    state.keys = registry.keys()
-    state.values = registry.values()
-    state.entries = registry.entries()
-    state.size = registry.size
+    version.value++
   }
 
   registry.on('register:ticket', update)
@@ -103,5 +97,22 @@ export function useProxyRegistry<
     registry.off('reindex:registry', update)
   }, true)
 
-  return state as ProxyRegistryContext<E>
+  return reactive({
+    keys: computed(() => {
+      void version.value
+      return registry.keys()
+    }),
+    values: computed(() => {
+      void version.value
+      return wrap(registry.values())
+    }),
+    entries: computed(() => {
+      void version.value
+      return wrap(registry.entries())
+    }),
+    size: computed(() => {
+      void version.value
+      return registry.size
+    }),
+  }) as ProxyRegistryContext<E>
 }


### PR DESCRIPTION
## Summary

`useProxyRegistry` rebuilt its entire `{ keys, values, entries, size }` snapshot eagerly inside the listener subscribed to the five registry mutation events, reassigning four `shallowReactive` properties per event. When a registry grows while the proxy is attached, that per-event rebuild is the cost that matters:

- **Unbatched `register()`** (e.g. per-component registration): each call invalidates the registry's `values()` cache and dispatches immediately, so the eager listener rebuilt a snapshot of the *growing* collection on every call — **O(n²)**. Measured: 10,000 one-by-one registrations ran at ~0.8 ops/s (~1.2s each) before, ~250 ops/s after (**O(n)**).
- **Batched `onboard()`**: the registry replays its deferred events after the collection is stable and `values()` is cached, so even the eager path was already O(n). Here the rewrite is a **~6–8× constant-factor** win.

The fix: a private `version` counter (`shallowRef(0)`) bumped on the same five events, with `keys` / `values` / `entries` / `size` exposed as `computed`s that read `version` and rebuild on access. Per-event work is now O(1); the snapshot rebuilds once on the next read. `reactive({ … computed })` unwraps the refs, so consumers still read `proxy.values` etc. as plain properties — the public `ProxyRegistryContext` shape and the `deep` option are unchanged.

## Why

Prerequisite for routing `createDataTable`'s row registry through `useProxyRegistry` (#274 / #257) without paying per-row proxy cost.

## Notes

- No public API change; `deep` semantics preserved.
- The five `on`/`off` subscriptions and scope-disposal cleanup are unchanged.
- The lone in-repo consumer (`createGroup`) reads the proxy read-only and is unaffected.
- Benchmarks added under `bulk registration`; the unbatched 10,000 case is the O(n²) regression sentinel.