### PR TITLE
fix(createSlider): enforce minStepsBetweenThumbs in apply() for 3+ thumbs

### DIFF
--- a/packages/0/src/composables/createSlider/index.test.ts
+++ b/packages/0/src/composables/createSlider/index.test.ts
@@ -201,7 +201,10 @@ describe('createSlider', () => {
       addThumb(0)
       addThumb(100)
       slider.apply([50, 55])
-      expect(slider.values.value[0]).toBe(45)
+      // Forward sweep: the first thumb keeps its requested value and the second
+      // is pushed up to satisfy minStepsBetweenThumbs (gap 10), rather than
+      // pulling the first thumb down. Matches set()'s written-prev anchoring.
+      expect(slider.values.value[0]).toBe(50)
       expect(slider.values.value[1]).toBe(60)
     })
   })

--- a/packages/0/src/composables/createSlider/index.test.ts
+++ b/packages/0/src/composables/createSlider/index.test.ts
@@ -207,6 +207,19 @@ describe('createSlider', () => {
       expect(slider.values.value[0]).toBe(50)
       expect(slider.values.value[1]).toBe(60)
     })
+
+    it('should enforce the minimum gap across three or more thumbs', () => {
+      const { slider, addThumb } = setup({ min: 0, max: 100, step: 1, minStepsBetweenThumbs: 10 })
+      addThumb(10)
+      addThumb(20)
+      addThumb(30)
+      // The old two-sided clamp anchored on the raw incoming neighbours, so the
+      // middle thumb's upper bound (following - gap) could drop below its lower
+      // bound (prev + gap) and squeeze the gap under the minimum: apply([10,12,14])
+      // collapsed to [2,4,22] (a 2-step gap). The forward sweep keeps every gap >= 10.
+      slider.apply([10, 12, 14])
+      expect(slider.values.value).toEqual([10, 20, 30])
+    })
   })
 
   describe('defaults', () => {

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -522,22 +522,29 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
       return
     }
 
-    for (let index = 0; index < snapped.length; index++) {
+    const gap = minStepsBetweenThumbs * step
+    let written: number | undefined
+
+    for (const [index, element] of snapped.entries()) {
       const ticket = thumbs.value[index]
       if (!ticket || !isRef(ticket.value)) continue
 
-      let constrained = snapped[index]!
+      let constrained = element!
 
-      if (!crossover) {
-        const gap = minStepsBetweenThumbs * step
-        const prev = index > 0 ? snapped[index - 1] : undefined
-        const following = index < snapped.length - 1 ? snapped[index + 1] : undefined
-
-        if (!isUndefined(prev)) constrained = Math.max(constrained, prev + gap)
-        if (!isUndefined(following)) constrained = Math.min(constrained, following - gap)
+      // Forward sweep: push each thumb at least `gap` past the previously
+      // written thumb, so apply() always satisfies minStepsBetweenThumbs. The
+      // old two-sided clamp anchored off the *raw* incoming neighbours, so a
+      // middle thumb's `following - gap` upper bound could fall below its
+      // `prev + gap` lower bound and shrink the gap below the minimum with 3+
+      // thumbs (e.g. apply([10,12,14]) gap 10 -> [2,4,22]). Mirrors set(),
+      // which anchors its prev constraint off the live written value.
+      if (!crossover && !isUndefined(written)) {
+        constrained = Math.max(constrained, written + gap)
       }
 
-      ticket.value.value = clamp(constrained, min, max)
+      constrained = clamp(constrained, min, max)
+      ticket.value.value = constrained
+      written = constrained
     }
   }
 


### PR DESCRIPTION
## Problem

`createSlider.apply()` enforces `minStepsBetweenThumbs` by clamping each thumb against its **raw incoming** neighbours with a two-sided clamp:

```ts
if (!isUndefined(prev))      constrained = Math.max(constrained, prev + gap)       // prev = snapped[index-1]
if (!isUndefined(following)) constrained = Math.min(constrained, following - gap)  // following = snapped[index+1]
```

For a **middle** thumb whose incoming neighbours are closer together than `gap`, the `following - gap` upper bound falls below the `prev + gap` lower bound, the `min()` runs last and wins, and the gap collapses below the minimum. With 3+ thumbs:

```ts
createSlider({ min: 0, max: 100, step: 1, minStepsBetweenThumbs: 10 })
// register 3 thumbs, then:
apply([10, 12, 14])   // -> [2, 4, 22]   (gap 2 < 10, contract violated)
```

The documented contract (apply enforces `minStepsBetweenThumbs`) is broken. The two-thumb case happened to "work" only because there's no middle thumb.

## Fix

Replace the two-sided raw clamp with a **forward sweep** that pushes each thumb at least `gap` past the previously *written* thumb — the same anchoring `set()` already uses for its `prev` constraint (off the live value, not the raw input). This always satisfies the minimum gap and is order-independent:

```ts
const gap = minStepsBetweenThumbs * step
let written: number | undefined
for (...) {
  let constrained = snapped[index]!
  if (!crossover && written !== undefined) constrained = Math.max(constrained, written + gap)
  constrained = clamp(constrained, min, max)
  ticket.value.value = constrained
  written = constrained
}
```

`apply([10, 12, 14])` → `[10, 20, 30]`.

## Behavior change (please review the direction)

This changes how *over-constrained* input resolves. `apply([50, 55])` with gap 10 now yields **`[50, 60]`** (keep the first thumb at its requested value, push the second up) instead of the old **`[45, 60]`** (which pulled the first thumb *down* and over-spread to gap 15). Both satisfy the gap, but the new direction:

- keeps the requested start value (more intuitive for "apply these values"),
- produces the *exact* minimum gap rather than over-spreading,
- matches `set()`'s resolution direction.

The one existing test that pinned `[45, 60]` is updated to `[50, 60]` with an explanatory comment. Flagging the direction explicitly in case you prefer pull-down semantics.

## Verification

- Throwaway test (since removed): the 3-thumb case asserts every adjacent gap ≥ 10 — **failed on master** (`[2,4,22]`) **and passes with the fix**; the 2-thumb case asserts `[50,60]`.
- Regression: full createSlider + Slider suites pass (137 tests). `pnpm typecheck` (vue-tsc) clean; lint clean.
