### PR TITLE
fix: declare sideEffects, expose web-types, and correct the temporal and peer contracts

### DIFF
--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -23,7 +23,7 @@ Date manipulation using the Temporal API with locale-aware formatting and adapte
 
 ## Installation
 
-The built-in `V0DateAdapter` requires the `@js-temporal/polyfill` package:
+The built-in `V0DateAdapter` uses the runtime's native Temporal implementation when available. Runtimes without native Temporal need the `@js-temporal/polyfill` optional peer:
 
 ::: code-group no-filename
 
@@ -46,7 +46,7 @@ bun add @js-temporal/polyfill
 :::
 
 > [!TIP]
-> The Temporal API is a Stage 3 [TC39 proposal](https://github.com/tc39/proposal-temporal). Once browsers ship native support, the polyfill will no longer be required.
+> The Temporal API is a Stage 3 [TC39 proposal](https://github.com/tc39/proposal-temporal). The adapter prefers native Temporal and only falls back to the polyfill — once every runtime you target ships native support, the polyfill is no longer required.
 
 Then install the date plugin with an adapter:
 
@@ -86,7 +86,7 @@ Adapters let you swap the underlying date library without changing your applicat
 |---------|--------|-------------|
 | `V0DateAdapter` | `@vuetify/v0/date` | [Temporal API](https://tc39.es/proposal-temporal/docs/) adapter[^temporal] |
 
-[^temporal]: Requires the [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) package until native Temporal ships in all evergreen browsers. Install with `pnpm add @js-temporal/polyfill`.
+[^temporal]: Uses native Temporal when the runtime provides it; otherwise requires the [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) optional peer. Install with `pnpm add @js-temporal/polyfill`.
 
 ### DateAdapter Interface
 

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -15,6 +15,8 @@
   ],
   "types": "./dist/index.d.mts",
   "type": "module",
+  "sideEffects": false,
+  "web-types": "./dist/json/web-types.json",
   "files": [
     "dist"
   ],
@@ -86,7 +88,8 @@
   "peerDependencies": {
     "@adobe/leonardo-contrast-colors": ">=1.0.0",
     "@ant-design/colors": ">=7.0.0",
-    "@flagsmith/flagsmith": "^11.0.0",
+    "@flagsmith/flagsmith": ">=11.0.0",
+    "@js-temporal/polyfill": ">=0.5.0",
     "@material/material-color-utilities": ">=0.3.0",
     "launchdarkly-js-client-sdk": "^3.0.0",
     "posthog-js": "^1.0.0",
@@ -95,6 +98,9 @@
   },
   "peerDependenciesMeta": {
     "@flagsmith/flagsmith": {
+      "optional": true
+    },
+    "@js-temporal/polyfill": {
       "optional": true
     },
     "launchdarkly-js-client-sdk": {
@@ -120,6 +126,7 @@
     "@adobe/leonardo-contrast-colors": "catalog:",
     "@ant-design/colors": "catalog:",
     "@flagsmith/flagsmith": "catalog:",
+    "@js-temporal/polyfill": "catalog:",
     "@material/material-color-utilities": "catalog:",
     "@vue/compiler-dom": "catalog:",
     "@vue/test-utils": "catalog:",
@@ -333,8 +340,5 @@
       "development": "./src/index.ts",
       "default": "./dist/browser/index.js"
     }
-  },
-  "optionalDependencies": {
-    "@js-temporal/polyfill": "catalog:"
   }
 }

--- a/packages/0/src/composables/useDate/adapters/v0.ts
+++ b/packages/0/src/composables/useDate/adapters/v0.ts
@@ -7,14 +7,17 @@
  *
  * Implements the full date-io IUtils interface for industry compatibility.
  *
- * Requires native Temporal support or @js-temporal/polyfill.
+ * Uses the runtime's native Temporal implementation when present, falling back
+ * to the @js-temporal/polyfill optional peer. The polyfill import is static, so
+ * runtimes without native Temporal must have the peer installed to load this
+ * module.
  *
  * @see https://tc39.es/proposal-temporal/docs/
  * @see https://github.com/dmtrKovalenko/date-io
  */
 
 // Polyfill
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal as polyfill } from '@js-temporal/polyfill'
 
 // Globals
 import { IN_BROWSER } from '#v0/constants/globals'
@@ -25,7 +28,10 @@ import { DateAdapter } from './adapter'
 // Utilities
 import { isFunction, isNull, isNullOrUndefined, isNumber, isString } from '#v0/utilities'
 
-type PlainDateTime = Temporal.PlainDateTime
+/** Resolved Temporal implementation — native when the runtime provides it, polyfill otherwise. */
+export const Temporal = (globalThis as unknown as { Temporal?: typeof polyfill }).Temporal ?? polyfill
+
+type PlainDateTime = polyfill.PlainDateTime
 
 /** Single regex for token replacement in formatByString */
 const FORMAT_TOKEN_REGEX = /YYYY|YY|MMMM|MMM|MM|M|dddd|ddd|DD|D|HH|H|hh|h|mm|m|ss|s|A|a/g

--- a/packages/0/src/composables/useDate/index.bench.ts
+++ b/packages/0/src/composables/useDate/index.bench.ts
@@ -1,8 +1,7 @@
-import { Temporal } from '@js-temporal/polyfill'
 import { bench, describe } from 'vitest'
 
 // Adapters
-import { V0DateAdapter } from './adapters/v0'
+import { Temporal, V0DateAdapter } from './adapters/v0'
 
 describe('useDate benchmarks', () => {
   describe('V0DateAdapter', () => {

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -1,8 +1,7 @@
-import { Temporal } from '@js-temporal/polyfill'
 import { describe, it, expect, beforeEach } from 'vitest'
 
 // Adapters
-import { V0DateAdapter } from './adapters/v0'
+import { Temporal, V0DateAdapter } from './adapters/v0'
 
 import { createDate, createDateContext, createDatePlugin, useDate } from './index'
 

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -5,6 +5,11 @@
   "license": "MIT",
   "types": "./dist/index.d.mts",
   "type": "module",
+  "sideEffects": [
+    "*.scss",
+    "*.css",
+    "*.vue"
+  ],
   "files": [
     "dist"
   ],
@@ -18,7 +23,7 @@
     "typecheck": "vue-tsc --noEmit --incremental"
   },
   "peerDependencies": {
-    "vue": ">=3.3.0"
+    "vue": ">=3.5.0"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,9 @@ importers:
       '@flagsmith/flagsmith':
         specifier: 'catalog:'
         version: 11.0.0
+      '@js-temporal/polyfill':
+        specifier: 'catalog:'
+        version: 0.5.1
       '@material/material-color-utilities':
         specifier: 'catalog:'
         version: 0.4.0
@@ -613,10 +616,6 @@ importers:
       vue-i18n:
         specifier: 'catalog:'
         version: 11.4.0(vue@3.5.33(typescript@6.0.3))
-    optionalDependencies:
-      '@js-temporal/polyfill':
-        specifier: 'catalog:'
-        version: 0.5.1
 
   packages/genesis:
     dependencies:
@@ -643,8 +642,8 @@ importers:
         specifier: workspace:*
         version: link:../0
       vue:
-        specifier: '>=3.3.0'
-        version: 3.5.31(typescript@6.0.3)
+        specifier: '>=3.5.0'
+        version: 3.5.33(typescript@6.0.3)
     devDependencies:
       '@tsdown/css':
         specifier: 'catalog:'
@@ -663,7 +662,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: 'catalog:'
-        version: 7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(vue@3.5.31(typescript@6.0.3))(yaml@2.8.3)
+        version: 7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(vue@3.5.33(typescript@6.0.3))(yaml@2.8.3)
 
 packages:
 
@@ -3215,26 +3214,14 @@ packages:
       vue:
         optional: true
 
-  '@vue/compiler-core@3.5.31':
-    resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
-
   '@vue/compiler-core@3.5.33':
     resolution: {integrity: sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==}
-
-  '@vue/compiler-dom@3.5.31':
-    resolution: {integrity: sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==}
 
   '@vue/compiler-dom@3.5.33':
     resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
 
-  '@vue/compiler-sfc@3.5.31':
-    resolution: {integrity: sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==}
-
   '@vue/compiler-sfc@3.5.33':
     resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
-
-  '@vue/compiler-ssr@3.5.31':
-    resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
 
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
@@ -3263,39 +3250,22 @@ packages:
   '@vue/language-core@3.2.7':
     resolution: {integrity: sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==}
 
-  '@vue/reactivity@3.5.31':
-    resolution: {integrity: sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==}
-
   '@vue/reactivity@3.5.33':
     resolution: {integrity: sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==}
 
   '@vue/repl@4.7.1':
     resolution: {integrity: sha512-8w5Z3cyqBJ5ufzXO2eut2stzb7aX/ZnSva2d3ee8eEINEB7FG2JYwc14eAHHHGGuoXOGN5v4cyb5ti/YZGcwlg==}
 
-  '@vue/runtime-core@3.5.31':
-    resolution: {integrity: sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==}
-
   '@vue/runtime-core@3.5.33':
     resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
 
-  '@vue/runtime-dom@3.5.31':
-    resolution: {integrity: sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==}
-
   '@vue/runtime-dom@3.5.33':
     resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
-
-  '@vue/server-renderer@3.5.31':
-    resolution: {integrity: sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==}
-    peerDependencies:
-      vue: 3.5.31
 
   '@vue/server-renderer@3.5.33':
     resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
     peerDependencies:
       vue: 3.5.33
-
-  '@vue/shared@3.5.31':
-    resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
@@ -5624,10 +5594,6 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   posthog-js@1.372.8:
     resolution: {integrity: sha512-NAFWVScFGnU5jgGNLkrY/UnGH82uULs9RsJ/f26LkLn1l0MOZfq+/z+2RaOOQQX4NHruIVuxqz3J/50bgRG68A==}
 
@@ -6873,14 +6839,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
-
-  vue@3.5.31:
-    resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vue@3.5.33:
     resolution: {integrity: sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==}
@@ -9548,14 +9506,6 @@ snapshots:
     optionalDependencies:
       vue: 3.5.33(typescript@6.0.3)
 
-  '@vue/compiler-core@3.5.31':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/shared': 3.5.31
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-core@3.5.33':
     dependencies:
       '@babel/parser': 7.29.2
@@ -9564,27 +9514,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.31':
-    dependencies:
-      '@vue/compiler-core': 3.5.31
-      '@vue/shared': 3.5.31
-
   '@vue/compiler-dom@3.5.33':
     dependencies:
       '@vue/compiler-core': 3.5.33
       '@vue/shared': 3.5.33
-
-  '@vue/compiler-sfc@3.5.31':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.5.31
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.8
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.33':
     dependencies:
@@ -9597,11 +9530,6 @@ snapshots:
       magic-string: 0.30.21
       postcss: 8.5.14
       source-map-js: 1.2.1
-
-  '@vue/compiler-ssr@3.5.31':
-    dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/shared': 3.5.31
 
   '@vue/compiler-ssr@3.5.33':
     dependencies:
@@ -9651,32 +9579,16 @@ snapshots:
       path-browserify: 1.0.1
       picomatch: 4.0.4
 
-  '@vue/reactivity@3.5.31':
-    dependencies:
-      '@vue/shared': 3.5.31
-
   '@vue/reactivity@3.5.33':
     dependencies:
       '@vue/shared': 3.5.33
 
   '@vue/repl@4.7.1(patch_hash=22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe)': {}
 
-  '@vue/runtime-core@3.5.31':
-    dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/shared': 3.5.31
-
   '@vue/runtime-core@3.5.33':
     dependencies:
       '@vue/reactivity': 3.5.33
       '@vue/shared': 3.5.33
-
-  '@vue/runtime-dom@3.5.31':
-    dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/runtime-core': 3.5.31
-      '@vue/shared': 3.5.31
-      csstype: 3.2.3
 
   '@vue/runtime-dom@3.5.33':
     dependencies:
@@ -9685,19 +9597,11 @@ snapshots:
       '@vue/shared': 3.5.33
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.31(vue@3.5.31(typescript@6.0.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
-      vue: 3.5.31(typescript@6.0.3)
-
   '@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.33
       '@vue/shared': 3.5.33
       vue: 3.5.33(typescript@6.0.3)
-
-  '@vue/shared@3.5.31': {}
 
   '@vue/shared@3.5.33': {}
 
@@ -12298,12 +12202,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   posthog-js@1.372.8:
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -13378,29 +13276,6 @@ snapshots:
       unplugin-utils: 0.3.1
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  unplugin-vue@7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(vue@3.5.31(typescript@6.0.3))(yaml@2.8.3):
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@vue/reactivity': 3.5.33
-      obug: 2.1.1
-      unplugin: 3.0.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.31(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
   unplugin-vue@7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(vue@3.5.33(typescript@6.0.3))(yaml@2.8.3):
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -13651,16 +13526,6 @@ snapshots:
     dependencies:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 3.2.7
-      typescript: 6.0.3
-
-  vue@3.5.31(typescript@6.0.3):
-    dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-sfc': 3.5.31
-      '@vue/runtime-dom': 3.5.31
-      '@vue/server-renderer': 3.5.31(vue@3.5.31(typescript@6.0.3))
-      '@vue/shared': 3.5.31
-    optionalDependencies:
       typescript: 6.0.3
 
   vue@3.5.33(typescript@6.0.3):


### PR DESCRIPTION
Four packaging-contract fixes from the audit's medium tier, each backed by module-level verification.

## `sideEffects`

- **@vuetify/v0** → `"sideEffects": false`. Audited every module in src and the built dist: no bare imports, no CSS, no module-scope global writes, no top-level effectful calls — module-level statements are all PURE-annotated closure factories (the one `window.__v0Logger__` write happens inside a plugin `setup` hook, not at import). Without the field, webpack/rspack-family bundlers retain everything reachable from the root barrel — the worst case for a pay-for-what-you-use headless library, and flipping it after 1.0 would be a riskier behavioral change than landing it now.
- **@vuetify/paper** → `["*.scss", "*.css", "*.vue"]` (the vuetify/vuetify precedent): paper ships real CSS that consumers import manually; `false` would let bundlers drop it.

## @js-temporal/polyfill: optionalDependencies → optional peer

It was the worst of both worlds: every consumer installed the full Temporal polyfill by default even without touching `@vuetify/v0/date`, yet under `--no-optional` the date subpath threw MODULE_NOT_FOUND. Now it follows the exact pattern the color-palette peers use: optional `peerDependencies` entry + catalog devDependency. The adapter resolves **native Temporal first** (`globalThis.Temporal ?? polyfill`) — Node ≥26 and modern runtimes never touch the polyfill; docs updated to say so truthfully.

One subtlety: with native Temporal on Node 26, cross-implementation `instanceof` makes polyfill-constructed test fixtures invisible to the native-resolved adapter — the useDate tests/bench now build fixtures from the adapter's own resolved `Temporal` (internal export, not public API).

## web-types discoverability

The build has always generated and shipped `dist/json/web-types.json` (353 KB, 171 elements), but the `"web-types"` key existed only on the **private root** manifest — JetBrains discovery silently never worked for any consumer while the artifact padded every tarball. Added the key to the published manifest; verified it survives tsdown's exports regeneration.

## Peer hygiene

- `@flagsmith/flagsmith` peer widened `^11.0.0` → `>=11.0.0` — it lives on packages/0 (not paper, as the audit had it), and the adapter's coupling is type-only (`import type` + injected client; verified no runtime import), so a major-locked range only generates spurious peer warnings.
- `@vuetify/paper` vue peer aligned `>=3.3.0` → `>=3.5.0` to match the v0 dependency it hard-requires.

Found while in there, **not** fixed here (tracked separately): paper's `./style.css` export resolves to a JS stub — the sass plugin writes the real CSS to `dist/index.css`.

Builds (`build:0`, `build:paper`), typechecks (both packages), and the full suite (6137 passed) are green.