### PR TITLE
fix(isElement): guard against ReferenceError when Element is undefined under SSR

### DIFF
--- a/packages/0/src/utilities/helpers.test.ts
+++ b/packages/0/src/utilities/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   isObject,
   isThenable,
   isArray,
+  isElement,
   isNull,
   isNullOrUndefined,
   isUndefined,
@@ -189,6 +190,34 @@ describe('helpers', () => {
         expect(isArray({})).toBe(false)
         expect(isArray('array')).toBe(false)
         expect(isArray({ length: 3 })).toBe(false)
+      })
+    })
+
+    describe('isElement', () => {
+      it('should return true for DOM elements', () => {
+        expect(isElement(document.createElement('div'))).toBe(true)
+        expect(isElement(document.body)).toBe(true)
+      })
+
+      it('should return false for non-elements', () => {
+        expect(isElement(null)).toBe(false)
+        expect(isElement(undefined)).toBe(false)
+        expect(isElement({})).toBe(false)
+        expect(isElement('div')).toBe(false)
+      })
+
+      it('should return false instead of throwing when Element is undefined (SSR/SSG)', () => {
+        const ElementCtor = globalThis.Element
+        // Simulate a non-DOM server runtime where `Element` is not a global.
+        // Pre-guard, `item instanceof Element` threw a ReferenceError here,
+        // crashing SSG on every observer-using docs page.
+        Reflect.deleteProperty(globalThis, 'Element')
+        try {
+          expect(() => isElement({})).not.toThrow()
+          expect(isElement({})).toBe(false)
+        } finally {
+          globalThis.Element = ElementCtor
+        }
       })
     })
 

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -173,7 +173,7 @@ export function isArray (item: unknown): item is unknown[] {
  */
 /* #__NO_SIDE_EFFECTS__ */
 export function isElement (item: unknown): item is Element {
-  return item instanceof Element
+  return typeof Element !== 'undefined' && item instanceof Element
 }
 
 /**


### PR DESCRIPTION
## Problem

`isElement` (`packages/0/src/utilities/helpers.ts`) returned a bare `item instanceof Element`. Under SSR/SSG the `Element` DOM global is undefined, so `instanceof` throws `ReferenceError: Element is not defined`.

It is reached server-side through `toElement` → `createObserver`: the observer factory wraps `toElement(target)` in a `toRef` watched with `{ immediate: true }`, which forces synchronous evaluation during component setup. With a truthy target (a template ref object), `isElement` runs `refObject instanceof Element` on the server and throws. `vite-ssg` catches the per-page render error and continues, so the docs build stays green while every observer-using page (`useResizeObserver` / `useIntersectionObserver` / `useMutationObserver` consumers) errors at prerender. Output is correct after hydration, but it's prerender noise plus a latent correctness risk — and a violation of PHILOSOPHY §2.10 (SSR-safe by default).

## Fix

Guard the check:

```ts
return typeof Element !== 'undefined' && item instanceof Element
```

Mirrors the `typeof window !== 'undefined'` precedent in `constants/globals.ts`. Browser behavior is identical; under SSR it returns `false` instead of throwing.

## Verification

- In a DOM-less Node context (the vite-ssg condition), the old expression throws `ReferenceError: Element is not defined`; the guarded expression returns `false`.
- `pnpm typecheck` (packages/0) clean.
- 122 `toElement` + observer-family tests pass.
- Family audit: the sibling `instanceof HTMLElement` checks in the `useTheme` / `useRtl` adapters and the `instanceof Node` check in `useClickOutside` are all gated behind `IN_BROWSER` or run only inside browser-only event handlers. `isElement` was the sole unguarded DOM-global `instanceof` reachable server-side.
