### PR TITLE
fix(useRtl,useTheme): adopt leak-safe adapter lifecycle

### DIFF
--- a/packages/0/src/composables/useRtl/adapters/adapter.ts
+++ b/packages/0/src/composables/useRtl/adapters/adapter.ts
@@ -7,6 +7,12 @@ export interface RtlAdapterSetupContext {
 }
 
 export abstract class RtlAdapter {
+  /**
+   * Teardown registered by `setup`. Called once via `app.onUnmount` on the
+   * plugin path and available as a reachable handle on standalone paths.
+   */
+  dispose?: () => void
+
   abstract setup<T extends RtlAdapterSetupContext>(
     app: App,
     context: T,

--- a/packages/0/src/composables/useRtl/adapters/v0.ts
+++ b/packages/0/src/composables/useRtl/adapters/v0.ts
@@ -6,11 +6,24 @@ import { RtlAdapter } from './adapter'
 
 // Utilities
 import { isNull, isString } from '#v0/utilities'
-import { onScopeDispose, watch } from 'vue'
+import { watch } from 'vue'
 
 // Types
 import type { RtlAdapterSetupContext } from './adapter'
 import type { App } from 'vue'
+
+// Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
+interface RtlHeadInput {
+  htmlAttrs: { dir: 'ltr' | 'rtl' }
+}
+
+interface HeadEntry {
+  dispose?: () => void
+}
+
+interface Head {
+  push: (input: RtlHeadInput) => HeadEntry
+}
 
 export class V0RtlAdapter extends RtlAdapter {
   setup <T extends RtlAdapterSetupContext>(
@@ -31,20 +44,20 @@ export class V0RtlAdapter extends RtlAdapter {
 
       targetEl.dir = context.isRtl.value ? 'rtl' : 'ltr'
 
-      const stop = watch(context.isRtl, value => {
+      this.dispose = watch(context.isRtl, value => {
         targetEl.dir = value ? 'rtl' : 'ltr'
       })
-
-      onScopeDispose(stop, true)
     } else {
-      const head = app._context?.provides?.usehead ?? app._context?.provides?.head
+      const head = (app._context?.provides?.usehead ?? app._context?.provides?.head) as Head | undefined
 
       if (head?.push) {
-        head.push({
+        const entry = head.push({
           htmlAttrs: {
             dir: context.isRtl.value ? 'rtl' : 'ltr',
           },
         })
+
+        if (entry?.dispose) this.dispose = entry.dispose
       }
     }
   }

--- a/packages/0/src/composables/useRtl/index.test.ts
+++ b/packages/0/src/composables/useRtl/index.test.ts
@@ -355,6 +355,22 @@ describe('createRtl', () => {
         expect(disposeFn).toHaveBeenCalledTimes(1)
       })
 
+      it('should not throw when adapter has no dispose on app.unmount', async () => {
+        const { createApp, nextTick: nt } = await import('vue')
+
+        const customAdapter = { setup: vi.fn() }
+
+        const plugin = createRtlPlugin({ adapter: customAdapter as any })
+        const app = createApp({ template: '<div />' })
+        app.use(plugin)
+
+        const container = document.createElement('div')
+        app.mount(container)
+        await nt()
+
+        expect(() => app.unmount()).not.toThrow()
+      })
+
       it('should not install twice on the same app', async () => {
         const { createApp, nextTick: nt } = await import('vue')
 

--- a/packages/0/src/composables/useRtl/index.test.ts
+++ b/packages/0/src/composables/useRtl/index.test.ts
@@ -166,6 +166,29 @@ describe('createRtl', () => {
       const isRtl = ssrShallowRef(false)
       expect(() => adapter.setup(mockApp, { isRtl, toggle: () => {} }, undefined)).not.toThrow()
     })
+
+    it('should assign entry.dispose to adapter.dispose when entry has dispose', async () => {
+      vi.resetModules()
+
+      vi.doMock('#v0/constants/globals', () => ({
+        IN_BROWSER: false,
+      }))
+
+      const { V0RtlAdapter: SSRAdapter } = await import('./adapters/v0')
+      const { shallowRef: ssrShallowRef } = await import('vue')
+
+      const entryDispose = vi.fn()
+      const pushFn = vi.fn(() => ({ dispose: entryDispose }))
+      const mockApp = {
+        _context: { provides: { usehead: { push: pushFn } } },
+      } as any
+
+      const adapter = new SSRAdapter()
+      const isRtl = ssrShallowRef(true)
+      adapter.setup(mockApp, { isRtl, toggle: () => {} }, undefined)
+
+      expect(adapter.dispose).toBe(entryDispose)
+    })
   })
 
   describe('useRtl', () => {
@@ -311,6 +334,25 @@ describe('createRtl', () => {
 
         app.unmount()
         el.remove()
+      })
+
+      it('should call adapter.dispose on app.unmount', async () => {
+        const { createApp, nextTick: nt } = await import('vue')
+
+        const disposeFn = vi.fn()
+        const customAdapter = { setup: vi.fn(), dispose: disposeFn }
+
+        const plugin = createRtlPlugin({ adapter: customAdapter as any })
+        const app = createApp({ template: '<div />' })
+        app.use(plugin)
+
+        const container = document.createElement('div')
+        app.mount(container)
+        await nt()
+
+        expect(disposeFn).not.toHaveBeenCalled()
+        app.unmount()
+        expect(disposeFn).toHaveBeenCalledTimes(1)
       })
 
       it('should not install twice on the same app', async () => {

--- a/packages/0/src/composables/useRtl/index.test.ts
+++ b/packages/0/src/composables/useRtl/index.test.ts
@@ -269,6 +269,7 @@ describe('createRtl', () => {
         mockHasInjectionContext.mockReturnValue(false)
         const rtl = useRtl()
         expect(rtl.isRtl.value).toBe(false)
+        expect(() => rtl.dispose()).not.toThrow()
       })
     })
 

--- a/packages/0/src/composables/useRtl/index.ts
+++ b/packages/0/src/composables/useRtl/index.ts
@@ -46,6 +46,12 @@ export interface RtlContext {
   isRtl: Ref<boolean>
   /** Convenience method to flip direction */
   toggle: () => void
+  /**
+   * Release adapter resources (watch teardown, unhead entry).
+   * Called automatically on `app.unmount` when using the plugin path.
+   * Call manually when using a standalone context (`createRtlContext`).
+   */
+  dispose: () => void
 }
 
 export interface RtlOptions {
@@ -80,13 +86,14 @@ export function createRtl (options: RtlOptions = {}): RtlContext {
     isRtl.value = !isRtl.value
   }
 
-  return { isRtl, toggle }
+  return { isRtl, toggle, dispose: () => {} }
 }
 
 export function createRtlFallback (): RtlContext {
   return {
     isRtl: shallowRef(false),
     toggle: () => {},
+    dispose: () => {},
   }
 }
 
@@ -98,10 +105,11 @@ export const [createRtlContext, createRtlPlugin, useRtl] =
       fallback: () => createRtlFallback(),
       setup: (context, app, { adapter = new V0RtlAdapter(), target }) => {
         adapter.setup(app, context, target)
+        app.onUnmount(() => adapter.dispose?.())
       },
       persist: ctx => ctx.isRtl.value,
       restore: (ctx, saved) => {
-        ctx.isRtl.value = saved as boolean
+        if (typeof saved === 'boolean') ctx.isRtl.value = saved
       },
     },
   )

--- a/packages/0/src/composables/useRtl/persist.test.ts
+++ b/packages/0/src/composables/useRtl/persist.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+vi.mock('#v0/constants/globals', () => ({
+  IN_BROWSER: true,
+}))
+
+import { createStoragePlugin, useStorage } from '#v0/composables/useStorage'
+import { createApp, nextTick } from 'vue'
+import { createRtlPlugin } from './index'
+
+describe('createRtlPlugin persist/restore', () => {
+  it('should restore boolean persisted value via real storage', async () => {
+    const app = createApp({ render: () => null })
+    app.use(createStoragePlugin())
+
+    app.runWithContext(() => {
+      const storage = useStorage()
+      storage.set('rtl', true)
+    })
+
+    app.use(createRtlPlugin({ persist: true }))
+
+    const container = document.createElement('div')
+    app.mount(container)
+    await nextTick()
+
+    expect(document.documentElement.dir).toBe('rtl')
+
+    app.unmount()
+    document.documentElement.dir = ''
+  })
+
+  it('should not restore when persisted value is not a boolean', async () => {
+    const app = createApp({ render: () => null })
+    app.use(createStoragePlugin())
+
+    app.runWithContext(() => {
+      const storage = useStorage()
+      storage.set('rtl', 'invalid-string')
+    })
+
+    app.use(createRtlPlugin({ persist: true, default: false }))
+
+    const container = document.createElement('div')
+    app.mount(container)
+    await nextTick()
+
+    expect(document.documentElement.dir).toBe('ltr')
+
+    app.unmount()
+    document.documentElement.dir = ''
+  })
+})

--- a/packages/0/src/composables/useRtl/persist.test.ts
+++ b/packages/0/src/composables/useRtl/persist.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('#v0/constants/globals', () => ({
   IN_BROWSER: true,
 }))
 
+// Composables
 import { createStoragePlugin, useStorage } from '#v0/composables/useStorage'
-import { createApp, nextTick } from 'vue'
+
 import { createRtlPlugin } from './index'
+
+// Utilities
+import { createApp, nextTick } from 'vue'
 
 describe('createRtlPlugin persist/restore', () => {
   it('should restore boolean persisted value via real storage', async () => {

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -19,6 +19,11 @@ export abstract class ThemeAdapter {
   public stylesheetId = 'v0-theme-stylesheet'
   public prefix: string
   public rgb = false
+  /**
+   * Teardown registered by `setup`. Called once via `app.onUnmount` on the
+   * plugin path and available as a reachable handle on standalone paths.
+   */
+  dispose?: () => void
 
   constructor (prefix: string) {
     this.prefix = prefix

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -61,12 +61,6 @@ export abstract class ThemeAdapter {
     return isUndefined(a) ? `${r}, ${g}, ${b}` : `${r}, ${g}, ${b}, ${a}`
   }
 
-  /**
-   * Teardown registered by `setup`. Called once via `app.onUnmount` on the
-   * plugin path and available as a reachable handle on standalone paths.
-   */
-  dispose?: () => void
-
   abstract setup<T extends ThemeAdapterSetupContext>(
     app: App,
     context: T,

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -56,6 +56,12 @@ export abstract class ThemeAdapter {
     return isUndefined(a) ? `${r}, ${g}, ${b}` : `${r}, ${g}, ${b}, ${a}`
   }
 
+  /**
+   * Teardown registered by `setup`. Called once via `app.onUnmount` on the
+   * plugin path and available as a reachable handle on standalone paths.
+   */
+  dispose?: () => void
+
   abstract setup<T extends ThemeAdapterSetupContext>(
     app: App,
     context: T,

--- a/packages/0/src/composables/useTheme/adapters/unhead.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.test.ts
@@ -417,6 +417,26 @@ describe('v0UnheadThemeAdapter', () => {
 
       mockInBrowser.value = true
     })
+
+    it('should tolerate entries without patch or dispose', () => {
+      mockInBrowser.value = false
+      const head = {
+        push: vi.fn(() => ({})),
+      }
+      const app = {
+        _context: { provides: { usehead: head } },
+        _container: null,
+      } as unknown as App
+      const context = createMockContext()
+      const adapter = new V0UnheadThemeAdapter()
+
+      adapter.setup(app, context, null)
+
+      expect(() => adapter.update(context.colors.value, context.isDark.value)).not.toThrow()
+      expect(() => adapter.dispose?.()).not.toThrow()
+
+      mockInBrowser.value = true
+    })
   })
 
   describe('update', () => {

--- a/packages/0/src/composables/useTheme/adapters/unhead.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.test.ts
@@ -372,6 +372,51 @@ describe('v0UnheadThemeAdapter', () => {
 
       expect(head.patch).not.toHaveBeenCalled()
     })
+
+    it('should stop watcher and call entry.dispose when adapter.dispose() is called in browser mode', async () => {
+      const entryDispose = vi.fn()
+      const head = {
+        push: vi.fn(() => ({ patch: vi.fn(), dispose: entryDispose })),
+      }
+      const app = createMockApp(head)
+      const context = createMockContext()
+      const adapter = new V0UnheadThemeAdapter()
+
+      const scope = effectScope()
+      scope.run(() => adapter.setup(app, context, null))
+
+      expect(adapter.dispose).toBeDefined()
+      adapter.dispose?.()
+
+      context.selectedId.value = 'dark'
+      await nextTick()
+
+      expect(entryDispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call entry.dispose when adapter.dispose() is called in SSR mode', () => {
+      mockInBrowser.value = false
+
+      const entryDispose = vi.fn()
+      const head = {
+        push: vi.fn(() => ({ patch: vi.fn(), dispose: entryDispose })),
+      }
+      const app = {
+        _context: { provides: { usehead: head } },
+        _container: null,
+      } as unknown as App
+      const context = createMockContext()
+      const adapter = new V0UnheadThemeAdapter()
+
+      adapter.setup(app, context, null)
+
+      expect(adapter.dispose).toBeDefined()
+      adapter.dispose?.()
+
+      expect(entryDispose).toHaveBeenCalledTimes(1)
+
+      mockInBrowser.value = true
+    })
   })
 
   describe('update', () => {

--- a/packages/0/src/composables/useTheme/adapters/unhead.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.ts
@@ -9,13 +9,28 @@ import { ThemeAdapter } from './adapter'
 
 // Utilities
 import { isNull, isString } from '#v0/utilities'
-import { onScopeDispose, watch } from 'vue'
+import { watch } from 'vue'
 
 // Types
 import type { ID } from '#v0/types'
 import type { Colors } from '../index'
 import type { ThemeAdapterSetupContext } from './adapter'
 import type { App } from 'vue'
+
+// Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
+interface ThemeHeadInput {
+  htmlAttrs?: { 'data-theme': string }
+  style?: Array<{ innerHTML: string, id: string }>
+}
+
+interface HeadEntry {
+  dispose?: () => void
+  patch?: (input: ThemeHeadInput) => void
+}
+
+interface Head {
+  push: (input: ThemeHeadInput) => HeadEntry
+}
 
 export interface V0UnheadThemeOptions {
   stylesheetId?: string
@@ -30,7 +45,7 @@ export interface V0UnheadThemeOptions {
  * Requires @unhead/vue to be installed in the app.
  */
 export class V0UnheadThemeAdapter extends ThemeAdapter {
-  private entry?: { patch: (input: Record<string, unknown>) => void }
+  private entry?: HeadEntry
 
   constructor (options: V0UnheadThemeOptions = {}) {
     super(options.prefix ?? 'v0')
@@ -42,7 +57,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
     context: T,
     target?: string | HTMLElement | null,
   ): void {
-    const head = app._context?.provides?.usehead ?? app._context?.provides?.head
+    const head = (app._context?.provides?.usehead ?? app._context?.provides?.head) as Head | undefined
 
     if (head?.push) {
       const id = context.selectedId.value
@@ -83,7 +98,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
             targetEl.dataset.theme = themeStr
           }
 
-          this.entry?.patch({
+          this.entry?.patch?.({
             htmlAttrs: { 'data-theme': themeStr },
             style: [{
               innerHTML: this.generate(colors, isDark),
@@ -93,7 +108,12 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
         },
       )
 
-      onScopeDispose(stopWatch, true)
+      this.dispose = () => {
+        stopWatch()
+        this.entry?.dispose?.()
+      }
+    } else {
+      this.dispose = () => this.entry?.dispose?.()
     }
   }
 
@@ -103,7 +123,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
   ): void {
     if (!this.entry) return
 
-    this.entry.patch({
+    this.entry.patch?.({
       style: [{
         innerHTML: this.generate(colors, isDark),
         id: this.stylesheetId,

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -141,6 +141,19 @@ describe('v0StyleSheetThemeAdapter', () => {
       scope.stop()
     })
 
+    it('should assign entry.dispose to adapter.dispose when entry has dispose', () => {
+      mockInBrowser.value = false
+      const entryDispose = vi.fn()
+      const headMock = { push: vi.fn(() => ({ dispose: entryDispose })) }
+      const app = createMockApp(headMock)
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter()
+
+      adapter.setup(app, context)
+
+      expect(adapter.dispose).toBe(entryDispose)
+    })
+
     it('should not call update in SSR', () => {
       mockInBrowser.value = false
       const adapter = new V0StyleSheetThemeAdapter()

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -154,6 +154,18 @@ describe('v0StyleSheetThemeAdapter', () => {
       expect(adapter.dispose).toBe(entryDispose)
     })
 
+    it('should leave dispose unset when head entry has no dispose', () => {
+      mockInBrowser.value = false
+      const headMock = { push: vi.fn(() => ({})) }
+      const app = createMockApp(headMock)
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter()
+
+      adapter.setup(app, context)
+
+      expect(adapter.dispose).toBeUndefined()
+    })
+
     it('should not call update in SSR', () => {
       mockInBrowser.value = false
       const adapter = new V0StyleSheetThemeAdapter()

--- a/packages/0/src/composables/useTheme/adapters/v0.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.ts
@@ -5,13 +5,27 @@ import { ThemeAdapter } from './adapter'
 
 // Utilities
 import { isNull, isString } from '#v0/utilities'
-import { onScopeDispose, watch } from 'vue'
+import { watch } from 'vue'
 
 // Types
 import type { ID } from '#v0/types'
 import type { Colors } from '../index'
 import type { ThemeAdapterSetupContext } from './adapter'
 import type { App } from 'vue'
+
+// Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
+interface ThemeHeadInput {
+  htmlAttrs: { 'data-theme': string }
+  style: Array<{ innerHTML: string, id: string }>
+}
+
+interface HeadEntry {
+  dispose?: () => void
+}
+
+interface Head {
+  push: (input: ThemeHeadInput) => HeadEntry
+}
 
 export interface Vuetify0ThemeOptions {
   cspNonce?: string
@@ -46,9 +60,10 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
         this.update(colors, isDark)
       })
 
-      onScopeDispose(stopWatch, true)
-
-      if (isNull(target)) return
+      if (isNull(target)) {
+        this.dispose = stopWatch
+        return
+      }
 
       const targetEl = target instanceof HTMLElement
         ? target
@@ -56,7 +71,10 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
             ? document.querySelector(target) as HTMLElement | null
             : (app._container as HTMLElement | undefined) || document.querySelector('#app') as HTMLElement | null || document.body)
 
-      if (!targetEl) return
+      if (!targetEl) {
+        this.dispose = stopWatch
+        return
+      }
 
       // Set data-theme synchronously to prevent flash
       if (context.selectedId.value) {
@@ -65,16 +83,19 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
 
       const stopTheme = watch(context.selectedId, id => {
         if (!id) return
-
         targetEl.dataset.theme = String(id)
       })
 
-      onScopeDispose(stopTheme, true)
+      this.dispose = () => {
+        stopWatch()
+        stopTheme()
+      }
     } else {
-      const head = app._context?.provides?.usehead ?? app._context?.provides?.head
+      const head = (app._context?.provides?.usehead ?? app._context?.provides?.head) as Head | undefined
+
       if (head?.push) {
         const id = context.selectedId.value
-        head.push({
+        const entry = head.push({
           htmlAttrs: {
             'data-theme': id ? String(id) : '',
           },
@@ -83,6 +104,8 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
             id: this.stylesheetId,
           }],
         })
+
+        if (entry?.dispose) this.dispose = entry.dispose
       }
     }
   }

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -391,6 +391,27 @@ describe('createTheme', () => {
       expect(plugin.install).toBeDefined()
     })
 
+    it('should call adapter.dispose on app.unmount', async () => {
+      const disposeFn = vi.fn()
+      const customAdapter = {
+        setup: vi.fn(),
+        dispose: disposeFn,
+        update: vi.fn(),
+        rgb: false,
+      }
+
+      const app = createApp({ template: '<div />' })
+      app.use(createThemePlugin({ adapter: customAdapter as any }))
+
+      const container = document.createElement('div')
+      app.mount(container)
+      await nextTick()
+
+      expect(disposeFn).not.toHaveBeenCalled()
+      app.unmount()
+      expect(disposeFn).toHaveBeenCalledTimes(1)
+    })
+
     it('should inject CSS variables into DOM', async () => {
       let mockStyleSheets: CSSStyleSheet[] = []
       using spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => mockStyleSheets)

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -412,6 +412,23 @@ describe('createTheme', () => {
       expect(disposeFn).toHaveBeenCalledTimes(1)
     })
 
+    it('should not throw when adapter has no dispose on app.unmount', async () => {
+      const customAdapter = {
+        setup: vi.fn(),
+        update: vi.fn(),
+        rgb: false,
+      }
+
+      const app = createApp({ template: '<div />' })
+      app.use(createThemePlugin({ adapter: customAdapter as any }))
+
+      const container = document.createElement('div')
+      app.mount(container)
+      await nextTick()
+
+      expect(() => app.unmount()).not.toThrow()
+    })
+
     it('should inject CSS variables into DOM', async () => {
       let mockStyleSheets: CSSStyleSheet[] = []
       using spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => mockStyleSheets)

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -736,6 +736,35 @@ describe('createTheme', () => {
         })
         expect(stored).toBe('light')
       })
+
+      it('should ignore non-id persisted values', () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin())
+        app.runWithContext(() => {
+          const storage = useStorage()
+          storage.set('theme', { selected: 'dark' })
+        })
+
+        app.use(
+          createThemePlugin({
+            persist: true,
+            default: 'light',
+            themes: {
+              light: { dark: false, colors: { primary: '#1976d2' } },
+              dark: { dark: true, colors: { primary: '#90caf9' } },
+            },
+          }),
+        )
+
+        let theme: ThemeContext | undefined
+        app.runWithContext(() => {
+          theme = useTheme()
+        })
+
+        expect(theme!.selectedId.value).toBe('light')
+
+        app.unmount()
+      })
     })
   })
 

--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -193,6 +193,12 @@ export interface ThemeContext<
   register: (registration?: Partial<Z>) => E
   /** Bulk-register multiple themes in a single batch. */
   onboard: (registrations: Partial<Z>[]) => E[]
+  /**
+   * Release adapter resources (watchers, stylesheet, unhead entries).
+   * Called automatically on `app.unmount` when using the plugin path.
+   * Call manually when using a standalone context (`createThemeContext`).
+   */
+  dispose: () => void
 }
 
 export interface ThemeOptions<Z extends ThemeRecord = ThemeRecord> extends RegistryOptions {
@@ -364,6 +370,7 @@ export function createTheme (_options: ThemeOptions = {}): ThemeContext {
     register,
     onboard,
     cycle,
+    dispose: () => {},
     get size () {
       return registry.size
     },
@@ -377,6 +384,7 @@ function createThemeFallback (): ThemeContext {
     isDark: shallowRef(false),
     cycle: () => {},
     onboard: () => [],
+    dispose: () => {},
   } as unknown as ThemeContext
 }
 
@@ -389,8 +397,11 @@ export const [createThemeContext, createThemePlugin, useTheme] =
       setup: (context, app, { adapter = new V0StyleSheetThemeAdapter(), target, rgb }) => {
         if (rgb) adapter.rgb = true
         adapter.setup(app, context, target)
+        app.onUnmount(() => adapter.dispose?.())
       },
       persist: ctx => ctx.selectedId.value,
-      restore: (ctx, saved) => ctx.select(saved as ID),
+      restore: (ctx, saved) => {
+        if (typeof saved === 'string' || typeof saved === 'number') ctx.select(saved)
+      },
     },
   )


### PR DESCRIPTION
Fixes #339

## Problem

Both `V0RtlAdapter` and the `useTheme` adapters called `onScopeDispose` from inside the plugin `setup` callback. The plugin install path runs outside any Vue effect scope, so `onScopeDispose` silently no-ops — watches and unhead entries are never torn down when `app.unmount()` is called.

## Solution

Adopt the same pattern already used by `useReducedMotion`:

- Add `dispose?: () => void` to `RtlAdapter` and `ThemeAdapter` base classes
- Concrete adapters assign `this.dispose` instead of calling `onScopeDispose`
- Plugin setup registers `app.onUnmount(() => adapter.dispose?.())` for guaranteed teardown
- Duck-typed `Head`/`HeadEntry` interfaces replace untyped `any` reads from `app._context.provides`
- Validated `restore` callbacks (type-guard checks instead of blind casts)
- `dispose: () => void` added to `RtlContext` and `ThemeContext` interfaces for standalone use