### PR TITLE
fix(Input,NumberField): eager validation must wait for the first error

### DIFF
--- a/packages/0/src/components/Input/InputRoot.vue
+++ b/packages/0/src/components/Input/InputRoot.vue
@@ -229,7 +229,14 @@
     const { event, modifier } = parsed.value
     if (event === 'submit') return false
     if (modifier === 'lazy' && !input.isTouched.value) return false
-    if (modifier === 'eager' && input.isValid.value === false) return true
+    if (modifier === 'eager') {
+      // Eager validates on every keystroke only AFTER the first error. Before
+      // any error, a passing `input` keystroke must not trigger validation —
+      // the first error is seeded by the base trigger (blur/submit).
+      if (input.isValid.value === false) return true
+      if (trigger === 'input') return false
+      return trigger === event
+    }
     return trigger === event
   }
 

--- a/packages/0/src/components/Input/index.test.ts
+++ b/packages/0/src/components/Input/index.test.ts
@@ -730,11 +730,14 @@ describe('input', () => {
         },
       })
 
-      // Initial input change — eager only triggers when already invalid
+      // A passing input keystroke before the first error must NOT validate in
+      // eager mode — eager re-validates on input only once an error exists.
+      // flushPromises is required: validate() is async, so without it this
+      // asserts before validation could resolve and passes vacuously.
       await wrapper.setProps({ modelValue: 'a' })
       await wait()
+      await flushPromises()
 
-      // Not invalid yet, so eager doesn't trigger
       expect(props().isValid).toBeNull()
     })
 

--- a/packages/0/src/components/NumberField/NumberFieldRoot.vue
+++ b/packages/0/src/components/NumberField/NumberFieldRoot.vue
@@ -252,7 +252,14 @@
     const { event, modifier } = parsed.value
     if (event === 'submit') return false
     if (modifier === 'lazy' && !input.isTouched.value) return false
-    if (modifier === 'eager' && input.isValid.value === false) return true
+    if (modifier === 'eager') {
+      // Eager validates on every keystroke only AFTER the first error. Before
+      // any error, a passing `input` keystroke must not trigger validation —
+      // the first error is seeded by the base trigger (blur/submit).
+      if (input.isValid.value === false) return true
+      if (trigger === 'input') return false
+      return trigger === event
+    }
     return trigger === event
   }
 

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -1880,6 +1880,26 @@ describe('numberField', () => {
       expect(rule).toHaveBeenCalled()
     })
 
+    it('should not validate on input before the first error in eager mode', async () => {
+      const model = ref<number | null>(5)
+      const rule = vi.fn(() => true)
+      const { wrapper, wait } = mountNumberField({
+        model,
+        props: { rules: [rule], validateOn: 'eager input' },
+      })
+      await wait()
+      await flushPromises()
+      rule.mockClear()
+
+      // A passing input change before any error must NOT validate in eager
+      // mode — eager re-validates on input only once an error exists.
+      await wrapper.setProps({ modelValue: 7 })
+      await wait()
+      await flushPromises()
+
+      expect(rule).not.toHaveBeenCalled()
+    })
+
     it('should accept input modifier in validateOn string', async () => {
       const model = ref<number | null>(5)
       const rule = vi.fn(() => true)


### PR DESCRIPTION
## Problem

`Input.Root` and `NumberField.Root` share a byte-identical `shouldValidate()`:

```ts
function shouldValidate (trigger: ValidateEvent): boolean {
  const { event, modifier } = parsed.value
  if (event === 'submit') return false
  if (modifier === 'lazy' && !input.isTouched.value) return false
  if (modifier === 'eager' && input.isValid.value === false) return true
  return trigger === event
}
```

The eager branch only short-circuits when the field is **already** invalid. Otherwise control falls through to `return trigger === event`, so with `validateOn: "eager input"` (or `"input eager"`) an `input` trigger validates on the **very first keystroke** — before any error exists.

That contradicts the documented eager contract (`apps/docs/.../input.md`): *"Eager: after first error, validate on every keystroke."* Eager is meant to stay quiet until a non-input trigger (blur/submit) seeds the first error, then re-validate on every keystroke.

The existing `should parse eager input modifier` test asserts the correct intent (`isValid` stays `null` after the first keystroke) but **passed only by a timing accident** — it omits `flushPromises()`, so the async `validate()` hadn't resolved at assertion time. Adding `flushPromises()` makes it fail on master.

## Fix

Gate the eager `input` path behind a prior error:

```ts
if (modifier === 'eager') {
  if (input.isValid.value === false) return true   // re-validate once errored
  if (trigger === 'input') return false             // suppress input until first error
  return trigger === event
}
return trigger === event
```

Applied to **both** `InputRoot.vue` and `NumberFieldRoot.vue` (same defect). The realistic `blur eager` flow is unchanged: blur seeds the first error, then every keystroke re-validates.

## Verification

- Verified with a throwaway test (since removed): mount each Root with `validateOn: "eager input"` and a rule-call counter, type a passing value, `await flushPromises()`, and assert the rule was **not** called and `isValid` is `null`. **Both Input and NumberField failed on master** (`calls === 1`) **and pass with the fix.**
- Regression: full Input + NumberField suites pass (186 tests) — including `should validate eagerly when invalid with eager modifier` (`blur eager`), confirming the after-first-error behavior still works. `pnpm typecheck` clean; lint clean.
