### PR TITLE
chore(ci): split link checking into offline PR gate and scheduled external pass

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,66 @@
+name: Link Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - run: pnpm run build:docs
+        env:
+          VITE_API_SERVER_URL: ${{ vars.API_SERVER_URL }}
+          SKIP_OG_IMAGES: '1'
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      - name: Link Checker (full)
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          lycheeVersion: v0.22.0
+          # Full internal + external pass. 429 accepted: rate limiting is not
+          # link rot. Default accept set is 100..=103,200..=299 — keep it when
+          # extending.
+          args: >-
+            --config lychee.toml
+            --cache
+            --max-cache-age 3d
+            --cache-exclude-status '429,500..'
+            --max-retries 5
+            --retry-wait-time 5
+            --accept '100..=103,200..=299,429'
+            './apps/docs/dist'
+          fail: false
+      - name: Find existing report issue
+        id: existing
+        if: steps.lychee.outputs.exit_code != 0
+        run: |
+          number="$(gh issue list --repo "$GITHUB_REPOSITORY" --label documentation --state open --search 'Link checker report in:title' --json number --jq '.[0].number // empty')"
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Create or update report issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link checker report
+          content-filepath: ./lychee/out.md
+          issue-number: ${{ steps.existing.outputs.number }}
+          labels: documentation
+      - name: Surface broken links in run status
+        if: steps.lychee.outputs.exit_code != 0
+        run: exit 1

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -108,11 +108,18 @@ jobs:
         env:
           VITE_API_SERVER_URL: ${{ vars.API_SERVER_URL }}
           SKIP_OG_IMAGES: '1'
-      - name: Link Checker
+      - name: Link Checker (internal only)
         uses: lycheeverse/lychee-action@v2
         with:
           lycheeVersion: v0.22.0
-          args: --config lychee.toml './apps/docs/dist'
+          # --offline skips all remote URLs; the remap folds https://0.vuetifyjs.com
+          # self-links (canonical/og tags) onto the local dist so they are validated
+          # as files. External link health runs weekly in link-check.yml instead.
+          args: >-
+            --config lychee.toml
+            --offline
+            --remap 'https://0\.vuetifyjs\.com(.*) file://${{ github.workspace }}/apps/docs/dist$1'
+            './apps/docs/dist'
           fail: true
 
   playground-check:

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,4 @@
+# Shared by both passes: PR internal-only (pr-checks.yml, --offline) and weekly full (link-check.yml).
 # /dist/documents: breadcrumbs examples use intentional demo hrefs.
 # /dist/https:: lychee misparses Vue component markup (<DocsCard href>) in the
 # copied page-source markdown, resolving the URL as a relative path.


### PR DESCRIPTION
docs-check has failed spuriously 5 times in the last 3 days on PRs whose changes had nothing to do with links: third-party connection resets (unocss.dev, designtokens.org, contributor-covenant.org, vite.dev — a different domain each run) and 502s from `https://0.vuetifyjs.com` self-links whenever the run overlapped a docs deploy — which happens on every master merge, making the PR gate a race condition against our own merge cadence.

## PR gate (deterministic)

`docs-check` now runs lychee with `--offline` — no network at all; every intra-dist file link and anchor is still validated and still blocks (`fail: true`). The ~300 `https://0.vuetifyjs.com` self-links (canonical/og tags) are folded onto the local dist via `--remap`, so they're validated as files on PRs instead of hitting production. Verified against the real v0.22.0 binary on a fresh local build: 16,305 links, 0 errors, 0s runtime, zero network requests; negative tests (broken internal link, broken remapped self-link) both fail with exit 2.

## External pass (scheduled)

New `link-check.yml`: Mondays 09:00 UTC + `workflow_dispatch`. Full internal+external lychee with resilience the PR gate never had — `--max-retries 5`, retry wait, `--cache` (3-day age, persisted via actions/cache, transient 429/5xx excluded from the cache), and 429 accepted (rate limiting is not link rot). On failure it creates **or updates** a single "Link checker report" issue (labeled `documentation`) with lychee's markdown report, then marks the run red — the issue is the durable signal, and nothing blocks PRs.

One shared `lychee.toml` for both passes (the existing excludes are harmless under `--offline`). Both workflows actionlint-clean; setup-action pinned to the same SHA as pr-checks.yml.