### PR TITLE
docs(guide): add dedicated testing guide page

### DIFF
--- a/apps/docs/src/pages/guide/tooling/testing.md
+++ b/apps/docs/src/pages/guide/tooling/testing.md
@@ -39,6 +39,10 @@ npm install -D vitest @vue/test-utils happy-dom
 yarn add -D vitest @vue/test-utils happy-dom
 ```
 
+```bash bun
+bun add -D vitest @vue/test-utils happy-dom
+```
+
 :::
 
 Configure Vitest to use happy-dom:

--- a/apps/docs/src/pages/guide/tooling/testing.md
+++ b/apps/docs/src/pages/guide/tooling/testing.md
@@ -12,7 +12,7 @@ meta:
 related:
   - /guide/tooling/ai-tools
   - /guide/tooling/vuetify-cli
-  - /guide/essentials/types
+  - /guide/features/types
 ---
 
 # Testing
@@ -129,25 +129,27 @@ v0 throws structured errors that carry a typed `code` discriminant. Use `isV0Err
 
 ```ts
 import { expect, it } from 'vitest'
-import { isV0Error, V0Error } from '@vuetify/v0'
-import { useTheme } from '@vuetify/v0'
+import { isV0Error, useDate, V0Error } from '@vuetify/v0'
 
-it('should throw V0_CONTEXT_MISSING when theme plugin is absent', () => {
+it('should throw V0_PLUGIN_MISSING when the date plugin is absent', () => {
   let caught: unknown
   try {
-    useTheme()
+    useDate()
   } catch (err) {
     caught = err
   }
 
   expect(caught).toBeInstanceOf(V0Error)
-  expect(isV0Error(caught, 'V0_CONTEXT_MISSING')).toBe(true)
-  if (isV0Error(caught, 'V0_CONTEXT_MISSING')) {
-    // TypeScript now knows caught.key exists
-    expect(caught.key).toBeDefined()
+  expect(isV0Error(caught, 'V0_PLUGIN_MISSING')).toBe(true)
+  if (isV0Error(caught, 'V0_PLUGIN_MISSING')) {
+    // TypeScript now knows caught.plugin exists
+    expect(caught.plugin).toBe('createDatePlugin')
   }
 })
 ```
+
+> [!NOTE]
+> Plugin-backed composables differ on whether they throw. `useDate()` throws `V0_PLUGIN_MISSING` when no provider is installed, but composables that ship a fallback — such as `useTheme()` — return synthesized defaults instead of throwing. Assert against a composable that actually throws.
 
 ### Error codes
 

--- a/apps/docs/src/pages/guide/tooling/testing.md
+++ b/apps/docs/src/pages/guide/tooling/testing.md
@@ -1,0 +1,214 @@
+---
+title: Testing Guide - Unit and Component Testing for v0
+features:
+  label: Testing
+  order: 4
+  level: 1
+meta:
+  - name: description
+    content: Test v0-based code with Vitest and @vue/test-utils. Covers setup, Vue DI mocking, plugin mocking, fake timers, SSR-only tests, and asserting v0 errors and warnings.
+  - name: keywords
+    content: vuetify0, testing, vitest, vue test utils, unit tests, component tests, mocking, V0Error, isV0Error, happy-dom
+related:
+  - /guide/tooling/ai-tools
+  - /guide/tooling/vuetify-cli
+  - /guide/essentials/types
+---
+
+# Testing
+
+This guide covers testing patterns for v0 consumers — from environment setup through asserting errors, warnings, and locale-safe output.
+
+<DocsPageFeatures :frontmatter />
+
+## Setup
+
+v0 tests run on [Vitest](https://vitest.dev/) with [happy-dom](https://github.com/capricorn86/happy-dom) (or jsdom). Install the required packages:
+
+::: code-group no-filename
+
+```bash pnpm
+pnpm add -D vitest @vue/test-utils happy-dom
+```
+
+```bash npm
+npm install -D vitest @vue/test-utils happy-dom
+```
+
+```bash yarn
+yarn add -D vitest @vue/test-utils happy-dom
+```
+
+:::
+
+Configure Vitest to use happy-dom:
+
+```ts vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'happy-dom',
+  },
+})
+```
+
+## Mocking Vue DI
+
+Many v0 composables use `provide` / `inject` internally. Mock them at the top of any test file that exercises these composables:
+
+```ts
+import { vi } from 'vitest'
+
+vi.mock('vue', () => ({
+  provide: vi.fn(),
+  inject: vi.fn(),
+}))
+```
+
+When the composable also calls `hasInjectionContext()` to guard against use outside a component, extend the mock to keep that gate truthy:
+
+```ts
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    provide: vi.fn(),
+    inject: vi.fn(),
+    hasInjectionContext: vi.fn(() => true),
+  }
+})
+```
+
+## Mocking plugins
+
+Use `global.plugins` in `@vue/test-utils` mount options to install v0 plugins. This covers Stack, Theme, and any other plugin-based contexts:
+
+```ts
+import { mount } from '@vue/test-utils'
+import { createStackPlugin, createThemePlugin } from '@vuetify/v0'
+import MyComponent from './MyComponent.vue'
+
+const wrapper = mount(MyComponent, {
+  global: {
+    plugins: [createStackPlugin(), createThemePlugin()],
+  },
+})
+```
+
+## Fake timers
+
+Composables that schedule work via `setTimeout` or `setInterval` (such as `useTimer`, `useDelay`, and `usePopover`) require fake timers. Enable them in `beforeEach` and restore in `afterEach`:
+
+```ts
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { useTimer } from '@vuetify/v0'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+it('should fire handler after duration', () => {
+  const handler = vi.fn()
+  const timer = useTimer(handler, { duration: 1000 })
+  timer.start()
+  vi.advanceTimersByTime(1000)
+  expect(handler).toHaveBeenCalledTimes(1)
+})
+```
+
+## Asserting v0 errors
+
+v0 throws structured errors that carry a typed `code` discriminant. Use `isV0Error(err, code)` to narrow the caught value and assert the payload shape:
+
+```ts
+import { expect, it } from 'vitest'
+import { isV0Error, V0Error } from '@vuetify/v0'
+import { useTheme } from '@vuetify/v0'
+
+it('should throw V0_CONTEXT_MISSING when theme plugin is absent', () => {
+  let caught: unknown
+  try {
+    useTheme()
+  } catch (err) {
+    caught = err
+  }
+
+  expect(caught).toBeInstanceOf(V0Error)
+  expect(isV0Error(caught, 'V0_CONTEXT_MISSING')).toBe(true)
+  if (isV0Error(caught, 'V0_CONTEXT_MISSING')) {
+    // TypeScript now knows caught.key exists
+    expect(caught.key).toBeDefined()
+  }
+})
+```
+
+### Error codes
+
+| Code | Thrown when |
+| --- | --- |
+| `V0_CONTEXT_MISSING` | `inject()` returns nothing — required provider not installed |
+| `V0_PLUGIN_MISSING` | A plugin that the composable depends on was not registered |
+| `V0_PALETTE_INVALID_SEED` | An invalid seed color was passed to a palette factory |
+| `V0_PALETTE_UNKNOWN_VARIANT` | An unrecognised variant name was given to the Material palette |
+| `V0_ADAPTER_INSTANCE_MISSING` | The adapter composable was called without a mounted adapter instance |
+
+## Asserting warnings
+
+When a test intentionally triggers a v0 warning (for example, passing an invalid prop or registering a duplicate), capture it with `vi.spyOn` and assert it was called. The `using` form auto-restores the spy when the block exits:
+
+```ts
+import { expect, it, vi } from 'vitest'
+
+it('should warn on duplicate registration', () => {
+  using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  // ... code that triggers the warning ...
+
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining('duplicate'))
+})
+```
+
+> [!NOTE]
+> The `using` keyword relies on TC39 Explicit Resource Management and requires `target: "esnext"` in `tsconfig.json`. If your setup does not support it, use `const spy = vi.spyOn(...)` and call `spy.mockRestore()` manually after the assertion.
+
+Never silently swallow warnings — always assert that the spy was called.
+
+## SSR-only tests
+
+`vi.mock` is hoisted and applies file-wide, so mixing client and SSR branches in the same file causes the mock to leak. Split SSR-only tests into a sibling `*.ssr.test.ts` file and hoist the `IN_BROWSER` mock there:
+
+```ts index.ssr.test.ts
+// Must be the first statement — vi.mock is hoisted
+vi.mock('#v0/constants/globals', () => ({
+  IN_BROWSER: false,
+}))
+
+import { expect, it } from 'vitest'
+import { useDate } from './index'
+
+it('should throw when called outside a component in SSR', () => {
+  expect(() => useDate()).toThrow('[v0] useDate() must be called inside a Vue component')
+})
+```
+
+The corresponding client tests live in `index.test.ts` and are unaffected by the SSR mock.
+
+## Locale-safe assertions
+
+v0 formats user-visible strings through the locale system. Pin assertions to structure, not English text, so tests pass under any locale:
+
+```ts
+// Right — locale-safe
+expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBeDefined()
+
+// Wrong — breaks under non-English locales
+expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBe('Close dialog')
+```

--- a/apps/docs/src/typed-router.d.ts
+++ b/apps/docs/src/typed-router.d.ts
@@ -989,6 +989,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/guide/tooling/testing': RouteRecordInfo<
+      '/guide/tooling/testing',
+      '/guide/tooling/testing',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/guide/tooling/vuetify-cli': RouteRecordInfo<
       '/guide/tooling/vuetify-cli',
       '/guide/tooling/vuetify-cli',
@@ -1947,6 +1954,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/guide/tooling/ai-tools.md': {
       routes:
         | '/guide/tooling/ai-tools'
+      views:
+        | never
+    }
+    'src/pages/guide/tooling/testing.md': {
+      routes:
+        | '/guide/tooling/testing'
       views:
         | never
     }


### PR DESCRIPTION
Closes #249

Adds `/guide/tooling/testing` — a consumer-facing testing guide covering:

- **Setup** — Vitest + happy-dom, `vitest.config.ts` snippet
- **Mocking Vue DI** — `vi.mock('vue', ...)` pattern + `hasInjectionContext` extension
- **Mocking plugins** — `global.plugins: [createStackPlugin(), createThemePlugin()]`
- **Fake timers** — `vi.useFakeTimers()` + `vi.advanceTimersByTime` for timer/delay/popover composables
- **Asserting v0 errors** — `isV0Error(err, code)` narrowing with a table of all `V0ErrorCode` variants
- **Asserting warnings** — `vi.spyOn(console, 'warn')` with `using` auto-restore
- **SSR-only tests** — `*.ssr.test.ts` split + hoisted `vi.mock('#v0/constants/globals')`
- **Locale-safe assertions** — `toBeDefined()` over exact text values

Content is adapted from the contributor-private `.claude/rules/testing.md` into a user-facing reference.