### PR TITLE
fix(NumberField): expose Scrub pointer handlers in slot attrs for renderless mode

### DIFF
--- a/packages/0/src/components/NumberField/NumberFieldScrub.vue
+++ b/packages/0/src/components/NumberField/NumberFieldScrub.vue
@@ -36,6 +36,9 @@
       'style': { cursor: string }
       'data-disabled': true | undefined
       'data-readonly': true | undefined
+      'onPointerdown': (e: PointerEvent) => void
+      'onPointermove': (e: PointerEvent) => void
+      'onPointerup': () => void
     }
   }
 </script>
@@ -99,27 +102,21 @@
     document.exitPointerLock()
   }
 
-  const scrubAttrs = toRef((): Record<string, unknown> => ({
-    'style': { cursor: 'ew-resize' },
-    'data-disabled': root.isDisabled.value ? true : undefined,
-    'data-readonly': root.isReadonly.value ? true : undefined,
-    onPointerdown,
-    onPointermove,
-    onPointerup,
-  }))
-
   const slotProps = toRef((): NumberFieldScrubSlotProps => ({
     attrs: {
       'style': { cursor: 'ew-resize' },
       'data-disabled': root.isDisabled.value ? true : undefined,
       'data-readonly': root.isReadonly.value ? true : undefined,
+      onPointerdown,
+      onPointermove,
+      onPointerup,
     },
   }))
 </script>
 
 <template>
   <Atom
-    v-bind="mergeProps(attrs, scrubAttrs)"
+    v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless
   >

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -1327,7 +1327,7 @@ describe('numberField', () => {
       expect(captured.attrs['data-readonly']).toBeUndefined()
     })
 
-    it.skip('should expose pointer event handlers in slot attrs for renderless mode', async () => {
+    it('should expose pointer event handlers in slot attrs for renderless mode', async () => {
       const model = ref<number | null>(5)
       let captured: any
       mount(NumberField.Root, {
@@ -1350,7 +1350,7 @@ describe('numberField', () => {
       expect(captured.attrs.onPointerup).toBeTypeOf('function')
     })
 
-    it.skip('should support renderless mode with bound slot attrs', async () => {
+    it('should support renderless mode with bound slot attrs', async () => {
       const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: any) => {
         cb(0)
         return 1


### PR DESCRIPTION
## Problem

`NumberFieldScrub` maintained two separate attribute objects:

- `scrubAttrs` — style + data attrs **plus** the pointer handlers (`onPointerdown`/`onPointermove`/`onPointerup`), bound to `<Atom>` via `mergeProps(attrs, scrubAttrs)`.
- `slotProps.attrs` — a hand-typed subset with the style + data attrs but **no handlers**, exposed to the slot.

In non-renderless mode the handlers live on Atom's rendered element, so scrubbing works. In **renderless** mode Atom renders no element of its own; the consumer spreads `slotProps.attrs` onto their custom element — but that object omitted the pointer handlers, so a renderless custom scrub element was inert (`attrs.onPointerdown` was `undefined`, and dragging it didn't change the value).

## Fix

Collapse the duplicate. Put the handlers in `slotProps.attrs` (the single source) and bind that to Atom:

```ts
const slotProps = toRef((): NumberFieldScrubSlotProps => ({
  attrs: {
    'style': { cursor: 'ew-resize' },
    'data-disabled': root.isDisabled.value ? true : undefined,
    'data-readonly': root.isReadonly.value ? true : undefined,
    onPointerdown,
    onPointermove,
    onPointerup,
  },
}))
```

```vue
<Atom v-bind="mergeProps(attrs, slotProps.attrs)" :as :renderless>
```

The handlers are bound to Atom once via `mergeProps` (no double-fire); renderless consumers now receive them by spreading `attrs`. This is the "collapse the hand-typed subset into slotProps.attrs" fix the scrub control's sibling controls already follow.

## Verification

- The repo already shipped two regression tests as `it.skip` (`NumberField/index.test.ts:1330` and `:1353`) — this PR un-skips both. One asserts `attrs.onPointerdown/onPointermove/onPointerup` are functions; the other drives a renderless custom scrub via `pointerdown` + `pointermove` and asserts the model increases.
- Proven before/after: with the source reverted, both tests fail (handlers absent; model unchanged). With the fix, the full NumberField suite passes (131 tests) with no regression to the non-renderless scrub path.
- `pnpm typecheck` clean; lint clean.
