### PR TITLE
fix(createPlugin): defer factory call to install time to prevent resource leaks

### DIFF
--- a/packages/0/src/composables/createPlugin/index.test.ts
+++ b/packages/0/src/composables/createPlugin/index.test.ts
@@ -240,6 +240,20 @@ describe('createPluginContext', () => {
     expect(factory).not.toHaveBeenCalled()
   })
 
+  it('should not run a second factory when a duplicate namespace is installed', () => {
+    const first = vi.fn(() => ({ value: 'first' }))
+    const second = vi.fn(() => ({ value: 'second' }))
+
+    const [, createFirst] = createPluginContext('v0:duplicate-namespace-test', first)
+    const [, createSecond] = createPluginContext('v0:duplicate-namespace-test', second)
+
+    createFirst().install(mockApp)
+    createSecond().install(mockApp)
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+  })
+
   it('should call setup callback on plugin install', () => {
     const setup = vi.fn()
 
@@ -420,6 +434,50 @@ describe('createPluginContext', () => {
       app.use(createXPlugin())
 
       expect(restore).not.toHaveBeenCalled()
+    })
+
+    it('should persist each app independently when one plugin object is reused', async () => {
+      const stateA = shallowRef('a-initial')
+      const stateB = shallowRef('b-initial')
+
+      let installCount = 0
+
+      const [, createXPlugin] = createPluginContext<
+        { namespace?: string, persist?: boolean },
+        { state: typeof stateA }
+      >(
+        'v0:multi-app-isolation-test',
+        () => ({ state: installCount++ === 0 ? stateA : stateB }),
+        {
+          persist: context => context.state.value,
+          restore: (context, saved) => {
+            context.state.value = saved as string
+          },
+        },
+      )
+
+      // The same plugin object installed on two apps. Each install runs the factory
+      // again, so each app owns a distinct context; the persist watch must track the
+      // context that provide created for that app, not the most-recently-installed one.
+      const plugin = createXPlugin({ persist: true })
+
+      const appA = createApp({ render: () => null })
+      appA.use(createStoragePlugin())
+      appA.use(plugin)
+
+      const appB = createApp({ render: () => null })
+      appB.use(createStoragePlugin())
+      appB.use(plugin)
+
+      stateA.value = 'a-updated'
+      await nextTick()
+
+      let storedA: unknown
+      appA.runWithContext(() => {
+        storedA = useStorage().get('multi-app-isolation-test').value
+      })
+
+      expect(storedA).toBe('a-updated')
     })
   })
 })

--- a/packages/0/src/composables/createPlugin/index.test.ts
+++ b/packages/0/src/composables/createPlugin/index.test.ts
@@ -207,6 +207,39 @@ describe('createPluginContext', () => {
     expect(factory).toHaveBeenCalledWith({ prefix: 'my-prefix' })
   })
 
+  it('should not invoke factory until plugin is installed', () => {
+    const factory = vi.fn(() => ({ value: 'lazy' }))
+
+    const [, createXPlugin] = createPluginContext(
+      'v0:lazy-factory-test',
+      factory,
+    )
+
+    createXPlugin()
+    expect(factory).not.toHaveBeenCalled()
+
+    const plugin = createXPlugin()
+    expect(factory).not.toHaveBeenCalled()
+
+    plugin.install(mockApp)
+    expect(factory).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not invoke factory for a plugin created but never installed', () => {
+    const factory = vi.fn(() => ({ value: 'uninstalled' }))
+
+    const [, createXPlugin] = createPluginContext(
+      'v0:never-installed-test',
+      factory,
+    )
+
+    createXPlugin()
+    createXPlugin()
+    createXPlugin()
+
+    expect(factory).not.toHaveBeenCalled()
+  })
+
   it('should call setup callback on plugin install', () => {
     const setup = vi.fn()
 

--- a/packages/0/src/composables/createPlugin/index.ts
+++ b/packages/0/src/composables/createPlugin/index.ts
@@ -175,18 +175,14 @@ export function createPluginContext<
   function createXPlugin (_options: O = {} as O): Plugin {
     const { namespace = defaultNamespace, persist: shouldPersist, ...options } = _options as O & { namespace?: string, persist?: boolean }
 
-    // context is set inside provide (at install time) and read inside setup (which
-    // always runs after provide). The definite assignment assertion is safe because
-    // createPlugin guarantees provide → setup ordering and the INSTALLED guard
-    // prevents setup from running without a prior provide call.
+    // Created lazily inside provide (install time) so a never-installed or skipped
+    // duplicate-namespace plugin allocates no live resources.
+    // https://github.com/vuetifyjs/0/issues/338
     let context!: E
 
     return createPlugin({
       namespace,
       provide: app => {
-        // Lazy: run the factory at install time, not at createXPlugin() call time.
-        // This prevents allocating live resources (watchers, matchMedia listeners,
-        // unhead entries) for plugins that are created but never installed.
         const [, provide, ctx] = createXContext({ ...options, namespace } as O)
         context = ctx
         provide(context, app)
@@ -202,14 +198,19 @@ export function createPluginContext<
       },
       setup: (config?.setup || shouldPersist)
         ? app => {
-          config?.setup?.(context, app, options as Omit<O, 'namespace' | 'persist'>)
+          // Capture once: provide ran first and set context for this app. Reusing the
+          // same plugin object on another app reassigns the shared binding, so the
+          // persist watch must close over this local, not the outer `context`.
+          const ctx = context
+
+          config?.setup?.(ctx, app, options as Omit<O, 'namespace' | 'persist'>)
 
           if (shouldPersist && config?.persist) {
             const storage = getPersistedStorage()
             const key = deriveKey(namespace)
             const stored = storage.get(key)
             const stop = watch(
-              () => config.persist!(context),
+              () => config.persist!(ctx),
               val => {
                 stored.value = val
               },

--- a/packages/0/src/composables/createPlugin/index.ts
+++ b/packages/0/src/composables/createPlugin/index.ts
@@ -174,11 +174,21 @@ export function createPluginContext<
 
   function createXPlugin (_options: O = {} as O): Plugin {
     const { namespace = defaultNamespace, persist: shouldPersist, ...options } = _options as O & { namespace?: string, persist?: boolean }
-    const [, provide, context] = createXContext({ ...options, namespace } as O)
+
+    // context is set inside provide (at install time) and read inside setup (which
+    // always runs after provide). The definite assignment assertion is safe because
+    // createPlugin guarantees provide → setup ordering and the INSTALLED guard
+    // prevents setup from running without a prior provide call.
+    let context!: E
 
     return createPlugin({
       namespace,
       provide: app => {
+        // Lazy: run the factory at install time, not at createXPlugin() call time.
+        // This prevents allocating live resources (watchers, matchMedia listeners,
+        // unhead entries) for plugins that are created but never installed.
+        const [, provide, ctx] = createXContext({ ...options, namespace } as O)
+        context = ctx
         provide(context, app)
 
         if (shouldPersist && config?.restore) {


### PR DESCRIPTION
Fixes #338

## Problem

`createXPlugin()` (via `createPluginContext`) called the context factory **at plugin-creation time** — before `app.use()` ever runs:

```ts
// Before: factory runs here, at createXPlugin() call time
const [, provide, context] = createXContext({ ...options, namespace } as O)
```

This means:
- A plugin **created but never installed** allocates live resources (matchMedia listeners, watchers, unhead entries) that are never torn down
- Two plugin instances with the **same namespace** on one app: the second install is silently skipped, but its factory already ran and its resources are stranded
- `useMediaQuery`'s hydration-deferral contract silently breaks on the plugin path — the factory runs outside any injection context

## Solution

Move factory invocation inside the `provide` callback so it runs at install time, not factory time:

```ts
// After: factory deferred to install time
let context!: E

return createPlugin({
  namespace,
  provide: app => {
    const [, provide, ctx] = createXContext({ ...options, namespace } as O)
    context = ctx
    provide(context, app)
    // ...restore...
  },
  setup: app => {
    // context is set by provide, which always runs first
    config?.setup?.(context, app, options)
    // ...persist watch...
  },
})
```

`provide` always runs before `setup` (enforced by `createPlugin`), so the definite assignment is safe. The `INSTALLED` guard ensures `setup` never runs without a prior `provide` call.

`createXContext` (the standalone path) is unchanged — standalone contexts still create eagerly, which is correct.

## Test plan

- [ ] 2 new tests verify factory is not called at `createXPlugin()` time
- [ ] All existing persist/restore ordering tests pass
- [ ] 6110 tests pass, typecheck and lint clean