### PR TITLE
fix(components): forward renderless to Atom and expose element contracts in slot attrs

### DIFF
--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -50,6 +50,9 @@
       'aria-modal': 'true'
       'aria-labelledby': string
       'aria-describedby': string
+      'style': { zIndex: number }
+      'onCancel': (e: Event) => void
+      'onClose': (e: Event) => void
     }
   }
 </script>
@@ -81,6 +84,7 @@
     closeOnClickOutside = false,
     closeOnEscape = false,
     blocking = false,
+    renderless,
   } = defineProps<AlertDialogContentProps>()
 
   const emit = defineEmits<AlertDialogContentEmits>()
@@ -149,8 +153,6 @@
     emit('close', e)
   }
 
-  const styles = toRef(() => ({ zIndex: ticket.zIndex.value }))
-
   const slotProps = toRef((): AlertDialogContentSlotProps => ({
     isOpen: context.isOpen.value,
     globalTop: ticket.globalTop.value,
@@ -161,6 +163,9 @@
       'aria-modal': 'true',
       'aria-labelledby': context.titleId,
       'aria-describedby': context.descriptionId,
+      'style': { zIndex: ticket.zIndex.value },
+      'onCancel': onCancel,
+      'onClose': onClose,
     },
   }))
 </script>
@@ -169,10 +174,8 @@
   <Atom
     ref="content"
     :as
-    :style="styles"
+    :renderless
     v-bind="slotProps.attrs"
-    @cancel="onCancel"
-    @close="onClose"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
@@ -44,6 +44,7 @@
   const {
     as = 'p',
     namespace = 'v0:alert-dialog',
+    renderless,
   } = defineProps<AlertDialogDescriptionProps>()
 
   const context = useAlertDialogContext(namespace)
@@ -58,6 +59,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
@@ -44,6 +44,7 @@
   const {
     as = 'h2',
     namespace = 'v0:alert-dialog',
+    renderless,
   } = defineProps<AlertDialogTitleProps>()
 
   const context = useAlertDialogContext(namespace)
@@ -58,6 +59,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/AlertDialog/index.test.ts
+++ b/packages/0/src/components/AlertDialog/index.test.ts
@@ -415,6 +415,30 @@ describe('alertDialog', () => {
       outsideEl.remove()
       HTMLDialogElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
     })
+
+    it('should expose the modal contract in slot attrs so renderless mode works', async () => {
+      let captured: any
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { modelValue: true },
+        slots: {
+          default: () => h(AlertDialog.Content, { renderless: true }, {
+            default: (props: any) => {
+              captured = props
+              return h('section', { 'data-testid': 'custom-content', ...props.attrs }, 'Content')
+            },
+          }),
+        },
+      })
+
+      await nextTick()
+      expect(captured.attrs.role).toBe('alertdialog')
+      expect(captured.attrs['aria-modal']).toBe('true')
+
+      const custom = wrapper.find('[data-testid="custom-content"]')
+      expect(custom.element.parentElement?.tagName).not.toBe('DIALOG')
+      expect(wrapper.findAll('[role="alertdialog"]')).toHaveLength(1)
+    })
   })
 
   describe('title', () => {
@@ -444,6 +468,30 @@ describe('alertDialog', () => {
       const title = wrapper.findComponent(AlertDialog.Title as any)
       expect(title.attributes('id')).toBe('test-alert-title')
     })
+
+    it('should expose id in slot attrs so renderless mode works', () => {
+      let captured: any
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'test-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Title, { renderless: true }, {
+              default: (props: any) => {
+                captured = props
+                return h('span', { 'data-testid': 'custom-title', ...props.attrs }, 'Title')
+              },
+            }),
+          ]),
+        },
+      })
+
+      expect(captured.attrs.id).toBe('test-alert-title')
+
+      const custom = wrapper.find('[data-testid="custom-title"]')
+      expect(custom.element.parentElement?.tagName).not.toBe('H2')
+      expect(wrapper.findAll('#test-alert-title')).toHaveLength(1)
+    })
   })
 
   describe('description', () => {
@@ -472,6 +520,30 @@ describe('alertDialog', () => {
 
       const description = wrapper.findComponent(AlertDialog.Description as any)
       expect(description.attributes('id')).toBe('test-alert-description')
+    })
+
+    it('should expose id in slot attrs so renderless mode works', () => {
+      let captured: any
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'test-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Description, { renderless: true }, {
+              default: (props: any) => {
+                captured = props
+                return h('span', { 'data-testid': 'custom-description', ...props.attrs }, 'Description')
+              },
+            }),
+          ]),
+        },
+      })
+
+      expect(captured.attrs.id).toBe('test-alert-description')
+
+      const custom = wrapper.find('[data-testid="custom-description"]')
+      expect(custom.element.parentElement?.tagName).not.toBe('P')
+      expect(wrapper.findAll('#test-alert-description')).toHaveLength(1)
     })
   })
 

--- a/packages/0/src/components/Collapsible/CollapsibleCue.vue
+++ b/packages/0/src/components/Collapsible/CollapsibleCue.vue
@@ -45,6 +45,7 @@
   const {
     as = 'span',
     namespace = 'v0:collapsible',
+    renderless,
   } = defineProps<CollapsibleCueProps>()
 
   const context = useCollapsible(namespace)
@@ -61,6 +62,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Collapsible/index.test.ts
+++ b/packages/0/src/components/Collapsible/index.test.ts
@@ -737,6 +737,26 @@ describe('collapsible', () => {
         expect(cueProps().isOpen).toBe(true)
       })
     })
+
+    describe('renderless', () => {
+      it('should not render a wrapper element when renderless', async () => {
+        const wrapper = mount(Collapsible.Root, {
+          slots: {
+            default: () => h(Collapsible.Cue as any, { renderless: true }, {
+              default: (props: any) => h('i', { 'data-testid': 'custom', ...props.attrs }, '▼'),
+            }),
+          },
+        })
+
+        await nextTick()
+
+        const custom = wrapper.find('[data-testid="custom"]')
+        expect(custom.attributes('aria-hidden')).toBe('true')
+        expect(custom.attributes('data-state')).toBe('closed')
+        expect(wrapper.find('span').exists()).toBe(false)
+        expect(wrapper.findAll('[aria-hidden]')).toHaveLength(1)
+      })
+    })
   })
 
   describe('integration', () => {

--- a/packages/0/src/components/Combobox/ComboboxActivator.vue
+++ b/packages/0/src/components/Combobox/ComboboxActivator.vue
@@ -32,6 +32,7 @@
     /** Attributes to bind to the activator element */
     attrs: {
       'data-state': 'open' | 'closed'
+      'style': Record<string, string>
     }
   }
 </script>
@@ -46,16 +47,16 @@
   const {
     as = 'div',
     namespace = 'v0:combobox',
+    renderless,
   } = defineProps<ComboboxActivatorProps>()
 
   const context = useComboboxContext(namespace)
-
-  const style = toRef(() => context.popover.anchorStyles.value)
 
   const slotProps = toRef((): ComboboxActivatorSlotProps => ({
     isOpen: context.isOpen.value,
     attrs: {
       'data-state': context.isOpen.value ? 'open' : 'closed',
+      'style': context.popover.anchorStyles.value,
     },
   }))
 </script>
@@ -64,7 +65,7 @@
   <Atom
     v-bind="slotProps.attrs"
     :as
-    :style
+    :renderless
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Combobox/ComboboxContent.vue
+++ b/packages/0/src/components/Combobox/ComboboxContent.vue
@@ -55,6 +55,7 @@
     as = 'div',
     namespace = 'v0:combobox',
     eager = false,
+    renderless,
   } = defineProps<ComboboxContentProps>()
 
   const context = useComboboxContext(namespace)
@@ -84,10 +85,9 @@
       'aria-multiselectable': context.multiple || undefined,
       'popover': 'manual',
       'tabindex': -1,
+      'style': context.popover.contentStyles.value,
     },
   }))
-
-  const style = toRef(() => context.popover.contentStyles.value)
 </script>
 
 <template>
@@ -95,7 +95,7 @@
     ref="content"
     v-bind="slotProps.attrs"
     :as
-    :style
+    :renderless
   >
     <slot v-if="hasContent" v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Combobox/ComboboxControl.vue
+++ b/packages/0/src/components/Combobox/ComboboxControl.vue
@@ -50,6 +50,8 @@
       'aria-invalid': boolean | undefined
       'aria-disabled': boolean
       'disabled': boolean | undefined
+      'placeholder': string | undefined
+      'value': string
       'onInput': (e: Event) => void
       'onFocus': () => void
       'onKeydown': (e: KeyboardEvent) => void
@@ -69,6 +71,7 @@
     namespace = 'v0:combobox',
     openOn = 'focus',
     placeholder,
+    renderless,
   } = defineProps<ComboboxControlProps>()
 
   const context = useComboboxContext(namespace)
@@ -154,6 +157,8 @@
       'aria-invalid': invalid.value || undefined,
       'aria-disabled': toValue(context.disabled),
       'disabled': toValue(context.disabled) || undefined,
+      'placeholder': placeholder,
+      'value': context.display.value,
       'onInput': onInput,
       'onFocus': onFocus,
       'onKeydown': onKeydown,
@@ -166,8 +171,7 @@
     ref="input"
     v-bind="slotProps.attrs"
     :as
-    :placeholder
-    :value="context.display.value"
+    :renderless
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Combobox/ComboboxCue.vue
+++ b/packages/0/src/components/Combobox/ComboboxCue.vue
@@ -47,6 +47,7 @@
   const {
     as = 'span',
     namespace = 'v0:combobox',
+    renderless,
   } = defineProps<ComboboxCueProps>()
 
   const context = useComboboxContext(namespace)
@@ -69,6 +70,7 @@
   <Atom
     v-bind="slotProps.attrs"
     :as
+    :renderless
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Combobox/ComboboxEmpty.vue
+++ b/packages/0/src/components/Combobox/ComboboxEmpty.vue
@@ -43,6 +43,7 @@
   const {
     as = 'div',
     namespace = 'v0:combobox',
+    renderless,
   } = defineProps<ComboboxEmptyProps>()
 
   const context = useComboboxContext(namespace)
@@ -53,7 +54,7 @@
 </script>
 
 <template>
-  <Atom v-if="context.isEmpty.value" :as>
+  <Atom v-if="context.isEmpty.value" :as :renderless>
     <slot v-bind="slotProps">No results</slot>
   </Atom>
 </template>

--- a/packages/0/src/components/Combobox/ComboboxItem.vue
+++ b/packages/0/src/components/Combobox/ComboboxItem.vue
@@ -78,6 +78,7 @@
     id,
     value,
     disabled,
+    renderless,
   } = defineProps<ComboboxItemProps<V>>()
 
   const context = useComboboxContext(namespace)
@@ -124,6 +125,7 @@
     v-show="isFiltered"
     v-bind="slotProps.attrs"
     :as
+    :renderless
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Combobox/index.test.ts
+++ b/packages/0/src/components/Combobox/index.test.ts
@@ -1517,4 +1517,174 @@ describe('combobox', () => {
       expect((hidden.element as HTMLInputElement).value).toBe('')
     })
   })
+
+  describe('renderless', () => {
+    async function createRenderless (options: {
+      'modelValue'?: unknown
+      'onUpdate:modelValue'?: (v: unknown) => void
+      'adapter'?: InstanceType<typeof ClientComboboxAdapter>
+    } = {}) {
+      const captured: Record<string, any> = {}
+      let context: { open: () => void, close: () => void }
+
+      const wrapper = mount(
+        defineComponent({
+          render () {
+            return h(Combobox.Root as any, options, {
+              default: (sp: typeof context) => {
+                context = sp
+                return [
+                  h(Combobox.Activator as any, { renderless: true }, {
+                    default: (activator: any) => {
+                      captured.activator = activator
+                      return h('div', { 'data-testid': 'activator', ...activator.attrs }, [
+                        h(Combobox.Control as any, { renderless: true, placeholder: 'Search' }, {
+                          default: (control: any) => {
+                            captured.control = control
+                            return h('input', { 'data-testid': 'control', ...control.attrs })
+                          },
+                        }),
+                        h(Combobox.Cue as any, { renderless: true }, {
+                          default: (cue: any) => {
+                            captured.cue = cue
+                            return h('span', { 'data-testid': 'cue', ...cue.attrs })
+                          },
+                        }),
+                      ])
+                    },
+                  }),
+                  h(Combobox.Content as any, { renderless: true, eager: true }, {
+                    default: (content: any) => {
+                      captured.content = content
+                      return h('ul', { 'data-testid': 'content', ...content.attrs }, [
+                        ...['Apple', 'Banana', 'Cherry'].map(value =>
+                          h(Combobox.Item as any, { key: value, value, renderless: true }, {
+                            default: (item: any) => {
+                              captured[value] = item
+                              return h('li', { 'data-testid': `item-${value}`, ...item.attrs }, value)
+                            },
+                          }),
+                        ),
+                        h(Combobox.Empty as any, { renderless: true }, {
+                          default: () => h('li', { 'data-testid': 'empty' }, 'No results'),
+                        }),
+                      ])
+                    },
+                  }),
+                ]
+              },
+            })
+          },
+        }),
+        { attachTo: document.body },
+      )
+
+      wrappers.push(wrapper)
+      await nextTick()
+
+      return {
+        wrapper,
+        captured,
+        open: () => context!.open(),
+        close: () => context!.close(),
+      }
+    }
+
+    it('should forward the combobox contract to a renderless control', async () => {
+      const { wrapper, captured } = await createRenderless()
+
+      const control = wrapper.find('[data-testid="control"]')
+      expect(control.exists()).toBe(true)
+      expect(wrapper.findAll('input')).toHaveLength(1)
+      expect(control.attributes('role')).toBe('combobox')
+      expect(control.attributes('aria-haspopup')).toBe('listbox')
+      expect(control.attributes('aria-controls')).toBe(captured.content.attrs.id)
+      expect(control.attributes('placeholder')).toBe('Search')
+      expect(captured.control.attrs.onInput).toBeTypeOf('function')
+      expect(captured.control.attrs.onFocus).toBeTypeOf('function')
+      expect(captured.control.attrs.onKeydown).toBeTypeOf('function')
+
+      await control.trigger('focus')
+      await nextTick()
+
+      expect(control.attributes('aria-expanded')).toBe('true')
+    })
+
+    it('should forward the listbox contract to renderless content', async () => {
+      const { wrapper, captured } = await createRenderless()
+
+      const listboxes = wrapper.findAll('[role="listbox"]')
+      expect(listboxes).toHaveLength(1)
+      expect(listboxes[0]!.element.tagName).toBe('UL')
+      expect(captured.content.attrs.id).toBeDefined()
+      expect(captured.content.attrs.popover).toBe('manual')
+      expect(captured.content.attrs['aria-labelledby']).toBe(captured.control.attrs.id)
+      expect(captured.content.attrs.style['position-anchor']).toMatch(/^--/)
+    })
+
+    it('should forward the option contract to renderless items', async () => {
+      const selected = ref<string>()
+      const { wrapper, captured } = await createRenderless({
+        'modelValue': selected.value,
+        'onUpdate:modelValue': v => {
+          selected.value = v as string
+        },
+      })
+
+      const options = wrapper.findAll('[role="option"]')
+      expect(options).toHaveLength(3)
+      expect(options.every(o => o.element.tagName === 'LI')).toBe(true)
+      expect(captured.Apple.attrs.onClick).toBeTypeOf('function')
+      expect(captured.Apple.attrs['aria-selected']).toBe(false)
+
+      await wrapper.find('[data-testid="item-Apple"]').trigger('click')
+      await nextTick()
+
+      expect(selected.value).toBe('Apple')
+      expect(wrapper.find('[data-testid="item-Apple"]').attributes('data-selected')).toBe('true')
+    })
+
+    it('should forward anchor styles to a renderless activator', async () => {
+      const { wrapper, captured, open } = await createRenderless()
+
+      expect(wrapper.findAll('[data-state]')).toHaveLength(2)
+      expect(captured.activator.attrs['data-state']).toBe('closed')
+      expect(captured.activator.attrs.style.anchorName).toMatch(/^--/)
+
+      open()
+      await nextTick()
+
+      expect(wrapper.find('[data-testid="activator"]').attributes('data-state')).toBe('open')
+    })
+
+    it('should forward the toggle handler to a renderless cue', async () => {
+      const { wrapper, captured } = await createRenderless()
+
+      expect(captured.cue.attrs['aria-hidden']).toBe(true)
+      expect(captured.cue.attrs.onClick).toBeTypeOf('function')
+
+      await wrapper.find('[data-testid="cue"]').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('[data-testid="control"]').attributes('aria-expanded')).toBe('true')
+    })
+
+    it('should render renderless empty state without a wrapper', async () => {
+      const { wrapper, open } = await createRenderless({
+        adapter: new ClientComboboxAdapter(),
+      })
+
+      open()
+      await nextTick()
+
+      const control = wrapper.find('[data-testid="control"]')
+      await control.setValue('zzz')
+      await control.trigger('input')
+      await nextTick()
+
+      const empty = wrapper.find('[data-testid="empty"]')
+      expect(empty.exists()).toBe(true)
+      expect(empty.element.parentElement?.dataset.testid).toBe('content')
+    })
+  })
 })

--- a/packages/0/src/components/Dialog/DialogContent.vue
+++ b/packages/0/src/components/Dialog/DialogContent.vue
@@ -49,6 +49,9 @@
       'aria-modal': 'true'
       'aria-labelledby': string
       'aria-describedby': string
+      'style': { zIndex: number }
+      'onCancel': (e: Event) => void
+      'onClose': (e: Event) => void
     }
   }
 </script>
@@ -79,6 +82,7 @@
     namespace = 'v0:dialog',
     closeOnClickOutside = true,
     blocking = false,
+    renderless,
   } = defineProps<DialogContentProps>()
 
   const emit = defineEmits<DialogContentEmits>()
@@ -143,8 +147,6 @@
     emit('close', e)
   }
 
-  const styles = toRef(() => ({ zIndex: ticket.zIndex.value }))
-
   const slotProps = toRef((): DialogContentSlotProps => ({
     isOpen: context.isOpen.value,
     globalTop: ticket.globalTop.value,
@@ -155,6 +157,9 @@
       'aria-modal': 'true',
       'aria-labelledby': context.titleId,
       'aria-describedby': context.descriptionId,
+      'style': { zIndex: ticket.zIndex.value },
+      'onCancel': onCancel,
+      'onClose': onClose,
     },
   }))
 </script>
@@ -163,10 +168,8 @@
   <Atom
     ref="content"
     :as
-    :style="styles"
+    :renderless
     v-bind="slotProps.attrs"
-    @cancel="onCancel"
-    @close="onClose"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Dialog/DialogDescription.vue
+++ b/packages/0/src/components/Dialog/DialogDescription.vue
@@ -44,6 +44,7 @@
   const {
     as = 'p',
     namespace = 'v0:dialog',
+    renderless,
   } = defineProps<DialogDescriptionProps>()
 
   const context = useDialogContext(namespace)
@@ -58,6 +59,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Dialog/DialogTitle.vue
+++ b/packages/0/src/components/Dialog/DialogTitle.vue
@@ -44,6 +44,7 @@
   const {
     as = 'h2',
     namespace = 'v0:dialog',
+    renderless,
   } = defineProps<DialogTitleProps>()
 
   const context = useDialogContext(namespace)
@@ -58,6 +59,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Dialog/index.test.ts
+++ b/packages/0/src/components/Dialog/index.test.ts
@@ -336,6 +336,30 @@ describe('dialog', () => {
 
         expect(wrapper.find('p').text()).toBe('Dialog content')
       })
+
+      it('should expose the modal contract in slot attrs so renderless mode works', async () => {
+        let captured: any
+
+        const wrapper = mountWithStack(Dialog.Root, {
+          props: { modelValue: true },
+          slots: {
+            default: () => h(Dialog.Content, { renderless: true }, {
+              default: (props: any) => {
+                captured = props
+                return h('section', { 'data-testid': 'custom-content', ...props.attrs }, 'Content')
+              },
+            }),
+          },
+        })
+
+        await nextTick()
+        expect(captured.attrs.role).toBe('dialog')
+        expect(captured.attrs['aria-modal']).toBe('true')
+
+        const custom = wrapper.find('[data-testid="custom-content"]')
+        expect(custom.element.parentElement?.tagName).not.toBe('DIALOG')
+        expect(wrapper.findAll('[role="dialog"]')).toHaveLength(1)
+      })
     })
 
     describe('accessibility', () => {
@@ -720,6 +744,30 @@ describe('dialog', () => {
         const title = wrapper.findComponent(Dialog.Title as any)
         expect(title.element.tagName).toBe('SPAN')
       })
+
+      it('should expose id in slot attrs so renderless mode works', () => {
+        let captured: any
+
+        const wrapper = mountWithStack(Dialog.Root, {
+          props: { id: 'test-dialog' },
+          slots: {
+            default: () => h(Dialog.Content, {}, () => [
+              h(Dialog.Title, { renderless: true }, {
+                default: (props: any) => {
+                  captured = props
+                  return h('span', { 'data-testid': 'custom-title', ...props.attrs }, 'Title')
+                },
+              }),
+            ]),
+          },
+        })
+
+        expect(captured.attrs.id).toBe('test-dialog-title')
+
+        const custom = wrapper.find('[data-testid="custom-title"]')
+        expect(custom.element.parentElement?.tagName).not.toBe('H2')
+        expect(wrapper.findAll('#test-dialog-title')).toHaveLength(1)
+      })
     })
 
     describe('accessibility', () => {
@@ -765,6 +813,30 @@ describe('dialog', () => {
 
         const description = wrapper.findComponent(Dialog.Description as any)
         expect(description.element.tagName).toBe('SPAN')
+      })
+
+      it('should expose id in slot attrs so renderless mode works', () => {
+        let captured: any
+
+        const wrapper = mountWithStack(Dialog.Root, {
+          props: { id: 'test-dialog' },
+          slots: {
+            default: () => h(Dialog.Content, {}, () => [
+              h(Dialog.Description, { renderless: true }, {
+                default: (props: any) => {
+                  captured = props
+                  return h('span', { 'data-testid': 'custom-description', ...props.attrs }, 'Description')
+                },
+              }),
+            ]),
+          },
+        })
+
+        expect(captured.attrs.id).toBe('test-dialog-description')
+
+        const custom = wrapper.find('[data-testid="custom-description"]')
+        expect(custom.element.parentElement?.tagName).not.toBe('P')
+        expect(wrapper.findAll('#test-dialog-description')).toHaveLength(1)
       })
     })
 

--- a/packages/0/src/components/ExpansionPanel/ExpansionPanelCue.vue
+++ b/packages/0/src/components/ExpansionPanel/ExpansionPanelCue.vue
@@ -45,6 +45,7 @@
   const {
     as = 'span',
     namespace = 'v0:expansion-panel',
+    renderless,
   } = defineProps<ExpansionPanelCueProps>()
 
   const context = useExpansionPanelRoot(namespace)
@@ -61,6 +62,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/ExpansionPanel/index.test.ts
+++ b/packages/0/src/components/ExpansionPanel/index.test.ts
@@ -1321,5 +1321,25 @@ describe('expansionPanel', () => {
       expect(cue.exists()).toBe(true)
       expect(cue.attributes('aria-hidden')).toBe('true')
     })
+
+    it('should not render a wrapper element when renderless', () => {
+      const wrapper = mount(ExpansionPanel.Group, {
+        slots: {
+          default: () =>
+            h(
+              ExpansionPanel.Root as any,
+              { id: 'item-1', value: 'value-1' },
+              () => h(ExpansionPanel.Cue, { renderless: true }, {
+                default: (props: any) => h('i', { 'data-testid': 'custom', ...props.attrs }, 'cue'),
+              }),
+            ),
+        },
+      })
+
+      const custom = wrapper.find('[data-testid="custom"]')
+      expect(custom.attributes('aria-hidden')).toBe('true')
+      expect(custom.attributes('data-state')).toBe('closed')
+      expect(wrapper.find('span').exists()).toBe(false)
+    })
   })
 })

--- a/packages/0/src/components/Form/Form.vue
+++ b/packages/0/src/components/Form/Form.vue
@@ -35,6 +35,11 @@
     submit: () => Promise<boolean>
     /** Reset all field validations */
     reset: () => void
+    /** Attributes to bind to the form element */
+    attrs: {
+      onSubmit: (event: Event) => void
+      onReset: (event: Event) => void
+    }
   }
 </script>
 
@@ -47,7 +52,7 @@
   import { createForm } from '#v0/composables/createForm'
 
   // Utilities
-  import { toRef, toValue, useAttrs, watchEffect } from 'vue'
+  import { mergeProps, toRef, toValue, useAttrs, watchEffect } from 'vue'
 
   // eslint-disable-next-line vue/no-reserved-component-names
   defineOptions({ name: 'Form', inheritAttrs: false })
@@ -67,6 +72,7 @@
     namespace = 'v0:form',
     disabled = false,
     readonly = false,
+    renderless,
   } = defineProps<FormProps>()
 
   const model = defineModel<boolean | null>({ default: null })
@@ -103,15 +109,18 @@
     isReadonly: toValue(form.readonly),
     submit: form.submit,
     reset: form.reset,
+    attrs: {
+      onSubmit,
+      onReset,
+    },
   }))
 </script>
 
 <template>
   <Atom
+    v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
-    v-bind="attrs"
-    @reset="onReset"
-    @submit="onSubmit"
+    :renderless
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Form/index.test.ts
+++ b/packages/0/src/components/Form/index.test.ts
@@ -36,6 +36,45 @@ describe('form', () => {
     })
   })
 
+  describe('renderless', () => {
+    it('should expose onSubmit and onReset in slot attrs so renderless mode works', async () => {
+      let slot: any
+
+      const wrapper = mount(Form, {
+        props: { renderless: true },
+        slots: {
+          default: (props: any) => {
+            slot = props
+            return h('form', { 'data-testid': 'custom', ...props.attrs })
+          },
+        },
+      })
+
+      expect(slot.attrs.onSubmit).toBeTypeOf('function')
+      expect(slot.attrs.onReset).toBeTypeOf('function')
+
+      const form = wrapper.find('form')
+      expect(form.exists()).toBe(true)
+      expect(form.element.dataset.testid).toBe('custom')
+      expect(form.element.parentElement?.tagName).not.toBe('FORM')
+      expect(wrapper.findAll('form')).toHaveLength(1)
+
+      const submit = new Event('submit', { bubbles: true, cancelable: true })
+      form.element.dispatchEvent(submit)
+      await flushPromises()
+
+      expect(submit.defaultPrevented).toBe(true)
+      expect(wrapper.emitted('submit')).toHaveLength(1)
+
+      const reset = new Event('reset', { bubbles: true, cancelable: true })
+      form.element.dispatchEvent(reset)
+      await nextTick()
+
+      expect(reset.defaultPrevented).toBe(true)
+      expect(wrapper.emitted('reset')).toHaveLength(1)
+    })
+  })
+
   describe('context provision', () => {
     it('should provide form context consumable via useForm()', () => {
       let injected: ReturnType<typeof useForm>

--- a/packages/0/src/components/Popover/PopoverActivator.vue
+++ b/packages/0/src/components/Popover/PopoverActivator.vue
@@ -25,6 +25,7 @@
       'popovertarget': string
       'type': 'button' | undefined
       'data-open': true | undefined
+      'style': Record<string, string>
     }
   }
 </script>
@@ -45,7 +46,7 @@
     default: (props: PopoverActivatorSlotProps) => any
   }>()
 
-  const { as = 'button', target } = defineProps<PopoverActivatorProps>()
+  const { as = 'button', renderless, target } = defineProps<PopoverActivatorProps>()
 
   const context = usePopoverContext()
 
@@ -64,6 +65,7 @@
       'popovertarget': toValue(popovertarget),
       'type': as === 'button' ? 'button' : undefined,
       'data-open': context.isOpen.value || undefined,
+      'style': style.value,
     },
   }))
 </script>
@@ -71,7 +73,7 @@
 <template>
   <Atom
     :as
-    :style
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Popover/PopoverContent.vue
+++ b/packages/0/src/components/Popover/PopoverContent.vue
@@ -33,6 +33,8 @@
     attrs: {
       id: string
       popover: ''
+      style: Record<string, string>
+      onBeforetoggle: (e: ToggleEvent) => void
     }
   }
 </script>
@@ -58,6 +60,7 @@
     id: _id,
     positionArea,
     positionTry,
+    renderless,
   } = defineProps<PopoverContentProps>()
 
   const emit = defineEmits<PopoverContentEmits>()
@@ -92,6 +95,8 @@
     attrs: {
       id: id.value,
       popover: '',
+      style: style.value,
+      onBeforetoggle: onBeforeToggle,
     },
   }))
 </script>
@@ -100,9 +105,8 @@
   <Atom
     ref="ref"
     :as
-    :style
+    :renderless
     v-bind="slotProps.attrs"
-    @beforetoggle="onBeforeToggle"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Popover/index.test.ts
+++ b/packages/0/src/components/Popover/index.test.ts
@@ -282,6 +282,36 @@ describe('popover', () => {
         expect(anchorProps.attrs['data-open']).toBe(true)
       })
     })
+
+    describe('renderless', () => {
+      it('should expose anchor attrs and style in slot props so renderless mode works', async () => {
+        let anchorProps: any
+
+        const wrapper = mount(Popover.Root, {
+          props: { id: 'test-popover' },
+          slots: {
+            default: () => h('div', [
+              h(Popover.Activator, { renderless: true }, {
+                default: (props: any) => {
+                  anchorProps = props
+                  return h('button', { 'data-testid': 'custom', ...props.attrs }, 'Toggle')
+                },
+              }),
+            ]),
+          },
+        })
+
+        await nextTick()
+
+        expect(anchorProps.attrs.popovertarget).toBe('test-popover')
+        expect(anchorProps.attrs.style.anchorName).toBe('--test-popover')
+
+        const custom = wrapper.find('[data-testid="custom"]')
+        expect(custom.attributes('popovertarget')).toBe('test-popover')
+        expect(custom.element.parentElement?.tagName).toBe('DIV')
+        expect(wrapper.findAll('button')).toHaveLength(1)
+      })
+    })
   })
 
   describe('content', () => {
@@ -438,6 +468,41 @@ describe('popover', () => {
         await content.trigger('beforetoggle', { newState: 'open' })
 
         expect(beforetoggle).toHaveBeenCalled()
+      })
+    })
+
+    describe('renderless', () => {
+      it('should expose popover attrs, style, and onBeforetoggle in slot props so renderless mode works', async () => {
+        let contentProps: any
+
+        const wrapper = mount(Popover.Root, {
+          props: { id: 'test-popover' },
+          slots: {
+            default: () => h('div', [
+              h(Popover.Content, { renderless: true }, {
+                default: (props: any) => {
+                  contentProps = props
+                  return h('div', { 'data-testid': 'custom', ...props.attrs }, 'Content')
+                },
+              }),
+            ]),
+          },
+        })
+
+        await nextTick()
+
+        expect(contentProps.attrs.popover).toBe('')
+        expect(contentProps.attrs.style).toBeDefined()
+        expect(contentProps.attrs.onBeforetoggle).toBeTypeOf('function')
+
+        const custom = wrapper.find('[data-testid="custom"]')
+        expect(custom.attributes('id')).toBe('test-popover')
+        expect(wrapper.findAll('[popover]')).toHaveLength(1)
+
+        await custom.trigger('beforetoggle', { newState: 'open' })
+
+        const content = wrapper.findComponent(Popover.Content as any)
+        expect(content.emitted('beforetoggle')).toHaveLength(1)
       })
     })
   })

--- a/packages/0/src/components/Select/SelectActivator.vue
+++ b/packages/0/src/components/Select/SelectActivator.vue
@@ -40,6 +40,7 @@
       'aria-haspopup': 'listbox'
       'aria-controls': string
       'data-open': true | undefined
+      'style': Record<string, string>
       'onClick': () => void
       'onKeydown': (e: KeyboardEvent) => void
     }
@@ -56,6 +57,7 @@
   const {
     as = 'button',
     namespace = 'v0:select',
+    renderless,
   } = defineProps<SelectActivatorProps>()
 
   const context = useSelectContext(namespace)
@@ -111,8 +113,6 @@
     }
   }
 
-  const style = toRef(() => context.popover.anchorStyles.value)
-
   const slotProps = toRef((): SelectActivatorSlotProps => ({
     isOpen: context.isOpen.value,
     attrs: {
@@ -123,6 +123,7 @@
       'aria-haspopup': 'listbox',
       'aria-controls': context.listboxId,
       'data-open': context.isOpen.value || undefined,
+      'style': context.popover.anchorStyles.value,
       onClick,
       onKeydown,
     },
@@ -133,7 +134,7 @@
   <Atom
     ref="activator"
     :as
-    :style
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Select/SelectContent.vue
+++ b/packages/0/src/components/Select/SelectContent.vue
@@ -39,7 +39,14 @@
     /** Whether the dropdown is open */
     isOpen: boolean
     /** Attributes to bind to the content element */
-    attrs: Record<string, unknown>
+    attrs: {
+      'id': string
+      'popover': ''
+      'role': 'listbox'
+      'aria-multiselectable': true | undefined
+      'tabindex': -1
+      'style': Record<string, string>
+    }
   }
 </script>
 
@@ -53,6 +60,7 @@
   const {
     as = 'div',
     namespace = 'v0:select',
+    renderless,
     eager = false,
   } = defineProps<SelectContentProps>()
 
@@ -71,18 +79,17 @@
       'role': 'listbox',
       'aria-multiselectable': context.multiple || undefined,
       'tabindex': -1,
+      'style': context.popover.contentStyles.value,
     },
   }))
-
-  const style = toRef(() => context.popover.contentStyles.value)
 </script>
 
 <template>
   <Atom
     ref="content"
-    v-bind="slotProps.attrs"
     :as
-    :style
+    :renderless
+    v-bind="slotProps.attrs"
   >
     <slot v-if="hasContent" v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Select/SelectCue.vue
+++ b/packages/0/src/components/Select/SelectCue.vue
@@ -45,6 +45,7 @@
   const {
     as = 'span',
     namespace = 'v0:select',
+    renderless,
   } = defineProps<SelectCueProps>()
 
   const context = useSelectContext(namespace)
@@ -61,6 +62,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Select/SelectItem.vue
+++ b/packages/0/src/components/Select/SelectItem.vue
@@ -70,6 +70,7 @@
   const {
     as = 'div',
     namespace = 'v0:select',
+    renderless,
     id,
     value,
     disabled,
@@ -115,6 +116,7 @@
 <template>
   <Atom
     :as
+    :renderless
     v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />

--- a/packages/0/src/components/Select/SelectPlaceholder.vue
+++ b/packages/0/src/components/Select/SelectPlaceholder.vue
@@ -42,6 +42,7 @@
   const {
     as = 'span',
     namespace = 'v0:select',
+    renderless,
   } = defineProps<SelectPlaceholderProps>()
 
   const context = useSelectContext(namespace)
@@ -53,7 +54,7 @@
 </script>
 
 <template>
-  <Atom v-if="!hasValue" :as>
+  <Atom v-if="!hasValue" :as :renderless>
     <slot :has-value />
   </Atom>
 </template>

--- a/packages/0/src/components/Select/SelectValue.vue
+++ b/packages/0/src/components/Select/SelectValue.vue
@@ -55,6 +55,7 @@
   const {
     as = 'span',
     namespace = 'v0:select',
+    renderless,
   } = defineProps<SelectValueProps>()
 
   const context = useSelectContext(namespace)
@@ -86,7 +87,7 @@
 </script>
 
 <template>
-  <Atom v-if="hasValue" :as>
+  <Atom v-if="hasValue" :as :renderless>
     <slot v-bind="slotProps">
       {{ values[0] }}
     </slot>

--- a/packages/0/src/components/Select/index.test.ts
+++ b/packages/0/src/components/Select/index.test.ts
@@ -1211,6 +1211,102 @@ describe('select', () => {
       expect(wrapper.find('.child').exists()).toBe(true)
     })
 
+    it('should render Select.Content without a wrapper and expose the listbox contract in renderless mode', async () => {
+      let captured: any
+      const wrapper = mount(
+        defineComponent({
+          render () {
+            return h(Select.Root as any, { multiple: true }, {
+              default: () => h(Select.Content as any, { eager: true, renderless: true }, {
+                default: (props: any) => {
+                  captured = props
+                  return h('ul', props.attrs)
+                },
+              }),
+            })
+          },
+        }),
+      )
+
+      await nextTick()
+
+      const lists = wrapper.findAll('[role="listbox"]')
+      expect(lists).toHaveLength(1)
+      expect(lists[0]!.element.tagName).toBe('UL')
+      expect(lists[0]!.element.parentElement?.getAttribute('role')).toBeNull()
+      expect(captured.attrs.role).toBe('listbox')
+      expect(captured.attrs.popover).toBe('')
+      expect(captured.attrs['aria-multiselectable']).toBe(true)
+      expect(captured.attrs.tabindex).toBe(-1)
+      expect(captured.attrs.id).toBeDefined()
+      expect(captured.attrs.style).toBeDefined()
+    })
+
+    it('should render Select.Item without a wrapper and expose the option contract in renderless mode', async () => {
+      let captured: any
+      const wrapper = mount(
+        defineComponent({
+          render () {
+            return h(Select.Root as any, {}, {
+              default: () => h(Select.Content as any, { eager: true }, {
+                default: () => h(Select.Item as any, { value: 'Apple', renderless: true }, {
+                  default: (props: any) => {
+                    captured = props
+                    return h('li', props.attrs, 'Apple')
+                  },
+                }),
+              }),
+            })
+          },
+        }),
+      )
+
+      await nextTick()
+
+      const options = wrapper.findAll('[role="option"]')
+      expect(options).toHaveLength(1)
+      expect(options[0]!.element.tagName).toBe('LI')
+      expect(options[0]!.element.parentElement?.getAttribute('role')).toBe('listbox')
+      expect(captured.attrs.role).toBe('option')
+      expect(captured.attrs['aria-selected']).toBe(false)
+      expect(captured.attrs.onClick).toBeTypeOf('function')
+
+      await wrapper.find('li').trigger('click')
+      expect(captured.isSelected).toBe(true)
+    })
+
+    it('should render Select.Activator without a wrapper and expose anchor styles in renderless mode', async () => {
+      let captured: any
+      const wrapper = mount(
+        defineComponent({
+          render () {
+            return h(Select.Root as any, {}, {
+              default: () => h(Select.Activator as any, { renderless: true }, {
+                default: (props: any) => {
+                  captured = props
+                  return h('button', props.attrs, 'Open')
+                },
+              }),
+            })
+          },
+        }),
+      )
+
+      await nextTick()
+
+      const activators = wrapper.findAll('[role="combobox"]')
+      expect(activators).toHaveLength(1)
+      expect(activators[0]!.element.tagName).toBe('BUTTON')
+      expect(activators[0]!.element.parentElement?.getAttribute('role')).toBeNull()
+      expect(captured.attrs.role).toBe('combobox')
+      expect(captured.attrs.style.anchorName).toBeDefined()
+      expect(captured.attrs.onClick).toBeTypeOf('function')
+      expect(captured.attrs.onKeydown).toBeTypeOf('function')
+
+      await wrapper.find('button').trigger('click')
+      expect(captured.isOpen).toBe(true)
+    })
+
     it('should use activator id from root', async () => {
       const { wrapper } = await createSelect({ id: 'my-select' })
 

--- a/packages/0/src/components/Snackbar/SnackbarClose.vue
+++ b/packages/0/src/components/Snackbar/SnackbarClose.vue
@@ -47,7 +47,7 @@
     default: (props: SnackbarCloseSlotProps) => any
   }>()
 
-  const { as = 'button', namespace = 'v0:notifications' } = defineProps<SnackbarCloseProps>()
+  const { as = 'button', namespace = 'v0:notifications', renderless } = defineProps<SnackbarCloseProps>()
 
   const context = useSnackbarRootContext(namespace)
   const locale = useLocale()
@@ -67,8 +67,9 @@
 
 <template>
   <Atom
-    v-bind="slotProps.attrs"
     :as
+    :renderless
+    v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Snackbar/SnackbarContent.vue
+++ b/packages/0/src/components/Snackbar/SnackbarContent.vue
@@ -24,11 +24,11 @@
     default: () => any
   }>()
 
-  const { as = 'div' } = defineProps<SnackbarContentProps>()
+  const { as = 'div', renderless } = defineProps<SnackbarContentProps>()
 </script>
 
 <template>
-  <Atom :as>
+  <Atom :as :renderless>
     <slot />
   </Atom>
 </template>

--- a/packages/0/src/components/Snackbar/SnackbarQueue.vue
+++ b/packages/0/src/components/Snackbar/SnackbarQueue.vue
@@ -57,7 +57,7 @@
     default: (props: SnackbarQueueSlotProps) => any
   }>()
 
-  const { as = 'div', namespace = 'v0:notifications' } = defineProps<SnackbarQueueProps>()
+  const { as = 'div', namespace = 'v0:notifications', renderless } = defineProps<SnackbarQueueProps>()
 
   const notifications = useNotifications(namespace)
 
@@ -127,8 +127,9 @@
 <template>
   <Atom
     ref="container"
-    v-bind="slotProps.attrs"
     :as
+    :renderless
+    v-bind="slotProps.attrs"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Snackbar/SnackbarRoot.vue
+++ b/packages/0/src/components/Snackbar/SnackbarRoot.vue
@@ -61,7 +61,7 @@
     default: (props: SnackbarRootSlotProps) => any
   }>()
 
-  const { as = 'div', namespace = 'v0:notifications', id = useId() } = defineProps<SnackbarRootProps>()
+  const { as = 'div', namespace = 'v0:notifications', id = useId(), renderless } = defineProps<SnackbarRootProps>()
 
   const queue = useSnackbarQueueContext(namespace, null)
 
@@ -84,7 +84,11 @@
 </script>
 
 <template>
-  <Atom v-bind="slotProps.attrs" :as>
+  <Atom
+    :as
+    :renderless
+    v-bind="slotProps.attrs"
+  >
     <slot v-bind="slotProps" />
   </Atom>
 </template>

--- a/packages/0/src/components/Snackbar/index.test.ts
+++ b/packages/0/src/components/Snackbar/index.test.ts
@@ -29,6 +29,11 @@ function mountWithStack<T extends Parameters<typeof mount>[0]> (
   })
 }
 
+function makeNotificationsPlugin () {
+  const [, provide, context] = createNotificationsContext()
+  return { context, install: (app: any) => app.runWithContext(() => provide(context, app)) }
+}
+
 describe('snackbar', () => {
   describe('portal', () => {
     it('should render content inline when teleport=false', () => {
@@ -214,11 +219,6 @@ describe('snackbar', () => {
   })
 
   describe('queue', () => {
-    function makeNotificationsPlugin () {
-      const [, provide, context] = createNotificationsContext()
-      return { context, install: (app: any) => app.runWithContext(() => provide(context, app)) }
-    }
-
     it('should expose items via slot', async () => {
       const { context, install } = makeNotificationsPlugin()
       let slotProps: any
@@ -466,6 +466,89 @@ describe('snackbar', () => {
       expect(context.queue.values()[0]?.isPaused).toBe(true)
 
       wrapper.unmount()
+    })
+  })
+
+  describe('renderless', () => {
+    it('should render no wrapper and carry role in slot attrs on root', () => {
+      let captured: any
+
+      const wrapper = mount(Snackbar.Root, {
+        props: { renderless: true },
+        slots: {
+          default: (props: any) => {
+            captured = props
+            return h('span', { 'data-testid': 'custom-root', ...props.attrs }, 'Saved')
+          },
+        },
+      })
+
+      const custom = wrapper.find('span')
+      expect(captured.attrs.role).toBe('status')
+      expect(custom.exists()).toBe(true)
+      expect(custom.attributes('role')).toBe('status')
+      expect(wrapper.findAll('[role="status"]')).toHaveLength(1)
+      expect(wrapper.findAll('div')).toHaveLength(0)
+    })
+
+    it('should expose onClick in slot attrs so renderless mode works on close', async () => {
+      let captured: any
+
+      const wrapper = mount(Snackbar.Root, {
+        props: { id: 'test-id' },
+        slots: {
+          default: () => h(Snackbar.Close, { renderless: true }, {
+            default: (props: any) => {
+              captured = props
+              return h('span', { 'data-testid': 'custom-close', ...props.attrs }, 'X')
+            },
+          }),
+        },
+      })
+
+      expect(captured.attrs.onClick).toBeTypeOf('function')
+
+      const custom = wrapper.find('[data-testid="custom-close"]')
+      expect(custom.element.parentElement?.tagName).not.toBe('BUTTON')
+      expect(wrapper.findAll('[aria-label]')).toHaveLength(1)
+
+      await custom.trigger('click')
+      expect(wrapper.emitted('dismiss')![0]).toEqual(['test-id'])
+    })
+
+    it('should expose pause handlers in slot attrs so renderless mode works on queue', async () => {
+      const { context, install } = makeNotificationsPlugin()
+      context.send({ subject: 'Test', timeout: 5000 })
+      let captured: any
+
+      const wrapper = mount(Snackbar.Queue, {
+        props: { renderless: true },
+        global: { plugins: [stackPlugin, { install }] },
+        slots: {
+          default: (props: any) => {
+            captured = props
+            return h('section', { 'data-testid': 'custom-queue', ...props.attrs })
+          },
+        },
+      })
+
+      const custom = wrapper.find('section')
+      expect(captured.attrs.onMouseenter).toBeTypeOf('function')
+      expect(captured.attrs.onFocusin).toBeTypeOf('function')
+      expect(custom.exists()).toBe(true)
+      expect(wrapper.findAll('div')).toHaveLength(0)
+
+      await custom.trigger('mouseenter')
+      expect(context.queue.values()[0]?.isPaused).toBe(true)
+
+      await custom.trigger('mouseleave')
+      expect(context.queue.values()[0]?.isPaused).toBe(false)
+
+      await custom.trigger('focusin')
+      expect(context.queue.values()[0]?.isPaused).toBe(true)
+
+      await custom.trigger('focusout', { relatedTarget: null })
+      expect(context.queue.values()[0]?.isPaused).toBe(false)
     })
   })
 

--- a/packages/0/src/components/Treeview/TreeviewItem.vue
+++ b/packages/0/src/components/Treeview/TreeviewItem.vue
@@ -96,27 +96,30 @@
     close: ticket.close,
     activate: ticket.activate,
     deactivate: ticket.deactivate,
+    attrs: {
+      'role': 'treeitem',
+      'aria-disabled': toValue(isDisabled),
+      'aria-expanded': hasContent.value ? toValue(ticket.isOpen) : undefined,
+      'aria-level': toValue(ticket.depth) + 1,
+      'aria-posinset': ticket.position(),
+      'aria-selected': toValue(ticket.isSelected),
+      'aria-setsize': ticket.siblings().length,
+      'data-active': toValue(ticket.isActive) || undefined,
+      'data-disabled': toValue(isDisabled) || undefined,
+      'data-open': toValue(ticket.isOpen) || undefined,
+      'data-selected': toValue(ticket.isSelected) || undefined,
+      'tabindex': roving ? (roving.isTabbable(ticket.id) ? 0 : -1) : undefined,
+      'style': { '--v0-treeview-depth': toValue(ticket.depth) },
+    },
   }))
 </script>
 
 <template>
   <Atom
     ref="root"
-    :aria-disabled="slotProps.isDisabled"
-    :aria-expanded="hasContent ? slotProps.isOpen : undefined"
-    :aria-level="slotProps.depth + 1"
-    :aria-posinset="ticket.position()"
-    :aria-selected="slotProps.isSelected"
-    :aria-setsize="ticket.siblings().length"
+    v-bind="slotProps.attrs"
     :as
-    :data-active="slotProps.isActive || undefined"
-    :data-disabled="slotProps.isDisabled || undefined"
-    :data-open="slotProps.isOpen || undefined"
-    :data-selected="slotProps.isSelected || undefined"
     :renderless
-    role="treeitem"
-    :style="{ '--v0-treeview-depth': slotProps.depth }"
-    :tabindex="roving ? (roving.isTabbable(ticket.id) ? 0 : -1) : undefined"
   >
     <slot v-bind="slotProps" />
   </Atom>

--- a/packages/0/src/components/Treeview/index.test.ts
+++ b/packages/0/src/components/Treeview/index.test.ts
@@ -403,6 +403,41 @@ describe('treeview', () => {
       })
     })
 
+    describe('renderless', () => {
+      it('should expose treeitem attrs in slot props so renderless mode works', async () => {
+        let captured: any
+
+        const wrapper = mount(Treeview.Root, {
+          props: {
+            modelValue: ['item-1'],
+          },
+          slots: {
+            default: () =>
+              h(Treeview.List as any, {}, () =>
+                h(Treeview.Item as any, { value: 'item-1', renderless: true }, {
+                  default: (props: any) => {
+                    captured = props
+                    return h('div', { 'data-testid': 'custom-item', ...props.attrs }, 'Item')
+                  },
+                }),
+              ),
+          },
+        })
+
+        await nextTick()
+
+        expect(captured.attrs.role).toBe('treeitem')
+
+        const custom = wrapper.find('[data-testid="custom-item"]')
+        expect(wrapper.find('li').exists()).toBe(false)
+        expect(custom.element.parentElement?.tagName).toBe('UL')
+        expect(custom.attributes('role')).toBe('treeitem')
+        expect(custom.attributes('aria-level')).toBe('1')
+        expect(custom.attributes('aria-selected')).toBe('true')
+        expect(custom.attributes('tabindex')).toBe('0')
+      })
+    })
+
     describe('disabled state', () => {
       it('should be disabled when item disabled=true', async () => {
         let itemProps: any

--- a/packages/0/src/components/Treeview/types.ts
+++ b/packages/0/src/components/Treeview/types.ts
@@ -192,6 +192,22 @@ export interface TreeviewItemSlotProps<V = unknown> {
   activate: () => void
   /** Deactivate/unhighlight this item */
   deactivate: () => void
+  /** Attributes to bind to the item element */
+  attrs: {
+    'role': 'treeitem'
+    'aria-disabled': boolean
+    'aria-expanded': boolean | undefined
+    'aria-level': number
+    'aria-posinset': number
+    'aria-selected': boolean
+    'aria-setsize': number
+    'data-active': true | undefined
+    'data-disabled': true | undefined
+    'data-open': true | undefined
+    'data-selected': true | undefined
+    'tabindex': 0 | -1 | undefined
+    'style': { '--v0-treeview-depth': number }
+  }
 }
 
 // TreeviewList


### PR DESCRIPTION
## What

`renderless` is a declared prop on every sub-component (via `AtomProps`), so Vue consumes it — it never falls through to the inner `<Atom>`. Any template binding `<Atom :as>` without an explicit `:renderless` rendered its wrapper element even in renderless mode: duplicate element, duplicate accessible name, double-bound handlers. #295/#297/#296/#298 fixed 9 components; this sweep closes the remaining 28.

Two changes per component:

1. **Forward the prop**: destructure `renderless`, bind `<Atom :as :renderless>`.
2. **Expose the element contract in slot attrs**: everything the component binds on its Atom (handlers, role, aria-*, data-*, anchor/positioning styles) now lives in the slot-props `attrs` object and is spread onto the Atom from there — single source of truth. Without this, forwarding alone would be a regression: the wrapper disappears and takes the contract with it.

## Files

| Family | Components |
|---|---|
| AlertDialog | Content, Title, Description |
| Dialog | Content, Title, Description |
| Combobox | Activator, Content, Control, Cue, Empty, Item |
| Select | Activator, Content, Cue, Item, Placeholder, Value |
| Snackbar | Root, Content, Close, Queue |
| Popover | Activator, Content |
| Collapsible / ExpansionPanel | Cue, Cue |
| Form | Form (`onSubmit`/`onReset` now in slot attrs — renderless forms previously lost submit interception) |
| Treeview | Item (already forwarded `:renderless`, but its entire `treeitem` contract — role, 5 aria-*, 4 data-*, roving tabindex, depth style — was inline-only and vanished in renderless mode; now typed in `TreeviewItemSlotProps.attrs`) |

Notable contract additions: anchor/positioning styles (`anchorName`, native-popover `contentStyles`) for Activator/Content pairs, so a renderless consumer's element still anchors the dropdown; `onCancel`/`onClose` + z-index style on the dialog Contents; pause/resume handlers on SnackbarQueue.

## Deliberately untouched

- **Scrim** — teleported `v-for` infrastructure; renderless semantics unclear, needs a design decision.
- **SnackbarPortal** — teleport host with the same hole; same decision needed.
- AlertDialogRoot/DialogRoot — already forward (hardcoded `renderless` on a null-as Atom); SelectRoot/ComboboxRoot/PopoverRoot/TooltipRoot and the six other Treeview sub-components were verified correct.

## Tests

24 regression tests across 10 existing test files. Every one was executed against the unfixed source and failed (24/24), then against the fixed source — full suite green (6088 passed). Renderless roots are fragments, so assertions query the DOM (uniqueness + parentage) rather than `wrapper.element`, which falls back to the mount container on fragment roots.