### PR TITLE
fix(createTokens): guard flatten against prototype pollution and unsafe keys

### DIFF
--- a/packages/0/src/composables/createTokens/index.test.ts
+++ b/packages/0/src/composables/createTokens/index.test.ts
@@ -94,6 +94,33 @@ describe('createTokens', () => {
         expect(context.resolve('rtl')).toEqual({ value: true, variation: 'toggle' })
         expect(context.resolve('complex')).toEqual({ inner: { leaf: '#FFFFFF' } })
       })
+
+      it('should not flatten prototype-pollution keys into token ids', () => {
+        // JSON.parse creates OWN "__proto__"/"constructor" properties — an
+        // object literal would set the prototype instead — modelling untrusted
+        // token input. Pre-guard these surfaced as registrable token ids.
+        const malicious = JSON.parse(
+          '{"__proto__":{"$value":"#bad"},"constructor":{"$value":"#bad"},"prototype":{"$value":"#bad"},"color":{"$value":"#fff"}}',
+        ) as TokenCollection
+
+        const ids = flatten(malicious).map(token => token.id)
+
+        expect(ids).toContain('color')
+        expect(ids).not.toContain('__proto__')
+        expect(ids).not.toContain('constructor')
+        expect(ids).not.toContain('prototype')
+      })
+
+      it('should skip inherited keys when flattening', () => {
+        const base = { inherited: { $value: '#bad' } }
+        const tokens: Record<string, unknown> = Object.create(base)
+        tokens.color = { $value: '#fff' }
+
+        const ids = flatten(tokens as TokenCollection).map(token => token.id)
+
+        expect(ids).toContain('color')
+        expect(ids).not.toContain('inherited')
+      })
     })
 
     describe('alias resolution', () => {

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -33,7 +33,7 @@ import { createTrinity } from '#v0/composables/createTrinity'
 import { useLogger } from '#v0/composables/useLogger'
 
 // Utilities
-import { isObject, isString, isUndefined } from '#v0/utilities'
+import { isObject, isString, isUndefined, UNSAFE_KEYS } from '#v0/utilities'
 
 // Types
 import type { RegistryContext, RegistryContextOptions, RegistryOptions, RegistryTicket } from '#v0/composables/createRegistry'
@@ -405,6 +405,7 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
 
     const meta: Record<string, unknown> = {}
     for (const k in currentTokens) {
+      if (!Object.prototype.hasOwnProperty.call(currentTokens, k)) continue
       if (k.startsWith('$')) meta[k] = (currentTokens as Record<string, unknown>)[k]
     }
 
@@ -413,6 +414,11 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
     }
 
     for (const key in currentTokens) {
+      // Skip inherited keys and prototype-pollution sinks so a polluted
+      // Object.prototype (or a caller-supplied `constructor`/`prototype` token)
+      // can't leak in as a registered token id. Mirrors mergeDeep.
+      if (!Object.prototype.hasOwnProperty.call(currentTokens, key)) continue
+      if (UNSAFE_KEYS.has(key)) continue
       if (key.startsWith('$')) continue
 
       const value = (currentTokens as Record<string, unknown>)[key]
@@ -429,6 +435,8 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
         const inner = value.$value
         if (isObject(inner) && !flat) {
           for (const innerKey in inner) {
+            if (!Object.prototype.hasOwnProperty.call(inner, innerKey)) continue
+            if (UNSAFE_KEYS.has(innerKey)) continue
             if (innerKey.startsWith('$')) continue
 
             const child = inner[innerKey]


### PR DESCRIPTION
## Problem

`createTokens`' `flatten()` walks token objects with three `for...in` loops (token-key, `$`-meta scan, nested-inner) and **none** guarded against inherited or prototype-pollution keys:

```ts
for (const key in currentTokens) {
  if (key.startsWith('$')) continue
  const value = currentTokens[key]
  const id = currentPrefix ? `${currentPrefix}.${key}` : key
  // ... flattened.push({ id, value }) -> registry.onboard
}
```

`flatten` is the **ingestion** layer that derives token ids and feeds `registry.onboard`. Because it iterated the prototype chain with no `hasOwnProperty` / `UNSAFE_KEYS` guard, two leaks were reachable:

- **Global prototype pollution → phantom tokens.** If anything in the process has set e.g. `Object.prototype.injected`, *every* `createTokens(...)` call silently gains an `injected` token — and `useTheme` / `useLocale` / `useFeatures` all build their token tables through `flatten`.
- **Caller-supplied unsafe key → real token id.** `createTokens({ constructor: '#x', prototype: '#y' })` registers `constructor` and `prototype` as token ids.

`.claude/rules/implementation.md` ("Security primitives") states tokens are "Map-based and prototype-pollution-immune by construction" — true for the *storage* Map, but `flatten` runs **before** ingestion and was the unpatched sibling, exactly the shape the 2026-06-04 audit flagged for `usePermissions`.

## Fix

Guard each loop, mirroring `mergeDeep` (`helpers.ts:360-363`):

```ts
if (!Object.prototype.hasOwnProperty.call(currentTokens, key)) continue
if (UNSAFE_KEYS.has(key)) continue   // on the id-generating loops
```

`UNSAFE_KEYS` (`__proto__` / `constructor` / `prototype`) is imported from `#v0/utilities`.

## Verification

- Verified with a throwaway test (since removed): `createTokens({ constructor, prototype, safe })` must register only `safe`; with `Object.prototype.injected` set, `createTokens({ brand })` must have `size === 1` and no `injected` token. **Both failed on master and pass with the fix.**
- Regression: createTokens + useTheme + useLocale + useFeatures suites pass (488 tests) — the token-table consumers are unaffected. `pnpm typecheck` clean; lint clean.

## Precedent

`mergeDeep` (`utilities/helpers.ts:360-363`) guards every `for...in` with `hasOwnProperty` + `UNSAFE_KEYS.has(key)`; `UNSAFE_KEYS` is exported for exactly this sink.
