### PR TITLE
refactor: align v0 composable layer with documented precedents

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -279,7 +279,7 @@ When a composable uses `useProxyModel`, its underlying registry/model must have 
 
 Never `export *` from `.vue` files — breaks Volar slot type inference. [intent:184, intent:338]
 
-A barrel is one of two shapes — **compound** or **single** — chosen by whether the component exposes dotted sub-components. Audited 100% consistent across all 39 component barrels (the one historical violator, Tooltip's `Object.assign`, was normalized to this canon).
+A barrel is one of two shapes — **compound** or **single** — chosen by whether the component exposes dotted sub-components. Audited 100% consistent across all 40 component barrels (the one historical violator, Tooltip's `Object.assign`, was normalized to this canon).
 
 ### Compound (Root + sub-components)
 

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -155,8 +155,8 @@ When destructuring the options object, the rest variable is `options`, never `mo
 
 ```ts
 // Right
-function createFoo (options: FooOptions = {}) {
-  const { disabled, namespace = 'v0:foo', ...rest } = options
+function createFoo (_options: FooOptions = {}) {
+  const { disabled, namespace = 'v0:foo', ...options } = _options
 }
 ```
 

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -485,7 +485,7 @@ Always use `useId()` from `#v0/utilities`. Never auto-increment. SSR-safe. [inte
 
 ## Events and Lifecycle
 
-See PHILOSOPHY §2.5 for the DOM-event rule. Scope-specific reminder: the only composables exempt from it are the three browser-primitive wrappers — `useEventListener`, `useHotkey`, `useClickOutside`. Anything else that reaches for `addEventListener` is in the wrong file.
+See PHILOSOPHY §2.5 for the DOM-event rule. Scope-specific reminder: the only composables exempt from it are the four browser-primitive wrappers — `useEventListener`, `useHotkey`, `useClickOutside`, `useMediaQuery`. Anything else that reaches for `addEventListener` is in the wrong file.
 
 ## Naming Instance (PHILOSOPHY §3.3)
 

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -211,7 +211,7 @@ const model = createModel(options)
 return { ...model, selectedIds, select, toggle, /* ... */ }
 ```
 
-Used by the selection chain: `createModel → createSelection → createSingle → createGroup → createStep`.
+Used by the selection chain: `createModel → createSelection → { createSingle → createStep, createGroup → createNested }`.
 
 ### 2. Aggregation (multi-system orchestrator)
 
@@ -391,7 +391,7 @@ Layer 1: Single-layer deps
   useBreakpoints, useLocale, useTheme, useRules, etc.
 
 Layer 2: Complex orchestrators
-  createSelection → createSingle → createGroup → createStep
+  createSelection → { createSingle → createStep, createGroup → createNested }
   createCombobox, createDataTable
 ```
 

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -206,9 +206,9 @@ See PHILOSOPHY §2.9 for the three-way split (throw / warn / return) and the ful
 Child spreads parent and adds or overrides: [intent:142]
 
 ```ts
-// packages/0/src/composables/createSelection/index.ts:286
+// packages/0/src/composables/createSelection/index.ts:296
 const model = createModel(options)
-return { ...model, selectedIds, select, toggle, /* ... */ }
+return { ...model, multiple, register, onboard, unselect, toggle, apply, mandate, seek }
 ```
 
 Used by the selection chain: `createModel → createSelection → { createSingle → createStep, createGroup → createNested }`.

--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -81,8 +81,8 @@ This is the proactive half. `feedback_bug_family_audit` is the reactive half: af
 RegistryTicketInput
   ├── ModelTicketInput
   │     ├── SelectionTicketInput
-  │     │     ├── SingleTicketInput
-  │     │     └── StepTicketInput
+  │     │     └── SingleTicketInput
+  │     │           └── StepTicketInput
   │     └── GroupTicketInput
   │           └── NestedTicketInput
   ├── QueueTicketInput

--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -137,7 +137,7 @@ return {
 }
 ```
 
-This is the single mechanism by which `createModel → createSelection → createSingle → createGroup → createStep` remain type-substitutable.
+This is the single mechanism by which `createModel → createSelection → { createSingle → createStep, createGroup → createNested }` remain type-substitutable.
 
 ## Reactive Collections (PHILOSOPHY §4.1)
 

--- a/apps/docs/src/examples/composables/use-notifications/context.ts
+++ b/apps/docs/src/examples/composables/use-notifications/context.ts
@@ -1,9 +1,9 @@
 import { createContext, createNotifications } from '@vuetify/v0'
-import type { NotificationsContext, NotificationInput } from '@vuetify/v0'
+import type { NotificationsContext, NotificationTicketInput } from '@vuetify/v0'
 
 export type NotificationType = 'banner' | 'toast' | 'inline' | 'inbox'
 
-export interface AppNotificationInput extends NotificationInput {
+export interface AppNotificationInput extends NotificationTicketInput {
   data?: { [key: string]: unknown, type?: NotificationType }
 }
 

--- a/apps/docs/src/pages/composables/plugins/use-notifications.md
+++ b/apps/docs/src/pages/composables/plugins/use-notifications.md
@@ -346,13 +346,13 @@ app.use(createNotificationsPlugin({ adapter: new MyBackendAdapter() }))
 
 ### Custom Ticket Fields
 
-Extend `NotificationInput` to add domain-specific fields. Pass the type parameter through the adapter and plugin:
+Extend `NotificationTicketInput` to add domain-specific fields. Pass the type parameter through the adapter and plugin:
 
 ```ts
 import { NotificationsAdapter } from '@vuetify/v0/notifications'
-import type { NotificationInput, NotificationsAdapterContext } from '@vuetify/v0'
+import type { NotificationTicketInput, NotificationsAdapterContext } from '@vuetify/v0'
 
-interface AppNotification extends NotificationInput {
+interface AppNotification extends NotificationTicketInput {
   priority: 'low' | 'medium' | 'high'
   imageUrl?: string
 }

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -334,8 +334,8 @@ Choose 3.1.3 only when there is literally one useful return. Any time you reach 
 
 ```ts
 // Right
-function createSelection <Z, E> (options: SelectionOptions = {}): SelectionContext<Z, E> {
-  const { multiple, mandatory, ...rest } = options
+function createSelection <Z, E> (_options: SelectionOptions = {}): SelectionContext<Z, E> {
+  const { multiple, mandatory, ...options } = _options
   const model = createModel(options)
   // ...
 }

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -532,15 +532,15 @@ createOverflow({ gap: () => gap })
 
 `reactive: true` on a registry wraps the internal collection as `shallowReactive` and each registered ticket as a `shallowReactive` proxy. When this option is set, `values()` / `keys()` / `entries()` skip their result cache and re-iterate on every call, so Vue's dep tracking holds across computed re-runs. Template iteration, `registry.size` reads, `get(id)` reads, and per-ticket field mutations via `upsert` all propagate to consumers. [intent:253]
 
-`useProxyRegistry(registry, { events: true })` exposes `proxy.values` / `proxy.keys` / `proxy.entries` / `proxy.size` as properties on a shallow-reactive object, updated from `register:ticket` / `unregister:ticket` / `update:ticket` / `clear:registry` / `reindex:registry` events. It does not wrap the tickets themselves, and supports `{ deep: true }` for nested tracking. [intent:254]
+`useProxyRegistry(registry)` (on a registry created with `events: true`) exposes `proxy.values` / `proxy.keys` / `proxy.entries` / `proxy.size` as properties on a shallow-reactive object, updated from `register:ticket` / `unregister:ticket` / `update:ticket` / `clear:registry` / `reindex:registry` events. It does not wrap the tickets themselves, and supports `{ deep: true }` for nested tracking. [intent:254]
 
 Both are valid and complementary. Pick based on the consumer's actual need:
 
 | Want | Use |
 |---|---|
 | Reactive iteration **plus** per-ticket field mutations via `upsert` | `reactive: true` on the registry |
-| Reactive iteration without wrapping each ticket in a proxy | `useProxyRegistry(registry, { events: true })` |
-| `{ deep: true }` tracking on registered tickets | `useProxyRegistry(registry, { deep: true, events: true })` |
+| Reactive iteration without wrapping each ticket in a proxy | `useProxyRegistry(registry)` |
+| `{ deep: true }` tracking on registered tickets | `useProxyRegistry(registry, { deep: true })` |
 | Explicit event-driven snapshot semantics, no registry-level reactivity | `useProxyRegistry` |
 
 Plugins bake one or the other in internally — see `.claude/rules/composables.md` "Plugins and Reactive Defaults" for the convention. Primitives expose the choice to callers.

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -483,9 +483,9 @@ Always use `.value` when reading these in templates. Never rely on Vue's auto-un
 
 **Intentional mutable returns.** Some composables return *mutable* refs by design because the consumer is expected to write to them. The return interface types them as `ShallowRef<T>` (or `Ref<T>`) so the write contract is visible at the type level:
 
-- `packages/0/src/composables/useTimer/index.ts:187-196` — `remaining`, `isActive`, `isPaused` typed as `ShallowRef<...>` in `TimerContext`. Consumers pause and resume by writing.
-- `packages/0/src/composables/usePopover/index.ts:173-184` — `isOpen: Ref<boolean>` for v-model bidirectional binding.
-- `packages/0/src/composables/createInput/index.ts:173-180` — `value`, `isDirty`, `isFocused`, `isTouched`, `isPristine` mutable so bound components can write.
+- `packages/0/src/composables/useTimer/index.ts:68,70,72` — `remaining`, `isActive`, `isPaused` typed as `ShallowRef<...>` in `TimerContext`. Consumers pause and resume by writing.
+- `packages/0/src/composables/usePopover/index.ts:58` — `isOpen: Ref<boolean>` for v-model bidirectional binding.
+- `packages/0/src/composables/createInput/index.ts:90,94,98` — `value`, `isFocused`, `isTouched` mutable so bound components can write; `isDirty` / `isPristine` are `Readonly<Ref<boolean>>` (do not write).
 
 **Follow-up audit.** `useRovingFocus` and `createFocusTraversal` are flagged for the same shape audit — confirm every consumer-visible ref is wrapped in `shallowReadonly` at the boundary, or, if it is intentionally mutable, declared as `ShallowRef<T>` in the return interface.
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -282,9 +282,7 @@ Bare `Error` is forbidden in `packages/0/src` source by the `vuetify/no-bare-err
 
 **Why.** v0 runs under SSR. An unguarded `window.x` crashes the server build. The gate is one line and composes through adapters.
 
-**Canonical example.** `packages/0/src/composables/useStorage/index.ts:105` — `IN_BROWSER ? window.localStorage : new MemoryStorageAdapter()`.
-
-**Known soft-violations.** `packages/0/src/composables/useClickOutside/index.ts:346-350`, `packages/0/src/composables/useHotkey/index.ts:159`, `packages/0/src/composables/createCombobox/index.ts:187` — each reads `document.*` inside a browser-only handler. Safe in practice, but the rule is per-composable, not per-call-site. Add the guard.
+**Canonical example.** `packages/0/src/composables/useStorage/index.ts:114` — `IN_BROWSER ? window.localStorage : new MemoryStorageAdapter()`.
 
 ---
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -310,7 +310,7 @@ return {
 **3.1.2 Trinity tuple.** `[useX, provideX, defaultX]as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly three foundation factories: `createTrinity`, `createContext`, `createPlugin`. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
 
 ```ts
-// packages/0/src/composables/createTrinity/index.ts:92-97
+// packages/0/src/composables/createTrinity/index.ts:100-104
 return [
   keyOrUseContext,
   (_context: Z = context, app?: App): Z => provideContext(_context, app),

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -307,7 +307,7 @@ return {
 }
 ```
 
-**3.1.2 Trinity tuple.** `[useX, provideX, defaultX]as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly three foundation factories: `createTrinity`, `createContext`, `createPlugin`. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
+**3.1.2 Trinity tuple.** `[useX, provideX, defaultX] as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly three foundation factories: `createTrinity`, `createContext`, `createPlugin`. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
 
 ```ts
 // packages/0/src/composables/createTrinity/index.ts:100-104

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -894,7 +894,7 @@ return [useX, provideX, context]
 
 ### 8.7 Generic bounds
 
-Registry-based composables carry two generic parameters: `Z extends FooTicketInput` (input shape) and `E extends FooTicket<Z>` (output shape). Consumers parameterize once at the call site; the composable internally threads `Z` and `E` through every return-type contract.
+Registry-based composables carry `Z extends FooTicketInput` (input shape) and `E extends FooTicket<Z>` (output shape); consumers parameterize once at the call site and the composable threads `Z` and `E` through every return-type contract. Factories in the selection chain (`createModel`, `createSelection`, `createSingle`, `createGroup`, `createStep`) add a third generic `R extends FooContext<Z, E>` so subclasses can override the return type; leaf factories (`createSortable`, `createKanban`, `createTimeline`, `createTokens`) stop at `Z` and `E`.
 
 ```ts
 // packages/0/src/composables/createSortable/index.ts

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -943,7 +943,7 @@ Every key passed to `createContext(key)` or `createXContext({ namespace })` must
 **Static-key vs dynamic-key modes.** `createContext` operates in two modes:
 
 - **Static-key mode** — the call site passes a single string (`createContext('v0:tabs')`). The namespace is fixed at module load; the `[useX, provideX]` pair injects against that one key. Used by every compound component that scopes a single context per Root (`Tabs`, `Dialog`, `Combobox`).
-- **Dynamic-key mode** — the call site passes a `{ suffix: true }` configuration, which makes the returned `useX` / `provideX` accept a runtime namespace argument. Used when a single composable services multiple disjoint subtrees within the same app (e.g., nested `Selection` providers). The colon-namespace rule still applies — the runtime argument must contain `:`, and the warning fires for keys that don't.
+- **Dynamic-key mode** — the call site passes an options object or omits the positional key (`createContext({ suffix: 'item' })` or `createContext()`), which makes the returned `useX` / `provideX` accept a runtime namespace argument; `suffix` is an optional string appended to that runtime key (`key:suffix`). Used when a single composable services multiple disjoint subtrees within the same app (e.g., nested `Selection` providers). The `[v0:context]` colon warning is static-key-mode only (gated on `isString(keyOrOptions)`); the dynamic branch performs no colon check on the runtime key.
 
 ### 9.4 SSR gating
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -778,7 +778,7 @@ table.columns.clear()
 
 Callers who want domain-stable identity pass `id` explicitly — same pattern as `createSortable`. Omit `id` and the registry auto-generates one via `useId()`. Consumers with a reactive items source watch it themselves and call `clear()` + `onboard()` (or maintain `register` / `unregister` incrementally); the composable does not auto-sync from an external ref.
 
-**Composables that follow this rule.** `createRegistry`, `createModel`, `createSelection`, `createSingle`, `createGroup`, `createStep`, `createNested`, `createSortable`, `createKanban`, `createQueue`, `createTimeline`, `createTokens`. `createDataTable` predated the convention and has been brought in line — `items`, `itemValue`, and `columns` are all gone; consumers `onboard` rows on the returned context and columns on `table.columns`. The forthcoming `createDataGrid` will follow the same shape. [intent:353]
+**Composables that follow this rule.** `createRegistry`, `createModel`, `createSelection`, `createSingle`, `createGroup`, `createStep`, `createNested`, `createSortable`, `createKanban`, `createQueue`, `createTimeline`, `createTokens`, `createDataGrid`. `createDataTable` predated the convention and has been brought in line — `items`, `itemValue`, and `columns` are all gone; consumers `onboard` rows on the returned context and columns on `table.columns`. [intent:353]
 
 ---
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -108,7 +108,7 @@ function register (input: unknown): unknown {
 
 **Exceptions.** `packages/0/src/utilities/helpers.ts` defines the guards themselves and must use primitive comparisons at its root. This is the only file that gets to.
 
-**Anti-example.** `packages/0/src/composables/useNotifications/index.ts:490, 524` — `every(t => t.readAt !== null)` and `every(t => t.archivedAt !== null)` inside JSDoc `@example` blocks. These render on the docs API page and teach the wrong form to readers. Should be `!isNull(t.readAt)` / `!isNull(t.archivedAt)`. Source-code comparisons across `packages/0/src/` are clean as of this writing — the holdouts that survived are inside doc strings.
+**Anti-example.** `every(t => t.readAt !== null)` — a raw `!== null` comparison; the guard form is `every(t => !isNull(t.readAt))`. Both source-code and JSDoc `@example` comparisons across `packages/0/src/` are clean as of this writing.
 
 **Canonical example.** `packages/0/src/composables/createDataTable/index.ts` — 10 guard calls in one file, zero raw comparisons.
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -177,10 +177,10 @@ return {
 
 **Why.** Consumers import from a flat barrel. Without the marker, bundlers retain every utility the barrel touches. Meta-frameworks with 64 composables and 37 components cannot afford a lazy barrel.
 
-**Canonical example.** `packages/0/src/utilities/helpers.ts:27,44,64,82,108,126,144,164,189,209` — every exported guard carries the comment directly above the function declaration.
+**Canonical example.** `packages/0/src/utilities/helpers.ts:32,49,69,87,113,138,156,174,194,219` — every exported guard carries the comment directly above the function declaration.
 
 ```ts
-// packages/0/src/utilities/helpers.ts:27-30
+// packages/0/src/utilities/helpers.ts:32-35
 /* #__NO_SIDE_EFFECTS__ */
 export function isFunction (item: unknown): item is Function {
   return typeof item === 'function'

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -153,7 +153,7 @@ import { createRegistry } from '../createRegistry'
 
 **Why.** Spread guarantees the child remains substitutable for the parent in types. The 27 registry-based composables all compose this way; consumers who hold a reference to the parent type can upgrade to the child type without refactoring call sites.
 
-**Canonical example.** `packages/0/src/composables/createSelection/index.ts:286-294` — spreads `createModel`, adds `multiple`, `toggle`, `apply`, `mandate`.
+**Canonical example.** `packages/0/src/composables/createSelection/index.ts:296-309` — spreads `createModel`, adds `multiple`, `toggle`, `apply`, `mandate`.
 
 ```ts
 return {
@@ -297,7 +297,7 @@ Three allowable return shapes, in order of prevalence:
 **3.1.1 Plain object.** The dominant shape. Used by ~51 of 63 composable directories. Returned from every selection, registry, model, data, and browser composable that is not a trinity builder itself.
 
 ```ts
-// packages/0/src/composables/createSelection/index.ts:286
+// packages/0/src/composables/createSelection/index.ts:296
 return {
   ...model,
   multiple,

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -1080,7 +1080,7 @@ function createThing () {
 }
 ```
 
-Reason: §3.1. Tuples are reserved for the three foundation trinity builders. Everything else returns a plain object with named keys.
+Reason: §3.1. Tuples are reserved for the foundation builders — `createTrinity` and `createPlugin` return the trinity, `createContext` returns the `[useX, provideX]` pair. Everything else returns a plain object with named keys.
 
 ---
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -618,7 +618,7 @@ RegistryTicketInput
   └── FormTicketInput
 ```
 
-Every ticket has the base interface `{ id: ID, index: number, value: unknown, valueIsIndex: boolean }`. [intent:96] Extensions spread the parent; they never override it. [intent:101]
+Every ticket has the base interface `{ id: ID, index: number, value: unknown, valueIsIndex: boolean, unregister: () => void }`. [intent:96] Extensions spread the parent; they never override it. [intent:101]
 
 ### 6.3 Element refs via registry
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -321,7 +321,6 @@ return [
 **3.1.3 Single value / function.** Pass-through transformers and event composables:
 - `useEventListener` → cleanup `stop: () => void`
 - `toArray`, `toElement`, `toReactive` → value or proxy
-- `useMutationObserver` → underlying observer
 - `useRaf` → augmented function via `Object.assign`
 
 Choose 3.1.3 only when there is literally one useful return. Any time you reach for a tuple other than a trinity, switch to a plain object with named keys.

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -612,8 +612,8 @@ Every user-facing string (`aria-label`, error messages, day-of-week names, month
 RegistryTicketInput
   ├── ModelTicketInput
   │     ├── SelectionTicketInput
-  │     │     ├── SingleTicketInput
-  │     │     └── StepTicketInput
+  │     │     └── SingleTicketInput
+  │     │           └── StepTicketInput
   │     └── GroupTicketInput
   │           └── NestedTicketInput
   ├── QueueTicketInput

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -853,9 +853,9 @@ export interface UseFooOptions {
 
 ### 8.5 `Extensible<T>`
 
-Use `Extensible<T>` for enums that must retain autocomplete while accepting arbitrary string extensions. The trick is `T | (string & {})` — see `packages/0/src/types/index.ts:124`. Without `& {}`, TypeScript collapses `'a' | 'b' | string` down to `string` and drops the autocomplete.
+Use `Extensible<T>` for enums that must retain autocomplete while accepting arbitrary string extensions. The trick is `T | (string & {})` — see `packages/0/src/types/index.ts:116`. Without `& {}`, TypeScript collapses `'a' | 'b' | string` down to `string` and drops the autocomplete.
 
-**Canonical example.** `packages/0/src/composables/useNotifications/index.ts:34`:
+**Canonical example.** `packages/0/src/composables/useNotifications/index.ts:43`:
 
 ```ts
 export type NotificationSeverity = Extensible<'info' | 'warning' | 'error' | 'success'>

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -897,11 +897,11 @@ return [useX, provideX, context]
 Registry-based composables carry two generic parameters: `Z extends FooTicketInput` (input shape) and `E extends FooTicket<Z>` (output shape). Consumers parameterize once at the call site; the composable internally threads `Z` and `E` through every return-type contract.
 
 ```ts
-// packages/0/src/composables/createSelection/index.ts
-export function createSelection <
-  Z extends SelectionTicketInput = SelectionTicketInput,
-  E extends SelectionTicket<Z> = SelectionTicket<Z>,
-> (options: SelectionOptions = {}): SelectionContext<Z, E>
+// packages/0/src/composables/createSortable/index.ts
+export function createSortable<
+  Z extends SortableTicketInput = SortableTicketInput,
+  E extends SortableTicket<Z> = SortableTicket<Z>,
+> (_options: SortableOptions = {}): SortableContext<Z, E>
 ```
 
 ### 8.8 Slot type guardrails

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -549,7 +549,7 @@ Plugins bake one or the other in internally — see `.claude/rules/composables.m
 ### 4.5 Scope cleanup contract
 
 - DOM observers and event listeners use `onScopeDispose(cleanup)`. [intent:139]
-- Performance-critical DOM observers use deferred cleanup: `onScopeDispose(cleanup, true)`. [intent:140]
+- Composables that may run outside a Vue setup scope (tests, manual scopes) pass `failSilently`: `onScopeDispose(cleanup, true)` — the `true` suppresses the no-active-scope warning, not a perf/deferred toggle. [intent:140]
 - Pure data structures and computed state need no cleanup — Vue's effect scope handles them. [intent:141]
 - Conditional cleanup: use `useToggleScope(source, fn)` when side effects should only run while a reactive boolean is true. When the boolean flips false, the entire scope is torn down (watchers stop, event listeners detach, `onScopeDispose` fires) without manual bookkeeping. Canonical: `packages/0/src/composables/useToggleScope/index.ts`.
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -640,7 +640,7 @@ Composables needing global/injected context use `instanceExists()` or an equival
 
 **Rule.** Components and composables never call Vue's raw `inject` / `provide` directly. Subtree DI always flows through `createContext(key)`, which returns a `[useX, provideX]` pair with namespace validation, optional-injection support, and a `[v0:context]` warning when the key lacks a `:`. [intent:119, intent:226, intent:227]
 
-**Current state.** `packages/0/src/` uses raw `inject`/`provide` in exactly two non-test locations: `composables/createContext/index.ts:20` (the factory that implements the wrapper itself) and `composables/createPlugin/index.ts:23` (the plugin context factory, which wraps `inject` for app-level singletons). Both are foundational — they define the contract every caller consumes. No component or user-facing composable imports `inject`/`provide` from Vue.
+**Current state.** `packages/0/src/` uses raw `inject`/`provide` in exactly two non-test locations: `composables/createContext/index.ts:30` (the factory that implements the wrapper itself) and `composables/createPlugin/index.ts:34` (the plugin context factory, which wraps `inject` for app-level singletons). Both are foundational — they define the contract every caller consumes. No component or user-facing composable imports `inject`/`provide` from Vue.
 
 **Canonical example (component side).**
 ```ts

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -601,7 +601,7 @@ Every user-facing string (`aria-label`, error messages, day-of-week names, month
 |-----------|------|
 | `createContext` | Subtree DI with a strict key namespace. Returns a `[useX, provideX]` pair or a dynamic-key pair when a `suffix` is passed. [intent:119] |
 | `createRegistry` | Indexed ticket store with value-is-index semantics. Foundation for all registered-child patterns. [intent:96] |
-| `createTrinity` | Return-tuple builder. Invoked by `createContext` and `createPlugin`; rarely called directly outside foundation code. [intent:80] |
+| `createTrinity` | Return-tuple builder. Consumes `createContext`; invoked by `createPlugin`. Rarely called directly outside foundation code. [intent:80] |
 | `createPlugin` / `createPluginContext` | App-level singleton with install hook, adapter wiring, optional persist/restore. [intent:120, intent:144] |
 
 ### 6.2 Ticket hierarchy

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -305,7 +305,7 @@ return {
 }
 ```
 
-**3.1.2 Trinity tuple.** `[useX, provideX, defaultX] as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly three foundation factories: `createTrinity`, `createContext`, `createPlugin`. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
+**3.1.2 Trinity tuple.** `[useX, provideX, defaultX] as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly two foundation factories: `createTrinity` and `createPlugin`. `createContext` returns the `[useX, provideX]` pair that `createTrinity` consumes and extends into the trinity. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
 
 ```ts
 // packages/0/src/composables/createTrinity/index.ts:100-104

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -262,10 +262,17 @@ function useFoo () {
 // Right — throw on missing required context
 function useFoo () {
   const ctx = inject(key)
-  if (!ctx) throw new Error('useFoo must be called within FooProvider')
+  if (isUndefined(ctx)) {
+    throw new V0Error('useFoo must be called within FooProvider', {
+      code: 'V0_CONTEXT_MISSING',
+      key,
+    })
+  }
   return ctx
 }
 ```
+
+Bare `Error` is forbidden in `packages/0/src` source by the `vuetify/no-bare-error-throw` ESLint config (a `no-restricted-syntax` rule over `packages/0/src/**/*.ts`). Throw a `V0Error` with a code from `V0ErrorDetails` (`packages/0/src/utilities/errors.ts`) instead — see `createContext` for the canonical form.
 
 ---
 

--- a/packages/0/src/components/Atom/index.ts
+++ b/packages/0/src/components/Atom/index.ts
@@ -10,13 +10,13 @@ export type { AtomExpose, AtomProps, AtomSlots } from './Atom.vue'
  * <script lang="ts" setup>
  *   import { Atom } from '@vuetify/v0'
  *
- *   function handleClick() {
+ *   function onClick() {
  *     console.log('clicked')
  *   }
  * </script>
  *
  * <template>
- *   <Atom as="button" @click="handleClick">
+ *   <Atom as="button" @click="onClick">
  *     Click me
  *   </Atom>
  * </template>

--- a/packages/0/src/composables/createBreadcrumbs/index.ts
+++ b/packages/0/src/composables/createBreadcrumbs/index.ts
@@ -1,7 +1,7 @@
 /**
  * @module createBreadcrumbs
  *
- * @see https://0.vuetifyjs.com/composables/utilities/create-breadcrumbs
+ * @see https://0.vuetifyjs.com/composables/semantic/create-breadcrumbs
  *
  * @remarks
  * Breadcrumb navigation composable built on createSingle.

--- a/packages/0/src/composables/createCombobox/index.ts
+++ b/packages/0/src/composables/createCombobox/index.ts
@@ -316,10 +316,10 @@ export function createCombobox (options: ComboboxOptions = {}): ComboboxContext 
  * ```
  */
 export function createComboboxContext (
-  options: ComboboxOptions & { namespace?: string } = {},
+  _options: ComboboxOptions & { namespace?: string } = {},
 ): ContextTrinity<ComboboxContext> {
-  const { namespace = 'v0:combobox', ...rest } = options
-  const context = createCombobox(rest)
+  const { namespace = 'v0:combobox', ...options } = _options
+  const context = createCombobox(options)
 
   return createTrinity<ComboboxContext>(namespace, context)
 }

--- a/packages/0/src/composables/createCombobox/index.ts
+++ b/packages/0/src/composables/createCombobox/index.ts
@@ -56,6 +56,7 @@ import type { MaybeArray, ID } from '#v0/types'
 import type { ComboboxAdapter } from './adapters'
 import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 
+// Exports
 export { ClientComboboxAdapter, ComboboxAdapter, ServerComboboxAdapter } from './adapters'
 export type { ClientComboboxAdapterOptions, ComboboxAdapterContext, ComboboxAdapterResult } from './adapters'
 

--- a/packages/0/src/composables/createDataGrid/index.ts
+++ b/packages/0/src/composables/createDataGrid/index.ts
@@ -58,6 +58,7 @@ import type { ColumnLayout, PinPosition } from './layout'
 import type { SpanEntry } from './spanning'
 import type { App, ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 
+// Exports
 export type { ColumnLayout, GridColumnDef, PinnedRegion, PinPosition, ResolvedColumn } from './layout'
 export type { ActiveCell, CellEditing, CellEditingOptions, CellEditingRegistry, EditableColumn } from './editing'
 export type { RowSpanningOptions, SpanEntry } from './spanning'

--- a/packages/0/src/composables/createDataTable/index.ts
+++ b/packages/0/src/composables/createDataTable/index.ts
@@ -71,7 +71,7 @@ import type { DataTableAdapter, SortDirection, SortEntry } from './adapters/adap
 import type { InternalHeader } from './columns'
 import type { Ref, ShallowRef } from 'vue'
 
-// Re-export adapter types
+// Exports
 export { DataTableAdapter } from './adapters'
 export type { DataTableAdapterContext, DataTableAdapterResult, SortDirection, SortEntry } from './adapters'
 export { ClientDataTableAdapter, ServerDataTableAdapter, VirtualDataTableAdapter } from './adapters'

--- a/packages/0/src/composables/createFocusTraversal/index.ts
+++ b/packages/0/src/composables/createFocusTraversal/index.ts
@@ -19,7 +19,7 @@
  * ```
  */
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/createForm/index.ts
+++ b/packages/0/src/composables/createForm/index.ts
@@ -132,14 +132,14 @@ export interface FormContextOptions extends FormOptions {
  * form.reset()
  * ```
  */
-export function createForm (options: FormOptions = {}): FormContext {
+export function createForm (_options: FormOptions = {}): FormContext {
   const {
     disabled = false,
     readonly = false,
-    ..._options
-  } = options
+    ...options
+  } = _options
 
-  const registry = createRegistry<FormTicket>({ ..._options, reactive: true })
+  const registry = createRegistry<FormTicket>({ ...options, reactive: true })
 
   const isValidating = computed(() => {
     for (const ticket of registry.values()) {

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -239,7 +239,7 @@ export interface ModelContext<
   /**
    * Register a new ticket
    *
-   * @param ticket Partial ticket data. ID is auto-generated if not provided. Disabled defaults to `false`.
+   * @param registration Partial ticket data. ID is auto-generated if not provided. Disabled defaults to `false`.
    * @returns The registered ticket with `isSelected` computed ref attached.
    * @remarks Delegates to `registry.register()` after adding model-specific fields (`disabled`, `isSelected`).
    *

--- a/packages/0/src/composables/createNumeric/index.ts
+++ b/packages/0/src/composables/createNumeric/index.ts
@@ -16,7 +16,7 @@
  *
  * const numeric = createNumeric({ min: 0, max: 10, step: 1 })
  * console.log(numeric.snap(3.7)) // 4
- * console.log(numeric.toPercent(5)) // 0.5
+ * console.log(numeric.fromValue(5)) // 50
  * ```
  */
 

--- a/packages/0/src/composables/createOtp/index.ts
+++ b/packages/0/src/composables/createOtp/index.ts
@@ -159,7 +159,7 @@ export interface OtpContext {
   accepts: (char: string) => boolean
 }
 
-export function createOtp (options: OtpOptions = {}): OtpContext {
+export function createOtp (_options: OtpOptions = {}): OtpContext {
   const {
     value = shallowRef(''),
     length = 6,
@@ -167,8 +167,8 @@ export function createOtp (options: OtpOptions = {}): OtpContext {
     disabled = false,
     readonly: _readonly = false,
     onComplete,
-    ...inputOptions
-  } = options
+    ...options
+  } = _options
 
   const logger = useLogger()
 
@@ -176,7 +176,7 @@ export function createOtp (options: OtpOptions = {}): OtpContext {
   const errorMessagesRef = shallowRef<string[] | undefined>(undefined)
 
   const input = createInput<string>({
-    ...inputOptions,
+    ...options,
     value,
     disabled,
     readonly: _readonly,

--- a/packages/0/src/composables/createOverflow/index.ts
+++ b/packages/0/src/composables/createOverflow/index.ts
@@ -1,7 +1,7 @@
 /**
  * @module createOverflow
  *
- * @see https://0.vuetifyjs.com/composables/utilities/create-overflow
+ * @see https://0.vuetifyjs.com/composables/semantic/create-overflow
  *
  * @remarks
  * Composable for computing how many items fit in a container based on available width.

--- a/packages/0/src/composables/createPagination/index.ts
+++ b/packages/0/src/composables/createPagination/index.ts
@@ -84,7 +84,7 @@ export interface PaginationOptions {
   size?: MaybeRefOrGetter<number>
   /** Maximum visible page buttons. @default 7 */
   visible?: MaybeRefOrGetter<number>
-  /** Ellipsis character. @default '…' */
+  /** Ellipsis character. @default '...' */
   ellipsis?: string | false
 }
 

--- a/packages/0/src/composables/createPagination/index.ts
+++ b/packages/0/src/composables/createPagination/index.ts
@@ -26,6 +26,7 @@
  * ```
  */
 
+// Composables
 import { useContext } from '#v0/composables/createContext'
 import { createTrinity } from '#v0/composables/createTrinity'
 

--- a/packages/0/src/composables/createPagination/index.ts
+++ b/packages/0/src/composables/createPagination/index.ts
@@ -82,7 +82,7 @@ export interface PaginationOptions {
   itemsPerPage?: MaybeRefOrGetter<number>
   /** Total number of items. @default 0 */
   size?: MaybeRefOrGetter<number>
-  /** Maximum visible page buttons. @default 5 */
+  /** Maximum visible page buttons. @default 7 */
   visible?: MaybeRefOrGetter<number>
   /** Ellipsis character. @default '…' */
   ellipsis?: string | false

--- a/packages/0/src/composables/createPlugin/index.ts
+++ b/packages/0/src/composables/createPlugin/index.ts
@@ -26,6 +26,7 @@
  * ```
  */
 
+// Composables
 import { useContext } from '#v0/composables/createContext'
 import { createTrinity } from '#v0/composables/createTrinity'
 

--- a/packages/0/src/composables/createQueue/index.ts
+++ b/packages/0/src/composables/createQueue/index.ts
@@ -293,9 +293,9 @@ export interface QueueContextOptions extends QueueOptions {
  *
  * @example
  * ```ts
- * import { useQueue } from '@vuetify/v0'
+ * import { createQueue } from '@vuetify/v0'
  *
- * const queue = useQueue()
+ * const queue = createQueue()
  *
  * // Register an ticket with default timeout (3000ms)
  * const ticket1 = queue.register({ value: 'Ticket 1' })

--- a/packages/0/src/composables/createRating/index.ts
+++ b/packages/0/src/composables/createRating/index.ts
@@ -28,6 +28,7 @@
  * ```
  */
 
+// Composables
 import { useContext } from '#v0/composables/createContext'
 import { createTrinity } from '#v0/composables/createTrinity'
 

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -19,11 +19,10 @@
  *
  * @example
  * ```ts
- * import { shallowRef } from 'vue'
  * import { createSlider } from '@vuetify/v0'
  *
  * const slider = createSlider({ min: 0, max: 100, step: 5 })
- * slider.register({ value: shallowRef(25) })
+ * slider.register({ value: 25 })
  * slider.set(0, 60)
  * ```
  */

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -486,8 +486,8 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
     return inverted.value ? 100 - p : p
   }
 
-  function fromPercent (p: number): number {
-    const value = numeric.fromPercent(p)
+  function fromPercent (percent: number): number {
+    const value = numeric.fromPercent(percent)
     return inverted.value ? numeric.max - (value - numeric.min) : value
   }
 

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -445,27 +445,27 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
     min = 0,
     max = 100,
     step = 1,
-    disabled: disabledProp = false,
-    readonly: readonlyProp = false,
-    orientation: orientationProp = 'horizontal',
-    inverted: invertedProp = false,
+    disabled: _disabled = false,
+    readonly: _readonly = false,
+    orientation: _orientation = 'horizontal',
+    inverted: _inverted = false,
     minStepsBetweenThumbs = 0,
     crossover = false,
     range = false,
   } = options
 
   const model = createModel<SliderTicketInput, ModelTicket<SliderTicketInput>>({
-    disabled: disabledProp,
+    disabled: _disabled,
     multiple: true,
     events: true,
   })
 
   const numeric = createNumeric({ min, max, step })
 
-  const disabled = toRef(() => toValue(disabledProp))
-  const readonly = toRef(() => toValue(readonlyProp))
-  const orientation = toRef(() => toValue(orientationProp))
-  const inverted = toRef(() => toValue(invertedProp))
+  const disabled = toRef(() => toValue(_disabled))
+  const readonly = toRef(() => toValue(_readonly))
+  const orientation = toRef(() => toValue(_orientation))
+  const inverted = toRef(() => toValue(_inverted))
 
   let pending: number[] | null = null
 

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -45,6 +45,8 @@ export interface SliderTicketInput extends ModelTicketInput<ShallowRef<number>> 
   value: ShallowRef<number>
 }
 
+export type SliderTicket = ModelTicket<SliderTicketInput>
+
 /**
  * Configuration options for createSlider.
  *
@@ -148,7 +150,7 @@ export interface SliderOptions {
  * @see {@link createModel} for the base model API (collection, selectedIds, etc.)
  */
 export interface SliderContext extends Omit<
-  ModelContext<SliderTicketInput, ModelTicket<SliderTicketInput>>,
+  ModelContext<SliderTicketInput, SliderTicket>,
   'values' | 'selectedValues' | 'apply' | 'disabled' | 'register'
 > {
   /**
@@ -234,7 +236,7 @@ export interface SliderContext extends Omit<
    * console.log(slider.values.value) // [50]
    * ```
    */
-  register: (input?: number | { value: number }) => ModelTicket<SliderTicketInput>
+  register: (input?: number | { value: number }) => SliderTicket
   /**
    * Unregister a thumb by ticket ID.
    *
@@ -454,7 +456,7 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
     range = false,
   } = options
 
-  const model = createModel<SliderTicketInput, ModelTicket<SliderTicketInput>>({
+  const model = createModel<SliderTicketInput, SliderTicket>({
     disabled: _disabled,
     multiple: true,
     events: true,
@@ -490,7 +492,7 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
     return inverted.value ? numeric.max - (value - numeric.min) : value
   }
 
-  function register (input?: number | { value: number }): ModelTicket<SliderTicketInput> {
+  function register (input?: number | { value: number }): SliderTicket {
     const initialValue = isObject(input) ? input.value : input
     const thumbIndex = thumbs.value.length
     const pendingValue = pending?.[thumbIndex]
@@ -584,7 +586,7 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
     set(index, max)
   }
 
-  function onboard (registrations: (number | { value: number } | Partial<SliderTicketInput>)[]): ModelTicket<SliderTicketInput>[] {
+  function onboard (registrations: (number | { value: number } | Partial<SliderTicketInput>)[]): SliderTicket[] {
     return model.batch(() => registrations.map(r => register(r as number | { value: number })))
   }
 

--- a/packages/0/src/composables/createTimeline/index.ts
+++ b/packages/0/src/composables/createTimeline/index.ts
@@ -105,7 +105,7 @@ export interface TimelineContextOptions extends TimelineOptions {
 /**
  * Creates a new timeline instance.
  *
- * @param _options The options for the timeline instance.
+ * @param options The options for the timeline instance.
  * @template Z The type of the timeline ticket.
  * @template E The type of the timeline context.
  * @returns A new timeline instance.

--- a/packages/0/src/composables/createTimeline/index.ts
+++ b/packages/0/src/composables/createTimeline/index.ts
@@ -39,7 +39,7 @@ export interface TimelineContext<Z extends TimelineTicket> extends RegistryConte
   /**
    * Removes the last registered ticket and stores it for redo
    *
-   * @return The removed ticket, or undefined if there are no tickets to undo.
+   * @returns The removed ticket, or undefined if there are no tickets to undo.
    *
    * @see https://0.vuetifyjs.com/composables/registration/create-timeline
    *

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -331,8 +331,7 @@ export function createTokens<
 /**
  * Creates a new token context.
  *
- * @param namespace The namespace for the token context.
- * @param tokens The tokens to use.
+ * @param options The options for the token context.
  * @template Z The type of the token ticket.
  * @template E The type of the token context.
  * @returns A new token context.

--- a/packages/0/src/composables/createVirtual/index.ts
+++ b/packages/0/src/composables/createVirtual/index.ts
@@ -35,7 +35,7 @@ import { useContext } from '#v0/composables/createContext'
 import { createTrinity } from '#v0/composables/createTrinity'
 import { useResizeObserver } from '#v0/composables/useResizeObserver'
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/useBreakpoints/index.ts
+++ b/packages/0/src/composables/useBreakpoints/index.ts
@@ -109,7 +109,7 @@ function createDefaultBreakpoints () {
  * ```ts
  * import { createBreakpoints } from '@vuetify/v0'
  *
- * export const [useBreakpoints, provideBreakpoints] = createBreakpoints({
+ * const breakpoints = createBreakpoints({
  *   namespace: 'v0:breakpoints',
  *   mobileBreakpoint: 'md',
  *   breakpoints: {

--- a/packages/0/src/composables/useBreakpoints/index.ts
+++ b/packages/0/src/composables/useBreakpoints/index.ts
@@ -30,7 +30,7 @@ import { createPluginContext } from '#v0/composables/createPlugin'
 import { useWindowEventListener } from '#v0/composables/useEventListener'
 import { useHydration } from '#v0/composables/useHydration'
 
-// Constants
+// Globals
 import { IN_BROWSER, SUPPORTS_MATCH_MEDIA } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/useClickOutside/index.ts
+++ b/packages/0/src/composables/useClickOutside/index.ts
@@ -314,7 +314,7 @@ export function useClickOutside (
   /**
    * Handle pointerdown - store initial target and position.
    */
-  function onPointerDown (event: PointerEvent) {
+  function onPointerdown (event: PointerEvent) {
     if (isPaused.value) return
     if (event.defaultPrevented) return
 
@@ -329,7 +329,7 @@ export function useClickOutside (
   /**
    * Handle pointerup - check if it's an outside click.
    */
-  function onPointerUp (event: PointerEvent) {
+  function onPointerup (event: PointerEvent) {
     if (isPaused.value) return
     if (event.defaultPrevented) return
     if (!initialTarget) return
@@ -377,8 +377,8 @@ export function useClickOutside (
   /* v8 ignore stop */
 
   function setup () {
-    cleanupPointerDown = useDocumentEventListener('pointerdown', onPointerDown, capture)
-    cleanupPointerUp = useDocumentEventListener('pointerup', onPointerUp, capture)
+    cleanupPointerDown = useDocumentEventListener('pointerdown', onPointerdown, capture)
+    cleanupPointerUp = useDocumentEventListener('pointerup', onPointerup, capture)
 
     if (!detectIframe) return
 

--- a/packages/0/src/composables/useDate/adapters/index.ts
+++ b/packages/0/src/composables/useDate/adapters/index.ts
@@ -10,5 +10,5 @@
  * ```
  */
 
-// Types
-export type { DateAdapter } from './adapter'
+// Adapters
+export { DateAdapter } from './adapter'

--- a/packages/0/src/composables/useDate/adapters/v0.ts
+++ b/packages/0/src/composables/useDate/adapters/v0.ts
@@ -16,7 +16,7 @@
 // Polyfill
 import { Temporal } from '@js-temporal/polyfill'
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Adapters

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -246,9 +246,9 @@ export function createDate<
 export function createDateContext<
   Z,
   E extends DateContext<Z> = DateContext<Z>,
-> (options: DateContextOptions<Z>): ContextTrinity<E> {
-  const { namespace = 'v0:date', ...dateOptions } = options
-  const context = createDate<Z, E>(dateOptions)
+> (_options: DateContextOptions<Z>): ContextTrinity<E> {
+  const { namespace = 'v0:date', ...options } = _options
+  const context = createDate<Z, E>(options)
 
   return createTrinity<E>(namespace, context)
 }
@@ -280,9 +280,9 @@ export function createDateContext<
 export function createDatePlugin<
   Z,
   E extends DateContext<Z> = DateContext<Z>,
-> (options: DatePluginOptions<Z>) {
-  const { namespace = 'v0:date', ...dateOptions } = options
-  const [, provideDateContext, context] = createDateContext<Z, E>({ namespace, ...dateOptions })
+> (_options: DatePluginOptions<Z>) {
+  const { namespace = 'v0:date', ...options } = _options
+  const [, provideDateContext, context] = createDateContext<Z, E>({ namespace, ...options })
 
   return createPlugin({
     namespace,

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -55,7 +55,7 @@ import type { ID } from '#v0/types'
 import type { App, ComputedRef, Ref } from 'vue'
 
 // Exports
-export type { DateAdapter } from '#v0/composables/useDate/adapters'
+export { DateAdapter } from '#v0/composables/useDate/adapters'
 
 export interface DateContext<Z> {
   /** The date adapter instance */

--- a/packages/0/src/composables/useDelay/index.ts
+++ b/packages/0/src/composables/useDelay/index.ts
@@ -46,8 +46,8 @@ export interface UseDelayOptions {
    *
    * @example
    * ```ts
-   * useDelay({ openDelay: 300 })
-   * useDelay({ openDelay: () => isFocus.value ? 0 : 500 })
+   * useDelay(undefined, { openDelay: 300 })
+   * useDelay(undefined, { openDelay: () => isFocus.value ? 0 : 500 })
    * ```
    */
   openDelay?: MaybeRefOrGetter<number>
@@ -56,7 +56,7 @@ export interface UseDelayOptions {
    *
    * @example
    * ```ts
-   * useDelay({ closeDelay: 200 })
+   * useDelay(undefined, { closeDelay: 200 })
    * ```
    */
   closeDelay?: MaybeRefOrGetter<number>
@@ -96,7 +96,7 @@ export interface UseDelayReturn {
    *
    * @example
    * ```ts
-   * const delay = useDelay({ openDelay: 300, closeDelay: 200 })
+   * const delay = useDelay(undefined, { openDelay: 300, closeDelay: 200 })
    * await delay.start(true)                    // resolves true after 300ms
    * await delay.start(false, { minDelay: 500 }) // resolves false after max(200, 500)
    * ```

--- a/packages/0/src/composables/useDragDrop/adapters/keyboard.ts
+++ b/packages/0/src/composables/useDragDrop/adapters/keyboard.ts
@@ -71,7 +71,7 @@ export class KeyboardAdapter<Z extends DragType = DragType> extends DragDropAdap
     if (!IN_BROWSER) return
 
     // Arrow form so `this.locate` / `this.activate` / `this.step` resolve on the adapter instance.
-    const onKeyDown = (event: KeyboardEvent) => {
+    const onKeydown = (event: KeyboardEvent) => {
       const focused = document.activeElement
       if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
       if (isEditable(focused)) return
@@ -135,7 +135,7 @@ export class KeyboardAdapter<Z extends DragType = DragType> extends DragDropAdap
       }
     }
 
-    const stop = useEventListener(document, 'keydown', onKeyDown)
+    const stop = useEventListener(document, 'keydown', onKeydown)
     this.cleanup = () => stop()
   }
 }

--- a/packages/0/src/composables/useEventListener/index.ts
+++ b/packages/0/src/composables/useEventListener/index.ts
@@ -26,8 +26,8 @@
  */
 
 // Transformers
-// Framework
-import { toArray } from '#v0/composables'
+import { toArray } from '#v0/composables/toArray'
+
 // Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 

--- a/packages/0/src/composables/useEventListener/index.ts
+++ b/packages/0/src/composables/useEventListener/index.ts
@@ -28,7 +28,7 @@
 // Transformers
 // Framework
 import { toArray } from '#v0/composables'
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/useFeatures/adapters/posthog.ts
+++ b/packages/0/src/composables/useFeatures/adapters/posthog.ts
@@ -5,7 +5,7 @@
  * PostHog adapter for feature flags.
  */
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Adapters

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -42,8 +42,10 @@ import type { TokenCollection } from '#v0/composables/createTokens'
 import type { FeaturesAdapterFlags, FeaturesAdapter } from '#v0/composables/useFeatures/adapters'
 import type { ID, MaybeArray } from '#v0/types'
 
-export type { FeaturesAdapterFlags, FeaturesAdapterValue } from '#v0/composables/useFeatures/adapters'
+// Exports
 export { FeaturesAdapter } from '#v0/composables/useFeatures/adapters'
+
+export type { FeaturesAdapterFlags, FeaturesAdapterValue } from '#v0/composables/useFeatures/adapters'
 
 /**
  * Input type for feature tickets - what users provide to register().

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -113,8 +113,7 @@ export interface FeaturePluginOptions extends FeatureContextOptions {
  * ```ts
  * import { createFeatures } from '@vuetify/v0'
  *
- * const [useFeatures, provideFeaturesContext, context] = createFeatures({
- *   namespace: 'v0:features',
+ * const features = createFeatures({
  *   features: {
  *     'dark-mode': true,
  *     'theme-color': { $variation: 'blue' },

--- a/packages/0/src/composables/useHotkey/index.ts
+++ b/packages/0/src/composables/useHotkey/index.ts
@@ -31,7 +31,7 @@
 // Composables
 import { useWindowEventListener } from '#v0/composables/useEventListener'
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 import { splitKeyCombination, splitKeySequence, MODIFIERS } from './parsing'

--- a/packages/0/src/composables/useHydration/index.ts
+++ b/packages/0/src/composables/useHydration/index.ts
@@ -26,6 +26,7 @@
  * ```
  */
 
+// Composables
 import { createPluginContext } from '#v0/composables/createPlugin'
 
 // Utilities

--- a/packages/0/src/composables/useMediaQuery/index.ts
+++ b/packages/0/src/composables/useMediaQuery/index.ts
@@ -29,7 +29,7 @@
 // Composables
 import { useHydration } from '#v0/composables/useHydration'
 
-// Constants
+// Globals
 import { IN_BROWSER, SUPPORTS_MATCH_MEDIA } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/useNotifications/adapters/adapter.ts
+++ b/packages/0/src/composables/useNotifications/adapters/adapter.ts
@@ -26,10 +26,10 @@
  */
 
 // Types
-import type { NotificationInput, NotificationsAdapterContext, NotificationTicket } from '../index'
+import type { NotificationTicketInput, NotificationsAdapterContext, NotificationTicket } from '../index'
 
 export abstract class NotificationsAdapter<
-  Z extends NotificationInput = NotificationInput,
+  Z extends NotificationTicketInput = NotificationTicketInput,
   E extends NotificationTicket<Z> = NotificationTicket<Z>,
 > {
   /** Called once when the plugin installs. Wire inbound/outbound sync here. */

--- a/packages/0/src/composables/useNotifications/adapters/knock.ts
+++ b/packages/0/src/composables/useNotifications/adapters/knock.ts
@@ -31,7 +31,7 @@ import { IN_BROWSER } from '#v0/constants/globals'
 import { NotificationsAdapter } from './adapter'
 
 // Types
-import type { NotificationInput, NotificationsAdapterContext, NotificationTicket } from '../index'
+import type { NotificationTicketInput, NotificationsAdapterContext, NotificationTicket } from '../index'
 
 /** Minimal Knock feed item shape. Uses type-only imports to avoid bundling the SDK. */
 export interface KnockFeedItem {
@@ -63,7 +63,7 @@ export interface KnockFeed {
 
 function noop () {}
 
-function mapItem (item: KnockFeedItem): NotificationInput {
+function mapItem (item: KnockFeedItem): NotificationTicketInput {
   const subject = item.blocks?.find(b => b.name === 'subject')?.rendered
   const body = item.blocks?.find(b => b.name === 'body')?.rendered
 

--- a/packages/0/src/composables/useNotifications/adapters/knock.ts
+++ b/packages/0/src/composables/useNotifications/adapters/knock.ts
@@ -5,7 +5,7 @@
  * Knock adapter for useNotifications.
  * Bridges a Knock feed instance with the notification system.
  *
- * Inbound: Maps real-time feed events to ctx.send()
+ * Inbound: Maps real-time feed events to context.send()
  * Outbound: Listens to notification:read and notification:archived
  *           events and calls feed.markAsRead/markAsArchived
  *
@@ -77,7 +77,7 @@ function mapItem (item: KnockFeedItem): NotificationTicketInput {
 
 export class KnockNotificationsAdapter extends NotificationsAdapter {
   private items = new Map<string, KnockFeedItem>()
-  private ctx: NotificationsAdapterContext | undefined
+  private context: NotificationsAdapterContext | undefined
   private onReceived: ((data: unknown) => void) | undefined
   private onPage: ((data: unknown) => void) | undefined
   private onRead: ((data: unknown) => void) | undefined
@@ -87,8 +87,8 @@ export class KnockNotificationsAdapter extends NotificationsAdapter {
     super()
   }
 
-  setup (_ctx: NotificationsAdapterContext) {
-    this.ctx = _ctx
+  setup (context: NotificationsAdapterContext) {
+    this.context = context
 
     // Inbound: real-time → send (toast + registry)
     this.onReceived = (data: unknown) => {
@@ -97,7 +97,7 @@ export class KnockNotificationsAdapter extends NotificationsAdapter {
       for (const item of payload.items) {
         if (this.items.has(item.id)) continue
         this.items.set(item.id, item)
-        this.ctx!.send(mapItem(item))
+        this.context!.send(mapItem(item))
       }
     }
 
@@ -108,7 +108,7 @@ export class KnockNotificationsAdapter extends NotificationsAdapter {
       for (const item of payload.items) {
         if (this.items.has(item.id)) continue
         this.items.set(item.id, item)
-        this.ctx!.register(mapItem(item))
+        this.context!.register(mapItem(item))
       }
     }
 
@@ -131,16 +131,16 @@ export class KnockNotificationsAdapter extends NotificationsAdapter {
       if (item) this.feed.markAsArchived(item).catch(noop)
     }
 
-    this.ctx.on('notification:read', this.onRead)
-    this.ctx.on('notification:archived', this.onArchived)
+    this.context.on('notification:read', this.onRead)
+    this.context.on('notification:archived', this.onArchived)
   }
 
   dispose () {
-    if (!this.ctx) return
+    if (!this.context) return
     this.feed.off('items.received.realtime', this.onReceived!)
     this.feed.off('items.received.page', this.onPage!)
-    this.ctx.off('notification:read', this.onRead!)
-    this.ctx.off('notification:archived', this.onArchived!)
+    this.context.off('notification:read', this.onRead!)
+    this.context.off('notification:archived', this.onArchived!)
     this.items.clear()
     this.feed.teardown()
   }

--- a/packages/0/src/composables/useNotifications/adapters/novu.ts
+++ b/packages/0/src/composables/useNotifications/adapters/novu.ts
@@ -93,7 +93,7 @@ function mapItem (item: NovuNotification, resolveSeverity: (s: string) => Notifi
 export class NovuNotificationsAdapter extends NotificationsAdapter {
   private resolveSeverity: (s: string) => NotificationSeverity | undefined
   private ids = new Set<string>()
-  private ctx: NotificationsAdapterContext | undefined
+  private context: NotificationsAdapterContext | undefined
   private disposed = false
   private unsubscribers: Array<() => void> = []
 
@@ -108,16 +108,16 @@ export class NovuNotificationsAdapter extends NotificationsAdapter {
     this.resolveSeverity = options.severity ?? defaultSeverity
   }
 
-  setup (_ctx: NotificationsAdapterContext) {
-    this.ctx = _ctx
+  setup (context: NotificationsAdapterContext) {
+    this.context = context
     this.disposed = false
 
-    // Inbound: real-time new notifications -> ctx.send()
+    // Inbound: real-time new notifications -> context.send()
     const unsub = this.novu.on('notifications.notification_received', (data: unknown) => {
       const item = data as NovuNotification
       if (this.disposed || !item?.id || this.ids.has(item.id)) return
       this.ids.add(item.id)
-      this.ctx!.send(mapItem(item, this.resolveSeverity))
+      this.context!.send(mapItem(item, this.resolveSeverity))
     })
 
     this.unsubscribers.push(unsub)
@@ -129,7 +129,7 @@ export class NovuNotificationsAdapter extends NotificationsAdapter {
         for (const item of data?.notifications ?? []) {
           if (!item.id || this.ids.has(item.id)) continue
           this.ids.add(item.id)
-          this.ctx!.register(mapItem(item, this.resolveSeverity))
+          this.context!.register(mapItem(item, this.resolveSeverity))
         }
       }).catch(noop)
     }
@@ -160,11 +160,11 @@ export class NovuNotificationsAdapter extends NotificationsAdapter {
       if (this.ids.has(id)) this.novu.notifications.unarchive({ notificationId: id }).catch(noop)
     }
 
-    this.ctx.on('notification:read', this.onRead)
-    this.ctx.on('notification:unread', this.onUnread)
-    this.ctx.on('notification:seen', this.onSeen)
-    this.ctx.on('notification:archived', this.onArchived)
-    this.ctx.on('notification:unarchived', this.onUnarchived)
+    this.context.on('notification:read', this.onRead)
+    this.context.on('notification:unread', this.onUnread)
+    this.context.on('notification:seen', this.onSeen)
+    this.context.on('notification:archived', this.onArchived)
+    this.context.on('notification:unarchived', this.onUnarchived)
   }
 
   dispose () {
@@ -172,13 +172,13 @@ export class NovuNotificationsAdapter extends NotificationsAdapter {
     for (const unsub of this.unsubscribers) unsub()
     this.unsubscribers.length = 0
 
-    if (this.ctx) {
+    if (this.context) {
       /* v8 ignore next 5 -- handlers always assigned during setup; guards are defensive */
-      if (this.onRead) this.ctx.off('notification:read', this.onRead)
-      if (this.onUnread) this.ctx.off('notification:unread', this.onUnread)
-      if (this.onSeen) this.ctx.off('notification:seen', this.onSeen)
-      if (this.onArchived) this.ctx.off('notification:archived', this.onArchived)
-      if (this.onUnarchived) this.ctx.off('notification:unarchived', this.onUnarchived)
+      if (this.onRead) this.context.off('notification:read', this.onRead)
+      if (this.onUnread) this.context.off('notification:unread', this.onUnread)
+      if (this.onSeen) this.context.off('notification:seen', this.onSeen)
+      if (this.onArchived) this.context.off('notification:archived', this.onArchived)
+      if (this.onUnarchived) this.context.off('notification:unarchived', this.onUnarchived)
     }
 
     this.ids.clear()

--- a/packages/0/src/composables/useNotifications/adapters/novu.ts
+++ b/packages/0/src/composables/useNotifications/adapters/novu.ts
@@ -33,7 +33,7 @@ import { IN_BROWSER } from '#v0/constants/globals'
 import { NotificationsAdapter } from './adapter'
 
 // Types
-import type { NotificationInput, NotificationSeverity, NotificationTicket, NotificationsAdapterContext } from '../index'
+import type { NotificationTicketInput, NotificationSeverity, NotificationTicket, NotificationsAdapterContext } from '../index'
 
 /** Minimal Novu notification shape. Uses type-only imports to avoid bundling the SDK. */
 export interface NovuNotification {
@@ -80,7 +80,7 @@ function defaultSeverity (s: string): NotificationSeverity | undefined {
 
 function noop () {}
 
-function mapItem (item: NovuNotification, resolveSeverity: (s: string) => NotificationSeverity | undefined): NotificationInput {
+function mapItem (item: NovuNotification, resolveSeverity: (s: string) => NotificationSeverity | undefined): NotificationTicketInput {
   return {
     id: item.id,
     subject: item.subject,

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -42,6 +42,9 @@ import type { NotificationsAdapter } from './adapters/adapter'
 /** Notification urgency level. Maps to ARIA roles: `'error'`/`'warning'` → `role="alert"`, `'info'`/`'success'` → `role="status"`. Extensible — custom values like `'critical'` are allowed with autocomplete for defaults. */
 export type NotificationSeverity = Extensible<'info' | 'warning' | 'error' | 'success'>
 
+/** @deprecated Renamed to `NotificationTicketInput` (FooTicketInput/FooTicket pair rule); will be removed at 1.0.0 final. */
+export type NotificationInput = NotificationTicketInput
+
 /** Input shape for creating a notification via {@link send} or {@link register}. */
 export interface NotificationTicketInput extends RegistryTicketInput {
   /** Notification headline. */

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -24,9 +24,8 @@
  * ```
  */
 
-// Foundational
-import { createPluginContext } from '#v0/composables/createPlugin'
 // Composables
+import { createPluginContext } from '#v0/composables/createPlugin'
 import { createQueue } from '#v0/composables/createQueue'
 import { createRegistry } from '#v0/composables/createRegistry'
 

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -146,12 +146,12 @@ export interface NotificationsContext<
 }
 
 export function createNotifications (
-  options: NotificationsOptions = {},
+  _options: NotificationsOptions = {},
 ): NotificationsContext {
-  const { timeout = 3000, ...registryOptions } = options
+  const { timeout = 3000, ...options } = _options
 
   const registry = createRegistry<NotificationTicket>({
-    ...registryOptions,
+    ...options,
     events: true,
     reactive: true,
   })

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -44,7 +44,7 @@ import type { NotificationsAdapter } from './adapters/adapter'
 export type NotificationSeverity = Extensible<'info' | 'warning' | 'error' | 'success'>
 
 /** Input shape for creating a notification via {@link send} or {@link register}. */
-export interface NotificationInput extends RegistryTicketInput {
+export interface NotificationTicketInput extends RegistryTicketInput {
   /** Notification headline. */
   subject?: string
   /** Extended message body. */
@@ -61,7 +61,7 @@ export interface NotificationInput extends RegistryTicketInput {
  * Hydrated notification with lifecycle state and convenience methods.
  * Returned by {@link send}, {@link register}, and {@link onboard}.
  */
-export type NotificationTicket<Z extends NotificationInput = NotificationInput> = RegistryTicket & Z & {
+export type NotificationTicket<Z extends NotificationTicketInput = NotificationTicketInput> = RegistryTicket & Z & {
   /** When the notification was created. */
   createdAt: Date
   /** When the notification was marked as read, or `null` if unread. */
@@ -95,7 +95,7 @@ export type NotificationTicket<Z extends NotificationInput = NotificationInput> 
  * notification creation and event subscription for outbound sync.
  */
 export interface NotificationsAdapterContext<
-  Z extends NotificationInput = NotificationInput,
+  Z extends NotificationTicketInput = NotificationTicketInput,
   E extends NotificationTicket<Z> = NotificationTicket<Z>,
 > {
   /** Create a notification and enqueue for toast display. Use for real-time inbound items. */
@@ -116,7 +116,7 @@ export interface NotificationsOptions extends RegistryOptions {
 
 /** Full notification context returned by {@link createNotifications} and {@link useNotifications}. */
 export interface NotificationsContext<
-  Z extends NotificationInput = NotificationInput,
+  Z extends NotificationTicketInput = NotificationTicketInput,
   E extends NotificationTicket<Z> = NotificationTicket<Z>,
 > extends RegistryContext<E> {
   /** Create a notification and enqueue for toast display. */
@@ -176,7 +176,7 @@ export function createNotifications (
    * @returns A partial ticket with timestamps, lifecycle methods, and an ID.
    * @internal Used by {@link send}, {@link register}, and {@link onboard}.
    */
-  function hydrate (input: NotificationInput): Partial<NotificationTicket> {
+  function hydrate (input: NotificationTicketInput): Partial<NotificationTicket> {
     const id = input.id ?? useId()
     const now = new Date()
 
@@ -232,7 +232,7 @@ export function createNotifications (
    * ticket.dismiss() // removes from toast queue, keeps in registry
    * ```
    */
-  function send (input: NotificationInput): NotificationTicket {
+  function send (input: NotificationTicketInput): NotificationTicket {
     const ticket = registry.register(hydrate(input))
 
     queue.register(isUndefined(input.timeout) ? { id: ticket.id } : { id: ticket.id, timeout: input.timeout })
@@ -270,7 +270,7 @@ export function createNotifications (
    * ticket.archive()
    * ```
    */
-  function register (input: NotificationInput): NotificationTicket {
+  function register (input: NotificationTicketInput): NotificationTicket {
     return registry.register(hydrate(input))
   }
 
@@ -302,7 +302,7 @@ export function createNotifications (
    * console.log(notifications.values().length) // 2 (in registry)
    * ```
    */
-  function onboard (inputs: NotificationInput[]): NotificationTicket[] {
+  function onboard (inputs: NotificationTicketInput[]): NotificationTicket[] {
     return registry.batch(() => inputs.map(input => register(input)))
   }
 

--- a/packages/0/src/composables/usePermissions/index.ts
+++ b/packages/0/src/composables/usePermissions/index.ts
@@ -76,8 +76,7 @@ export interface PermissionPluginOptions extends PermissionContextOptions {}
  * ```ts
  * import { createPermissions } from '@vuetify/v0'
  *
- * const [usePermissions, providePermissions] = createPermissions({
- *   namespace: 'v0:permissions',
+ * const permissions = createPermissions({
  *   permissions: {
  *     admin: [['read', 'users']],
  *     editor: [['edit', 'posts']],

--- a/packages/0/src/composables/useRaf/index.ts
+++ b/packages/0/src/composables/useRaf/index.ts
@@ -25,7 +25,7 @@
  * ```
  */
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities

--- a/packages/0/src/composables/useRtl/index.ts
+++ b/packages/0/src/composables/useRtl/index.ts
@@ -37,9 +37,9 @@ import type { RtlAdapter } from './adapters'
 import type { Ref } from 'vue'
 
 // Exports
-export { V0RtlAdapter } from '#v0/composables/useRtl/adapters'
+export { RtlAdapter, V0RtlAdapter } from '#v0/composables/useRtl/adapters'
 
-export type { RtlAdapter, RtlAdapterSetupContext } from '#v0/composables/useRtl/adapters'
+export type { RtlAdapterSetupContext } from '#v0/composables/useRtl/adapters'
 
 export interface RtlContext {
   /** Writable ref — true = RTL, false = LTR */

--- a/packages/0/src/composables/useRules/index.ts
+++ b/packages/0/src/composables/useRules/index.ts
@@ -44,8 +44,10 @@ import { instanceExists, isFunction } from '#v0/utilities'
 import type { FormValidationRule } from '#v0/composables/createForm'
 import type { StandardSchemaV1 } from './adapters/standard'
 
-export type { StandardSchemaV1 } from './adapters/standard'
+// Exports
 export { isStandardSchema } from './adapters/standard'
+
+export type { StandardSchemaV1 } from './adapters/standard'
 
 /** A rule alias: a string name referencing a registered predicate. */
 export type RuleAlias = string

--- a/packages/0/src/composables/useStorage/index.ts
+++ b/packages/0/src/composables/useStorage/index.ts
@@ -29,6 +29,7 @@
 // Composables
 import { createPluginContext } from '#v0/composables/createPlugin'
 import { useWindowEventListener } from '#v0/composables/useEventListener'
+import { useLogger } from '#v0/composables/useLogger'
 
 // Adapters
 import { MemoryStorageAdapter } from '#v0/composables/useStorage/adapters'
@@ -120,6 +121,8 @@ export function createStorage<
     ttl,
   } = options
 
+  const logger = useLogger()
+
   const cache = new Map<string, Ref<unknown>>()
   const watchers = new Map<string, () => void>()
 
@@ -149,7 +152,7 @@ export function createStorage<
 
       return parsed
     } catch (error) {
-      console.error(`[v0:storage] Failed to parse stored value for key "${prefixedKey}":`, error)
+      logger.error(`[v0:storage] Failed to parse stored value for key "${prefixedKey}":`, error)
       return undefined
     }
   }
@@ -160,7 +163,7 @@ export function createStorage<
     try {
       adapter?.setItem(prefixedKey, serializer.write(wrapped))
     } catch (error) {
-      console.error(`[v0:storage] Failed to write key "${prefixedKey}":`, error)
+      logger.error(`[v0:storage] Failed to write key "${prefixedKey}":`, error)
     }
   }
 

--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -256,8 +256,7 @@ export interface ThemePluginOptions extends ThemeContextOptions {
  * ```ts
  * import { createTheme } from '@vuetify/v0'
  *
- * export const [useTheme, provideTheme] = createTheme({
- *   namespace: 'v0:theme',
+ * const theme = createTheme({
  *   default: 'light',
  *   themes: {
  *     light: {

--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -50,7 +50,7 @@ import type { ComputedRef, Ref } from 'vue'
 // Exports
 export { V0StyleSheetThemeAdapter, V0UnheadThemeAdapter } from '#v0/composables/useTheme/adapters'
 
-export type { ThemeAdapter } from '#v0/composables/useTheme/adapters'
+export { ThemeAdapter } from '#v0/composables/useTheme/adapters'
 
 export type Colors = {
   [key: string]: string

--- a/packages/0/src/composables/useTimer/index.ts
+++ b/packages/0/src/composables/useTimer/index.ts
@@ -23,7 +23,7 @@
  * ```
  */
 
-// Constants
+// Globals
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities


### PR DESCRIPTION
Aligns the `@vuetify/v0` composable layer with its own documented precedents — reconciling `PHILOSOPHY.md`, `.claude/rules/*`, JSDoc, naming, and export conventions against the actual source. 45 atomic commits across 50 files (+220/-502).

**Breakdown:** 30 docs, 9 refactor, 4 chore, 2 fix.

### Two genuine source fixes worth highlighting
- **fix**: `DateAdapter` / `RtlAdapter` were re-exported via `export type`. Under `verbatimModuleSyntax` that erases the runtime class, so a consumer extending the base adapter through `@vuetify/v0/date` got `undefined`. Now value-exported, matching `useTheme`/`useLogger`/`useLocale`.
- **fix(useStorage)**: catch-block errors used raw `console.error`, bypassing the §9.2 logger contract; they now route through `useLogger()` so failures honor the consumer's adapter and dev-gating.

### Representative alignments
- **PHILOSOPHY/rules accuracy** — corrected the §6.2 ticket and selection-chain hierarchies (a tree, not a linear chain); §3.1.2 `createContext` returns a pair, not a trinity (+ the §10.5 sibling); §9.3 dynamic-key mode; §4.2 readonly-return contract; §4.4 `useProxyRegistry` options; removed resolved "known-violation" notes; refreshed ~a dozen stale `file:line` cites.
- **Naming / structure** — §3.2 options-bag rest var (`_options` + `...options`) across 3 composables; `onPointerdown`/`onKeydown` DOM-handler casing; `_name` option-mirror form; `NotificationTicketInput` ticket-pair; `SliderTicket` output pair; adapter `context` (not `ctx`).
- **JSDoc / examples** — fixed broken `@example`s (`createNumeric.toPercent`→`fromValue`, `createSlider` `shallowRef`→number, the bare-factory trinity-destructure family); `@param`/`@returns`/`@see` corrections.
- **Section-comment normalization** — `// Globals`, `// Composables`, `// Exports`, `// Transformers`.

Each change verified with `eslint --fix` + `vue-tsc` typecheck.