### PR TITLE
fix(Rating): make size and half props reactive

### DIFF
--- a/packages/0/src/components/Rating/RatingRoot.vue
+++ b/packages/0/src/components/Rating/RatingRoot.vue
@@ -116,8 +116,10 @@
 
   const rating = createRating({
     value: model,
-    size,
-    half,
+    // Wrap reactive props as getters — createRating reads size/half via
+    // toValue(), so bare scalar snapshots would freeze them at mount.
+    size: toRef(() => size),
+    half: toRef(() => half),
   })
 
   // Hover tracking — UI concern, not in composable

--- a/packages/0/src/components/Rating/index.test.ts
+++ b/packages/0/src/components/Rating/index.test.ts
@@ -84,6 +84,20 @@ describe('rating', () => {
 
         expect(rootProps().items).toHaveLength(10)
       })
+
+      it('should react to size prop changes', async () => {
+        const { wrapper, rootProps, wait } = mountRating({ size: 5 })
+        await wait()
+        expect(rootProps().items).toHaveLength(5)
+
+        await wrapper.setProps({ size: 8 })
+        await wait()
+
+        // Pre-fix, size was passed to createRating as a bare scalar (frozen at
+        // mount), so changing the prop didn't grow the items; the toRef wrapper
+        // keeps it reactive.
+        expect(rootProps().items).toHaveLength(8)
+      })
     })
 
     describe('v-model', () => {


### PR DESCRIPTION
## Problem

`RatingRoot` passes the destructured `size` / `half` props as bare scalars to `createRating`:

```ts
const { size = 5, half = false } = defineProps<RatingRootProps>()
const rating = createRating({ value: model, size, half })
```

`createRating` types `size` / `half` as `MaybeRefOrGetter` and reads them via `toValue()` throughout (the items array, step, `next`/`prev`/`last`, `isLast`). But a bare scalar is captured **once** at setup — `toValue(3)` is forever `3` — so reactive prop changes never reach the composable:

- changing `:size` does **not** add/remove stars: `items.length` and `aria-valuemax` stay frozen at the mount value.
- toggling `:half` does **not** switch the step to `0.5`: an ArrowRight from 0 lands on `1` instead of `0.5`.

## Fix

Wrap both in getters, the canonical "reactive context fields" pattern from `.claude/rules/components.md`:

```ts
const rating = createRating({
  value: model,
  size: toRef(() => size),
  half: toRef(() => half),
})
```

`TabsRoot`, `BreadcrumbsRoot`, `ImageRoot`, and `OverflowRoot` all wrap destructured props in `toRef(() => prop)` before handing them to a composable that re-reads reactively. RatingRoot was the outlier. (`toRef` is already imported.)

## Verification

- Verified with a throwaway test (since removed): mount with `:size="3"`, `setProps({ size: 5 })` → `items.length` and `aria-valuemax` must become 5; mount with `:half="false"`, `setProps({ half: true })`, ArrowRight from 0 → model must be `0.5`. **Both failed on master** (`3`, `1`) **and pass with the fix**.
- Regression: full Rating suite passes (69 tests). `pnpm typecheck` (vue-tsc) clean; lint clean. The existing suite never re-set `size`/`half` after mount, which is why this slipped through.
