### PR TITLE
docs(Scrim): fix backdrop dismissal in basic example

### DIFF
--- a/apps/docs/src/examples/components/scrim/basic.vue
+++ b/apps/docs/src/examples/components/scrim/basic.vue
@@ -50,10 +50,10 @@
 
   <div
     v-if="open"
-    class="fixed inset-0 flex items-center justify-center"
+    class="fixed inset-0 flex items-center justify-center pointer-events-none"
     :style="{ zIndex: ticket.zIndex.value }"
   >
-    <div class="rounded-xl bg-surface border border-divider p-6 max-w-sm w-full shadow-lg">
+    <div class="rounded-xl bg-surface border border-divider p-6 max-w-sm w-full shadow-lg pointer-events-auto">
       <h3 class="text-lg font-semibold text-on-surface mb-2">
         Dismissible Overlay
       </h3>
@@ -73,10 +73,10 @@
 
   <div
     v-if="blocking"
-    class="fixed inset-0 flex items-center justify-center"
+    class="fixed inset-0 flex items-center justify-center pointer-events-none"
     :style="{ zIndex: blockingTicket.zIndex.value }"
   >
-    <div class="rounded-xl bg-surface border border-divider p-6 max-w-sm w-full shadow-lg">
+    <div class="rounded-xl bg-surface border border-divider p-6 max-w-sm w-full shadow-lg pointer-events-auto">
       <h3 class="text-lg font-semibold text-on-surface mb-2">
         Blocking Overlay
       </h3>


### PR DESCRIPTION
The basic Scrim example claims you can click the backdrop to dismiss the overlay, but it never worked.

**Cause:** the full-screen overlay container (`fixed inset-0`, z-index 2000) sits one layer above the Scrim (z-index 1999) and covers the entire viewport with default `pointer-events`. It has no click handler, so it swallows every backdrop click and the Scrim's own `onClick → dismiss()` never fires.

**Fix:** add `pointer-events-none` to the overlay containers and `pointer-events-auto` to the cards — mirroring the working `use-stack` `StackConsumer` pattern — so backdrop clicks fall through to the scrim while the card stays interactive. The blocking overlay now correctly ignores backdrop clicks because of its `blocking: true` flag rather than by accidental occlusion.

Verified in a browser: a backdrop click now resolves to the scrim element and dismisses the overlay.