### PR TITLE
fix(AlertDialog,Dialog): expose action handlers in slot attrs for renderless mode

### DIFF
--- a/packages/0/src/components/AlertDialog/AlertDialogAction.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogAction.vue
@@ -68,6 +68,7 @@
     as = 'button',
     namespace = 'v0:alert-dialog',
     disabled = false,
+    renderless,
   } = defineProps<AlertDialogActionProps>()
 
   const emit = defineEmits<AlertDialogActionEmits>()
@@ -112,6 +113,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/AlertDialog/AlertDialogAction.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogAction.vue
@@ -43,6 +43,7 @@
       'disabled': boolean | undefined
       'data-disabled': '' | undefined
       'data-pending': '' | undefined
+      'onClick': () => void
     }
   }
 </script>
@@ -103,6 +104,7 @@
       'disabled': disabled || undefined,
       'data-disabled': disabled ? '' : undefined,
       'data-pending': context.isPending.value ? '' : undefined,
+      'onClick': onClick,
     },
   }))
 </script>
@@ -111,7 +113,6 @@
   <Atom
     :as
     v-bind="slotProps.attrs"
-    @click="onClick"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/AlertDialog/AlertDialogActivator.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogActivator.vue
@@ -51,6 +51,7 @@
   const {
     as = 'button',
     namespace = 'v0:alert-dialog',
+    renderless,
   } = defineProps<AlertDialogActivatorProps>()
 
   const context = useAlertDialogContext(namespace)
@@ -74,6 +75,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/AlertDialog/AlertDialogActivator.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogActivator.vue
@@ -27,6 +27,7 @@
       'aria-haspopup': 'dialog'
       'aria-expanded': boolean
       'data-open': true | undefined
+      'onClick': () => void
     }
   }
 </script>
@@ -65,6 +66,7 @@
       'aria-haspopup': 'dialog',
       'aria-expanded': context.isOpen.value,
       'data-open': context.isOpen.value || undefined,
+      'onClick': onClick,
     },
   }))
 </script>
@@ -73,7 +75,6 @@
   <Atom
     :as
     v-bind="slotProps.attrs"
-    @click="onClick"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
@@ -27,6 +27,7 @@
       'type': 'button' | undefined
       'disabled': boolean | undefined
       'data-disabled': '' | undefined
+      'onClick': () => void
     }
   }
 </script>
@@ -66,6 +67,7 @@
       'type': as === 'button' ? 'button' : undefined,
       'disabled': disabled || undefined,
       'data-disabled': disabled ? '' : undefined,
+      'onClick': onClick,
     },
   }))
 </script>
@@ -74,7 +76,6 @@
   <Atom
     :as
     v-bind="slotProps.attrs"
-    @click="onClick"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
@@ -52,6 +52,7 @@
     as = 'button',
     namespace = 'v0:alert-dialog',
     disabled = false,
+    renderless,
   } = defineProps<AlertDialogCancelProps>()
 
   const context = useAlertDialogContext(namespace)
@@ -75,6 +76,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Dialog/DialogActivator.vue
+++ b/packages/0/src/components/Dialog/DialogActivator.vue
@@ -51,6 +51,7 @@
   const {
     as = 'button',
     namespace = 'v0:dialog',
+    renderless,
   } = defineProps<DialogActivatorProps>()
 
   const context = useDialogContext(namespace)
@@ -74,6 +75,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Dialog/DialogActivator.vue
+++ b/packages/0/src/components/Dialog/DialogActivator.vue
@@ -27,6 +27,7 @@
       'aria-haspopup': 'dialog'
       'aria-expanded': boolean
       'data-open': true | undefined
+      'onClick': () => void
     }
   }
 </script>
@@ -65,6 +66,7 @@
       'aria-haspopup': 'dialog',
       'aria-expanded': context.isOpen.value,
       'data-open': context.isOpen.value || undefined,
+      'onClick': onClick,
     },
   }))
 </script>
@@ -73,7 +75,6 @@
   <Atom
     :as
     v-bind="slotProps.attrs"
-    @click="onClick"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Dialog/DialogClose.vue
+++ b/packages/0/src/components/Dialog/DialogClose.vue
@@ -24,6 +24,7 @@
     attrs: {
       'type': 'button' | undefined
       'aria-label': string
+      'onClick': () => void
     }
   }
 </script>
@@ -64,6 +65,7 @@
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
       'aria-label': locale.t('Dialog.close'),
+      'onClick': onClick,
     },
   }))
 </script>
@@ -72,7 +74,6 @@
   <Atom
     :as
     v-bind="slotProps.attrs"
-    @click="onClick"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Dialog/DialogClose.vue
+++ b/packages/0/src/components/Dialog/DialogClose.vue
@@ -51,6 +51,7 @@
   const {
     as = 'button',
     namespace = 'v0:dialog',
+    renderless,
   } = defineProps<DialogCloseProps>()
 
   const context = useDialogContext(namespace)
@@ -73,6 +74,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />


### PR DESCRIPTION
## Problem

Five sibling sub-components in the Dialog/AlertDialog family bound their click handler via a template directive on `<Atom>` and left `onClick` out of the slot `attrs`:

- `AlertDialog.Action`, `AlertDialog.Cancel`, `AlertDialog.Activator`
- `Dialog.Close`, `Dialog.Activator`

```vue
<Atom :as v-bind="slotProps.attrs" @click="onClick">
  <slot v-bind="slotProps" />
</Atom>
```

In **renderless** mode `Atom` renders no element of its own — the consumer supplies the element and spreads the slot `attrs` onto it. Since `@click` had nothing to bind to and `attrs` didn't carry `onClick`, a renderless custom element was inert: open/close/cancel/action did nothing.

This is the same bug fixed for `AlertDialog.Close` in #295 — this PR completes the family.

## Fix

Move `onClick` into each component's slot `attrs` (and its type) and drop the `@click` directive — matching `AlertDialogClose` and the `ButtonRoot` precedent:

```ts
attrs: {
  // ...existing aria/data/type attrs...
  'onClick': onClick,
}
```

Non-renderless mode still binds `attrs.onClick` to Atom's rendered element via `v-bind="slotProps.attrs"` — a single binding, so no double-fire. Renderless consumers now get the handler by spreading `attrs`.

## Verification

- These five had **no** regression test (unlike `AlertDialog.Close`, which shipped one as `it.skip`). I verified each with a throwaway test that mounts every component renderless and asserts `attrs.onClick` is a function — **all five failed on master, all five pass with the fix** — then removed it (no new committed test file).
- Regression: the full AlertDialog + Dialog suites pass (100 tests), confirming non-renderless open/close/cancel/action still work with no double-fire.
- `pnpm typecheck` clean; lint clean.
