### PR TITLE
fix(composables): verify factory returns with satisfies and correct surfaced drift

### DIFF
--- a/packages/0/src/composables/createGroup/index.ts
+++ b/packages/0/src/composables/createGroup/index.ts
@@ -100,7 +100,7 @@ export interface GroupContext<
   /** Check if a ticket is in mixed/indeterminate state by ID */
   mixed: (id: ID) => boolean
   /** Whether no items are currently selected */
-  isNoneSelected: ComputedRef<boolean>
+  isNoneSelected: Readonly<Ref<boolean>>
   /** Whether all selectable (non-disabled) items are selected */
   isAllSelected: ComputedRef<boolean>
   /** Whether some but not all selectable items are selected */
@@ -360,7 +360,7 @@ export function createGroup<
     get size () {
       return selection.size
     },
-  } as unknown as R
+  } satisfies GroupContext<Z, E> as unknown as R
 }
 
 /**

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -378,7 +378,7 @@ export function createModel<
 
   const selectedValues = computed(() => {
     return new Set(
-      Array.from(selectedItems.value).map(item => toValue(item.value)),
+      Array.from(selectedItems.value).map(item => toValue(item.value) as E['value'] extends Ref<infer U> ? U : E['value']),
     )
   })
 
@@ -503,5 +503,5 @@ export function createModel<
     get size () {
       return registry.size
     },
-  } as unknown as R
+  } satisfies ModelContext<Z, E> as unknown as R
 }

--- a/packages/0/src/composables/createNested/index.ts
+++ b/packages/0/src/composables/createNested/index.ts
@@ -101,7 +101,7 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
   const mandatoryOption = _options.mandatory ?? false
   const multipleOption = _options.multiple ?? true
 
-  const group = createGroup(options)
+  const group = createGroup<NestedTicketInput, NestedTicket>(options)
   const logger = useLogger()
 
   const children = shallowReactive(new Map<ID, ID[]>())
@@ -883,7 +883,7 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     get size () {
       return group.size
     },
-  } as unknown as NestedContext
+  } satisfies NestedContext
 
   return context
 }

--- a/packages/0/src/composables/createPlugin/index.ts
+++ b/packages/0/src/composables/createPlugin/index.ts
@@ -90,7 +90,7 @@ export function createPlugin<Z extends Plugin = Plugin> (options: PluginOptions)
         options.setup?.(app)
       })
     },
-  } as Z
+  } satisfies Plugin as Z
 }
 
 export interface PluginContextConfig<O, E> {

--- a/packages/0/src/composables/createSelection/index.ts
+++ b/packages/0/src/composables/createSelection/index.ts
@@ -306,7 +306,7 @@ export function createSelection<
     get size () {
       return model.size
     },
-  } as R
+  } satisfies SelectionContext<Z, E> as R
 }
 
 /**

--- a/packages/0/src/composables/createSingle/index.ts
+++ b/packages/0/src/composables/createSingle/index.ts
@@ -36,7 +36,7 @@ import { toRef } from 'vue'
 import type { SelectionContext, SelectionContextOptions, SelectionOptions, SelectionTicket, SelectionTicketInput } from '#v0/composables/createSelection'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
 import type { ID } from '#v0/types'
-import type { ComputedRef } from 'vue'
+import type { Ref } from 'vue'
 
 /**
  * Input type for single selection tickets.
@@ -60,10 +60,10 @@ export interface SingleContext<
   Z extends SingleTicketInput = SingleTicketInput,
   E extends SingleTicket<Z> = SingleTicket<Z>,
 > extends Omit<SelectionContext<Z, E>, 'register' | 'onboard'> {
-  selectedId: ComputedRef<ID | undefined>
-  selectedIndex: ComputedRef<number>
-  selectedItem: ComputedRef<E | undefined>
-  selectedValue: ComputedRef<E['value'] | undefined>
+  selectedId: Readonly<Ref<ID | undefined>>
+  selectedIndex: Readonly<Ref<number>>
+  selectedItem: Readonly<Ref<E | undefined>>
+  selectedValue: Readonly<Ref<E['value'] | undefined>>
   /** Register a new ticket (accepts input type, returns output type) */
   register: (ticket?: Partial<Z>) => E
   /** Onboard multiple tickets at once */
@@ -162,7 +162,7 @@ export function createSingle<
     get size () {
       return registry.size
     },
-  } as R
+  } satisfies SingleContext<Z, E> as R
 }
 
 /**

--- a/packages/0/src/composables/createStep/index.ts
+++ b/packages/0/src/composables/createStep/index.ts
@@ -236,7 +236,7 @@ export function createStep<
     get size () {
       return registry.size
     },
-  } as R
+  } satisfies StepContext<Z, E> as R
 }
 
 /**


### PR DESCRIPTION
## Problem

The audit's type review (probe-verified): createModel, createSelection, createSingle, createGroup, createStep, createNested, and createPlugin all return through bare casts (`as R` / `as unknown as R`), so TypeScript never verified the returned literal implements the declared context. A removed method or drifted member type shipped silently — the createProgress frozen-`size` bug was this failure mode live.

## Fix

Each factory return now passes `satisfies <BaseContext>` before the cast. The compiler immediately surfaced 11 real drift errors the casts were hiding:

| Drift | Correction |
|---|---|
| `ModelContext.selectedValues` computed produced `Set<unknown>` vs the declared ref-unwrap element type | computed now types the unwrap `toValue` actually performs |
| `SingleContext` ×4 + `GroupContext.isNoneSelected` declared `ComputedRef`, implemented as `toRef` | interfaces corrected to `Readonly<Ref>` — the §4.2 boundary type and the house `toRef`-default rule |
| createNested spread an **un-parameterized** `createGroup`, so `openedItems`/`selectedItems`/etc. carried `GroupTicket` types instead of `NestedTicket` | internal group is `createGroup<NestedTicketInput, NestedTicket>`; the now-redundant `as unknown as NestedContext` cast is removed entirely |

## Scope notes

- `ComputedRef` → `Readonly<Ref>` on five interface members is the only public-type change; `ComputedRef` is assignable to `Readonly<Ref>`, so consumer reads are unaffected.
- The caller-side hole (`createSelection<Z, E, Fake>()` fabricating surface) is deliberately unchanged — closing it removes R from public signatures, a breaking change for post-1.0.

Full suite 6044 passed; packages/0 and paper vue-tsc clean.