### PR TITLE
docs: deep-link maturity chip to its category and highlight the feature row

### DIFF
--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
   // Framework
-  import { createDataTable, createGroup, createSingle } from '@vuetify/v0'
+  import { createDataTable, createGroup, createSingle, isString, toHighlight } from '@vuetify/v0'
 
   import maturityData from '#v0/maturity.json'
   import { releaseAlias } from '@/constants/releases'
 
   // Utilities
-  import { toRef, watch } from 'vue'
-  import { RouterLink } from 'vue-router'
+  import { onMounted, toRef, watch } from 'vue'
+  import { RouterLink, useRoute } from 'vue-router'
 
   // Types
   type Level = 'draft' | 'preview' | 'stable' | 'mature' | 'deprecated'
@@ -151,6 +151,23 @@
   function onSearch (event: Event) {
     table.search((event.target as HTMLInputElement).value)
   }
+
+  // Feature pages deep-link here with `?category=&feature=` so the reader's
+  // category is auto-expanded and their feature's row is highlighted, instead
+  // of being buried among collapsed groups.
+  const route = useRoute()
+
+  const feature = toRef(() => {
+    const value = route.query.feature
+    return isString(value) ? value : ''
+  })
+
+  onMounted(() => {
+    const category = route.query.category
+    if (isString(category) && category) {
+      table.grouping.open(category)
+    }
+  })
 
   const anyOpen = toRef(() => {
     return table.grouping.groups.value.some(g => table.grouping.isOpen(g.key))
@@ -332,7 +349,10 @@
           >
             <div class="flex-1 min-w-0">
               <div class="text-sm font-medium text-on-surface truncate">
-                {{ item.name }}
+                <template v-for="(chunk, position) in toHighlight(item.name, feature, { ignoreCase: true })" :key="position">
+                  <mark v-if="chunk.match" class="bg-warning text-on-warning rounded px-0.5">{{ chunk.text }}</mark>
+                  <template v-else>{{ chunk.text }}</template>
+                </template>
               </div>
 
               <div class="flex items-center gap-2 mt-1">
@@ -487,7 +507,12 @@
                   :is="(item as MaturityItem).level === 'draft' ? 'span' : RouterLink"
                   :class="(item as MaturityItem).level === 'draft' ? 'text-on-surface-variant' : 'text-primary no-underline hover:underline transition-colors'"
                   :to="(item as MaturityItem).level !== 'draft' ? item.path : undefined"
-                >{{ item.name }}</component>
+                >
+                  <template v-for="(chunk, position) in toHighlight(item.name, feature, { ignoreCase: true })" :key="position">
+                    <mark v-if="chunk.match" class="bg-warning text-on-warning rounded px-0.5">{{ chunk.text }}</mark>
+                    <template v-else>{{ chunk.text }}</template>
+                  </template>
+                </component>
               </td>
 
               <!-- Type badge -->

--- a/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
+++ b/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
@@ -278,6 +278,21 @@
     }
   })
 
+  // Deep-link the stability chip into the roadmap's maturity matrix, carrying
+  // the feature's category + name so the matrix auto-expands that group and
+  // highlights this feature's row instead of stranding the reader.
+  const maturityHref = toRef(() => {
+    const type = itemType.value
+    const name = itemName.value
+    if (!type || !name) return MATURITY_MATRIX_HREF
+
+    const bucket = (maturityData as Record<string, Record<string, MaturityEntry>>)[type]
+    const category = bucket?.[name]?.category
+    if (!category) return MATURITY_MATRIX_HREF
+
+    return `/roadmap?category=${encodeURIComponent(category)}&feature=${encodeURIComponent(name)}#maturity-matrix`
+  })
+
   // Last updated date from git history
   const date = useDate()
   const pageDate = toRef(() => {
@@ -412,7 +427,7 @@
         <DocsMetaItem
           v-if="phase"
           :color="phase.color"
-          :href="MATURITY_MATRIX_HREF"
+          :href="maturityHref"
           :icon="phase.icon"
           :text="phase.label"
           :title="phase.title"

--- a/apps/docs/src/plugins/router.ts
+++ b/apps/docs/src/plugins/router.ts
@@ -28,7 +28,7 @@ function readPersistedPosition (to: RouteLocationNormalized) {
 
 const routerOptions: Omit<RouterOptions, 'history'> = {
   routes: setupLayouts(routes),
-  scrollBehavior (to, _from, savedPosition) {
+  scrollBehavior (to, from, savedPosition) {
     // SSR safety - scrollBehavior only runs client-side but guard for clarity
     if (!IN_BROWSER) return { top: 0 }
 
@@ -52,14 +52,16 @@ const routerOptions: Omit<RouterOptions, 'history'> = {
     // If navigating to a hash (anchor), scroll to that element
     // Delay to allow DOM to settle after hydration
     if (to.hash) {
+      // Cross-page hashes jump instantly — a smooth scroll lets the scroll spy
+      // rewrite the URL through each heading it passes. Same-page anchors stay smooth.
+      const instant = to.path !== from.path || getPrefersReducedMotion()
       return new Promise(resolve => {
         setTimeout(() => {
           try {
             const el = document.querySelector(`#${CSS.escape(to.hash.slice(1))}`)
             if (el) {
               const top = el.getBoundingClientRect().top + window.scrollY - 80
-              const behavior = getPrefersReducedMotion() ? 'auto' : 'smooth'
-              resolve({ top, behavior })
+              resolve({ top, behavior: instant ? 'auto' : 'smooth' })
               return
             }
           } catch {


### PR DESCRIPTION
The stability chip on component/composable pages now links to `/roadmap?category=<cat>&feature=<name>#maturity-matrix` instead of the bare matrix anchor.

On the roadmap, the maturity matrix reads those params and:
- **auto-expands** the reader's category group on mount (`grouping.open`), and
- **highlights** the feature's row by name via `toHighlight`.

So a reader clicking through from a feature page lands on exactly what they came from, rather than a wall of collapsed groups.

Also fixes a hash-thrash on cross-page anchor links: the router's `scrollBehavior` now jumps **instantly** for cross-page hashes. A smooth scroll down a long page outlived `useToc`'s hash-sync guard (whose `isInitialLoad` window only covers the first page load, not later in-session navigations), letting the scroll spy rewrite the URL through every heading it animated past. Same-page TOC anchors are untouched (they never reach `scrollBehavior`).