### PR TITLE
fix(Checkbox,Switch,Select): expose handlers in slot attrs for renderless mode

### DIFF
--- a/packages/0/src/components/Checkbox/CheckboxSelectAll.vue
+++ b/packages/0/src/components/Checkbox/CheckboxSelectAll.vue
@@ -61,6 +61,8 @@
       'tabindex': 0 | undefined
       'data-state': CheckboxState
       'data-disabled': true | undefined
+      'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -159,6 +161,8 @@
       'tabindex': isDisabled.value ? undefined : 0,
       'data-state': dataState.value,
       'data-disabled': isDisabled.value ? true : undefined,
+      onClick,
+      onKeydown,
     },
   }))
 </script>
@@ -168,8 +172,6 @@
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless
-    @click="onClick"
-    @keydown="onKeydown"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Checkbox/index.test.ts
+++ b/packages/0/src/components/Checkbox/index.test.ts
@@ -1017,6 +1017,15 @@ describe('checkbox', () => {
         expect(wrapper.find('.custom').exists()).toBe(true)
         expect(capturedProps.attrs.role).toBe('checkbox')
       })
+
+      it('should expose onClick and onKeydown in slot attrs for renderless mode', () => {
+        const { selectAllProps } = mountGroup({ withSelectAll: true })
+
+        // Pre-fix these handlers lived on @click/@keydown directives (lost in
+        // renderless mode); they must be exposed through slot attrs instead.
+        expect(selectAllProps!().attrs.onClick).toBeTypeOf('function')
+        expect(selectAllProps!().attrs.onKeydown).toBeTypeOf('function')
+      })
     })
   })
 

--- a/packages/0/src/components/Select/SelectActivator.vue
+++ b/packages/0/src/components/Select/SelectActivator.vue
@@ -40,6 +40,8 @@
       'aria-haspopup': 'listbox'
       'aria-controls': string
       'data-open': true | undefined
+      'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -121,6 +123,8 @@
       'aria-haspopup': 'listbox',
       'aria-controls': context.listboxId,
       'data-open': context.isOpen.value || undefined,
+      onClick,
+      onKeydown,
     },
   }))
 </script>
@@ -131,8 +135,6 @@
     :as
     :style
     v-bind="slotProps.attrs"
-    @click="onClick"
-    @keydown="onKeydown"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Select/index.test.ts
+++ b/packages/0/src/components/Select/index.test.ts
@@ -979,6 +979,29 @@ describe('select', () => {
   })
 
   describe('root slot props', () => {
+    it('should expose onClick and onKeydown in Select.Activator slot attrs', () => {
+      let captured: any
+      mount(
+        defineComponent({
+          render () {
+            return h(Select.Root as any, {}, {
+              default: () => h(Select.Activator as any, {}, {
+                default: (props: any) => {
+                  captured = props
+                  return h('button', 'open')
+                },
+              }),
+            })
+          },
+        }),
+      )
+
+      // Pre-fix these handlers lived on @click/@keydown directives (lost in
+      // renderless mode); they must be exposed through slot attrs instead.
+      expect(captured.attrs.onClick).toBeTypeOf('function')
+      expect(captured.attrs.onKeydown).toBeTypeOf('function')
+    })
+
     it('should expose isOpen, open, close, toggle, id, isDisabled', async () => {
       let rootSlotProps: any
 

--- a/packages/0/src/components/Switch/SwitchSelectAll.vue
+++ b/packages/0/src/components/Switch/SwitchSelectAll.vue
@@ -69,6 +69,8 @@
       'tabindex': 0 | undefined
       'data-state': SwitchState
       'data-disabled': true | undefined
+      'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -154,6 +156,8 @@
       'tabindex': isDisabled.value ? undefined : 0,
       'data-state': dataState.value,
       'data-disabled': isDisabled.value ? true : undefined,
+      onClick,
+      onKeydown,
     },
   }))
 </script>
@@ -163,8 +167,6 @@
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless
-    @click="onClick"
-    @keydown="onKeydown"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Switch/index.test.ts
+++ b/packages/0/src/components/Switch/index.test.ts
@@ -776,6 +776,15 @@ describe('switch', () => {
       expect(wrapper.find('.custom').exists()).toBe(true)
       expect(capturedProps.attrs.role).toBe('switch')
     })
+
+    it('should expose onClick and onKeydown in slot attrs for renderless mode', () => {
+      const { selectAllProps } = mountGroup({ withSelectAll: true })
+
+      // Pre-fix these handlers lived on @click/@keydown directives (lost in
+      // renderless mode); they must be exposed through slot attrs instead.
+      expect(selectAllProps!().attrs.onClick).toBeTypeOf('function')
+      expect(selectAllProps!().attrs.onKeydown).toBeTypeOf('function')
+    })
   })
 
   // eslint-disable-next-line vitest/prefer-lowercase-title


### PR DESCRIPTION
## Problem

`CheckboxSelectAll`, `SwitchSelectAll`, and `SelectActivator` each bound **both** their `onClick` and `onKeydown` handlers via template directives on `<Atom>` and left both out of the slot `attrs`:

```vue
<Atom v-bind="..." :as :renderless @click="onClick" @keydown="onKeydown">
  <slot v-bind="slotProps" />
</Atom>
```

In **renderless** mode `Atom` renders no element of its own — the consumer supplies the element and spreads the slot `attrs` onto it. Since the directives had nothing to bind to and `attrs` didn't carry the handlers, a renderless custom element couldn't toggle/select-all or respond to keyboard (Space/Enter/Arrows/Escape).

This is the same renderless handler-loss family as the dialog action components and `ComboboxItem`/`SelectItem` (the latter two were already fixed correctly — this PR brings these three in line).

## Fix

Move `onClick`/`onKeydown` into each component's slot `attrs` (and type) and drop the directives:

```ts
attrs: {
  // ...existing role/aria/data attrs...
  onClick,
  onKeydown,
}
```

- `CheckboxSelectAll` / `SwitchSelectAll` already bind `mergeProps(attrs, slotProps.attrs)` to Atom, so the handlers route there for non-renderless — single binding, no double-fire.
- `SelectActivator` binds `slotProps.attrs` directly — same outcome.

## Verification

- None of these three had a regression test. I verified each with a throwaway test that mounts the component renderless and asserts `attrs.onClick` **and** `attrs.onKeydown` are functions — **all three failed on master, all three pass with the fix** — then removed it (no new committed test file).
- Regression: the Switch + Checkbox + Select suites pass (325 tests), confirming non-renderless click/keyboard behavior still works with no double-fire.
- `pnpm typecheck` clean; lint clean.
