### PR TITLE
fix(Carousel): measure slideStep from first slide's index, not literal 1

### DIFF
--- a/packages/0/src/components/Carousel/CarouselViewport.vue
+++ b/packages/0/src/components/Carousel/CarouselViewport.vue
@@ -116,19 +116,20 @@
     if (!el.value) return 0
     if ((isVertical.value ? height.value : width.value) === 0) return 0
 
-    const firstTicket = carousel.seek('first') as CarouselTicket | undefined
-    const first = toValue(firstTicket?.el) as HTMLElement | undefined
+    /* v8 ignore start -- happy-dom has no layout engine: width/height and offset* read 0, so this measurement block is unreachable in tests */
+    const ticket = carousel.seek('first') as CarouselTicket | undefined
+    const first = toValue(ticket?.el) as HTMLElement | undefined
 
-    if (!firstTicket || !first) return 0
+    if (!ticket || !first) return 0
 
     // seek('first') skips disabled items, so a literal `1` offset collides with
     // the first slide when leading slides are disabled (both resolve to the same
     // element → slideStep 0). Measure from the first slide's own index instead.
-    const second = toValue((carousel.seek('first', firstTicket.index + 1) as CarouselTicket | undefined)?.el) as HTMLElement | undefined
+    const second = toValue((carousel.seek('first', ticket.index + 1) as CarouselTicket | undefined)?.el) as HTMLElement | undefined
 
-    /* v8 ignore next 3 -- happy-dom returns 0 for offset* so layout-dependent branches never reach here */
     if (!second) return isVertical.value ? first.offsetHeight : first.offsetWidth
     return isVertical.value ? second.offsetTop - first.offsetTop : second.offsetLeft - first.offsetLeft
+    /* v8 ignore stop */
   })
 
   if (IN_BROWSER) {

--- a/packages/0/src/components/Carousel/CarouselViewport.vue
+++ b/packages/0/src/components/Carousel/CarouselViewport.vue
@@ -116,10 +116,16 @@
     if (!el.value) return 0
     if ((isVertical.value ? height.value : width.value) === 0) return 0
 
-    const first = toValue((carousel.seek('first') as CarouselTicket | undefined)?.el) as HTMLElement | undefined
-    const second = toValue((carousel.seek('first', 1) as CarouselTicket | undefined)?.el) as HTMLElement | undefined
+    const firstTicket = carousel.seek('first') as CarouselTicket | undefined
+    const first = toValue(firstTicket?.el) as HTMLElement | undefined
 
-    if (!first) return 0
+    if (!firstTicket || !first) return 0
+
+    // seek('first') skips disabled items, so a literal `1` offset collides with
+    // the first slide when leading slides are disabled (both resolve to the same
+    // element → slideStep 0). Measure from the first slide's own index instead.
+    const second = toValue((carousel.seek('first', firstTicket.index + 1) as CarouselTicket | undefined)?.el) as HTMLElement | undefined
+
     /* v8 ignore next 3 -- happy-dom returns 0 for offset* so layout-dependent branches never reach here */
     if (!second) return isVertical.value ? first.offsetHeight : first.offsetWidth
     return isVertical.value ? second.offsetTop - first.offsetTop : second.offsetLeft - first.offsetLeft


### PR DESCRIPTION
## Problem

`CarouselViewport`'s `slideStep` measures the pixel distance between two consecutive slides to drive scroll-snap math:

```ts
const first = carousel.seek('first')?.el
const second = carousel.seek('first', 1)?.el  // literal 1
```

The Carousel context is `createStep`-based, and `createSelection.seek` (inherited up the chain) **skips disabled items** via a `ticket => !disabled` predicate. So when a leading slide is disabled, `seek('first')` returns the first *enabled* slide (e.g. index 1) and `seek('first', 1)` — starting its scan at index 1 — returns that **same** slide. `first === second`, so `slideStep` collapses to `0`.

Every scroll-snap handler guards with `if (slideStep.value === 0) return`, so scroll-snapping (snap-to-slide on `scrollend`, programmatic scroll positioning) silently dies whenever the first slide is disabled.

## Fix

Capture the first ticket and seek from **its own index + 1**, so the second measurement is always the next enabled slide *after* the first:

```ts
const firstTicket = carousel.seek('first')
const second = carousel.seek('first', firstTicket.index + 1)?.el
```

Normal carousels (no disabled slides) are unaffected — `first` lands at index 0, so `index + 1 === 1`, identical to before.

## Verification

- Runtime-verified the seek collision directly on `createStep`: with item 0 disabled, `seek('first')` and `seek('first', 1)` both resolve to the index-1 ticket (collision → `slideStep` 0); `seek('first', first.index + 1)` resolves to the index-2 ticket (a distinct slide). Normal case: `first` at index 0, both forms agree.
- `pnpm typecheck` (packages/0) clean.
- 93 Carousel tests pass (1 pre-existing skip).

This was a known, deferred finding — deferred only because an end-to-end `slideStep` test needs happy-dom layout stubbing (`offsetTop`/`offsetLeft`). The root cause is a pure `seek` index collision, which is verifiable without layout.
