### PR TITLE
fix(Portal): don't forward the Teleport disabled toggle into the stack ticket

### DIFF
--- a/packages/0/src/components/Portal/Portal.vue
+++ b/packages/0/src/components/Portal/Portal.vue
@@ -53,8 +53,12 @@
   } = defineProps<PortalProps>()
 
   const stack = useStack()
+  // `disabled` is the Teleport toggle (render inline) — bound on <Teleport>
+  // below. It must NOT reach the stack ticket, whose `disabled` means
+  // selection-disabled: forwarding it makes ticket.select() a no-op, so an
+  // inline portal is excluded from the stack (z-index pins to base, inline
+  // portals collide, no dismiss/scrim coordination).
   const ticket = stack.register({
-    disabled,
     blocking,
     onDismiss: () => emit('close'),
   })

--- a/packages/0/src/components/Portal/index.test.ts
+++ b/packages/0/src/components/Portal/index.test.ts
@@ -121,6 +121,39 @@ describe('portal', () => {
 
       wrapper.unmount()
     })
+
+    it('should still occupy a stack slot when rendered inline (disabled)', () => {
+      const zIndexes: number[] = []
+
+      const Host = defineComponent({
+        setup () {
+          return () => [
+            h(Portal, { disabled: true }, {
+              default: (props: any) => {
+                zIndexes[0] = props.zIndex
+                return h('div', 'Inline')
+              },
+            }),
+            h(Portal, null, {
+              default: (props: any) => {
+                zIndexes[1] = props.zIndex
+                return h('div', 'Teleported')
+              },
+            }),
+          ]
+        },
+      })
+
+      const wrapper = mount(Host)
+
+      // The inline (disabled) portal still registers AND selects into the stack,
+      // so the second portal stacks above it. Pre-fix, forwarding `disabled`
+      // (the Teleport toggle) to the stack ticket made its select() a no-op, so
+      // it took no slot and the second portal collapsed onto the base z-index.
+      expect(zIndexes[1]).toBe(2010)
+
+      wrapper.unmount()
+    })
   })
 
   describe('disabled reactivity', () => {


### PR DESCRIPTION
## Problem

`Portal`'s `disabled` prop is documented as the **Teleport toggle** — "Render inline instead of teleporting" — and drives `<Teleport :disabled>`. But it was *also* forwarded into the stack ticket:

```ts
const ticket = stack.register({
  disabled,          // <-- StackTicketInput.disabled means SELECTION-disabled
  blocking,
  onDismiss: () => emit('close'),
})
ticket.select()      // <-- no-ops when the ticket is selection-disabled
```

`StackTicketInput extends SelectionTicketInput`, whose `disabled` gates selection. So `<Portal disabled>` (rendered inline) had its `ticket.select()` silently no-op — the overlay was **excluded from the stack**:

- `ticket.zIndex` falls back to `baseZIndex` because the ticket isn't in `selectedIds` — so **multiple inline portals all report the same z-index** (e.g. `2000`), with zero layering.
- it never participates in `globalTop`, dismiss, or Scrim backdrop coordination.

The Portal clearly intends to participate in the stack (it calls `ticket.select()` and exposes `zIndex` via slot props); forwarding the teleport flag just breaks that.

## Fix

Drop `disabled` from the `stack.register` call. The `<Teleport :disabled>` binding is independent and unchanged:

```ts
const ticket = stack.register({
  blocking,
  onDismiss: () => emit('close'),
})
```

This mirrors `Dialog/DialogContent` and `AlertDialog/AlertDialogContent`, which register only `{ onDismiss, blocking }` and never forward a teleport/visibility flag into the stack ticket.

## Verification

- Verified with a throwaway test (since removed): mount two `<Portal disabled>` under a shared `createStackPlugin()` and assert their slot `zIndex`es differ. **It failed on master** (both `2000` — collision) **and passes with the fix** (distinct slots).
- Regression: Portal + useStack + Dialog + AlertDialog suites pass (145 tests). The existing "render inline when disabled" and single-portal "base zIndex = 2000" tests are unaffected (a lone portal still sits at position 0 → base). `pnpm typecheck` clean; lint clean.
