### PR TITLE
fix(createRegistry): remove spurious non-null assertions in seek()

### DIFF
--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -1256,13 +1256,13 @@ export function createRegistry<
     if (direction === 'last') {
       const start = isUndefined(index) ? tickets.length - 1 : index
       for (let i = start; i >= 0; i--) {
-        const ticket = tickets[i]!
+        const ticket = tickets[i]
         if (!predicate || predicate(ticket)) return ticket
       }
     } else {
       const start = isUndefined(index) ? 0 : index
       for (let i = start; i < tickets.length; i++) {
-        const ticket = tickets[i]!
+        const ticket = tickets[i]
         if (!predicate || predicate(ticket)) return ticket
       }
     }


### PR DESCRIPTION
Closes #281

Both `tickets[i]!` occurrences in `seek()` are unnecessary:

- `tickets` is the result of `values()`, typed `readonly E[]`
- Neither `noUncheckedIndexedAccess` is enabled in the relevant tsconfig (`tsconfig.dom.json` base, not `tsconfig.lib.json`)
- Both loops are bounds-checked (`i >= 0` / `i < tickets.length`), so the index is always in range

Dropping the `!` removes noise without any behavior change. These are the last spurious assertions in `createRegistry/index.ts` — the remaining ones (`listeners.get(event)!`, `get(id)!`) document genuine Map invariants and are intentionally left as-is.