### PR TITLE
perf(createDataTable): skip per-row shallowReactive proxy via reactiveTickets option

### DIFF
--- a/packages/0/src/composables/createDataTable/index.ts
+++ b/packages/0/src/composables/createDataTable/index.ts
@@ -375,6 +375,7 @@ export function createDataTable<T extends Record<string, unknown>> (
   const registry = createRegistry<DataTableTicketInput<T>, DataTableTicket<T>>({
     events: true,
     reactive: true,
+    reactiveTickets: false,
   })
 
   const columns = createRegistry<DataTableColumnTicketInput<T>, DataTableColumnTicket<T>>({

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -726,6 +726,17 @@ export interface RegistryOptions {
    * ```
   */
   reactive?: boolean
+  /**
+   * Wrap each registered ticket in `shallowReactive` so that mutations to its
+   * properties are observable by Vue effects.
+   *
+   * @default same as `reactive`
+   * @remarks Set to `false` together with `reactive: true` when you need the
+   * collection to be observable (adds/removes re-trigger computed) but do not
+   * need per-ticket property reactivity. This avoids the proxy-allocation cost
+   * for large sets of items that are read, not mutated in place.
+   */
+  reactiveTickets?: boolean
 }
 
 export interface RegistryContextOptions extends RegistryOptions {
@@ -763,6 +774,7 @@ export function createRegistry<
 
   const events = options?.events ?? false
   const reactive = options?.reactive ?? false
+  const reactiveTickets = options?.reactiveTickets ?? reactive
 
   const collection = reactive ? shallowReactive(new Map<ID, E>()) : new Map<ID, E>()
   const catalog = new Map<unknown, ID[]>()
@@ -1068,7 +1080,7 @@ export function createRegistry<
       unregister: () => unregister(id),
     } as E
 
-    const ticket = reactive ? shallowReactive(input) : input
+    const ticket = reactiveTickets ? shallowReactive(input) : input
 
     collection.set(ticket.id, ticket)
     order.push(ticket)


### PR DESCRIPTION
Closes #257

## Problem

After #236 replaced the bulk `items` option with registry `onboard`, a 10 k-row
table allocates 10 k `shallowReactive` proxies at construction — one per ticket.
The proxy allocation is the dominant cost in the regression benchmarks:

| Benchmark | Before | After this PR |
|---|---|---|
| Create table (10,000 items) | slow (~25 ms) | eliminates per-row proxy cost |
| Create with all options (1,000 items) | slow (~117 ms) | eliminates per-row proxy cost |
| Create with openAll (1,000 items) | slow (~107 ms) | eliminates per-row proxy cost |

## Solution

Adds `reactiveTickets?: boolean` to `RegistryOptions`. When `false`, the **collection**
(shallowReactive Map + shallowReactive order array) stays reactive so that computed
derivations like `source` re-evaluate when rows are added or removed, but individual
tickets are plain objects instead of Proxy wrappers.

```ts
// createRegistry options type — new field:
reactiveTickets?: boolean  // defaults to same as `reactive`
```

Sets `reactiveTickets: false` on the **row** registry in `createDataTable`.
Column tickets remain fully reactive because columns can be mutated in place
(sort state, width, visibility).

The key invariant: `source = computed(() => registry.values().map(t => t.value))`
reads from `order` which is still `shallowReactive`, so the computed re-triggers
on any register/unregister. Per-ticket reactivity was never consumed by the pipeline.

## Changes

- `packages/0/src/composables/createRegistry/index.ts` — add `reactiveTickets` option, default to `reactive`; use it in the `register()` ticket-wrapping path
- `packages/0/src/composables/createDataTable/index.ts` — pass `reactiveTickets: false` for the row registry

All 6108 tests pass.