### PR TITLE
fix(createKanban): preserve item id when transferring across columns

### DIFF
--- a/packages/0/src/composables/createKanban/index.test.ts
+++ b/packages/0/src/composables/createKanban/index.test.ts
@@ -187,6 +187,20 @@ describe('createKanban', () => {
       expect(done.items.get(a.id)?.index).toBe(0)
     })
 
+    it('should preserve the id when transferring a value-as-index item', () => {
+      const kanban = createKanban()
+      const todo = kanban.columns.register({})
+      const done = kanban.columns.register({})
+      // No explicit value → a value-as-index ticket, whose id offboard strips.
+      const a = todo.items.register({})
+
+      const moved = kanban.transfer(a.id, done.id, 0)
+
+      expect(moved?.id).toBe(a.id)
+      expect(todo.items.get(a.id)).toBeUndefined()
+      expect(done.items.get(a.id)?.id).toBe(a.id)
+    })
+
     it('should fire transfer:ticket with the full payload', () => {
       const { kanban, todo, done, a } = setup()
 

--- a/packages/0/src/composables/createKanban/index.ts
+++ b/packages/0/src/composables/createKanban/index.ts
@@ -487,7 +487,9 @@ export function createKanban<
     destination.items.batch(() => {
       const [input] = source.items.offboard([id])
       if (isUndefined(input)) return
-      registered = destination.items.register(input)
+      // offboard strips id/value off value-as-index tickets; re-pin the id so the
+      // ticket keeps its identity across columns (lookup map, caller handle, event).
+      registered = destination.items.register({ ...input, id } as Partial<ItemZ>)
       moved = registered.index === toIndex ? registered : destination.items.move(registered.id, toIndex)
     })
 


### PR DESCRIPTION
## Problem

`createKanban.transfer(id, toColumnId, toIndex)` moves an item between columns by offboarding it from the source list and re-registering it in the destination:

```ts
const [input] = source.items.offboard([id])
if (isUndefined(input)) return
registered = destination.items.register(input)
```

For items registered **without an explicit `value`** (so `valueIsIndex === true`), `createRegistry.toInput` deliberately strips both `id` and `value` from the offboarded input (correct for generic `onboard`/`offboard` round-trips, where auto-generated ids should be reassigned). So `destination.items.register(input)` receives no id and **mints a fresh one**.

The moved item silently loses its identity:
- the `lookup` registry (item id → column id) is rekeyed under the new id;
- the returned handle and the `transfer:ticket` event payload carry the new id;
- a subsequent `transfer(originalId, …)` fails with `unknown ticket id` (it looks the item up in `lookup` by the original id, which no longer exists).

Items registered *with* a `value` are unaffected (`toInput` keeps their id), which is why the existing tests — all of which use `register({ value: {...} })` — never caught it.

## Fix

Re-pin the id when re-registering in the destination:

```ts
registered = destination.items.register({ ...input, id } as Partial<ItemZ>)
```

`id` is the stable identity contract every consumer keys off. This is a no-op for explicit-value items and restores identity for value-as-index items. The same-column branch already preserves the id via `move()`, and the duplicate-id guard (`destination.items.get(id)`) assumes preservation — this brings the cross-column path in line.

## Verification

- Verified with a throwaway test (since removed): register an item with no explicit value, `transfer` it across columns, and assert the moved ticket keeps its id, is findable in the destination by the original id, is gone from the source, and can be transferred back by the original id. **It failed on master** (`expected 'v0-2', received 'v0-3'`) **and passes with the fix.** The explicit-value case passes in both.
- Regression: createKanban + createSortable suites pass (66 tests). `pnpm typecheck` clean; lint clean.
