### PR TITLE
fix(useLocale): resolve repeated token references in one message

### DIFF
--- a/packages/0/src/composables/useLocale/adapters/v0.ts
+++ b/packages/0/src/composables/useLocale/adapters/v0.ts
@@ -64,12 +64,14 @@ export class V0LocaleAdapter extends LocaleAdapter {
 
       if (visited.has(path)) return match
 
-      visited.add(path)
-
       const resolved = this.context.tokens.get(path)?.value
 
       if (isString(resolved)) {
-        return this.resolve(target, resolved, visited)
+        // Branch with a copy of `visited` so sibling references to the same
+        // token resolve independently; only ancestor paths (carried down the
+        // copy) count as cycles. A shared, mutated set would drop the second
+        // `{app}` in `'{app} loves {app}'`.
+        return this.resolve(target, resolved, new Set(visited).add(path))
       }
 
       return match

--- a/packages/0/src/composables/useLocale/index.test.ts
+++ b/packages/0/src/composables/useLocale/index.test.ts
@@ -194,7 +194,7 @@ describe('createLocale', () => {
         expect(result).toContain('{')
       })
 
-      it.skip('should resolve the same token reference multiple times in one message', () => {
+      it('should resolve the same token reference multiple times in one message', () => {
         const locale = createLocale({
           default: 'en',
           messages: {


### PR DESCRIPTION
## Problem

`V0LocaleAdapter.resolve()` uses one `visited` Set, shared across every `{token}` match in a message and mutated as it walks:

```ts
if (visited.has(path)) return match
visited.add(path)                       // mutates the shared set
const resolved = this.context.tokens.get(path)?.value
if (isString(resolved)) return this.resolve(target, resolved, visited)
```

The Set exists to break reference cycles, but because it's shared and mutated, **sibling** references to the same token collide. With:

```ts
messages: { en: { app: 'Vuetify', banner: '{app} loves {app}' } }
```

the first `{app}` adds `en.app` to the set; the second `{app}` then hits `visited.has('en.app')` and is returned literally — `t('banner')` yields `'Vuetify loves {app}'` instead of `'Vuetify loves Vuetify'`.

## Fix

Don't mutate the shared set — pass a per-branch copy down the recursion:

```ts
if (visited.has(path)) return match
const resolved = this.context.tokens.get(path)?.value
if (isString(resolved)) {
  return this.resolve(target, resolved, new Set(visited).add(path))
}
```

Each sibling branch sees only the **ancestor** chain (carried in the copy), so repeated references resolve independently while genuine cycles (`a → {b} → {a}`, `x → {x}`) are still caught.

## Verification

- The repo already shipped a regression test as `it.skip` (`useLocale/index.test.ts:197`) — this PR un-skips it. It asserts `t('banner') === 'Vuetify loves Vuetify'`.
- Proven before/after: with the source reverted to the shared-mutated form, the test fails (second `{app}` dropped). With the fix, the full useLocale suite passes 66/66 — **including** the existing "should detect circular references" and "should handle self-referencing tokens" tests, confirming cycle protection is preserved.
- `pnpm typecheck` clean; lint clean.
