### PR TITLE
fix(useNotifications): no-op lifecycle methods on unknown notification id

### DIFF
--- a/packages/0/src/composables/useNotifications/index.test.ts
+++ b/packages/0/src/composables/useNotifications/index.test.ts
@@ -145,7 +145,7 @@ describe('createNotifications', () => {
       })
     })
 
-    it.skip('should no-op when state mutations are called with a non-existent id', () => {
+    it('should no-op when state mutations are called with a non-existent id', () => {
       withScope(() => {
         const notifications = createNotifications()
 

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -331,6 +331,7 @@ export function createNotifications (
    * ```
    */
   function read (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { readAt: new Date() } as Partial<NotificationTicket>, 'notification:read')
   }
 
@@ -352,6 +353,7 @@ export function createNotifications (
    * ```
    */
   function unread (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { readAt: null } as Partial<NotificationTicket>, 'notification:unread')
   }
 
@@ -376,6 +378,7 @@ export function createNotifications (
    * ```
    */
   function seen (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { seenAt: new Date() } as Partial<NotificationTicket>, 'notification:seen')
   }
 
@@ -397,6 +400,7 @@ export function createNotifications (
    * ```
    */
   function archive (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { archivedAt: new Date() } as Partial<NotificationTicket>, 'notification:archived')
   }
 
@@ -418,6 +422,7 @@ export function createNotifications (
    * ```
    */
   function unarchive (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { archivedAt: null } as Partial<NotificationTicket>, 'notification:unarchived')
   }
 
@@ -443,6 +448,7 @@ export function createNotifications (
    * ```
    */
   function snooze (id: ID, until: Date) {
+    if (!registry.has(id)) return
     registry.upsert(id, { snoozedUntil: until } as Partial<NotificationTicket>, 'notification:snoozed')
   }
 
@@ -464,6 +470,7 @@ export function createNotifications (
    * ```
    */
   function wake (id: ID) {
+    if (!registry.has(id)) return
     registry.upsert(id, { snoozedUntil: null } as Partial<NotificationTicket>, 'notification:unsnoozed')
   }
 


### PR DESCRIPTION
## Problem

All seven `useNotifications` lifecycle methods — `read`, `unread`, `seen`, `archive`, `unarchive`, `snooze`, `wake` — mutate state by calling `registry.upsert(id, …)` directly:

```ts
function read (id: ID) {
  registry.upsert(id, { readAt: new Date() } as Partial<NotificationTicket>, 'notification:read')
}
```

`registry.upsert` **auto-registers** when the id is unknown (`createRegistry`: `if (!existing) return register({ ...patch, id })`). So calling any lifecycle method with a non-existent id silently creates a **malformed** notification ticket — no `createdAt`, `subject`, `body`, or ticket lifecycle methods — that pollutes `values()` and crashes on later access. Adapter code that forwards "read this id" events for ids the local registry has never seen is the realistic trigger.

## Fix

Guard each of the seven methods:

```ts
function read (id: ID) {
  if (!registry.has(id)) return
  registry.upsert(id, { readAt: new Date() } as Partial<NotificationTicket>, 'notification:read')
}
```

`readAll` / `archiveAll` are unaffected — they only `upsert` ids drawn from `registry.values()`, which are guaranteed to exist.

## Verification

- The repo already shipped a regression test for this as `it.skip` (`useNotifications/index.test.ts:148`) — this PR un-skips it. It calls `read('non-existent')` and asserts `values().length === 0`.
- Proven before/after: with the source reverted to the unguarded form, the test fails (the unknown id auto-registered a ticket). With the fix, the full useNotifications + Snackbar suites pass (136 tests).
- `pnpm typecheck` clean; lint clean.
