### PR TITLE
docs(Single): reposition as single-selection provider, route radio users to Radio

### DIFF
--- a/apps/docs/src/examples/components/single/basic.vue
+++ b/apps/docs/src/examples/components/single/basic.vue
@@ -8,16 +8,18 @@
 <template>
   <Single.Root v-model="selected">
     <div class="flex flex-col gap-2">
-      <Single.Item v-for="size in ['small', 'medium', 'large']" :key="size" :value="size">
-        <template #default="{ isSelected, toggle }">
-          <button
-            class="px-3 py-1.5 border rounded text-left text-sm"
-            :class="isSelected ? 'bg-surface-tint border-primary' : 'bg-surface border-divider'"
-            @click="toggle"
-          >
-            {{ size }}
-          </button>
-        </template>
+      <Single.Item
+        v-for="size in ['small', 'medium', 'large']"
+        :key="size"
+        v-slot="{ attrs }"
+        :value="size"
+      >
+        <button
+          v-bind="attrs"
+          class="px-3 py-1.5 border rounded text-left text-sm bg-surface border-divider data-[selected]:bg-surface-tint data-[selected]:border-primary"
+        >
+          {{ size }}
+        </button>
       </Single.Item>
     </div>
   </Single.Root>

--- a/apps/docs/src/examples/components/single/mandatory.vue
+++ b/apps/docs/src/examples/components/single/mandatory.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+  import { Single } from '@vuetify/v0'
+  import { shallowRef } from 'vue'
+
+  const selected = shallowRef<string>()
+
+  const plans = [
+    { value: 'free', label: 'Free', disabled: true },
+    { value: 'pro', label: 'Pro' },
+    { value: 'enterprise', label: 'Enterprise' },
+  ]
+</script>
+
+<template>
+  <Single.Root v-model="selected" mandatory="force">
+    <div class="flex flex-col gap-2">
+      <Single.Item
+        v-for="plan in plans"
+        :key="plan.value"
+        v-slot="{ attrs }"
+        :disabled="plan.disabled"
+        :value="plan.value"
+      >
+        <button
+          v-bind="attrs"
+          class="px-3 py-1.5 border rounded text-left text-sm bg-surface border-divider data-[selected]:bg-surface-tint data-[selected]:border-primary data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
+        >
+          {{ plan.label }}
+        </button>
+      </Single.Item>
+    </div>
+  </Single.Root>
+
+  <p class="mt-4">Selected: {{ selected }}</p>
+</template>

--- a/apps/docs/src/pages/components/providers/single.md
+++ b/apps/docs/src/pages/components/providers/single.md
@@ -1,10 +1,10 @@
 ---
-title: Single - Radio Group Pattern for Vue 3
+title: Single - Headless Single-Selection Provider for Vue 3
 meta:
 - name: description
-  content: Build radio buttons and single-selection UIs with automatic deselection. Extends Selection composable for tabs, toggles, and exclusive choice patterns in Vue 3.
+  content: Headless single-selection state for Vue 3 — build tabs, segmented controls, theme pickers, and radio-style choice groups. Selecting an item auto-deselects the previous one.
 - name: keywords
-  content: single, radio button, single-select, tabs, toggle, Vue 3, headless, exclusive selection
+  content: single, single-select, exclusive selection, tabs, segmented control, theme picker, radio group, Vue 3, headless
 features:
   category: Component
   label: 'C: Single'
@@ -12,15 +12,19 @@ features:
   renderless: true
   level: 2
 related:
+  - /components/forms/radio
   - /composables/selection/create-single
   - /components/providers/selection
 ---
 
 # Single
 
-A headless component for managing single-selection with automatic deselection of previous items.
+A headless provider for exclusive single-selection — selecting an item automatically deselects the previously selected one. Drives tabs, segmented controls, theme pickers, and other exclusive-choice UIs.
 
 <DocsPageFeatures :frontmatter />
+
+> [!NOTE]
+> Single is a headless single-selection *state provider* — it tracks the selected item but ships no `role`, keyboard navigation, or focus management. For an accessible radio group with `role="radio"` and arrow-key navigation, use [Radio](/components/forms/radio), which is built on the same single-selection logic.
 
 ## Usage
 
@@ -31,40 +35,9 @@ The Single component is a specialization of Selection that enforces single-selec
 
 ### Single-Select Group
 
-Radio-button-style single selection with size options that automatically deselects the previous choice.
+Three size options that behave as an exclusive choice — selecting one deselects the rest. Each item binds its slot `attrs`, so selection state drives styling through the `data-selected` attribute.
 
 :::
-
-## Features
-
-### Auto-Enrollment
-
-Set `enroll` to automatically select the first registered item. Useful when items are rendered dynamically:
-
-```vue
-<template>
-  <!-- First item to register is selected automatically -->
-  <Single.Root enroll v-model="selected">
-    <Single.Item v-for="opt in options" :key="opt" :value="opt">
-      {{ opt }}
-    </Single.Item>
-  </Single.Root>
-</template>
-```
-
-### Mandatory Selection
-
-Use `mandatory` to prevent deselecting the currently selected item. Use `mandatory="force"` to also auto-select the first item on mount:
-
-```vue
-<template>
-  <!-- User cannot deselect — at least one item must remain selected -->
-  <Single.Root mandatory v-model="selected">
-    <Single.Item value="a">Option A</Single.Item>
-    <Single.Item value="b">Option B</Single.Item>
-  </Single.Root>
-</template>
-```
 
 ## Anatomy
 
@@ -75,11 +48,61 @@ Use `mandatory` to prevent deselecting the currently selected item. Use `mandato
 
 <template>
   <Single.Root>
-    <Single.Item value="option-1" />
+    <Single.Item value="option-1" v-slot="{ attrs }">
+      <button v-bind="attrs">Option 1</button>
+    </Single.Item>
 
-    <Single.Item value="option-2" />
+    <Single.Item value="option-2" v-slot="{ attrs }">
+      <button v-bind="attrs">Option 2</button>
+    </Single.Item>
   </Single.Root>
 </template>
 ```
+
+## Examples
+
+::: example
+/components/single/mandatory
+
+### Mandatory Selection
+
+Use `mandatory` to prevent deselecting the active item — once something is selected, clicking it again is a no-op, so at least one item always stays selected. `mandatory="force"` goes further: it auto-selects the first non-disabled item on mount and enforces the no-deselect rule.
+
+In this example the first option is disabled, so `mandatory="force"` skips it and selects the second item on mount.
+
+:::
+
+## Accessibility
+
+Single is a headless **state provider**, not a complete interactive widget. It manages which item is selected and exposes that state on each item's slot `attrs`; it does not ship a role, keyboard navigation, or focus management.
+
+- `Single.Root` exposes `aria-multiselectable="false"`.
+- `Single.Item` exposes `aria-selected` and `aria-disabled`, plus `data-selected` and `data-disabled` for styling.
+
+This is listbox/tab-style selection state. For an accessible radio group — `role="radiogroup"`, `role="radio"`, arrow-key navigation, and roving `tabindex` — use [Radio](/components/forms/radio), which composes the same single-selection logic. When you bind `attrs` to your own element, you are responsible for supplying the appropriate `role` and keyboard handlers for the pattern you are building.
+
+## FAQ
+
+::: faq
+
+??? How is Single different from Radio?
+
+`Single` is a headless single-selection state provider — it tracks the selected item and exposes selection state, but ships no `role`, keyboard navigation, or focus management. `Radio` is a complete, accessible radio group built on the same logic, adding `role="radiogroup"` / `role="radio"`, arrow-key navigation, roving `tabindex`, and native form integration. Reach for `Radio` when you want radio buttons; reach for `Single` when you are building your own exclusive-choice UI — tabs, segmented controls, theme pickers — and will supply your own semantics.
+
+??? How is Single different from Selection?
+
+`Single` enforces exactly one selected item — selecting a new item automatically deselects the previous one — and exposes singular computed state (`selectedId`, `selectedValue`, `selectedItem`, `selectedIndex`). `Selection` is the multi-select parent: its model holds an array of values. Use `Single` for exclusive choice, `Selection` for multi-choice.
+
+??? What is the difference between enroll and mandatory?
+
+Neither controls registration — every `Single.Item` registers with its `Single.Root` automatically on mount. Both options only affect which item starts (or stays) *selected*:
+
+- `enroll` selects each item as it registers. Despite the name it registers nothing — registration is automatic. Because Single keeps only one item selected, each registration replaces the previous, so the most recently registered non-disabled item wins (the last item in a static list). The user can still deselect it.
+- `mandatory` prevents deselecting the active item once one is selected (no auto-select on mount).
+- `mandatory="force"` auto-selects the *first* non-disabled item on mount and prevents deselection.
+
+To preselect a specific item, initialize the `v-model` with its value.
+
+:::
 
 <DocsApi />


### PR DESCRIPTION
## Summary

A report flagged the Single provider docs page as unhelpful. Root cause: the page was titled and SEO-keyed as a "Radio Group Pattern" and captured radio-group search traffic, but `Single` ships no ARIA role or keyboard navigation — the accessible radio group is the [Radio](https://0.vuetifyjs.com/components/forms/radio) component. Readers landed on the wrong page and found a thin state-provider doc.

## Changes

- **Reposition** the page toward single-selection (title, description, keywords); add a routing callout and a reciprocal `related` link to Radio (Radio already linked back).
- **Document the accessibility boundary** explicitly — Single emits `aria-selected` / `aria-multiselectable=false` and styling data attributes, but no role/keyboard nav; new Accessibility + FAQ sections route radio-button needs to Radio.
- **Convert** the non-runnable `enroll` / `mandatory` code fences into runnable examples (`enroll.vue`, `mandatory.vue`).
- **Correct the `enroll` description** the old page got wrong: in single-select `enroll` re-selects on every registration, so the last-registered non-disabled item wins — not the first. `mandatory="force"` is the one that reliably selects the first non-disabled item on mount.
- **Rewrite `basic.vue`** to bind slot `attrs` with data-attribute styling and `v-slot` shorthand (it previously ignored the component's own selection attrs).
- **Repair the Anatomy** block, which rendered nothing because items need slot content.

Docs-only; no package source touched.