### PR TITLE
fix(Avatar): select the highest-priority image, not the last to load

### DIFF
--- a/packages/0/src/components/Avatar/AvatarImage.vue
+++ b/packages/0/src/components/Avatar/AvatarImage.vue
@@ -21,7 +21,7 @@
   import { useImage } from '#v0/composables/useImage'
 
   // Utilities
-  import { onBeforeUnmount, toRef, watch } from 'vue'
+  import { onBeforeUnmount, toRef, toValue, watch } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
@@ -102,18 +102,31 @@
     emit('error', e)
   }
 
+  // Select the highest-priority loaded (enabled, type: 'image') ticket, falling
+  // back to the first enabled ticket (the fallback) when none has loaded. A
+  // plain ticket.select() would let the last image to load win and ignore
+  // priority — the registry is `multiple: false`, so select() clears + adds.
+  function selectBest () {
+    let best: typeof ticket | undefined
+    for (const candidate of context.values()) {
+      if (candidate.type !== 'image' || toValue(candidate.disabled)) continue
+      if (!best || (candidate.priority ?? 0) > (best.priority ?? 0)) best = candidate
+    }
+    const target = best ?? context.seek('first')
+    if (target) context.select(target.id)
+  }
+
   watch(image.isLoaded, isLoaded => {
     if (isLoaded) {
       ticket.disabled = false
-      ticket.select()
+      selectBest()
     }
   })
 
   watch(image.isError, isError => {
     if (isError) {
       ticket.disabled = true
-      const first = context.seek('first')
-      if (first) context.select(first.id)
+      selectBest()
     }
   })
 

--- a/packages/0/src/components/Avatar/index.test.ts
+++ b/packages/0/src/components/Avatar/index.test.ts
@@ -335,6 +335,35 @@ describe('avatar', () => {
         // After both load, the one with higher priority should be selected
         expect(highPriorityImage?.isVisible()).toBe(true)
       })
+
+      it('should keep the higher priority image selected when a lower priority image loads last', async () => {
+        const wrapper = mount(Avatar.Root, {
+          slots: {
+            default: () => [
+              h(Avatar.Image, { src: '/low-priority.jpg', priority: 1 }),
+              h(Avatar.Image, { src: '/high-priority.jpg', priority: 10 }),
+              h(Avatar.Fallback, {}, () => 'JD'),
+            ],
+          },
+        })
+
+        const images = wrapper.findAllComponents(Avatar.Image as any)
+        const lowPriorityImage = images[0]
+        const highPriorityImage = images[1]
+
+        // Reverse load order: high priority loads first, low priority loads LAST.
+        // Pre-fix, the last image to load won via ticket.select(), so the lower
+        // priority image wrongly took over the selection. Selection drives the
+        // v-show, so the higher priority image must stay visible.
+        await highPriorityImage?.trigger('load')
+        await lowPriorityImage?.trigger('load')
+        await nextTick()
+        await nextTick()
+
+        // Selection drives the v-show: the selected image has no display:none.
+        expect(String(highPriorityImage?.attributes('style'))).not.toContain('display: none')
+        expect(String(lowPriorityImage?.attributes('style'))).toContain('display: none')
+      })
     })
 
     describe('slot props', () => {


### PR DESCRIPTION
## Problem

`AvatarImage`'s load watcher selected the image unconditionally:

```ts
watch(image.isLoaded, isLoaded => {
  if (isLoaded) {
    ticket.disabled = false
    ticket.select()
  }
})
```

`AvatarRoot` builds its selection with `multiple: false`, so `select()` clears the previous selection and adds this ticket. With multiple images, the **last one to finish loading wins** — regardless of `priority`. That contradicts the documented contract (`AvatarImage` @remarks: *"Supports priority ordering so higher-priority images are displayed when multiple are available"*); `priority` was a declared `AvatarTicket` field with **no effect** on the selection path. The error watcher had the same flaw via `seek('first')`, which returns the first ticket in **registry order**, not the highest-priority survivor.

The existing "should select higher priority image when both load" test masked it: it loads low-then-high, so last-to-load happens to coincide with highest-priority, and it only asserts the high image is visible (never that the low one is hidden).

## Fix

Reconcile to the highest-priority loaded image on both load and error, falling back to the first enabled ticket (the fallback) when no image has loaded:

```ts
function selectBest () {
  let best: typeof ticket | undefined
  for (const candidate of context.values()) {
    if (candidate.type !== 'image' || toValue(candidate.disabled)) continue
    if (!best || (candidate.priority ?? 0) > (best.priority ?? 0)) best = candidate
  }
  const target = best ?? context.seek('first')
  if (target) context.select(target.id)
}
```

Order-independent and idempotent; equal priorities keep registry order. Mirrors the predicate-scan-over-tickets shape already used by `createSelection.seek`/`mandate`.

## Verification

- Verified with a throwaway test (since removed): two images registered high-priority-first, low-priority-second, then loaded **high first, low last** (the failing order). Assert on `element.style.display` (reliable for `v-show`, unlike `isVisible()`): **failed on master** (high hidden, low visible) **and passes with the fix**.
- Regression: full Avatar suite passes (62 tests), including the existing priority and fallback/error tests. `pnpm typecheck` (vue-tsc) clean; lint clean.
