### PR TITLE
fix(createFocusTraversal): check every position in circular step()

### DIFF
--- a/packages/0/src/composables/createFocusTraversal/index.test.ts
+++ b/packages/0/src/composables/createFocusTraversal/index.test.ts
@@ -109,6 +109,21 @@ describe('createFocusTraversal', () => {
       expect(traversal.activeId.value).toBeUndefined()
       expect(activate).not.toHaveBeenCalled()
     })
+
+    it('should reach an enabled item beyond ceil(length/stride) hops in circular mode', () => {
+      // Circular stride 2 over 7 items visits every position in 7 hops, not the
+      // ceil(7/2)=4 the old bound assumed. The only enabled item (i5) lands at
+      // hop 5, so the old bound stopped before ever checking it.
+      const traversal = createFocusTraversal(
+        itemsWithDisabled(['i0', true], ['i1', true], ['i2', true], ['i3', true], ['i4', true], ['i5'], ['i6', true]),
+        () => {},
+        { circular: true },
+      )
+      traversal.activeId.value = 'i0'
+      traversal.step(2)
+
+      expect(traversal.activeId.value).toBe('i5')
+    })
   })
 
   describe('next / prev', () => {

--- a/packages/0/src/composables/createFocusTraversal/index.ts
+++ b/packages/0/src/composables/createFocusTraversal/index.ts
@@ -99,8 +99,12 @@ export function createFocusTraversal (
     const direction = stride > 0 ? 1 : -1
     const absStride = Math.abs(stride)
     let index = current + stride
-    // Max attempts: for stride=1 check all items, for larger strides check proportionally
-    const maxHops = Math.ceil(length / absStride)
+    // Bounded: each hop advances absStride slots toward a boundary, so the line
+    // is exhausted in ceil(length / absStride) hops. Circular: each hop lands on a
+    // fresh position until the stride cycle closes — up to `length` hops (e.g.
+    // stride 2 over 7 items visits all 7 positions) — so every position must be
+    // checkable, otherwise a reachable enabled item beyond the bound is missed.
+    const maxHops = circular ? length : Math.ceil(length / absStride)
     let hops = 0
 
     if (circular) {


### PR DESCRIPTION
## Problem

`createFocusTraversal.step(stride)` skips disabled items by hopping `stride` positions at a time until it finds an enabled one, bounded by:

```ts
const maxHops = Math.ceil(length / absStride)
```

That bound is correct for **bounded** mode — each hop advances `absStride` slots toward a boundary, so the line is exhausted in `ceil(length / absStride)` hops. But in **circular** mode each hop lands on a *fresh* position until the stride cycle closes, which takes up to `length` hops (the cycle length is `length / gcd(stride, length)`). When the cycle is longer than `maxHops`, the loop exits early and a reachable enabled item beyond the bound is **missed** — focus silently doesn't move.

This surfaces in grid keyboard navigation: `useRovingFocus` / `useVirtualFocus` with `columns` set issue `step(columns)` for ArrowUp/Down. With `circular: true` and `columns >= 2` (especially an incomplete final row, where `length` isn't a multiple of `columns`), a vertical move can land on nothing even though an enabled cell exists.

**Concrete repro:** 7 items, only indices 0 and 3 enabled, `circular: true`. From index 0, `step(2)` should reach index 3. The stride-2 circular cycle visits `2, 4, 6, 1, 3` — index 3 is the 5th hop, but `maxHops = ceil(7/2) = 4` exits one hop short, so focus stays at index 0.

## Fix

```ts
const maxHops = circular ? length : Math.ceil(length / absStride)
```

In circular mode every position is a distinct candidate until the cycle returns, so `length` hops guarantees all are checked. Bounded mode is unchanged.

## Verification

- Verified with a throwaway test (since removed): the 7-item / indices-0,3-enabled / `step(2)` circular case. **It failed on master** (`expected 'd', received 'a'`) **and passes with the fix**; a stride-1 circular wrap test passes in both.
- Regression: the full createFocusTraversal + useRovingFocus + useVirtualFocus suites pass (191 tests). `pnpm typecheck` clean; lint clean.

## Note

`step(1)` (plain `next`/`prev`) was always safe — `maxHops = ceil(length/1) = length` already equals the cycle length. The bug is specific to `|stride| >= 2` in circular mode.
