### PR TITLE
docs: fix redirecting external links flagged by link checker (#351)

### DIFF
--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -91,7 +91,7 @@
           'programmingLanguage': 'TypeScript',
           'runtimePlatform': 'Vue 3',
           'codeRepository': 'https://github.com/vuetifyjs/0',
-          'license': 'https://opensource.org/licenses/MIT',
+          'license': 'https://opensource.org/license/MIT',
         }),
       }]
       : [],

--- a/apps/docs/src/pages/composables/plugins/use-features.md
+++ b/apps/docs/src/pages/composables/plugins/use-features.md
@@ -91,12 +91,12 @@ Adapters let you swap the underlying feature flag provider without changing your
 | Adapter | Import | Description |
 |---------|--------|-------------|
 | `PostHogFeaturesAdapter` | `@vuetify/v0/features/adapters/posthog` | [PostHog](https://posthog.com/) integration |
-| `FlagsmithFeaturesAdapter` | `@vuetify/v0/features/adapters/flagsmith` | [Flagsmith](https://flagsmith.com/) integration |
+| `FlagsmithFeaturesAdapter` | `@vuetify/v0/features/adapters/flagsmith` | [Flagsmith](https://www.flagsmith.com/) integration |
 | `LaunchDarklyFeaturesAdapter` | `@vuetify/v0/features/adapters/launchdarkly` | [LaunchDarkly](https://launchdarkly.com/) integration |
 
 ### Flagsmith
 
-[Flagsmith](https://flagsmith.com/) is an open-source feature flag platform. Requires the `@flagsmith/flagsmith` package.
+[Flagsmith](https://www.flagsmith.com/) is an open-source feature flag platform. Requires the `@flagsmith/flagsmith` package.
 
 ::: code-group no-filename
 

--- a/apps/docs/src/pages/composables/plugins/use-notifications.md
+++ b/apps/docs/src/pages/composables/plugins/use-notifications.md
@@ -194,7 +194,7 @@ Adapters let you swap the underlying notification service without changing your 
 
 ### Knock
 
-[Knock](https://knock.app) is a notification infrastructure platform with feeds, preferences, and multi-channel delivery. Install their [JavaScript SDK](https://docs.knock.app/sdks/javascript/overview) to get started. Supports both inbound (feed → notifications) and outbound (read/archive → Knock API).
+[Knock](https://knock.app) is a notification infrastructure platform with feeds, preferences, and multi-channel delivery. Install their [JavaScript SDK](https://docs.knock.app/in-app-ui/javascript/sdk/overview) to get started. Supports both inbound (feed → notifications) and outbound (read/archive → Knock API).
 
 ::: code-group no-filename
 
@@ -251,7 +251,7 @@ export const feed = knock.feeds.initialize(
 
 ### Novu
 
-[Novu](https://novu.co) is an open-source notification infrastructure with in-app feeds, digests, and multi-channel delivery. Install their [JavaScript SDK](https://docs.novu.co/sdks/javascript) to get started. Supports both inbound (feed → notifications) and outbound (read/unread/seen/archive/unarchive → Novu API).
+[Novu](https://novu.co) is an open-source notification infrastructure with in-app feeds, digests, and multi-channel delivery. Install their [JavaScript SDK](https://docs.novu.co/platform/sdks/javascript) to get started. Supports both inbound (feed → notifications) and outbound (read/unread/seen/archive/unarchive → Novu API).
 
 The adapter maps Novu severity strings to `NotificationSeverity` by default: `critical`/`high` → `error`, `medium` → `warning`, `low` → `info`. Pass a custom `severity` function to override.
 

--- a/apps/docs/src/pages/guide/integration/devkey.md
+++ b/apps/docs/src/pages/guide/integration/devkey.md
@@ -41,7 +41,7 @@ DevKey pairs `@vuetify/v0` with a minimal but production-shaped toolchain so you
 | Layer | Choice |
 | - | - |
 | Framework | [Vue 3.5+](https://vuejs.org) |
-| Build tool | [Vite 8](https://vitejs.dev) |
+| Build tool | [Vite 8](https://vite.dev) |
 | Language | [TypeScript](https://www.typescriptlang.org) |
 | UI primitives | [@vuetify/v0](https://www.npmjs.com/package/@vuetify/v0) |
 | Styling | [UnoCSS](https://unocss.dev) |

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -37,7 +37,7 @@ v0 provides machine-readable documentation files following the [llms.txt](https:
 
 ## Usage
 
-Install SKILL.md via [skills.sh](https://skills.sh) — works with Claude Code, Cursor, Windsurf, Codex, and [35+ agents](https://github.com/vercel-labs/skills#supported-agents):
+Install SKILL.md via [skills.sh](https://www.skills.sh) — works with Claude Code, Cursor, Windsurf, Codex, and [35+ agents](https://github.com/vercel-labs/skills#supported-agents):
 
 ```bash
 npx skills add vuetifyjs/0
@@ -166,7 +166,7 @@ Hallucinated v0 APIs fail to compile. Run `vue-tsc --noEmit` (or `tsc --noEmit`)
 
 **llms-full.txt** includes the complete content of every documentation page, stripped of Vue components and frontmatter for cleaner LLM consumption.
 
-**SKILL.md** is a compact reference optimized for AI coding assistants. It focuses on decision trees, code conventions, anti-patterns, and the composition hierarchy. Detailed API examples live in a separate [REFERENCE.md](/references/REFERENCE.md) that agents load on demand. Install via [skills.sh](https://skills.sh) (`npx skills add vuetifyjs/0`) to make it available across Claude Code, Cursor, Windsurf, and 35+ other agents.
+**SKILL.md** is a compact reference optimized for AI coding assistants. It focuses on decision trees, code conventions, anti-patterns, and the composition hierarchy. Detailed API examples live in a separate [REFERENCE.md](/references/REFERENCE.md) that agents load on demand. Install via [skills.sh](https://www.skills.sh) (`npx skills add vuetifyjs/0`) to make it available across Claude Code, Cursor, Windsurf, and 35+ other agents.
 
 ## How It Works
 

--- a/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
@@ -50,7 +50,7 @@ bunx @vuetify/mcp config --remote
 
 ### Claude Code
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is Anthropic's agentic coding tool. Add the hosted MCP server directly via CLI:
+[Claude Code](https://code.claude.com/docs/en/overview) is Anthropic's agentic coding tool. Add the hosted MCP server directly via CLI:
 
 ```bash
 claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
@@ -58,7 +58,7 @@ claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
 
 ### Claude Desktop
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's GUI app. **Direct HTTP transport (`url:`) is not supported in `claude_desktop_config.json`** — Claude Desktop only accepts stdio servers. Use one of the two stdio configurations below.
+[Claude Desktop](https://claude.com/download) is Anthropic's GUI app. **Direct HTTP transport (`url:`) is not supported in `claude_desktop_config.json`** — Claude Desktop only accepts stdio servers. Use one of the two stdio configurations below.
 
 ::: code-group no-filename
 

--- a/apps/docs/src/pages/introduction/code-of-conduct.md
+++ b/apps/docs/src/pages/introduction/code-of-conduct.md
@@ -49,6 +49,6 @@ The project team will review and investigate all complaints, responding in a way
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4.
 
 View the full [CODE_OF_CONDUCT.md](https://github.com/vuetifyjs/0/blob/master/CODE_OF_CONDUCT.md) on GitHub.

--- a/apps/docs/src/pages/introduction/license.md
+++ b/apps/docs/src/pages/introduction/license.md
@@ -15,7 +15,7 @@ related:
 
 # License
 
-Vuetify0 is released under the [MIT License](https://opensource.org/licenses/MIT), one of the most permissive and widely-used open source licenses.
+Vuetify0 is released under the [MIT License](https://opensource.org/license/MIT), one of the most permissive and widely-used open source licenses.
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/pages/introduction/why-vuetify0.md
+++ b/apps/docs/src/pages/introduction/why-vuetify0.md
@@ -142,7 +142,7 @@ Built-in adapters ship for the most common integrations:
 | `useLogger` | `ConsolaLoggerAdapter` | [Consola](https://github.com/unjs/consola) universal logging |
 | `useLocale` | `VueI18nLocaleAdapter` | [Vue I18n](https://vue-i18n.intlify.dev) internationalization |
 | `useFeatures` | `LaunchDarklyFeaturesAdapter` | [LaunchDarkly](https://launchdarkly.com) feature flags |
-| `useFeatures` | `FlagsmithFeaturesAdapter` | [Flagsmith](https://flagsmith.com) feature flags |
+| `useFeatures` | `FlagsmithFeaturesAdapter` | [Flagsmith](https://www.flagsmith.com) feature flags |
 | `useFeatures` | `PostHogFeaturesAdapter` | [PostHog](https://posthog.com) feature flags and analytics |
 | `useNotifications` | `KnockNotificationsAdapter` | [Knock](https://knock.app) notification feeds |
 | `useNotifications` | `NovuNotificationsAdapter` | [Novu](https://novu.co) notification infrastructure |


### PR DESCRIPTION
Resolves the actionable subset of the lychee link-checker report in #351.

## What changed
Pointed nine source links at their canonical targets so they resolve `200` directly instead of via a redirect:

| Link | Before | After |
|------|--------|-------|
| Vite | `vitejs.dev` | `vite.dev` |
| Claude Code | `docs.anthropic.com/en/docs/claude-code/overview` | `code.claude.com/docs/en/overview` |
| Claude Desktop | `claude.ai/download` | `claude.com/download` |
| Knock SDK | `docs.knock.app/sdks/javascript/overview` | `docs.knock.app/in-app-ui/javascript/sdk/overview` |
| Novu SDK | `docs.novu.co/sdks/javascript` | `docs.novu.co/platform/sdks/javascript` |
| Flagsmith | `flagsmith.com` | `www.flagsmith.com` |
| skills.sh | `skills.sh` | `www.skills.sh` |
| opensource.org MIT | `/licenses/MIT` | `/license/MIT` |
| Contributor Covenant | `http://contributor-covenant.org` | `https://www.contributor-covenant.org` |

## What was deliberately left out
- **picsum.photos errors** — flaky third-party placeholder host (Cloudflare 522/timeout), not link rot. Transient; needs a separate decision (self-host, swap, or exclude from the checker), not a link edit.
- **MDN redirects** — bare URLs auto-resolve and MDN restructures often; pinning `/Reference/...` paths just invites re-breakage.
- **app.posthog.com** — it's an `api_host` config value inside a code example, not a hyperlink. Changing it would alter documented config.