### PR TITLE
fix(useStack): exclude non-modal overlays from isActive and top

### DIFF
--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -212,13 +212,18 @@ export function createStack (_options: StackOptions = {}): StackContext {
     multiple: true,
   })
 
-  const isActive = toRef(() => selection.selectedIds.size > 0)
+  // Non-modal overlays (scrim: false — snackbars, toasts) still stack for
+  // z-index but must not count as an active modal: isActive/top/scrimZIndex/
+  // isBlocking drive backdrop + scroll-lock, which a toast must never trigger.
+  function selectedScrims () {
+    return Array.from(selection.selectedIds)
+      .map(id => selection.get(id) as StackTicket | undefined)
+      .filter((ticket): ticket is StackTicket => !!ticket && ticket.scrim !== false)
+  }
 
-  const top = toRef(() => {
-    const ids = Array.from(selection.selectedIds)
-    if (ids.length === 0) return undefined
-    return selection.get(ids.at(-1)!) as StackTicket | undefined
-  })
+  const isActive = toRef(() => selectedScrims().length > 0)
+
+  const top = toRef(() => selectedScrims().at(-1))
 
   const scrimZIndex = toRef(() => {
     const ticket = top.value


### PR DESCRIPTION
Follow-up to #352.

## Problem
A mounted `Snackbar.Portal` selects a stack ticket with `scrim: false`, but `stack.isActive` (`selectedIds.size > 0`) still counted it. Any consumer keying scroll-lock or a backdrop off `stack.isActive` — e.g. the docs app's `useScrollLock(() => stack.isActive.value)` — fired for a non-modal toast, locking body scroll and hiding the scrollbar on the Snackbar and useNotifications pages. The #352 scrim fix only filtered `Scrim`'s rendering, not stack membership, so this surfaced once the masking backdrop was gone.

## Fix
`isActive` and `top` now derive from the scrim-bearing subset of selected tickets; `scrimZIndex` and `isBlocking` follow via `top`. Per-ticket `zIndex`/`globalTop` still span all selected tickets, so toasts keep correct z-index stacking. Modal overlays (Dialog/AlertDialog/Popover, `scrim: true`) are unaffected — existing useStack tests assert a default ticket still flips `isActive`.