### PR TITLE
fix(createNested): guard every tree walk against circular references

### DIFF
--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -247,9 +247,7 @@ describe('createNested', () => {
     })
   })
 
-  // skip: cycle-detection guards live in a parallel branch; in master the
-  // walk loops forever and hangs CI workers under vmThreads + v8 coverage.
-  describe.skip('circular reference protection', () => {
+  describe('circular reference protection', () => {
     it('should not infinite loop in getPath when circular parent exists', () => {
       using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/packages/0/src/composables/createNested/index.ts
+++ b/packages/0/src/composables/createNested/index.ts
@@ -156,7 +156,13 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
       // Runs AFTER single-open so ancestors stay open alongside the target
       if (revealOnOpen) {
         let parentId = parents.get(id)
+        const visited = new Set<ID>([id])
         while (!isUndefined(parentId)) {
+          if (visited.has(parentId)) {
+            logger.warn(`Circular parent reference detected at "${parentId}".`)
+            break
+          }
+          visited.add(parentId)
           openedIds.add(parentId)
           parentId = parents.get(parentId)
         }
@@ -320,10 +326,16 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     if (!initial) return descendants
 
     const queue: ID[] = initial.slice()
+    const visited = new Set<ID>([id])
     let index = 0
 
     while (index < queue.length) {
       const currentId = queue[index++]!
+      if (visited.has(currentId)) {
+        logger.warn(`Circular child reference detected at "${currentId}".`)
+        continue
+      }
+      visited.add(currentId)
       descendants.push(currentId)
       const childIds = children.get(currentId)
       if (childIds) {
@@ -354,8 +366,14 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     if (ancestorId === descendantId) return false
 
     let currentId: ID | undefined = parents.get(descendantId)
+    const visited = new Set<ID>([descendantId])
     while (!isUndefined(currentId)) {
       if (currentId === ancestorId) return true
+      if (visited.has(currentId)) {
+        logger.warn(`Circular parent reference detected at "${currentId}".`)
+        return false
+      }
+      visited.add(currentId)
       currentId = parents.get(currentId)
     }
     return false
@@ -402,8 +420,15 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     const result: NestedTicket[] = []
     const rootItems = Array.from(rootIds)
 
+    const visited = new Set<ID>()
+
     function walk (ids: ID[]) {
       for (const id of ids) {
+        if (visited.has(id)) {
+          logger.warn(`Circular child reference detected at "${id}".`)
+          continue
+        }
+        visited.add(id)
         const item = group.get(id) as NestedTicket | undefined
         if (!item) continue
         result.push(item)
@@ -425,7 +450,13 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
   function updateAncestors (id: ID): void {
     const { selectedIds, mixedIds } = group
     let parentId = parents.get(id)
+    const visited = new Set<ID>([id])
     while (!isUndefined(parentId)) {
+      if (visited.has(parentId)) {
+        logger.warn(`Circular parent reference detected at "${parentId}".`)
+        break
+      }
+      visited.add(parentId)
       const childIds = children.get(parentId)
       if (childIds && childIds.length > 0) {
         // Exclude disabled children from the "all selected" test — a disabled


### PR DESCRIPTION
## Problem

`createNested/index.test.ts` carried a `describe.skip`'d circular-reference suite with a comment saying the guards "live in a parallel branch" — that branch does not exist on origin. On master, only `getPath` is guarded; the other five walks loop forever or overflow when the parents/children maps contain a cycle:

- `getDescendants` — unguarded BFS, hangs
- `isAncestorOf` — unguarded parent walk, hangs
- `visibleItems` — unguarded recursion, RangeError stack overflow
- `open()` reveal walk — unguarded parent walk, hangs
- `updateAncestors` (cascade select) — unguarded parent walk, hangs

A cycle is reachable through public API: re-registering an existing id with a `parentId` inside its own subtree performs the parents/children wiring before the duplicate-id check returns the existing ticket. Treeview's keyboard-navigation order sits on `visibleItems`, so the worst case is a browser hang.

## Fix

Each walk now carries the same visited-set + `logger.warn` guard `getPath` already had: terminate, warn `Circular parent/child reference detected at "id"`, and degrade to the partial result instead of hanging.

Un-skips the six pre-written regression tests — they pass unchanged (176/176 suite, 99/99 Treeview, vue-tsc clean).

## Follow-up (separate PR)

The register-wiring order that makes cycles creatable via re-registration is the root cause and deserves its own change; these guards make any cycle non-fatal regardless of origin.