### PR TITLE
fix(createForm): submit(0) validated all fields instead of field id 0

### DIFF
--- a/packages/0/src/composables/createForm/index.test.ts
+++ b/packages/0/src/composables/createForm/index.test.ts
@@ -192,7 +192,7 @@ describe('createForm', () => {
       expect(result).toBe(true)
     })
 
-    it.skip('should validate only the targeted validation when id is the numeric value 0', async () => {
+    it('should validate only the targeted validation when id is the numeric value 0', async () => {
       const form = createForm()
       const val1 = shallowRef('')
       const val2 = shallowRef('')

--- a/packages/0/src/composables/createForm/index.ts
+++ b/packages/0/src/composables/createForm/index.ts
@@ -35,7 +35,7 @@ import { createTrinity } from '#v0/composables/createTrinity'
 import { toArray } from '#v0/composables/toArray'
 
 // Utilities
-import { isNull } from '#v0/utilities'
+import { isNull, isUndefined } from '#v0/utilities'
 import { computed, hasInjectionContext } from 'vue'
 
 // Types
@@ -171,7 +171,7 @@ export function createForm (options: FormOptions = {}): FormContext {
   }
 
   async function submit (id?: ID | ID[]): Promise<boolean> {
-    const ids = id ? toArray(id) : [...registry.keys()]
+    const ids = isUndefined(id) ? [...registry.keys()] : toArray(id)
     const results = await Promise.all(
       ids.map(async key => {
         const ticket = registry.get(key)


### PR DESCRIPTION
## Problem

`createForm`'s `submit(id?)` resolves which fields to validate:

```ts
const ids = id ? toArray(id) : [...registry.keys()]
```

`ID` is `string | number`, so the numeric id `0` is a legitimate field identifier. But `0` is falsy, so `submit(0)` falls into the no-argument branch and validates **every** registered field instead of only the field with id `0`.

This is the same falsy-coercion shape as the cited `isUndefined` guards elsewhere in the codebase — `submit` was the one place that tested presence with truthiness.

## Fix

Guard on presence, not truthiness:

```ts
const ids = isUndefined(id) ? [...registry.keys()] : toArray(id)
```

`isUndefined` is added to the existing `#v0/utilities` import.

## Verification

- The repo already shipped a regression test for this exact case as `it.skip` (`index.test.ts:195`) — this PR un-skips it. It registers field id `0` and field id `1`, calls `submit(0)`, and asserts only field `0` is validated (`v2.isValid === null`).
- Proven before/after: with the source reverted to the buggy form, the test fails at `expect(v2.isValid.value).toBe(null)` (v2 was validated — `submit(0)` validated all fields). With the fix, the full `createForm` suite passes 24/24.
- `pnpm typecheck` (packages/0) clean; lint clean.

## Precedent

`createQueue:363`, `createModel:428`, `createStep:212/223`, `createDataGrid/layout.ts:410`, `useDragDrop:594` all use `isUndefined(id)` for "no id → default, else target this id". Family grep confirms `submit` was the sole offender of the `id ? toArray(id) : …` shape.
