### PR TITLE
docs: drop redundant DocsNavigator async registration

### DIFF
--- a/apps/docs/src/plugins/app.ts
+++ b/apps/docs/src/plugins/app.ts
@@ -6,7 +6,6 @@ import type { App } from 'vue'
 
 export default function app (app: App) {
   app.component('DocsPageFeatures', defineAsyncComponent(() => import('@/components/docs/meta/DocsPageFeatures.vue')))
-  app.component('DocsNavigator', defineAsyncComponent(() => import('@/components/docs/DocsNavigator.vue')))
   app.component('DocsExample', defineAsyncComponent(() => import('@/components/docs/DocsExample.vue')))
   app.component('DocsCodeGroup', defineAsyncComponent(() => import('@/components/docs/DocsCodeGroup.vue')))
   app.component('DocsMermaid', defineAsyncComponent(() => import('@/components/docs/DocsMermaid.vue')))


### PR DESCRIPTION
## Summary

Removes the last `INEFFECTIVE_DYNAMIC_IMPORT` warning from the docs build (follow-up to #332):

```
[INEFFECTIVE_DYNAMIC_IMPORT] Warning: src/components/docs/DocsNavigator.vue is dynamically imported by src/plugins/app.ts but also statically imported by src/components/docs/DocsBackmatter.vue, src/pages/guide/essentials/using-the-docs.md
```

The global async registration in `plugins/app.ts` (from fe02de4b's lazy-register pass) is dead code for `DocsNavigator`: unplugin-vue-components injects a static import at every usage site — including markdown pages — and locally resolved components take precedence over global registration. `DocsBackmatter` renders it in the footer of every docs page, so lazy registration never bought anything. Nothing resolves it by string name (`resolveComponent`/`:is` sweeps are empty).

The other four registrations in the plugin are equally redundant for resolution but don't warn (their static importers all live in lazy page chunks); deleting the whole plugin is a candidate for a separate build-verified pass.

## Verified

Local `pnpm build:docs`: build green, zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings remaining, no component-resolution failures — `DocsNavigator` still emits the same shared chunk via its static importers.