### PR TITLE
fix(createDataGrid): stabilise pinned-column borders in PinnedGrid example

### DIFF
--- a/apps/docs/src/examples/composables/create-data-grid/pinned/PinnedGrid.vue
+++ b/apps/docs/src/examples/composables/create-data-grid/pinned/PinnedGrid.vue
@@ -43,8 +43,6 @@
                 :key="col.id"
                 class="group relative px-3 py-2 font-medium select-none bg-surface-tint"
                 :class="[
-                  col.pinned === 'left' ? 'border-r border-divider' : '',
-                  col.pinned === 'right' ? 'border-l border-divider' : '',
                   isNumeric(col.id) ? 'text-right' : 'text-left',
                 ]"
                 :style="{
@@ -53,7 +51,11 @@
                   left: col.pinned === 'left' ? inset(col.offset) : undefined,
                   right: col.pinned === 'right' ? inset(col.offset) : undefined,
                   zIndex: col.pinned ? 10 : undefined,
-                  boxShadow: col.pinned === 'left' ? '4px 0 6px -4px rgb(0 0 0 / 0.2)' : col.pinned === 'right' ? '-4px 0 6px -4px rgb(0 0 0 / 0.2)' : undefined,
+                  boxShadow: col.pinned === 'left'
+                    ? '1px 0 0 0 var(--v0-divider), 4px 0 6px -4px rgb(0 0 0 / 0.2)'
+                    : col.pinned === 'right'
+                      ? '-1px 0 0 0 var(--v0-divider), -4px 0 6px -4px rgb(0 0 0 / 0.2)'
+                      : undefined,
                 }"
                 @click="onSort(col.id)"
               >
@@ -98,11 +100,11 @@
             </tr>
           </thead>
 
-          <tbody class="divide-y divide-divider">
+          <tbody>
             <tr
               v-for="item in grid.items.value"
               :key="item.id"
-              class="group hover:bg-surface-tint"
+              class="group border-b border-divider last:border-b-0 hover:bg-surface-tint"
             >
               <td
                 v-for="col in grid.layout.columns.value"
@@ -110,8 +112,6 @@
                 class="px-3 py-1.5 truncate"
                 :class="[
                   col.pinned ? 'bg-surface group-hover:bg-surface-tint' : '',
-                  col.pinned === 'left' ? 'border-r border-divider' : '',
-                  col.pinned === 'right' ? 'border-l border-divider' : '',
                   isNumeric(col.id) ? 'text-right font-mono tabular-nums' : '',
                 ]"
                 :style="{
@@ -120,7 +120,11 @@
                   left: col.pinned === 'left' ? inset(col.offset) : undefined,
                   right: col.pinned === 'right' ? inset(col.offset) : undefined,
                   zIndex: col.pinned ? 10 : undefined,
-                  boxShadow: col.pinned === 'left' ? '4px 0 6px -4px rgb(0 0 0 / 0.2)' : col.pinned === 'right' ? '-4px 0 6px -4px rgb(0 0 0 / 0.2)' : undefined,
+                  boxShadow: col.pinned === 'left'
+                    ? '1px 0 0 0 var(--v0-divider), 4px 0 6px -4px rgb(0 0 0 / 0.2)'
+                    : col.pinned === 'right'
+                      ? '-1px 0 0 0 var(--v0-divider), -4px 0 6px -4px rgb(0 0 0 / 0.2)'
+                      : undefined,
                 }"
               >
                 <template v-if="col.id === 'ticker'">


### PR DESCRIPTION
Fixes #322 and #323.

## Problem

Two related rendering glitches in the `PinnedGrid` docs example:

**#322 – horizontal row dividers disappear at non-100% zoom in Chromium**

`<tbody class="divide-y divide-divider">` puts a `border-top` on each `<tr>`. At zoom levels other than 100%, Chromium's sub-pixel rounding can silently drop the border for individual rows. Hovering the row (which triggers a repaint) makes them re-appear, confirming this is a paint-caching artefact rather than a layout bug.

**#323 – pinned-column separator "moves" when scrolling horizontally**

The separator was a CSS `border-r`/`border-l` class on the sticky `<td>`. Chromium can paint a sticky cell's CSS border at a fractional offset, leaving a gap between the border and the cell edge as non-sticky content scrolls beneath it.

## Fix

1. **Row dividers**: replace `divide-y divide-divider` on `<tbody>` with `border-b border-divider last:border-b-0` on each `<tr>`. Each row now owns its border; there is no cross-element `border-top` that can be silently skipped.

2. **Pinned separator**: replace the `border-r`/`border-l` CSS classes with a zero-blur, zero-spread `box-shadow` (`1px 0 0 0 var(--v0-divider)` / `-1px 0 0 0 var(--v0-divider)`). Box-shadow composites on top of scrolling content and is not affected by the sub-pixel rounding that mis-positions CSS borders on sticky cells. The existing drop-shadow is retained as a second `box-shadow` layer.