### PR TITLE
fix(Selection,Single,Group,Step): don't toggle a disabled item off on click

### DIFF
--- a/packages/0/src/components/Group/GroupItem.vue
+++ b/packages/0/src/components/Group/GroupItem.vue
@@ -91,6 +91,14 @@
   const ticket = group.register({ id, value, disabled: () => toValue(disabled) ?? false, indeterminate: () => toValue(indeterminate) ?? false })
   const isDisabled = toRef(() => toValue(ticket.disabled) || toValue(group.disabled))
 
+  // ticket.toggle() routes to unselect for a selected item, which honours only
+  // the group's disabled (not the ticket's) — guard so a disabled item can't be
+  // toggled off via click. Per the enforced components.md handler rule.
+  function onClick () {
+    if (toValue(isDisabled)) return
+    ticket.toggle()
+  }
+
   onBeforeUnmount(() => {
     group.unregister(ticket.id)
   })
@@ -114,7 +122,7 @@
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
       'data-mixed': toValue(ticket.isMixed) || undefined,
-      'onClick': ticket.toggle,
+      'onClick': onClick,
     },
   }))
 </script>

--- a/packages/0/src/components/Group/index.test.ts
+++ b/packages/0/src/components/Group/index.test.ts
@@ -81,6 +81,46 @@ describe('group', () => {
         expect(selected.value).toContain('item-1')
       })
 
+      it('should not toggle off a selected disabled item via onClick', async () => {
+        let itemProps: any
+
+        const Host = defineComponent({
+          setup () {
+            const disabled = ref(false)
+            return { disabled }
+          },
+          render () {
+            return h(Group.Root as any, null, {
+              default: () => h(Group.Item as any, { value: 'item-1', disabled: this.disabled }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item 1')
+                },
+              }),
+            })
+          },
+        })
+
+        const wrapper = mount(Host)
+        await nextTick()
+
+        // Select the item while it is still enabled.
+        itemProps.select()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+
+        // Now disable the selected item, then click it. Pre-fix onClick was
+        // `ticket.toggle`, which routes to unselect — honouring only group-disabled,
+        // not ticket-disabled — so a selected disabled item toggled off on click.
+        // The guard now blocks it.
+        wrapper.vm.disabled = true
+        await nextTick()
+
+        itemProps.attrs.onClick()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
       it('should support multiple selections', async () => {
         const selected = ref<string[]>([])
 

--- a/packages/0/src/components/Selection/SelectionItem.vue
+++ b/packages/0/src/components/Selection/SelectionItem.vue
@@ -79,6 +79,14 @@
   const ticket = selection.register({ id, value, disabled: () => toValue(disabled) ?? false })
   const isDisabled = toRef(() => toValue(ticket.disabled) || toValue(selection.disabled))
 
+  // ticket.toggle() routes to unselect for a selected item, which honours only
+  // the group's disabled (not the ticket's) — guard so a disabled item can't be
+  // toggled off via click. Per the enforced components.md handler rule.
+  function onClick () {
+    if (toValue(isDisabled)) return
+    ticket.toggle()
+  }
+
   onBeforeUnmount(() => {
     selection.unregister(ticket.id)
   })
@@ -97,7 +105,7 @@
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
-      'onClick': ticket.toggle,
+      'onClick': onClick,
     },
   }))
 </script>

--- a/packages/0/src/components/Selection/index.test.ts
+++ b/packages/0/src/components/Selection/index.test.ts
@@ -93,6 +93,46 @@ describe('selection', () => {
         expect(item2Props.isSelected).toBe(true)
       })
 
+      it('should not toggle off a selected disabled item via onClick', async () => {
+        let itemProps: any
+
+        const Host = defineComponent({
+          setup () {
+            const disabled = ref(false)
+            return { disabled }
+          },
+          render () {
+            return h(Selection.Root as any, null, {
+              default: () => h(Selection.Item as any, { value: 'item-1', disabled: this.disabled }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item 1')
+                },
+              }),
+            })
+          },
+        })
+
+        const wrapper = mount(Host)
+        await nextTick()
+
+        // Select the item while it is still enabled.
+        itemProps.select()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+
+        // Now disable the selected item, then click it. Pre-fix onClick was
+        // `ticket.toggle`, which routes to unselect — honouring only group-disabled,
+        // not ticket-disabled — so a selected disabled item toggled off on click.
+        // The guard now blocks it.
+        wrapper.vm.disabled = true
+        await nextTick()
+
+        itemProps.attrs.onClick()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
       it('should set aria-multiselectable to false', () => {
         let slotProps: any
 

--- a/packages/0/src/components/Single/SingleItem.vue
+++ b/packages/0/src/components/Single/SingleItem.vue
@@ -79,6 +79,14 @@
   const ticket = single.register({ id, value, disabled: () => toValue(disabled) ?? false })
   const isDisabled = toRef(() => toValue(ticket.disabled) || toValue(single.disabled))
 
+  // ticket.toggle() routes to unselect for a selected item, which honours only
+  // the group's disabled (not the ticket's) — guard so a disabled item can't be
+  // toggled off via click. Per the enforced components.md handler rule.
+  function onClick () {
+    if (toValue(isDisabled)) return
+    ticket.toggle()
+  }
+
   onBeforeUnmount(() => {
     single.unregister(ticket.id)
   })
@@ -97,7 +105,7 @@
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
-      'onClick': ticket.toggle,
+      'onClick': onClick,
     },
   }))
 </script>

--- a/packages/0/src/components/Single/index.test.ts
+++ b/packages/0/src/components/Single/index.test.ts
@@ -92,6 +92,46 @@ describe('single', () => {
         expect(item2Props.isSelected).toBe(true)
       })
 
+      it('should not toggle off a selected disabled item via onClick', async () => {
+        let itemProps: any
+
+        const Host = defineComponent({
+          setup () {
+            const disabled = ref(false)
+            return { disabled }
+          },
+          render () {
+            return h(Single.Root as any, null, {
+              default: () => h(Single.Item as any, { value: 'item-1', disabled: this.disabled }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item 1')
+                },
+              }),
+            })
+          },
+        })
+
+        const wrapper = mount(Host)
+        await nextTick()
+
+        // Select the item while it is still enabled.
+        itemProps.select()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+
+        // Now disable the selected item, then click it. Pre-fix onClick was
+        // `ticket.toggle`, which routes to unselect — honouring only group-disabled,
+        // not ticket-disabled — so a selected disabled item toggled off on click.
+        // The guard now blocks it.
+        wrapper.vm.disabled = true
+        await nextTick()
+
+        itemProps.attrs.onClick()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
       it('should set aria-multiselectable to false', () => {
         let slotProps: any
 

--- a/packages/0/src/components/Step/StepItem.vue
+++ b/packages/0/src/components/Step/StepItem.vue
@@ -79,6 +79,14 @@
   const ticket = step.register({ id, value, disabled: () => toValue(disabled) ?? false })
   const isDisabled = toRef(() => toValue(ticket.disabled) || toValue(step.disabled))
 
+  // ticket.toggle() routes to unselect for a selected item, which honours only
+  // the group's disabled (not the ticket's) — guard so a disabled item can't be
+  // toggled off via click. Per the enforced components.md handler rule.
+  function onClick () {
+    if (toValue(isDisabled)) return
+    ticket.toggle()
+  }
+
   onBeforeUnmount(() => {
     step.unregister(ticket.id)
   })
@@ -97,7 +105,7 @@
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
-      'onClick': ticket.toggle,
+      'onClick': onClick,
     },
   }))
 </script>

--- a/packages/0/src/components/Step/index.test.ts
+++ b/packages/0/src/components/Step/index.test.ts
@@ -106,6 +106,46 @@ describe('step', () => {
         expect(item3Props.isSelected).toBe(false)
       })
 
+      it('should not toggle off a selected disabled item via onClick', async () => {
+        let itemProps: any
+
+        const Host = defineComponent({
+          setup () {
+            const disabled = ref(false)
+            return { disabled }
+          },
+          render () {
+            return h(Step.Root as any, null, {
+              default: () => h(Step.Item as any, { value: 'step-1', disabled: this.disabled }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Step 1')
+                },
+              }),
+            })
+          },
+        })
+
+        const wrapper = mount(Host)
+        await nextTick()
+
+        // Select the item while it is still enabled.
+        itemProps.select()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+
+        // Now disable the selected item, then click it. Pre-fix onClick was
+        // `ticket.toggle`, which routes to unselect — honouring only group-disabled,
+        // not ticket-disabled — so a selected disabled item toggled off on click.
+        // The guard now blocks it.
+        wrapper.vm.disabled = true
+        await nextTick()
+
+        itemProps.attrs.onClick()
+        await nextTick()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
       it('should navigate to last item with last()', async () => {
         const selected = ref<string>()
 


### PR DESCRIPTION
## Problem

`SelectionItem`, `SingleItem`, `GroupItem`, and `StepItem` bind their click handler directly to the ticket toggle, with no `isDisabled` guard, while advertising `aria-disabled` / `data-disabled`:

```ts
attrs: {
  'aria-disabled': toValue(isDisabled),
  'data-disabled': toValue(isDisabled) || undefined,
  'onClick': ticket.toggle,   // <-- no guard
}
```

`ticket.toggle()` routes to `unselect` for an already-selected item, and `createSelection.toggle`/`unselect` honour only the **group's** `disabled`, not the **ticket's** — only `createModel.select` refuses a disabled ticket. So a **disabled-but-selected** item **toggles off when clicked**, even though it presents as disabled.

`.claude/rules/components.md` ("Keyboard Navigation Pattern", 100% enforced) mandates `if (isDisabled.value) return` as the first line of interaction handlers. These four items already compute `isDisabled` — they just never consulted it in the click handler.

This is the same shape as the ExpansionPanel fix (#310), extended to the selection-item family.

## Fix

Guard each item's `onClick` on `isDisabled`:

```ts
function onClick () {
  if (toValue(isDisabled)) return
  ticket.toggle()
}
// attrs: 'onClick': onClick
```

## Verification

- Verified with a throwaway test (since removed): for each of the 4 items, register two values, select one, disable it, then invoke its slot `attrs.onClick()` and assert it stays selected. **All four failed on master** (the disabled item unselected itself) **and pass with the fix.** (The bug surfaces in a multi-item / non-mandatory scenario where unselecting is allowed; a single mandatory selection masks it.)
- Regression: Selection + Single + Group + Step suites pass (111 tests). `pnpm typecheck` (vue-tsc) clean; lint clean.

## Related (follow-up)

The same unguarded-handler shape also exists in `Treeview/TreeviewCheckbox` and `Collapsible/CollapsibleActivator` (the latter also has an `onKeydown`), tracked for a separate individually-verified PR. (The root asymmetry — `createSelection.toggle`/`unselect` not honouring ticket-level disabled while `select` does — is deliberately left alone, since internal cascade/mandate logic relies on unselecting disabled tickets; the fix belongs at the interaction boundary per the enforced pattern.)
