### PR TITLE
fix(createNested): exclude disabled children from the ancestor all-selected test

### DIFF
--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -1682,6 +1682,21 @@ describe('disabled state blocking', () => {
     expect(nested.selected('child-2')).toBe(false)
   })
 
+  it('should fully select an ancestor when all enabled children are selected despite a disabled sibling', () => {
+    const nested = createNested()
+
+    nested.register({ id: 'root', value: 'Root' })
+    nested.register({ id: 'child-1', value: 'Child 1', parentId: 'root' })
+    nested.register({ id: 'child-2', value: 'Child 2', parentId: 'root', disabled: true })
+
+    // Selecting the only enabled child must promote root to fully selected,
+    // not leave it trapped in the mixed state by the unselectable disabled sibling.
+    nested.select('child-1')
+
+    expect(nested.selected('root')).toBe(true)
+    expect(nested.mixed('root')).toBe(false)
+  })
+
   it('should skip disabled items in expandAll', () => {
     const nested = createNested()
 

--- a/packages/0/src/composables/createNested/index.ts
+++ b/packages/0/src/composables/createNested/index.ts
@@ -428,7 +428,15 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     while (!isUndefined(parentId)) {
       const childIds = children.get(parentId)
       if (childIds && childIds.length > 0) {
-        const allSelected = childIds.every(cid => selectedIds.has(cid))
+        // Exclude disabled children from the "all selected" test — a disabled
+        // child can never be selected, so counting it would trap the parent in
+        // the mixed state forever. Mirrors select()'s disabled skip and
+        // createGroup.isAllSelected's selectable-items filter.
+        const enabledIds = childIds.filter(cid => {
+          const child = group.get(cid)
+          return !child || !toValue(child.disabled)
+        })
+        const allSelected = enabledIds.length > 0 && enabledIds.every(cid => selectedIds.has(cid))
         const someSelected = !allSelected && childIds.some(cid => selectedIds.has(cid) || mixedIds.has(cid))
 
         if (allSelected) {


### PR DESCRIPTION
## Problem

In cascade mode, `createNested.updateAncestors()` rolls a parent's checked/mixed state up from its children:

```ts
const allSelected = childIds.every(cid => selectedIds.has(cid))
const someSelected = !allSelected && childIds.some(cid => selectedIds.has(cid) || mixedIds.has(cid))
```

`allSelected` counts **disabled** children. A disabled child can never enter `selectedIds` (cascade `select()` skips disabled descendants), so `allSelected` is permanently `false` for any parent with a disabled child — and `someSelected` is `true` once an enabled child is selected, forcing the parent into the **mixed (indeterminate)** state forever. It can never reach checked.

**Reproduction:**
```ts
const n = createNested()                                  // cascade (default)
n.register({ id: 'root', value: 'Root' })
n.register({ id: 'c1', value: 'C1', parentId: 'root' })
n.register({ id: 'c2', value: 'C2', parentId: 'root', disabled: true })
n.select('c1')                                            // the only enabled child
// expected: root fully selected; actual: root stuck mixed
```

This surfaces in `Treeview` as a parent checkbox stuck at `aria-checked="mixed"`. The inconsistency is concrete: `select('root')` (cascade) leaves root **checked** (it skips the disabled descendant), but selecting the only enabled child leaves root **mixed**.

## Fix

Exclude disabled children from the all-selected test (requiring at least one enabled child):

```ts
const enabledIds = childIds.filter(cid => {
  const child = group.get(cid)
  return !child || !toValue(child.disabled)
})
const allSelected = enabledIds.length > 0 && enabledIds.every(cid => selectedIds.has(cid))
```

`someSelected` is unchanged, so a parent with a still-unselected *enabled* child stays mixed exactly as before. This mirrors two existing conventions: `createNested.select()`'s disabled-descendant skip, and `createGroup.isAllSelected`'s `selectableItems` filter (`!toValue(item.disabled)`).

## Verification

- Verified with a throwaway test (since removed): with a disabled sibling, selecting the only enabled child makes `root` selected (not mixed); with an *enabled* unselected sibling, `root` correctly stays mixed. **The first failed on master and passes with the fix; the second passes in both** (no over-correction).
- Regression: createNested + Treeview + createGroup + createSelection suites pass (423 tests). `pnpm typecheck` (vue-tsc) clean; lint clean.
