### PR TITLE
fix(createCombobox): trim the query in the client filter adapter

### DIFF
--- a/packages/0/src/composables/createCombobox/adapters/client.test.ts
+++ b/packages/0/src/composables/createCombobox/adapters/client.test.ts
@@ -126,4 +126,23 @@ describe('clientComboboxAdapter', () => {
       expect(result.filtered.value.has('b')).toBe(false)
     })
   })
+
+  describe('whitespace query', () => {
+    it('should match against a whitespace-padded query', () => {
+      const adapter = new ClientComboboxAdapter()
+      const items = [
+        makeTicket('a', 'Apple'),
+        makeTicket('b', 'Banana'),
+        makeTicket('c', 'Cherry'),
+      ]
+      const ctx = createContext(items, '  an  ')
+      const result = adapter.setup(ctx)
+
+      // Pre-fix, filter.apply matched against the raw padded query, so '  an  '
+      // matched nothing even though 'Banana' contains 'an'.
+      expect(result.filtered.value.has('b')).toBe(true)
+      expect(result.filtered.value.has('a')).toBe(false)
+      expect(result.filtered.value.has('c')).toBe(false)
+    })
+  })
 })

--- a/packages/0/src/composables/createCombobox/adapters/client.ts
+++ b/packages/0/src/composables/createCombobox/adapters/client.ts
@@ -48,7 +48,11 @@ export class ClientComboboxAdapter extends ComboboxAdapter {
     })
 
     const values = toRef(() => context.items.value.map(t => t.value as FilterItem))
-    const { items: filteredValues } = filter.apply(context.query, values)
+    // Match against the trimmed query, consistent with the empty-query guard
+    // below and createFilter's own blank check. A padded query like ' an' would
+    // otherwise match nothing even though items contain the substring 'an'.
+    const trimmedQuery = toRef(() => String(context.query.value).trim())
+    const { items: filteredValues } = filter.apply(trimmedQuery, values)
 
     const filtered = computed(() => {
       const q = String(context.query.value).trim()

--- a/packages/0/src/composables/createCombobox/adapters/client.ts
+++ b/packages/0/src/composables/createCombobox/adapters/client.ts
@@ -51,8 +51,8 @@ export class ClientComboboxAdapter extends ComboboxAdapter {
     // Match against the trimmed query, consistent with the empty-query guard
     // below and createFilter's own blank check. A padded query like ' an' would
     // otherwise match nothing even though items contain the substring 'an'.
-    const trimmedQuery = toRef(() => String(context.query.value).trim())
-    const { items: filteredValues } = filter.apply(trimmedQuery, values)
+    const trimmed = toRef(() => String(context.query.value).trim())
+    const { items: filteredValues } = filter.apply(trimmed, values)
 
     const filtered = computed(() => {
       const q = String(context.query.value).trim()


### PR DESCRIPTION
## Problem

`ClientComboboxAdapter` computes its filtered set from `filter.apply(context.query, values)` using the **untrimmed** query, but the surrounding code treats whitespace as insignificant:

```ts
const { items: filteredValues } = filter.apply(context.query, values)   // untrimmed

const filtered = computed(() => {
  const q = String(context.query.value).trim()        // trimmed guard
  if (!q) return new Set(context.items.value.map(t => t.id))
  // ... uses filteredValues (computed from the untrimmed query)
})
```

So a whitespace-padded query like `" an"` is non-empty after trim (the guard passes), but the matching path tests the raw `" an"` — `"banana".includes(" an")` is `false` — so it matches **nothing**. The user sees "No results" for an item that plainly contains `an`. (`createFilter` itself also trims when testing blankness, so the adapter's two code paths disagree about whether surrounding whitespace matters.)

## Fix

Feed the trimmed query to `filter.apply`, matching the empty-query guard right below it:

```ts
const trimmedQuery = toRef(() => String(context.query.value).trim())
const { items: filteredValues } = filter.apply(trimmedQuery, values)
```

## Verification

- Verified with a throwaway test (since removed): register `Banana`/`Apple`, set `query = " an"`, and assert `filtered` contains the `Banana` id. **It failed on master** (empty filtered set) **and passes with the fix**; an unpadded `"an"` control matches in both.
- Regression: createCombobox + Combobox + Select suites pass (206 tests). `pnpm typecheck` (vue-tsc) clean; lint clean.
