### PR TITLE
docs: replace ineffective dynamic import of @vuetify/auth

### DIFF
--- a/apps/docs/src/main.ts
+++ b/apps/docs/src/main.ts
@@ -13,6 +13,10 @@ import { useIdleCallback } from './composables/useIdleCallback'
 import { registerPlugins } from './plugins'
 import pinia from './plugins/pinia'
 import routerOptions from './plugins/router'
+
+// Stores
+import { useAuthStore } from '@vuetify/auth'
+
 import './styles/tokens.css'
 import './styles/transitions.css'
 import 'virtual:uno.css'
@@ -39,8 +43,9 @@ export const createApp = ViteSSG(
       pinia.state.value = initialState.pinia || {}
 
     if (!import.meta.env.SSR) {
-      const { useAuthStore } = await import('@vuetify/auth')
-      useAuthStore().verify()
+      const auth = useAuthStore()
+
+      auth.verify()
 
       const logger = useLogger()
 


### PR DESCRIPTION
## Summary

Every Docs Deploy build logs a rolldown warning:

```
[INEFFECTIVE_DYNAMIC_IMPORT] Warning: @vuetify/auth/dist/index.mjs is dynamically imported by src/main.ts but also statically imported by src/components/app/AppAccount.vue, src/components/app/AppBar.vue, src/components/app/AppSettingsSheet.vue
```

The dynamic import in `main.ts` could never split `@vuetify/auth` into its own chunk: `AppBar` (eager in the app shell) statically imports `useAuthStore`, which pins the module to the entry chunk. Both sides of the pattern landed together in 8b8af456, so it has been ineffective since day one.

This replaces the dynamic import with a top-level static import. `useAuthStore().verify()` stays inside the client-only branch. SSR-safe — the module already evaluates during SSG via the component static imports. Zero bundle change; the module was always in the entry chunk.

The playground's dynamic import of `@vuetify/auth` is untouched — nothing imports it statically there, so it splits correctly.

## Verified

Local `pnpm build:docs` completes with no `@vuetify/auth` INEFFECTIVE_DYNAMIC_IMPORT warning.

## Follow-up candidate (not in this PR)

The build emits one sibling warning of the same class: `DocsNavigator.vue` is dynamically imported by `src/plugins/app.ts` but statically imported by `DocsBackmatter.vue` and `using-the-docs.md`.