### PR TITLE
fix(Treeview): don't intercept keys from embedded interactive controls

### DIFF
--- a/apps/docs/src/examples/components/treeview/SettingNode.vue
+++ b/apps/docs/src/examples/components/treeview/SettingNode.vue
@@ -74,8 +74,8 @@
         role="switch"
         tabindex="0"
         @click.stop="onToggle(node)"
-        @keydown.space.stop.prevent="onToggle(node)"
         @keydown.enter.stop.prevent="onToggle(node)"
+        @keydown.space.stop.prevent="onToggle(node)"
       >
         <span
           class="absolute size-3.5 rounded-full bg-white shadow-sm transition-transform duration-150"

--- a/apps/docs/src/examples/components/treeview/SettingNode.vue
+++ b/apps/docs/src/examples/components/treeview/SettingNode.vue
@@ -72,7 +72,10 @@
         class="relative inline-flex items-center w-8 h-4.5 rounded-full shrink-0 transition-colors duration-150"
         :class="node.value ? 'bg-primary' : 'bg-surface-variant'"
         role="switch"
+        tabindex="0"
         @click.stop="onToggle(node)"
+        @keydown.space.stop.prevent="onToggle(node)"
+        @keydown.enter.stop.prevent="onToggle(node)"
       >
         <span
           class="absolute size-3.5 rounded-full bg-white shadow-sm transition-transform duration-150"
@@ -87,7 +90,7 @@
           :model-value="node.value"
           @update:model-value="onSelect(node, String($event))"
         >
-          <Select.Activator as="div" class="inline-flex items-center gap-1 bg-transparent border border-divider rounded px-1.5 py-0.5 text-xs text-on-surface cursor-pointer">
+          <Select.Activator class="inline-flex items-center gap-1 bg-transparent border border-divider rounded px-1.5 py-0.5 text-xs text-on-surface cursor-pointer">
             <Select.Value v-slot="{ selectedValue }">{{ selectedValue }}</Select.Value>
             <Select.Cue v-slot="{ isOpen }" class="text-[10px] opacity-50">{{ isOpen ? '&#x25B4;' : '&#x25BE;' }}</Select.Cue>
           </Select.Activator>

--- a/packages/0/src/components/Treeview/TreeviewList.vue
+++ b/packages/0/src/components/Treeview/TreeviewList.vue
@@ -117,6 +117,12 @@
   }
 
   function onKeydown (e: KeyboardEvent) {
+    // When the event bubbles from a child element that is NOT a treeitem (e.g. an
+    // embedded switch or combobox inside a row), let that element handle its own
+    // key events rather than intercepting them at the tree level.
+    const target = e.target as Element
+    if (target !== e.currentTarget && target.getAttribute('role') !== 'treeitem') return
+
     const id = roving.focusedId.value
     const ticket = isNullOrUndefined(id) ? undefined : nested.get(id)
     const rtl = isRtl(e)

--- a/packages/0/src/components/Treeview/index.test.ts
+++ b/packages/0/src/components/Treeview/index.test.ts
@@ -913,6 +913,41 @@ describe('treeview', () => {
 
         expect(itemProps.isSelected).toBe(!initial)
       })
+
+      it('should not intercept keys originating from embedded interactive controls', async () => {
+        let switchClicked = 0
+
+        const wrapper = mount(Treeview.Root, {
+          slots: {
+            default: () =>
+              h(Treeview.List as any, {}, () =>
+                h(Treeview.Item as any, { value: 'item' }, () => [
+                  h(Treeview.Activator, {}, () => 'Label'),
+                  h('span', {
+                    role: 'switch',
+                    'aria-checked': 'false',
+                    onClick: () => switchClicked++,
+                    onKeydown: (e: KeyboardEvent) => {
+                      if (e.key === ' ') switchClicked++
+                    },
+                  }),
+                ]),
+              ),
+          },
+        })
+
+        await nextTick()
+
+        const switchEl = wrapper.find('[role="switch"]')
+        // Dispatch the keydown event on the switch element itself so it bubbles
+        // to the list with e.target = switchEl.element (not treeitem).
+        const spaceEvent = new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+        switchEl.element.dispatchEvent(spaceEvent)
+        await nextTick()
+
+        // The treeview should have passed the event through; the switch handler fired.
+        expect(switchClicked).toBe(1)
+      })
     })
 
     describe('slot props', () => {

--- a/packages/0/src/components/Treeview/index.test.ts
+++ b/packages/0/src/components/Treeview/index.test.ts
@@ -924,10 +924,10 @@ describe('treeview', () => {
                 h(Treeview.Item as any, { value: 'item' }, () => [
                   h(Treeview.Activator, {}, () => 'Label'),
                   h('span', {
-                    role: 'switch',
+                    'role': 'switch',
                     'aria-checked': 'false',
-                    onClick: () => switchClicked++,
-                    onKeydown: (e: KeyboardEvent) => {
+                    'onClick': () => switchClicked++,
+                    'onKeydown': (e: KeyboardEvent) => {
                       if (e.key === ' ') switchClicked++
                     },
                   }),


### PR DESCRIPTION
Fixes #336.

## Problem

`TreeviewList.onKeydown` intercepted **all** key events that bubbled up to the tree container, regardless of where they originated. When a user tab-focused into an embedded control inside a tree row (a `role="switch"` toggle or a `Select` combobox), pressing Space, Enter, or Arrow triggered the **tree** handler instead of the control's own handler:

- Space → toggled tree selection instead of flipping the switch
- Arrow keys → navigated the tree instead of moving through Select options
- The controls were also unreachable via Tab in the first place (no `tabindex`; `Select.Activator as="div"` is not natively focusable)

Analysis from issue #336 by @J-Sek:
> The list-level onKeydown would steal their Space/Enter/Arrow keys (no e.target guard), so the Select dropdown couldn't be operated.

## Fix

### `TreeviewList.vue` (core)

Add a guard at the top of `onKeydown`:

```ts
const target = e.target as Element
if (target !== e.currentTarget && target.getAttribute('role') !== 'treeitem') return
```

- Events dispatched directly on the tree container (`e.target === e.currentTarget`) are still handled — preserves existing roving-focus keyboard navigation.
- Events that bubble from a child element with `role="treeitem"` (the roving-focus element) are still handled.
- Events from any other descendant (switch, combobox, button, input, …) are passed through.

### `SettingNode.vue` (docs example)

- Add `tabindex="0"` + `@keydown.space` / `@keydown.enter` to the `role="switch"` span so the toggle is keyboard-reachable and operable.
- Remove `as="div"` from `Select.Activator` (defaults to `as="button"`) so the combobox is natively focusable and Tab-reachable.

## Test

New unit test dispatches a `keydown(Space)` event directly on a `role="switch"` child and asserts the switch's own handler fires (not the tree's selection toggle). All 101 existing Treeview tests continue to pass.