### PR TITLE
fix(createRegistry): keep iteration cache and index directory consistent

### DIFF
--- a/apps/docs/src/pages/composables/registration/create-registry.md
+++ b/apps/docs/src/pages/composables/registration/create-registry.md
@@ -112,14 +112,14 @@ Each branch extends the base ticket pattern with domain-specific capabilities. S
 
 | Method | Notes |
 | - | - |
-| `register(ticket)` | Add a ticket to the registry |
+| `register(ticket)` | Append a ticket to the registry; a supplied `index` is ignored — use `move()` to position |
 | `unregister(id)` | Remove a ticket by ID |
 | `upsert(id, partial)` | Register or update a ticket |
 | `move(id, index)` | Move a ticket to a new index position; reindexes only the affected `[from..to]` span |
 | `reorder(ids)` | Reorder the registry to match a canonical permutation in one O(n) pass |
 | `onboard(tickets)` | Batch-register an array of tickets |
 | `offboard(ids)` | Batch-unregister an array of IDs |
-| `batch(fn)` | Run multiple mutations with a single cache invalidation and deferred events |
+| `batch(fn)` | Run multiple mutations with deferred cache invalidation and events |
 | `get(id)` | Retrieve a ticket by ID |
 | `has(id)` | Check whether a ticket ID is registered |
 | `browse(value)` | Reverse-lookup — find ticket ID(s) by value |

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -7,6 +7,7 @@ import { computed, isReactive, nextTick, shallowRef, watchEffect } from 'vue'
 
 // Types
 import type { ID } from '#v0/types'
+import type { RegistryTicketInput } from './index'
 
 describe('createRegistry', () => {
   describe('registration', () => {
@@ -255,6 +256,71 @@ describe('createRegistry', () => {
       expect(explicit.valueIsIndex).toBe(false)
     })
 
+    it('should ignore a supplied index and append when registering', () => {
+      const registry = createRegistry()
+      const a = registry.register({ id: 'a' })
+      const b = registry.register({ id: 'b' })
+      const c = registry.register({ id: 'c', index: 0 })
+      const d = registry.register({ id: 'd', index: 99 })
+
+      expect(registry.keys()).toEqual(['a', 'b', 'c', 'd'])
+      expect(registry.lookup(0)).toBe('a')
+      expect(registry.lookup(2)).toBe('c')
+      expect(registry.lookup(99)).toBeUndefined()
+      expect(registry.values()[2]?.id).toBe('c')
+      expect(a.index).toBe(0)
+      expect(b.index).toBe(1)
+      expect(c.index).toBe(2)
+      expect(d.index).toBe(3)
+    })
+
+    it('should keep order and collection consistent when moving after a registration with a supplied index', () => {
+      const registry = createRegistry()
+      registry.register({ id: 'a' })
+      registry.register({ id: 'b' })
+      registry.register({ id: 'c', index: 0 })
+
+      registry.move('c', 0)
+
+      expect(registry.keys()).toEqual(['c', 'a', 'b'])
+      expect(registry.keys().length).toBe(registry.size)
+      expect(new Set(registry.keys()).size).toBe(registry.size)
+      for (const id of ['a', 'b', 'c']) {
+        expect(registry.has(id)).toBe(true)
+      }
+      for (const [index, ticket] of registry.values().entries()) {
+        expect(ticket.index).toBe(index)
+        expect(registry.lookup(index)).toBe(ticket.id)
+      }
+    })
+
+    it('should ignore a supplied index when upserting a missing id', () => {
+      const registry = createRegistry<RegistryTicketInput & { index?: number }>()
+      registry.register({ id: 'a' })
+      registry.register({ id: 'b' })
+      registry.upsert('c', { index: 0 })
+
+      expect(registry.keys()).toEqual(['a', 'b', 'c'])
+      expect(registry.lookup(0)).toBe('a')
+      expect(registry.get('c')?.index).toBe(2)
+    })
+
+    it('should append a re-registered ticket that carries a stale index', () => {
+      const registry = createRegistry()
+      registry.register({ id: 'a' })
+      const b = registry.register({ id: 'b' })
+      registry.register({ id: 'c' })
+
+      registry.unregister('b')
+      const again = registry.register({ ...b })
+
+      expect(again.index).toBe(2)
+      expect(registry.keys()).toEqual(['a', 'c', 'b'])
+      expect(registry.lookup(0)).toBe('a')
+      expect(registry.lookup(2)).toBe('b')
+      expect(new Set(registry.keys()).size).toBe(registry.size)
+    })
+
     it('should not remove an item if unregistering a non-existent id', () => {
       const registry = createRegistry()
       const tickets = registry.onboard([
@@ -282,7 +348,8 @@ describe('createRegistry', () => {
 
     it('should lookup an items ID by index', () => {
       const registry = createRegistry()
-      registry.register({ id: 'lookup-me', index: 1 })
+      registry.register({ id: 'zero' })
+      registry.register({ id: 'lookup-me' })
 
       const found = registry.lookup(1)
 
@@ -316,8 +383,8 @@ describe('createRegistry', () => {
       registry.register({ id: 'item-2', index: 3, value: 'value-2' })
       registry.register({ id: 'item-3', index: 4 })
 
-      expect(registry.lookup(2)).toBe('item-1')
-      expect(registry.get('item-1')?.index).toBe(2)
+      expect(registry.lookup(2)).toBe('item-3')
+      expect(registry.get('item-1')?.index).toBe(0)
 
       registry.reindex()
 
@@ -1076,6 +1143,58 @@ describe('createRegistry', () => {
 
       // Events emitted after batch completes
       expect(clearListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('should keep keys, values, and entries coherent after a listener mutates during batch dispatch', () => {
+      const registry = createRegistry({ events: true })
+      let mutated = false
+
+      registry.on('register:ticket', () => {
+        registry.keys()
+        registry.values()
+        registry.entries()
+      })
+      registry.on('register:ticket', () => {
+        if (mutated) return
+        mutated = true
+        registry.register({ id: 'extra' })
+      })
+
+      registry.batch(() => {
+        registry.register({ id: 'item-1' })
+      })
+
+      expect(registry.size).toBe(2)
+      expect(registry.keys().length).toBe(2)
+      expect(registry.values().length).toBe(2)
+      expect(registry.entries().length).toBe(2)
+      expect(registry.keys()).toContain('extra')
+    })
+
+    it('should keep caches coherent after a clear:registry listener mutates during batch dispatch', () => {
+      const registry = createRegistry({ events: true })
+      registry.register({ id: 'item-1' })
+
+      let seeded = false
+      registry.on('clear:registry', () => {
+        registry.keys()
+        registry.values()
+        registry.entries()
+      })
+      registry.on('clear:registry', () => {
+        if (seeded) return
+        seeded = true
+        registry.register({ id: 'seed' })
+      })
+
+      registry.batch(() => {
+        registry.clear()
+      })
+
+      expect(registry.size).toBe(1)
+      expect(registry.keys()).toEqual(['seed'])
+      expect(registry.values().length).toBe(1)
+      expect(registry.entries().length).toBe(1)
     })
 
     it('should update valueIsIndex and catalog on upsert', () => {

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -62,7 +62,7 @@ export interface RegistryTicket<V = unknown> {
   /**
    * The index of the ticket in the registry.
    *
-   * @remarks Automatically managed by the registry. Updated during reindexing. It's not recommended to manually set this.
+   * @remarks Automatically managed by the registry. Assigned at registration and updated during reindexing; a supplied index is ignored — use `move()` to position a ticket. It's not recommended to manually set this.
    */
   index: number
   /** The value associated with the ticket. If not provided, it defaults to the index. */
@@ -327,7 +327,7 @@ export interface RegistryContext<
    * Register a new ticket
    *
    * @param ticket The partial ticket data to register.
-   * @remarks If no ID is provided, a unique ID will be generated automatically. If no value is provided, it defaults to the ticket's index. This operation invalidates cached results from `keys()`, `values()`, and `entries()`.
+   * @remarks If no ID is provided, a unique ID will be generated automatically. If no value is provided, it defaults to the ticket's index. The index is always assigned by the registry — a supplied index is ignored; use `move()` to position a ticket. This operation invalidates cached results from `keys()`, `values()`, and `entries()`.
    *
    * @see https://0.vuetifyjs.com/composables/registration/create-registry
    *
@@ -663,7 +663,7 @@ export interface RegistryContext<
    *
    * @param fn The function containing batch operations.
    * @returns The return value of the batch function.
-   * @remarks Useful for bulk operations like onboard(). Invalidation and events happen once at the end, not after each operation.
+   * @remarks Useful for bulk operations like onboard(). Cache invalidation and events are deferred to the end of the batch instead of running after each operation.
    *
    * @see https://0.vuetifyjs.com/composables/registration/create-registry
    *
@@ -989,6 +989,7 @@ export function createRegistry<
     } finally {
       isBatching = false
       batched = []
+      cache.clear()
     }
   }
 
@@ -1051,7 +1052,7 @@ export function createRegistry<
     }
 
     const valueIsUndefined = isUndefined(registration.value)
-    const index = registration.index ?? size
+    const index = size
     const value = valueIsUndefined ? index : registration.value
     const valueIsIndex = registration.valueIsIndex ?? valueIsUndefined
 


### PR DESCRIPTION
Fixes two execution-verified cache/directory corruption bugs in the registry foundation, found by the 2026-06-09 audit and re-proven against current master before fixing.

## Bug 1 — `batch()` dispatch window corrupts the keys/values/entries cache

`invalidate()` early-returns while `isBatching`, and `batch()` resets the flag only after the dispatch loop — so a listener that reads `keys()` during dispatch repopulates the cache, a later listener that mutates gets a no-op invalidate, and the stale snapshot survives the batch (probe: post-batch `keys()` returned 1 entry while `size` was 2, persisting across reads and the reindex-draining accessors until the next unbatched mutation). Since `onboard` / `offboard` / `move` / `reorder` all batch internally, the window is open on every bulk operation of an `events: true` non-reactive registry.

**Fix:** an unconditional `cache.clear()` in `batch()`'s `finally`, after `isBatching = false`. The pre-loop clear stays (it lets in-loop reads see post-callback state); `finally` placement keeps the cache coherent even when a listener throws. Event buffering semantics during dispatch are untouched.

## Bug 2 — `register()` honored a caller-supplied `index` and corrupted directory/order

`register` took `registration.index ?? size`, then `order.push` appended while `directory.set(ticket.index, id)` overwrote the existing slot — without setting `needsReindex`. Probe on master: after `register({ id: 'c', index: 0 })`, `lookup(0)` returns `'c'` while `keys()[0]` is `'a'`, indefinitely; a subsequent `move()` on the mis-indexed ticket then splices from the stale index and produces `order = ['b','c','c']` with `'a'` dropped from order but still in the collection — permanent desync.

**Fix:** the registry owns index assignment — `register()` always appends and a supplied `index` is ignored (`move()` is the positioning API). JSDoc and docs updated to say so.

An insert-at-position contract was implemented first and rejected by evidence: tickets are routinely re-registered via spread (`registry.register({ ...old })`), which carries a stale `.index` — under insert-at-position that became an unintended `move()` and broke 7 `createTimeline` undo/overflow tests immediately. Ignore-semantics breaks nobody: explicit `index` never worked (it only ever corrupted), no internal caller passes it literally, and `offboard → toInput` already strips it as noise. A regression test pins the spread-re-register shape verbatim.

## Verification

- Both bugs re-proven on master `e51754e7` with stderr-dump probes before any fix was written.
- Red: all 6 new regression tests fail against unfixed source (plus one updated legacy test encoding the corrected contract).
- Green: full suite 6098 passed; `createTimeline` passes **unmodified** — the acceptance signal for the ignore-contract.