### PR TITLE
docs: fix link-checker failures in the shipped markdown exports

### DIFF
--- a/apps/docs/build/copy-markdown.ts
+++ b/apps/docs/build/copy-markdown.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
 import { glob } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
 
@@ -21,17 +21,20 @@ export default function copyMarkdownPlugin (): Plugin {
         copyFileSync(file, destPath)
       }
 
-      // Copy SKILL.md and references from skills/vuetify0 to dist root
+      // Copy SKILL.md and every reference it links from skills/vuetify0 to
+      // dist root — a partial copy ships a skill with dead relative links
       const skillBase = '../../skills/vuetify0'
       const skillSrc = join(skillBase, 'SKILL.md')
-      const refSrc = join(skillBase, 'references/REFERENCE.md')
+      const refsDir = join(skillBase, 'references')
       const skillDest = join(outDir, 'SKILL.md')
-      const refDest = join(outDir, 'references/REFERENCE.md')
       if (existsSync(skillSrc)) {
         copyFileSync(skillSrc, skillDest)
-        if (existsSync(refSrc)) {
+        if (existsSync(refsDir)) {
           mkdirSync(join(outDir, 'references'), { recursive: true })
-          copyFileSync(refSrc, refDest)
+          for (const ref of readdirSync(refsDir)) {
+            if (!ref.endsWith('.md')) continue
+            copyFileSync(join(refsDir, ref), join(outDir, 'references', ref))
+          }
         }
         console.log(`[copy-markdown] Copied ${files.length} markdown files + SKILL.md`)
       } else {

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,6 @@
-exclude = ["^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://.*\\.vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
+# /dist/documents: breadcrumbs examples use intentional demo hrefs.
+# /dist/https:: lychee misparses Vue component markup (<DocsCard href>) in the
+# copied page-source markdown, resolving the URL as a relative path.
+exclude = ["/dist/documents", "/dist/https:", "^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://.*\\.vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
 
 root_dir = "./apps/docs/dist"

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,6 @@
 # /dist/documents: breadcrumbs examples use intentional demo hrefs.
 # /dist/https:: lychee misparses Vue component markup (<DocsCard href>) in the
 # copied page-source markdown, resolving the URL as a relative path.
-exclude = ["/dist/documents", "/dist/https:", "^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://.*\\.vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
+exclude = ["/dist/documents", "/dist/https:", "^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://([^/]*\\.)?vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
 
 root_dir = "./apps/docs/dist"

--- a/skills/vuetify0/references/component-examples.md
+++ b/skills/vuetify0/references/component-examples.md
@@ -3,7 +3,7 @@
 Real-world examples of v0 headless components. All styling uses UnoCSS utility classes.
 
 > **Styling guide:** v0 components are headless — they emit `data-*` attributes as styling hooks.
-> See the [v0 styling docs](https://0.vuetifyjs.com/guide/styling) for UnoCSS setup and data attribute patterns.
+> See the [v0 styling docs](https://0.vuetifyjs.com/guide/fundamentals/styling) for UnoCSS setup and data attribute patterns.
 
 ## Contents
 


### PR DESCRIPTION
## Problem

docs-check is red on every PR that touches apps/docs (#314 and #319 fail identically) — none of it caused by those PRs. Three link classes in the built site:

1. **dist/SKILL.md → references/*.md (5 dead links)** — copy-markdown.ts shipped only `REFERENCE.md`, but SKILL.md links anti-patterns, authoring-guide, component-examples, layer-decisions, and selection-patterns. Real bug: anyone fetching the skill from the site gets dead pointers.
2. **Breadcrumbs demo hrefs** (`/documents/projects/…`) — intentional fake paths in the example.
3. **`dist/https:/v0play…`** — lychee misparses the raw `<DocsCard href>` Vue markup inside the copied roadmap.md page source and resolves the absolute URL as a relative path.

## Fix

- copy-markdown.ts ships the entire `references/` directory (verified locally: all six files land in dist, and their own relative links — `../SKILL.md`, `authoring-guide.md` — resolve against what ships).
- lychee.toml excludes the demo namespace and the parser-quirk shape, with comments explaining both.

docs-check runs on this PR (apps/docs path), so CI validates the fix directly. Unblocks #314.