### PR TITLE
fix(createModel): keep the selection when apply writes a ref-valued ticket

### DIFF
--- a/packages/0/src/composables/createModel/index.test.ts
+++ b/packages/0/src/composables/createModel/index.test.ts
@@ -427,9 +427,27 @@ describe('createModel', () => {
       model.apply(['updated'])
 
       expect(valueRef.value).toBe('updated')
-      // After ref write, apply still falls through to browse/clear
-      // Browse resolves by raw value, not ref — so selectedIds is cleared
-      expect(model.selectedIds.size).toBe(0)
+      // The ref write is the application — selection is kept so the next
+      // apply keeps writing (browse can't resolve a ref-keyed catalog entry)
+      expect(model.selected('item-1')).toBe(true)
+      expect(Array.from(model.selectedValues.value)).toContain('updated')
+
+      model.apply(['second'])
+
+      expect(valueRef.value).toBe('second')
+      expect(model.selected('item-1')).toBe(true)
+    })
+
+    it('should not clobber a selected ref with an undefined apply', () => {
+      const model = createModel()
+      const valueRef = ref('original')
+      model.register({ id: 'item-1', value: valueRef })
+      model.select('item-1')
+
+      model.apply([undefined])
+
+      expect(valueRef.value).toBe('original')
+      expect(model.selected('item-1')).toBe(true)
     })
 
     it('should resolve by browse for static values', () => {

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -214,12 +214,13 @@ export interface ModelContext<
    *
    * @param values Array of values to apply. Only `values[0]` is used (single-value store).
    * @param options Optional. Accepted for interface compatibility with `createSelection`; ignored at this layer.
-   * @remarks Used internally by `useProxyModel` to sync a ref with the model. Executes two steps sequentially:
+   * @remarks Used internally by `useProxyModel` to sync a ref with the model. Two paths:
    * 1. **Ref write**: Writes `values[0]` to any selected ticket whose value is a ref.
-   * 2. **Browse resolution**: Clears `selectedIds`, resolves `values[0]` via `registry.browse()`, and selects the match.
-   *
-   * For ref-valued tickets, browse typically finds no match (the catalog indexes by the ref object,
-   * not the unwrapped value), so `selectedIds` will be empty after apply.
+   *    The write is the application — the selection is kept and browse is skipped
+   *    (the catalog indexes the ref object, not the unwrapped value). An `undefined`
+   *    value leaves the ref untouched.
+   * 2. **Browse resolution**: Otherwise clears `selectedIds`, resolves `values[0]`
+   *    via `registry.browse()`, and selects the match.
    *
    * @see https://0.vuetifyjs.com/composables/selection/create-model
    *
@@ -411,13 +412,18 @@ export function createModel<
   function apply (values: unknown[], _options?: { multiple?: boolean }): void {
     const value = values[0]
 
-    // If the selected ticket's value is a ref, update it directly
+    // Browse indexes the ref object, not the unwrapped value, so a ref write
+    // IS the application — keep the selection. Skip undefined so an empty
+    // v-model init doesn't clobber the store ref.
+    let written = false
     for (const id of selectedIds) {
       const item = registry.get(id)
       if (!item || !isRef(item.value)) continue
 
-      item.value.value = value
+      if (!isUndefined(value)) item.value.value = value
+      written = true
     }
+    if (written) return
 
     // Fallback: browse resolution for static values
     if (!toValue(multiple)) selectedIds.clear()

--- a/packages/0/src/composables/useProxyModel/index.test.ts
+++ b/packages/0/src/composables/useProxyModel/index.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 // Composables
+import { createModel } from '#v0/composables/createModel'
 import { createSelection } from '#v0/composables/createSelection'
 
 import { useProxyModel } from './index'
 
 // Utilities
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 
 describe('useProxyModel', () => {
   it('should sync model when selection changes', () => {
@@ -25,6 +26,27 @@ describe('useProxyModel', () => {
     selection.unselect('item-1')
     selection.select('item-2')
     expect(model.value).toBe('value-2')
+  })
+
+  it('should keep a ref-valued ticket syncing across writes (bidirectional store)', () => {
+    const model = createModel({ events: true })
+    const value = shallowRef('original')
+    model.register({ id: 'fruit', value })
+
+    const vmodel = shallowRef()
+    useProxyModel(model, vmodel)
+
+    // Init pass with an empty v-model must not clobber the store ref
+    expect(value.value).toBe('original')
+    expect(model.selected('fruit')).toBe(true)
+
+    vmodel.value = 'banana'
+    expect(vmodel.value).toBe('banana')
+    expect(value.value).toBe('banana')
+
+    vmodel.value = 'cherry'
+    expect(vmodel.value).toBe('cherry')
+    expect(value.value).toBe('cherry')
   })
 
   it('should sync selection when model changes', () => {


### PR DESCRIPTION
## Problem

`createModel.apply()` wrote `values[0]` into selected ref-valued tickets, then unconditionally cleared `selectedIds` and re-resolved via `registry.browse(toRaw(value))`. The catalog indexes the **ref object**, not the unwrapped value, so browse always missed and the selection ended empty (the old JSDoc admitted this). Two consequences, both reproduced by execution:

1. **Sync dead after one write** — a second `apply()` finds no selected ids, so the ref-write loop never runs again.
2. **Silent data destruction through useProxyModel** — the post-apply writeback reads the now-empty `selectedValues` and sets the v-model to `undefined`. The factory's own `@example` ("value and model stay in sync bidirectionally") was exactly this broken case.

A third manifestation: `apply([undefined])` — which useProxyModel fires at init when the v-model starts empty — wrote `undefined` into the store ref, clobbering pre-registered state on mount.

## Fix

When a selected ticket's value is a ref, **the write is the application**: keep the selection and skip the browse fallback. An `undefined` value leaves the ref untouched while still short-circuiting (the selection identifies a ref-backed store; there is nothing to browse).

Bidirectionality now actually holds: `selectedValues` tracks the ref through `toValue`, so direct ref writes propagate out to the v-model via useProxyModel's existing watcher.

The previous test codifying the empty-selection behavior (with a comment apologizing for it) is updated to pin the fixed contract; new regressions cover the second-apply path, the undefined no-clobber, and the full useProxyModel roundtrip on a ref-valued ticket — all three fail on master.

Static-value resolution (browse path) is unchanged. `createSelection`/`createSlider`/`createProgress` override `apply` and are unaffected — full suite 6039 passed, vue-tsc clean.