### PR TITLE
docs(GnDocsExample): squircle corners on the example peek pill

### DIFF
--- a/packages/genesis/src/components/GnDocsExample/GnDocsExamplePeek.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExamplePeek.vue
@@ -48,7 +48,8 @@
     gap: 0.25rem;
     padding: 0.25rem 0.5rem;
     border: none;
-    border-radius: 0.25rem;
+    border-radius: 0.75rem;
+    corner-shape: squircle;
     background: var(--v0-primary, #5f3aed);
     color: var(--v0-on-primary, #fff);
     font: inherit;


### PR DESCRIPTION
Switches the `GnDocsExamplePeek` pill from circular corners to an iOS-style squircle.

- `corner-shape: squircle` (= `superellipse(2)`)
- `border-radius` bumped `0.25rem` → `0.75rem` so the superellipse curvature is actually visible (at 0.25rem the effect is sub-pixel; `corner-shape` only reshapes an existing radius)

Progressive enhancement: `corner-shape` is Chromium-only today, so non-Chromium browsers fall back to the plain `0.75rem` rounded pill. No JS or asset cost.

Visible on the only `gn-example` page: /components/primitives/aspect-ratio (Usage code-peek pill and the description-expand pill).