### PR TITLE
fix(composables): repair frozen size getters and drop the ES2025 Set dependency

### DIFF
--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -151,7 +151,7 @@ import { createRegistry } from '../createRegistry'
 
 **Statement.** Composable extension happens by `{ ...parent, newProperty }`. Never redefine a property the parent already exposed. [intent:101, intent:142, intent:147]
 
-**Why.** Spread guarantees the child remains substitutable for the parent in types. The 27 registry-based composables all compose this way; consumers who hold a reference to the parent type can upgrade to the child type without refactoring call sites.
+**Why.** Spread guarantees the child remains substitutable for the parent in types. The 27 registry-based composables all compose this way; consumers who hold a reference to the parent type can upgrade to the child type without refactoring call sites. Spread copies accessors by value — a parent's `get size ()` arrives as a data property frozen at spread time — so any accessor the child surface needs must be re-declared after the spread (`get size () { return model.size }`).
 
 **Canonical example.** `packages/0/src/composables/createSelection/index.ts:296-309` — spreads `createModel`, adds `multiple`, `toggle`, `apply`, `mandate`.
 

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -74,6 +74,14 @@ describe('createProgress', () => {
       const ticket = progress.register()
       expect(ticket.id).toBeDefined()
     })
+
+    it('should track size for segments registered after creation', () => {
+      const progress = setup()
+      progress.register()
+      progress.register()
+      progress.register()
+      expect(progress.size).toBe(3)
+    })
   })
 
   describe('total', () => {

--- a/packages/0/src/composables/createProgress/index.ts
+++ b/packages/0/src/composables/createProgress/index.ts
@@ -175,7 +175,10 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
     apply,
     min,
     max,
-  } as ProgressContext
+    get size () {
+      return model.size
+    },
+  } satisfies ProgressContext as ProgressContext
 }
 
 /**

--- a/packages/0/src/composables/createSelection/index.test.ts
+++ b/packages/0/src/composables/createSelection/index.test.ts
@@ -1021,6 +1021,49 @@ describe('createSelection', () => {
         // Mandatory must keep at least one selected, like in non-multiple mode
         expect(selection.selectedIds.size).toBe(1)
       })
+
+      it('should apply in multiple mode without Set.prototype.difference', () => {
+        const original = Set.prototype.difference
+
+        // @ts-expect-error removing the ES2025 method to pin the documented ES2016 floor
+        delete Set.prototype.difference
+
+        try {
+          const selection = createSelection({ multiple: true })
+          selection.onboard([
+            { id: 'a', value: 'A' },
+            { id: 'b', value: 'B' },
+            { id: 'c', value: 'C' },
+          ])
+          selection.select('a')
+          selection.select('b')
+
+          selection.apply(['B', 'C'])
+
+          expect(selection.selectedIds.has('a')).toBe(false)
+          expect(selection.selectedIds.has('b')).toBe(true)
+          expect(selection.selectedIds.has('c')).toBe(true)
+          expect(selection.selectedIds.size).toBe(2)
+        } finally {
+          Set.prototype.difference = original
+        }
+      })
+
+      it('should keep the mandatory survivor when apply swaps the last selected id', () => {
+        const selection = createSelection({ multiple: true, mandatory: true })
+        selection.onboard([
+          { id: 'a', value: 'A' },
+          { id: 'b', value: 'B' },
+        ])
+        selection.select('a')
+
+        selection.apply(['B'])
+
+        // Removals run before additions, so the mandatory guard keeps 'a'
+        expect(selection.selectedIds.has('a')).toBe(true)
+        expect(selection.selectedIds.has('b')).toBe(true)
+        expect(selection.selectedIds.size).toBe(2)
+      })
     })
 
     describe('custom ticket types', () => {

--- a/packages/0/src/composables/createSelection/index.ts
+++ b/packages/0/src/composables/createSelection/index.ts
@@ -253,11 +253,11 @@ export function createSelection<
     }
 
     if (isMultiple) {
-      for (const id of currentIds.difference(targetIds)) {
-        unselect(id)
+      for (const id of currentIds) {
+        if (!targetIds.has(id)) unselect(id)
       }
-      for (const id of targetIds.difference(currentIds)) {
-        model.selectedIds.add(id)
+      for (const id of targetIds) {
+        if (!currentIds.has(id)) model.selectedIds.add(id)
       }
     } else {
       const next = targetIds.values().next().value

--- a/packages/0/src/composables/usePermissions/index.test.ts
+++ b/packages/0/src/composables/usePermissions/index.test.ts
@@ -197,6 +197,21 @@ describe('createPermissions', () => {
         const missing = permissions.get('admin.delete.users')
         expect(missing).toBeUndefined()
       })
+
+      it('should track size for tokens registered after creation', () => {
+        const permissions = createPermissions({
+          permissions: {
+            admin: [
+              ['read', 'users'],
+            ],
+          },
+        })
+
+        permissions.register({ id: 'editor.edit.posts', value: true })
+        permissions.register({ id: 'viewer.read.posts', value: true })
+
+        expect(permissions.size).toBe(3)
+      })
     })
 
     describe('v0PermissionsAdapter', () => {

--- a/packages/0/src/composables/usePermissions/index.ts
+++ b/packages/0/src/composables/usePermissions/index.ts
@@ -113,6 +113,9 @@ export function createPermissions (_options: PermissionOptions = {}): Permission
   return {
     ...tokens,
     can,
+    get size () {
+      return tokens.size
+    },
   } as PermissionContext
 }
 


### PR DESCRIPTION
Three foundation fixes from the audit's medium tier, each execution-verified on master before fixing.

## Frozen `size` getters (createProgress, createPermissions)

Spreading a parent context copies accessor members **by value** — `{ ...model }` evaluates the parent's `get size()` once and freezes it as a data property. Twenty factories re-declare the getter after the spread; two forgot:

- **createProgress** returned `{ ...model, … }` with no re-patch — `progress.size` frozen at `0` forever (probe: still 0 with 3 segments registered).
- **createPermissions** returned `{ ...tokens, can }` — `size` frozen at the seeded-role count (probe: 1 vs truth 3). Found by sweeping every context-spread site; this one was missed by both the original audit and #325.

Fix: the standard 1-line getter re-patch in each (`get size () { return model.size }` / `tokens.size`); createProgress also gains `satisfies ProgressContext` to match the post-#325 selection-chain shape. PHILOSOPHY §2.6 gains one sentence warning that accessors must be re-declared after a spread — the pattern has now shipped two real bugs.

## `Set.prototype.difference` in the v-model hot path (createSelection)

`apply()` — the path every external v-model write takes via `useProxyModel` — called `Set.prototype.difference` twice. That's ES2025 (Chrome/Edge 122+, Firefox 127+, Safari 17+, Node 22+), while the docs' browser-support page promises an ES2016 / Chrome 52+ baseline: on the documented floor, the first multi-select v-model write throws `TypeError`. No engines field, no build target, no polyfill ships — the types (`lib: esnext`) just let it through silently.

Fix: manual loops over the existing plain-Set snapshots, preserving the exact semantics — removals fully before additions (the `mandatory` unselect-guard depends on phase order), receiver insertion order, no reads of the live reactive set mid-loop. These were the only ES2025 Set-method call sites in the package (full family swept); the documented baseline is true again.

## Tests

- `should track size for segments registered after creation` / `should track size for tokens registered after creation` — fail on master (0 and 1 respectively).
- `should apply in multiple mode without Set.prototype.difference` — deletes the method (save/restore) and exercises both apply directions; throws on master.
- `should keep the mandatory survivor when apply swaps the last selected id` — pins master's existing mandatory semantics (`{a}` + `apply(['B'])` → `{a, b}`) so the rewrite can't drift; passes on both, by design.

Red: 3/3 discriminators fail on unfixed source. Green: full suite 6102 passed.