### PR TITLE
fix(Snackbar): stop non-modal snackbars triggering the global scrim

### DIFF
--- a/packages/0/src/components/Portal/Portal.vue
+++ b/packages/0/src/components/Portal/Portal.vue
@@ -25,6 +25,8 @@
     disabled?: boolean
     /** Block scrim close. @default false */
     blocking?: boolean
+    /** Whether a scrim/backdrop should back this portal. @default true */
+    scrim?: boolean
   }
 
   export interface PortalSlotProps {
@@ -50,6 +52,7 @@
     to = 'body',
     disabled = false,
     blocking = false,
+    scrim = true,
   } = defineProps<PortalProps>()
 
   const stack = useStack()
@@ -60,6 +63,7 @@
   // portals collide, no dismiss/scrim coordination).
   const ticket = stack.register({
     blocking,
+    scrim,
     onDismiss: () => emit('close'),
   })
   ticket.select()

--- a/packages/0/src/components/Scrim/Scrim.vue
+++ b/packages/0/src/components/Scrim/Scrim.vue
@@ -81,7 +81,7 @@
   const attrs = useAttrs()
   const stack = useStack()
 
-  const tickets = computed(() => Array.from(stack.selectedItems.value))
+  const tickets = computed(() => Array.from(stack.selectedItems.value).filter(ticket => ticket.scrim !== false))
 
   function onDismiss (ticket: StackTicket) {
     if (!ticket.blocking) {

--- a/packages/0/src/components/Snackbar/SnackbarPortal.vue
+++ b/packages/0/src/components/Snackbar/SnackbarPortal.vue
@@ -5,7 +5,9 @@
  *
  * @remarks
  * Container component for snackbar notifications. Teleports to body
- * and registers with useStack for z-index coordination with Dialog/Scrim.
+ * and registers with useStack for z-index coordination. Passes
+ * `scrim: false` to its Portal — snackbars are non-modal, so `Scrim`
+ * never paints a backdrop for them even when one is active for a Dialog.
  *
  * Does not set aria-live — each SnackbarRoot handles its own live region
  * semantics via role to avoid nesting conflicts.
@@ -61,7 +63,7 @@
 </script>
 
 <template>
-  <Portal :disabled="teleport === false" :to="teleport || 'body'">
+  <Portal :disabled="teleport === false" :scrim="false" :to="teleport || 'body'">
     <template #default="{ zIndex }">
       <Atom :as :renderless v-bind="mergeProps($attrs, getSlotProps(zIndex).attrs)">
         <slot v-bind="getSlotProps(zIndex)" />

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -57,6 +57,15 @@ export interface StackTicketInput extends SelectionTicketInput {
    * Use for critical dialogs requiring explicit user action.
    */
   blocking?: boolean
+  /**
+   * Whether this overlay should be backed by a scrim/backdrop
+   *
+   * @default true
+   * @remarks When false, the overlay still participates in z-index stacking
+   * but `Scrim` skips rendering a backdrop for it. Use for non-modal overlays
+   * (snackbars, toasts, tooltips) that need layering without dimming.
+   */
+  scrim?: boolean
 }
 
 /**
@@ -71,6 +80,10 @@ export type StackTicket<Z extends StackTicketInput = StackTicketInput> = Selecti
    * Whether this overlay blocks scrim dismissal
    */
   blocking: boolean
+  /**
+   * Whether this overlay is backed by a scrim/backdrop
+   */
+  scrim: boolean
   /**
    * The calculated z-index for this overlay
    *
@@ -221,6 +234,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
   function register (input: Partial<StackTicketInput> = {} as Partial<StackTicketInput>): StackTicket {
     const id = input.id ?? useId()
     const blocking = input.blocking ?? false
+    const scrim = input.scrim ?? true
     const onDismiss = input.onDismiss
 
     const zIndex = toRef(() => {
@@ -243,6 +257,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
 
     const ticket = selection.register({
       blocking,
+      scrim,
       onDismiss,
       zIndex,
       globalTop,


### PR DESCRIPTION
## Problem

A mounted `Snackbar.Portal` selects a ticket on the shared `v0:stack` (via `Portal`'s unconditional `ticket.select()`), and `Scrim` paints a backdrop for **every** selected ticket. Because a snackbar region stays mounted even with zero toasts, any app with a global `<Scrim>` got a full-page backdrop on load — visible on the useNotifications and Snackbar docs pages.

## Fix

Add a per-ticket scrim opt-out, mirroring the existing `blocking` flag:

- `useStack` — `StackTicket` gains `scrim` (default `true`); `register()` defaults and forwards it.
- `Scrim` — renders backdrops only for tickets where `scrim !== false`.
- `Portal` — new `scrim` prop (default `true`) forwarded to its stack ticket.
- `SnackbarPortal` — passes `scrim: false`. Snackbars still stack for z-index but never trigger a backdrop.

Dialog, AlertDialog, and Popover keep `scrim: true` by default, so their backdrops are unchanged.