### PR TITLE
fix(useDragDrop): don't leak a zone's effect scope on duplicate-id registration

### DIFF
--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -209,6 +209,33 @@ describe('zones.register', () => {
     expect(zone.willAccept.value).toBe(true)
     expect(accept).toHaveBeenCalledTimes(1)
   })
+
+  it('should not leak an effect scope when registering a duplicate zone id', () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+
+    scope.run(() => {
+      const dnd = useDragDrop({ adapters: [] })
+      const el = shallowRef<HTMLElement | null>(null)
+
+      dnd.zones.register({ id: 'zone', el, accept: ['card'] })
+
+      // The source allocates one non-detached effect scope per zone, attached
+      // as a child of the active scope. Read that live child array.
+      const children = (scope as unknown as { scopes?: unknown[] }).scopes ?? []
+      const before = children.length
+      expect(before).toBeGreaterThan(0)
+
+      // Pre-fix a duplicate id allocated a second scope and overwrote
+      // scopes.set(id) without stopping the original, orphaning it as a
+      // permanent child whose observers leak past teardown.
+      dnd.zones.register({ id: 'zone', el, accept: ['card'] })
+      expect(children.length).toBe(before)
+    })
+
+    scope.stop()
+    expect(warn).toHaveBeenCalled()
+  })
 })
 
 function makeFocusableEl (id: string): HTMLElement {

--- a/packages/0/src/composables/useDragDrop/index.ts
+++ b/packages/0/src/composables/useDragDrop/index.ts
@@ -533,6 +533,13 @@ export function useDragDrop<Z extends DragType = DragType> (
     ..._zones,
     register (registration: DropZoneTicketInput<Z>): DropZoneTicket {
       const id = registration.id ?? useId()
+      // A duplicate id is rejected by the registry below (warn + return the
+      // existing ticket). Bail before allocating an effectScope/observers —
+      // otherwise scopes.set(id, …) overwrites the live scope without stopping
+      // it, leaking the original zone's observers past teardown.
+      if (_zones.has(id)) {
+        return _zones.register(registration as unknown as Partial<DropZoneTicketInput<Z> & RegistryTicket>) as DropZoneTicket
+      }
       const el = toRef(() => toValue(registration.el))
       const isOver = toRef(() => active.value?.over === id)
       const willAccept = toRef(() => safeAccept(registration.accept, active.value))


### PR DESCRIPTION
## Problem

`useDragDrop`'s `zones.register()` allocates a per-zone `effectScope`, runs the zone's observers inside it, and stores it — **before** deferring to the underlying registry:

```ts
const scope = effectScope()
scopes.set(id, scope)               // overwrites without stopping the prior entry
scope.run(() => {
  if (registration.orientation) {
    useResizeObserver(el, refresh)
    useMutationObserver(el, refresh, { childList: true })
    // + element watchers
  }
  watch(el, ...)
})
// ...
return _zones.register(input)       // duplicate id -> warn + return existing
```

When a caller registers a zone with an **explicit, already-used `id`**, `_zones.register` rejects it (`createRegistry`: warn + return the existing ticket). But by then the new `effectScope` has already been created and `scopes.set(id, scope)` has **overwritten the live scope without stopping it**. The original zone's `ResizeObserver` / `MutationObserver` / element watchers are now unreachable from both teardown paths — the `unregister:ticket` handler and the `onScopeDispose` loop only stop scopes still present in the `scopes` map — so they leak past teardown.

Auto-generated ids (`useId()`) never collide, so apps that don't pass an explicit `id` are unaffected; but `DropZoneTicketInput` exposes `id` as public API.

## Fix

Bail on a duplicate id before allocating the scope:

```ts
const id = registration.id ?? useId()
if (_zones.has(id)) {
  return _zones.register(registration as ...) as DropZoneTicket
}
```

The registry still emits its duplicate warning and returns the existing ticket — identical observable behavior, minus the leaked scope. `draggables.register` allocates no per-id scope, so it was already safe.

## Verification

- Verified with a throwaway test (since removed): patch `ResizeObserver` to track live (connected) instances, register an oriented zone twice with the same `id`, then `unregister()` the zone and assert no observer remains connected. **It failed on master** (`live.size === 1` — the overwritten scope's observer survived) **and passes with the fix.** (Asserting after `unregister` rather than after a full `scope.stop()` is deliberate — the enclosing scope's recursive stop would otherwise mask the orphan.)
- Regression: the full useDragDrop suite passes (96 tests). `pnpm typecheck` clean; lint clean.

## Precedent

`createRegistry.register` establishes the "duplicate id → warn + return existing, no side effects" contract; the zone wrapper violated it by committing a scope + observers before deferring to the registry.
