### PR TITLE
chore(ci): publish to npm before minting the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Install
         run: pnpm install
 
-      - name: GitHub release
-        run: pnpm conventional-github-releaser -p vuetify
-        env:
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build
         run: pnpm build
 
@@ -54,3 +49,9 @@ jobs:
 
       - name: Publish to NPM
         run: pnpm -r publish --access public --no-git-checks
+
+      # Runs last so a red build/publish never mints a GitHub release
+      - name: GitHub release
+        run: pnpm conventional-github-releaser -p vuetify
+        env:
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `GitHub release` step runs before build/publish in `release.yml`, so a red run still creates a non-draft GitHub release. This happened on both recent cuts:

- v1.0.0-beta.0 — run 26854214805 failed at publish, release minted anyway
- v1.0.0-beta.1 — run 27234394728 failed at publish (`@paper/genesis` 404), release minted anyway, and `@vuetify/paper` was left unpublished while the release page said beta.1 shipped

## Fix

Move `conventional-github-releaser` to the last step. A GitHub release now only exists if the npm publish actually succeeded.