### PR TITLE
fix(createSingle): force single selection, ignore caller multiple:true

### DIFF
--- a/packages/0/src/composables/createSingle/index.test.ts
+++ b/packages/0/src/composables/createSingle/index.test.ts
@@ -65,7 +65,7 @@ describe('createSingle', () => {
         expect(single.selectedId.value).toBe('item-1')
       })
 
-      it.skip('should ignore explicit multiple:true and still enforce single selection', () => {
+      it('should ignore explicit multiple:true and still enforce single selection', () => {
         // SelectionOptions.multiple is type-allowed because SingleOptions extends
         // SelectionOptions, but createSingle's contract is single-selection-only.
         const single = createSingle({ multiple: true })

--- a/packages/0/src/composables/createSingle/index.ts
+++ b/packages/0/src/composables/createSingle/index.ts
@@ -142,8 +142,11 @@ export function createSingle<
   E extends SingleTicket<Z> = SingleTicket<Z>,
   R extends SingleContext<Z, E> = SingleContext<Z, E>,
 > (_options: SingleOptions = {}): R {
-  const { mandatory = false, multiple = false, ...options } = _options
-  const registry = createSelection<Z, E>({ ...options, mandatory, multiple })
+  // createSingle is single-selection by contract. SingleOptions extends
+  // SelectionOptions so `multiple` is type-allowed, but it must never reach
+  // createSelection — force single mode regardless of what the caller passed.
+  const { mandatory = false, ...options } = _options
+  const registry = createSelection<Z, E>({ ...options, mandatory, multiple: false })
 
   const selectedId = toRef(() => registry.selectedIds.values().next().value)
   const selectedItem = toRef(() => registry.selectedItems.value.values().next().value)


### PR DESCRIPTION
## Problem

`createSingle` destructured `multiple` from its options and forwarded it straight to `createSelection`:

```ts
const { mandatory = false, multiple = false, ...options } = _options
const registry = createSelection<Z, E>({ ...options, mandatory, multiple })
```

`SingleOptions extends SelectionOptions`, so `multiple` is type-allowed. That means `createSingle({ multiple: true })` ran in **multi-select** mode — directly contradicting the composable's documented contract ("Single-selection composable that extends createSelection to **enforce only one selected item**").

## Fix

Force `multiple: false` regardless of what the caller passed:

```ts
const { mandatory = false, ...options } = _options
const registry = createSelection<Z, E>({ ...options, mandatory, multiple: false })
```

`createGroup` is intentionally **not** changed — `createNested` legitimately uses `createGroup({ multiple: false })` for cascade single-select, and `createGroup`'s `multiple` is configurable by design. This fix is scoped to `createSingle`, whose identity is single-selection.

## Verification

- The repo already shipped a regression test for this as `it.skip` (`createSingle/index.test.ts:68`) — this PR un-skips it. It registers two items, selects both, and asserts `selectedIds.size === 1` (only the last).
- Proven before/after: with the source reverted to the buggy form, the test fails at `expect(single.selectedIds.size).toBe(1)` (both items selected). With the fix, the full createSingle + createStep suites pass.
- No production code forwards `multiple` to `createSingle` (only the test constructs it that way), so nothing depends on the old behavior.
- Regression sweep: 416 tests across createSelection / createSingle / createStep / createGroup / Tabs / Carousel pass. `pnpm typecheck` clean; lint clean.
