### PR TITLE
test(AlertDialog,Dialog): cover renderless onClick exposure for action handlers

### DIFF
--- a/packages/0/src/components/AlertDialog/index.test.ts
+++ b/packages/0/src/components/AlertDialog/index.test.ts
@@ -99,6 +99,35 @@ describe('alertDialog', () => {
     })
   })
 
+  describe('renderless onClick handlers', () => {
+    it('should expose onClick in slot attrs for activator, action, and cancel', () => {
+      const captured: Record<string, any> = {}
+      function capture (key: string) {
+        return (props: any) => {
+          captured[key] = props
+          return h('button', key)
+        }
+      }
+
+      mountWithStack(AlertDialog.Root, {
+        props: { modelValue: true },
+        slots: {
+          default: () => [
+            h(AlertDialog.Activator as any, {}, { default: capture('activator') }),
+            h(AlertDialog.Action as any, {}, { default: capture('action') }),
+            h(AlertDialog.Cancel as any, {}, { default: capture('cancel') }),
+          ],
+        },
+      })
+
+      // Pre-fix the click handler lived on an `@click` directive (lost in
+      // renderless mode); it must be exposed through slot attrs instead.
+      expect(captured.activator.attrs.onClick).toBeTypeOf('function')
+      expect(captured.action.attrs.onClick).toBeTypeOf('function')
+      expect(captured.cancel.attrs.onClick).toBeTypeOf('function')
+    })
+  })
+
   describe('activator', () => {
     it('should render as button by default', () => {
       const wrapper = mountWithStack(AlertDialog.Root, {

--- a/packages/0/src/components/Dialog/index.test.ts
+++ b/packages/0/src/components/Dialog/index.test.ts
@@ -182,6 +182,33 @@ describe('dialog', () => {
     })
   })
 
+  describe('renderless onClick handlers', () => {
+    it('should expose onClick in slot attrs for activator and close', () => {
+      const captured: Record<string, any> = {}
+      function capture (key: string) {
+        return (props: any) => {
+          captured[key] = props
+          return h('button', key)
+        }
+      }
+
+      mountWithStack(Dialog.Root, {
+        props: { modelValue: true },
+        slots: {
+          default: () => [
+            h(Dialog.Activator as any, {}, { default: capture('activator') }),
+            h(Dialog.Close as any, {}, { default: capture('close') }),
+          ],
+        },
+      })
+
+      // Pre-fix the click handler lived on an `@click` directive (lost in
+      // renderless mode); it must be exposed through slot attrs instead.
+      expect(captured.activator.attrs.onClick).toBeTypeOf('function')
+      expect(captured.close.attrs.onClick).toBeTypeOf('function')
+    })
+  })
+
   describe('activator', () => {
     describe('rendering', () => {
       it('should render as button by default', () => {


### PR DESCRIPTION
Follow-up test coverage for #297 (merged without a test). Adds slot-attrs `onClick` assertions for AlertDialog Activator/Action/Cancel and Dialog Activator/Close — RED against pre-fix sources, GREEN against the merged fix.