### PR TITLE
fix(createVirtual): bootstrap variable-height mode and preserve measurements

### DIFF
--- a/packages/0/src/composables/createVirtual/index.test.ts
+++ b/packages/0/src/composables/createVirtual/index.test.ts
@@ -222,7 +222,7 @@ describe('createVirtual', () => {
     expect(virtual.size.value).toBeGreaterThan(0)
   })
 
-  it('should work with dynamic heights (null itemHeight)', async () => {
+  it('should render an initial window with no itemHeight (zero-config bootstrap)', async () => {
     const items = shallowRef(Array.from({ length: 10 }, (_, i) => i))
     const virtual = createVirtual(items, { itemHeight: null })
 
@@ -230,7 +230,31 @@ describe('createVirtual', () => {
 
     await nextTick()
 
-    expect(virtual.items.value).toEqual([])
+    // Estimated offsets render a first window so items can mount and measure —
+    // an unset itemHeight previously dead-ended update() and rendered nothing
+    expect(virtual.items.value.length).toBeGreaterThan(0)
+  })
+
+  it('should preserve measured heights when items are appended', async () => {
+    const items = shallowRef(Array.from({ length: 100 }, (_, i) => i))
+    const virtual = createVirtual(items, { itemHeight: 40, height: 500 })
+
+    virtual.element.value = mockContainer
+
+    await nextTick()
+
+    virtual.resize(0, 200)
+
+    await nextTick()
+
+    items.value = [...items.value, 100]
+
+    await nextTick()
+
+    // offsets[1] reflects the measured 200, not itemHeight — appending
+    // previously wiped every measurement back to null
+    virtual.scrollTo(1)
+    expect(mockContainer.scrollTop).toBe(200)
   })
 
   it('should include index in computed items', async () => {

--- a/packages/0/src/composables/createVirtual/index.ts
+++ b/packages/0/src/composables/createVirtual/index.ts
@@ -364,6 +364,8 @@ export interface VirtualContextOptions extends VirtualOptions {
  * </template>
  * ```
  */
+const FALLBACK_HEIGHT = 40
+
 export function createVirtual<T = unknown> (
   items: Ref<readonly T[]>,
   _options: VirtualOptions = {},
@@ -385,6 +387,10 @@ export function createVirtual<T = unknown> (
 
   const element = ref<HTMLElement>()
   const itemHeight = shallowRef(Number.parseFloat(String(_itemHeight || 0)))
+
+  function estimate () {
+    return itemHeight.value || FALLBACK_HEIGHT
+  }
   const heights = shallowRef<(number | null)[]>([])
   const offsets = shallowRef<number[]>([])
   const first = shallowRef(0)
@@ -435,7 +441,9 @@ export function createVirtual<T = unknown> (
   watch(items, newItems => {
     captureAnchor()
     const length = newItems.length
-    const newHeights = heights.value.length === length ? heights.value : Array.from({ length }, () => null)
+    // Preserve measured prefix; prepends misattribute until re-measured
+    const old = heights.value
+    const newHeights = old.length === length ? old : Array.from({ length }, (_, i) => (i < old.length ? old[i]! : null))
     if (heights.value !== newHeights) heights.value = newHeights as (number | null)[]
     rebuild()
   }, { immediate: true })
@@ -446,7 +454,7 @@ export function createVirtual<T = unknown> (
 
     if (direction === 'reverse' && items.value.length > 0) {
       const lastIndex = items.value.length - 1
-      const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || itemHeight.value)
+      const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || estimate())
       element.value.scrollTop = totalHeight
     }
 
@@ -502,7 +510,7 @@ export function createVirtual<T = unknown> (
     let offset = 0
     for (let i = 0; i < length; i++) {
       newOffsets[i] = offset
-      offset += heights.value[i] || itemHeight.value
+      offset += heights.value[i] || estimate()
     }
 
     if (offsets.value !== newOffsets) offsets.value = newOffsets
@@ -530,7 +538,7 @@ export function createVirtual<T = unknown> (
   function update () {
     if (!element.value) return
     const viewport = viewportHeight.value || cachedViewport
-    if (!viewport || !itemHeight.value) return
+    if (!viewport) return
 
     const scrollTop = element.value.scrollTop || 0
     const length = items.value.length
@@ -545,7 +553,7 @@ export function createVirtual<T = unknown> (
     last.value = end
     offset.value = offsets.value[start] || 0
     const lastIndex = length - 1
-    const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || itemHeight.value)
+    const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || estimate())
     size.value = totalHeight - (offsets.value[end] || totalHeight)
   }
 
@@ -621,14 +629,14 @@ export function createVirtual<T = unknown> (
     switch (block) {
       case 'center': {
         const viewport = viewportHeight.value || cachedViewport
-        const itemH = heights.value[index] || itemHeight.value
+        const itemH = heights.value[index] || estimate()
         scrollTop = targetOffset - (viewport / 2) + (itemH / 2) + extraOffset
 
         break
       }
       case 'end': {
         const viewport = viewportHeight.value || cachedViewport
-        const itemH = heights.value[index] || itemHeight.value
+        const itemH = heights.value[index] || estimate()
         scrollTop = targetOffset - viewport + itemH + extraOffset
 
         break
@@ -636,7 +644,7 @@ export function createVirtual<T = unknown> (
       case 'nearest': {
         const viewport = viewportHeight.value || cachedViewport
         const currentScroll = element.value.scrollTop
-        const itemH = heights.value[index] || itemHeight.value
+        const itemH = heights.value[index] || estimate()
 
         if (targetOffset < currentScroll) {
           scrollTop = targetOffset + extraOffset
@@ -667,7 +675,7 @@ export function createVirtual<T = unknown> (
     anchorOffset = 0
     if (element.value && direction === 'reverse' && items.value.length > 0) {
       const lastIndex = items.value.length - 1
-      const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || itemHeight.value)
+      const totalHeight = (offsets.value[lastIndex] || 0) + (heights.value[lastIndex] || estimate())
       element.value.scrollTop = totalHeight
     }
   }


### PR DESCRIPTION
## Problem

Two compounding failures in variable-height mode at defaults (audit gating item, both verified):

1. **Bootstrap deadlock** — with no `itemHeight`, `update()` bailed on the zero value: `first`/`last` stayed 0/0, the items slice was empty, nothing mounted, and `resize()` — the only `itemHeight` bootstrap — never ran because it needs a rendered item to measure. The module's own zero-config `@example` (`createVirtual(items)`) rendered nothing forever, and a test codified the empty render under the name 'should work with dynamic heights'.
2. **Measurement wipe** — the items watcher replaced the heights array wholesale on any length change, so appending one message to a fully-measured 10k list (the advertised chat use case) discarded every measurement, reverted offsets to estimates, and caused scroll jumps plus full re-measure churn.

## Fix

- Unmeasured heights fall back to a 40px estimate (`heights[i] || itemHeight || FALLBACK_HEIGHT`) so offsets are sane pre-measurement and a first window renders. The existing `resize()` bootstrap then takes over with real numbers — the estimate only ever covers unmeasured items.
- The items watcher preserves the measured prefix and null-fills only the delta. Appends keep all measurements; prepends misattribute by index until items re-measure, which `resize()` self-corrects (the standard tradeoff for index-keyed virtualizers).

Both regression tests fail on master. Suite 6041 passed, vue-tsc clean.

Not touched (deliberate): the `anchor: 'auto'` no-op and the full-prefix-sum `rebuild()` — those are the audit's medium-tier follow-ups, separate scope.