### PR TITLE
fix(ExpansionPanel): don't toggle a disabled panel via the Activator

### DIFF
--- a/packages/0/src/components/ExpansionPanel/ExpansionPanelActivator.vue
+++ b/packages/0/src/components/ExpansionPanel/ExpansionPanelActivator.vue
@@ -81,7 +81,13 @@
 
   const item = useExpansionPanelRoot(namespace)
 
+  function onClick () {
+    if (item.isDisabled.value) return
+    item.ticket.toggle()
+  }
+
   function onKeydown (e: KeyboardEvent) {
+    if (item.isDisabled.value) return
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       item.ticket.toggle()
@@ -103,7 +109,7 @@
       'data-selected': item.ticket.isSelected.value || undefined,
       'disabled': as === 'button' ? item.isDisabled.value : undefined,
       'type': as === 'button' ? 'button' : undefined,
-      'onClick': item.ticket.toggle,
+      'onClick': onClick,
       onKeydown,
     },
   }))

--- a/packages/0/src/components/ExpansionPanel/index.test.ts
+++ b/packages/0/src/components/ExpansionPanel/index.test.ts
@@ -143,6 +143,33 @@ describe('expansionPanel', () => {
 
         expect(capturedProps.isDisabled.value).toBe(true)
       })
+
+      it('should not preventDefault on keydown for a disabled panel', () => {
+        let activatorProps: any
+
+        mount(ExpansionPanel.Group, {
+          props: { multiple: true },
+          slots: {
+            default: () => h(ExpansionPanel.Root as any, { id: 'item-1', value: 'value-1', disabled: true }, {
+              default: () => h(ExpansionPanel.Activator as any, {}, {
+                default: (ap: any) => {
+                  activatorProps = ap
+                  return 'Header'
+                },
+              }),
+            }),
+          },
+        })
+
+        const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+
+        // toggle() already guards ticket-disabled, so the click path is a no-op
+        // either way. The observable fix is that keydown now returns early on a
+        // disabled panel instead of running preventDefault + toggle.
+        activatorProps.attrs.onKeydown(event)
+
+        expect(event.defaultPrevented).toBe(false)
+      })
     })
 
     describe('slot props', () => {


### PR DESCRIPTION
## Problem

`ExpansionPanelActivator` advertises that it is disabled — `aria-disabled`, `data-disabled`, `tabindex="-1"`, and `disabled` on a native button — but its handlers never check it:

```ts
function onKeydown (e: KeyboardEvent) {
  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.ticket.toggle() }
}
// attrs: 'onClick': item.ticket.toggle
```

`item.ticket.toggle()` → `createSelection.toggle()`, which (for an already-open panel) routes to `unselect()`. Both `toggle` and `unselect` guard only on the **group's** `disabled`, not the **ticket's** — only `createModel.select` refuses a disabled ticket. So a disabled-but-open panel **collapses on click or Enter/Space**. With a native `as="button"` the DOM `disabled` attribute masks the click path, but a non-button activator (`as="div"` + `role="button"`, an explicitly supported mode) has no native gate, so every interaction path — including keyboard — fires.

`.claude/rules/components.md` ("Keyboard Navigation Pattern", 100% enforced) mandates `if (isDisabled.value) return` as the first line of every keydown handler. The Activator already computes the correct combined `item.isDisabled` — it just never consulted it.

## Fix

Guard both handlers on `item.isDisabled`:

```ts
function onClick () {
  if (item.isDisabled.value) return
  item.ticket.toggle()
}
function onKeydown (e: KeyboardEvent) {
  if (item.isDisabled.value) return
  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.ticket.toggle() }
}
```

(Fixed at the component boundary per the enforced pattern, rather than changing `createSelection.toggle`/`unselect` semantics — internal cascade/mandate logic relies on unselecting disabled tickets.)

## Verification

- Verified with a throwaway test (since removed): an open panel (`as="div"`) disabled while open must not collapse on `click` or `keydown` Enter. **Both failed on master** (`modelValue` went `undefined`) **and pass with the fix**.
- Regression: full ExpansionPanel suite passes (55 tests). `pnpm typecheck` (vue-tsc) clean; lint clean.

## Related (follow-up)

A family audit found the same `onClick: <ticket method>` shape (handler bound without an `isDisabled` guard) in `SelectionItem`, `SingleItem`, `GroupItem`, `StepItem`, `TreeviewCheckbox`, and `CollapsibleActivator` — all of which can toggle-off a disabled-but-selected item. These are tracked for a separate, individually-verified PR. (`PaginationItem` binds `select` rather than `toggle` and has no unselect path, so it is likely exempt.)
