### PR TITLE
fix(Carousel): clamp next() at the perView edge in non-circular mode

### DIFF
--- a/packages/0/src/components/Carousel/CarouselRoot.vue
+++ b/packages/0/src/components/Carousel/CarouselRoot.vue
@@ -176,10 +176,13 @@
   useProxyModel(step, model, { multiple: false })
 
   function next () {
-    if (circular && perView > 1) {
+    if (perView > 1) {
       const maxStart = Math.max(0, step.size - perView)
       if (step.selectedIndex.value >= maxStart) {
-        step.first()
+        // At the perView edge: wrap to the start in circular mode, otherwise
+        // clamp. Advancing further would show a partial final view (fewer than
+        // perView slides) — the same edge CarouselNext disables its button at.
+        if (circular) step.first()
         return
       }
     }

--- a/packages/0/src/components/Carousel/index.test.ts
+++ b/packages/0/src/components/Carousel/index.test.ts
@@ -2764,7 +2764,7 @@ describe('carousel', () => {
       expect(slide1Props.isSelected).toBe(true)
     })
 
-    it.skip('should not advance past maxStart when next() called in non-circular mode with perView', async () => {
+    it('should not advance past maxStart when next() called in non-circular mode with perView', async () => {
       const selected = ref<string>('a')
 
       let rootProps: any


### PR DESCRIPTION
## Problem

`CarouselRoot.next()` only applied the `maxStart` (`size - perView`) clamp inside the `circular && perView > 1` branch:

```ts
function next () {
  if (circular && perView > 1) {
    const maxStart = Math.max(0, step.size - perView)
    if (step.selectedIndex.value >= maxStart) { step.first(); return }
  }
  step.next()
}
```

In **non-circular** `perView > 1` mode, control falls through to `step.next()`, which advances to `length - 1` — past `maxStart` — leaving a partial final view (fewer than `perView` slides) showing. For example with 3 slides and `perView: 2`, `maxStart` is `1` (showing `[b, c]`), but `next()` advances to index `2`, showing slide `c` alone.

`CarouselNext` already treats this as the edge and **disables its button there**:

```ts
const isAtEdge = toRef(() => carousel.selectedIndex.value >= carousel.size - carousel.perView.value)
const isDisabled = toRef(() => toValue(carousel.disabled) || isAtEdge.value)
```

So manual users can't over-advance, but **autoplay** (which calls `next()` on a timer) and any programmatic `next()` caller bypass the disabled button and hit the partial view.

## Fix

Apply the `maxStart` clamp for all `perView > 1`; only *wrap* when circular:

```ts
function next () {
  if (perView > 1) {
    const maxStart = Math.max(0, step.size - perView)
    if (step.selectedIndex.value >= maxStart) {
      if (circular) step.first()
      return
    }
  }
  step.next()
}
```

Circular behavior is unchanged (wrap to first at the edge); non-circular now clamps at `maxStart`, consistent with `CarouselNext.isAtEdge`.

## Verification

- The repo already shipped a regression test for this as `it.skip` (`index.test.ts:2767`) — this PR un-skips it. It mounts a non-circular `perView: 2` carousel with 3 slides and asserts a second `next()` stays at `'b'` (index 1 = maxStart) rather than advancing to `'c'`.
- Proven before/after: with the source reverted to the buggy form, the test fails at `expect(selected.value).toBe('b')` (it advanced to `'c'`). With the fix, the full Carousel suite passes 94/94.
- The passing `isAtEdge` tests (perView-aware edge) and the passing circular-wrap test confirm the intended contract; this change makes programmatic `next()` consistent with both.
- `pnpm typecheck` (packages/0) clean; lint clean.
