### PR TITLE
fix(Select,Combobox): genericize v-model — the model carries values, not IDs

### DIFF
--- a/apps/docs/src/pages/components/forms/combobox.md
+++ b/apps/docs/src/pages/components/forms/combobox.md
@@ -109,7 +109,7 @@ flowchart TD
 
 ### Multi-Select
 
-Set `multiple` on Root to enable multi-selection. The dropdown stays open after each selection and the query clears so the user can keep searching. `v-model` binds to an array of IDs. Render selected chips or tags using the `selected` model value directly.
+Set `multiple` on Root to enable multi-selection. The dropdown stays open after each selection and the query clears so the user can keep searching. `v-model` binds to an array of item values (the `value` prop of each selected item). Render selected chips or tags using the `selected` model value directly.
 
 :::
 

--- a/apps/docs/src/pages/components/forms/select.md
+++ b/apps/docs/src/pages/components/forms/select.md
@@ -104,7 +104,7 @@ Both individual items and the entire select can be disabled. Disabled items are 
 
 ### Multi-Select
 
-Set `multiple` on Root to enable multi-selection. The dropdown stays open after each selection. `v-model` binds to an array of IDs. The Value slot receives `selectedValues` for rendering chips, tags, or comma-separated text.
+Set `multiple` on Root to enable multi-selection. The dropdown stays open after each selection. `v-model` binds to an array of item values (the `value` prop of each selected item). The Value slot receives `selectedValues` for rendering chips, tags, or comma-separated text.
 
 :::
 

--- a/packages/0/src/components/Combobox/ComboboxRoot.vue
+++ b/packages/0/src/components/Combobox/ComboboxRoot.vue
@@ -28,7 +28,7 @@
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { ComboboxAdapter, ComboboxContext } from '#v0/composables/createCombobox'
-  import type { MaybeArray, ID } from '#v0/types'
+  import type { MaybeArray } from '#v0/types'
 
   export interface ComboboxRootProps extends AtomProps {
     /** Namespace for dependency injection */
@@ -91,7 +91,7 @@
   export const [useComboboxContext, provideComboboxContext] = createContext<ComboboxContext>()
 </script>
 
-<script setup lang="ts">
+<script lang="ts" setup generic="T = unknown">
   defineOptions({ name: 'ComboboxRoot' })
 
   defineSlots<{
@@ -99,7 +99,7 @@
   }>()
 
   defineEmits<{
-    'update:model-value': [value: ID | ID[]]
+    'update:model-value': [value: T | T[]]
   }>()
 
   const {
@@ -118,7 +118,7 @@
     displayValue,
   } = defineProps<ComboboxRootProps>()
 
-  const model = defineModel<ID | ID[]>()
+  const model = defineModel<T | T[]>()
 
   const context = createCombobox({
     id,

--- a/packages/0/src/components/Combobox/index.test.ts
+++ b/packages/0/src/components/Combobox/index.test.ts
@@ -1441,8 +1441,8 @@ describe('combobox', () => {
       const value = { foo: 'bar' }
       let ctx: { open: () => void } | undefined
 
-      // modelValue is typed String | Number | Array; passing an object to
-      // exercise JSON serialization makes Vue warn on the prop type. Silence it.
+      // The model is generic — object values are a legal type and must not
+      // trigger a prop-type warning (regression pin for the old ID-typed model)
       using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const wrapper = mount(
@@ -1477,7 +1477,7 @@ describe('combobox', () => {
       expect(hidden.exists()).toBe(true)
       // Object values should be serialized to JSON
       expect((hidden.element as HTMLInputElement).value).toBe(JSON.stringify(value))
-      expect(warn).toHaveBeenCalled()
+      expect(warn).not.toHaveBeenCalled()
     })
 
     it('should render empty string for null selection values', async () => {

--- a/packages/0/src/components/Select/SelectRoot.vue
+++ b/packages/0/src/components/Select/SelectRoot.vue
@@ -72,8 +72,8 @@
     toggle: () => void
     /** Select an item by ID, closing dropdown in single-select mode */
     select: (id: ID) => void
-    /** Raw model value for fallback display before items register */
-    modelValue: Ref<ID | ID[] | undefined>
+    /** Raw model value for fallback display before items register. Carries ticket values (type-erased at the compound boundary) */
+    modelValue: Ref<unknown>
   }
 
   export interface SelectRootProps extends AtomProps {
@@ -116,7 +116,7 @@
   export const [useSelectContext, provideSelectContext] = createContext<SelectContext>()
 </script>
 
-<script setup lang="ts">
+<script lang="ts" setup generic="T = unknown">
   defineOptions({ name: 'SelectRoot' })
 
   defineSlots<{
@@ -124,7 +124,7 @@
   }>()
 
   defineEmits<{
-    'update:model-value': [value: ID | ID[]]
+    'update:model-value': [value: T | T[]]
   }>()
 
   const {
@@ -138,7 +138,7 @@
     mandatory = false,
   } = defineProps<SelectRootProps>()
 
-  const model = defineModel<ID | ID[]>()
+  const model = defineModel<T | T[]>()
 
   const id = _id ?? useId()
   const listboxId = `${id}-listbox`

--- a/packages/0/src/components/Select/index.test.ts
+++ b/packages/0/src/components/Select/index.test.ts
@@ -689,8 +689,8 @@ describe('select', () => {
       const value = { id: 1 }
       let ctx: { open: () => void } | undefined
 
-      // modelValue is typed String | Number | Array; passing an object to
-      // exercise JSON serialization makes Vue warn on the prop type. Silence it.
+      // The model is generic — object values are a legal type and must not
+      // trigger a prop-type warning (regression pin for the old ID-typed model)
       using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const wrapper = mount(
@@ -723,7 +723,7 @@ describe('select', () => {
       const hidden = wrapper.find('input[type="hidden"]')
       expect(hidden.exists()).toBe(true)
       expect((hidden.element as HTMLInputElement).value).toBe(JSON.stringify(value))
-      expect(warn).toHaveBeenCalled()
+      expect(warn).not.toHaveBeenCalled()
     })
 
     it('should render empty string for null values in hidden input', async () => {


### PR DESCRIPTION
## Problem

SelectRoot and ComboboxRoot declared `defineModel<ID | ID[]>()` while the machinery demonstrably carries ticket **values**: `useProxyModel` resolves inbound through `registry.browse` and syncs outbound from `selectedValues`. The type only accidentally fit when values were strings:

- Object/typed values — legal and tested (`modelValue: { id: 1 }` JSON-serializes into the hidden input) — failed the declared type and triggered a Vue prop-type warning at runtime.
- `v-model` autocomplete promised `string | number` to consumers whose model actually holds whatever they put in `value`.
- select.md contradicted itself: 'binds to an array of IDs' (§multiple) vs 'the model always receives the value prop, not the id' (FAQ).

This was the lock-in-window item from the audit — breaking to fix after 1.0.

## Fix

Both Roots adopt the shape TabsRoot already had: `generic="T = unknown"`, `defineModel<T | T[]>()`, matching emit tuple. `SelectContext.modelValue` widens to `Ref<unknown>` — the context boundary is non-generic and its two consumers (SelectValue, SelectPlaceholder) only null-check and array-spread it.

The hidden-input JSON tests flip their warn assertion to `not.toHaveBeenCalled()`: object model values are legal and must not warn — a regression pin against re-narrowing the type.

Runtime semantics are unchanged (value resolution was already the tested behavior). Full suite 6040 passed, vue-tsc clean. Plumbing T through item registration/context (full inference) is the larger deferred item from the audit's type review — this closes the public-surface lie within the beta window.