### PR TITLE
fix(createValidation): no-rules validate must invalidate in-flight runs

### DIFF
--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -378,7 +378,7 @@ describe('createValidation', () => {
       expect(firstResult).toBe(false)
     })
 
-    it.skip('should not let an in-flight validate overwrite state set by a later no-rules call', async () => {
+    it('should not let an in-flight validate overwrite state set by a later no-rules call', async () => {
       let resolveSlow: ((val: string | boolean) => void) | undefined
       function slowRule (_v: unknown) {
         return new Promise<string | boolean>(r => {

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -140,6 +140,10 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   }
 
   async function validate (_value: unknown = UNSET, silent = false): Promise<boolean> {
+    // Bump generation up-front so every call — including the no-active-rules
+    // path below — invalidates any in-flight validation. Otherwise a slow rule
+    // resolving after a later no-rules call would overwrite the newer state.
+    const gen = ++generation
     const val = _value === UNSET ? toValue(valueSource) : _value
     const activeRules: FormValidationRule[] = []
 
@@ -148,11 +152,14 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     }
 
     if (activeRules.length === 0) {
-      if (!silent) isValid.value = true
+      if (!silent) {
+        errors.value = []
+        isValid.value = true
+        isValidating.value = false
+      }
       return true
     }
 
-    const gen = ++generation
     if (!silent) isValidating.value = true
 
     try {


### PR DESCRIPTION
## Problem

`createValidation.validate()` is race-safe via a `generation` counter: each run captures `gen = ++generation` and discards its result if `gen !== generation` when it resolves. But generation was only bumped in the path that actually runs rules:

```ts
if (activeRules.length === 0) {
  if (!silent) isValid.value = true   // no-rules path — does NOT bump generation
  return true
}
const gen = ++generation              // only here
```

So the no-active-rules early return couldn't invalidate a validation already in flight. Sequence:

1. `validate()` with a slow async rule selected → `gen = 1`, awaits.
2. The rule is unselected.
3. `validate()` again → no active rules → sets `isValid = true`, returns — **generation stays 1**.
4. The slow rule finally resolves (failure) → its `gen (1) === generation (1)` guard passes → it overwrites `isValid` back to `false` with a stale result.

## Fix

Hoist `++generation` to the top of `validate()` so **every** call — including the no-rules path — invalidates in-flight runs. The no-rules path also clears `errors` and resets `isValidating`:

```ts
const gen = ++generation
// ...
if (activeRules.length === 0) {
  if (!silent) {
    errors.value = []
    isValid.value = true
    isValidating.value = false
  }
  return true
}
```

The `isValidating` reset is required: once the no-rules call bumps generation, the in-flight run that set `isValidating = true` is invalidated and its `finally` (`gen === generation`) no longer resets it — so the no-rules path must.

## Verification

- The repo already shipped a regression test for this as `it.skip` (`createValidation/index.test.ts:381`) — this PR un-skips it. It interleaves a slow rule, an unselect, and a no-rules validate, then resolves the slow rule and asserts `isValid` stays `true` with empty `errors`.
- Proven before/after: with the source reverted, the test fails at `expect(validation.isValid.value).toBe(true)` (stale failure overwrote it). With the fix, the full createValidation suite passes (plus createForm consumer) — including the existing "reset during async validation" tests, confirming no regression.
- `pnpm typecheck` clean; lint clean.
