### PR TITLE
feat(genesis): extract GnPeek peek-pill primitive

### DIFF
--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  // Components
+  import { GnPeek } from '@paper/genesis'
+
   // Composables
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
@@ -91,16 +94,14 @@
       <div v-if="shouldCollapse && !expanded" class="docs-markup-fade absolute inset-x-0 bottom-0 h-16 rounded-b-2 pointer-events-none" />
     </div>
 
-    <button
+    <GnPeek
       v-if="shouldCollapse && !expanded"
-      aria-label="Expand code"
-      class="absolute -bottom-3 left-1/2 -translate-x-1/2 z-10 inline-flex items-center justify-center gap-1 px-2 py-1 text-xs text-on-primary bg-primary rounded cursor-pointer transition-200 hover:bg-primary/85 touch-action-manipulation"
-      type="button"
-      @click="expanded = true"
+      v-model:expanded="expanded"
+      collapsed-label="Expand code"
     >
       <span>Expand</span>
       <AppIcon icon="down" :size="14" />
-    </button>
+    </GnPeek>
   </div>
 </template>
 

--- a/packages/genesis/SPEC.md
+++ b/packages/genesis/SPEC.md
@@ -22,8 +22,8 @@ packages/genesis/
 │       ├── GnDocsExampleCode/
 │       ├── GnDocsExampleTabs/
 │       ├── GnDocsExamplePanel/
-│       ├── GnDocsExamplePeek/
-│       └── GnDocsExampleActions/
+│       ├── GnDocsExampleActions/
+│       └── GnPeek/
 ```
 
 No `GnDocsIcon`, no `adapter.ts`, no `plugin.ts`, no `theme.ts`. Genesis is just components.
@@ -82,8 +82,20 @@ interface GnDocsExampleProps {
 | `GnDocsExampleCode` | Single code pane; peek truncation; `<slot :code :language :file-name>` for highlighter (default: `<pre>` fallback) |
 | `GnDocsExampleTabs` | Tab list + overflow dropdown for hidden tabs; reset and combine action buttons; `<slot name="reset-icon">`, `<slot name="combine-icon">`, `<slot name="split-icon">` with inline-SVG defaults |
 | `GnDocsExamplePanel` | Wraps one file's code pane content; provides the structural row inside a tab |
-| `GnDocsExamplePeek` | Bottom-anchored expand toggle for peek mode |
 | `GnDocsExampleActions` | Toolbar host; renders an `aria-label`-ed group around action buttons |
+
+### `GnPeek` — standalone peek toggle
+
+A bottom-anchored expand/collapse pill (squircle, `--v0-primary`). **Not** a `GnDocsExample` sub-component — it's a top-level Genesis primitive, consumed by `GnDocsExampleDescription`, `GnDocsExample` (single-file peek mode), and docs-site code blocks.
+
+```ts
+interface GnPeekProps {
+  expandedLabel?: string   // default: 'Collapse'
+  collapsedLabel?: string  // default: 'Expand'
+}
+```
+
+`v-model:expanded` drives state; the default slot exposes `{ expanded }` for custom label/icon content (text-only by default).
 
 ## Icon strategy
 
@@ -94,7 +106,7 @@ Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
 | `GnDocsExample` | `reset-icon` (single-file mode reset button) | refresh |
 | `GnDocsExampleTabs` | `reset-icon`, `combine-icon`, `split-icon` | refresh / unfold-less / unfold-more |
 
-`GnDocsExamplePeek` is text-only.
+`GnPeek` is text-only (default slot for label/icon content).
 
 ```vue
 <GnDocsExampleTabs>

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
@@ -46,7 +46,6 @@
   import GnDocsExampleActions from './GnDocsExampleActions.vue'
   import GnDocsExampleCode from './GnDocsExampleCode.vue'
   import GnDocsExampleDescription from './GnDocsExampleDescription.vue'
-  import GnDocsExamplePeek from './GnDocsExamplePeek.vue'
   import GnDocsExamplePreview from './GnDocsExamplePreview.vue'
   import GnDocsExampleTabs from './GnDocsExampleTabs.vue'
 
@@ -54,6 +53,7 @@
   import { shallowRef, toRef, useId, useTemplateRef } from 'vue'
 
   import GnActionButton from '../GnActionButton/GnActionButton.vue'
+  import GnPeek from '../GnPeek/GnPeek.vue'
 
   defineOptions({ name: 'GnDocsExample' })
 
@@ -260,7 +260,7 @@
       </template>
     </div>
 
-    <GnDocsExamplePeek
+    <GnPeek
       v-if="peek && !hasMultipleFiles && hasCode"
       v-model:expanded="peekExpanded"
     />
@@ -290,17 +290,17 @@
     border-bottom: 1px solid color-mix(in srgb, var(--v0-on-surface, currentcolor) 14%, transparent);
   }
 
-  .genesis-docs-example > *:first-child:not(.genesis-docs-example-peek) {
+  .genesis-docs-example > *:first-child:not(.genesis-peek) {
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
   }
 
-  .genesis-docs-example > *:nth-last-child(1 of :not(.genesis-docs-example-peek)) {
+  .genesis-docs-example > *:nth-last-child(1 of :not(.genesis-peek)) {
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
   }
 
-  .genesis-docs-example > *:nth-last-child(1 of :not(.genesis-docs-example-peek)) .genesis-docs-example__toggle {
+  .genesis-docs-example > *:nth-last-child(1 of :not(.genesis-peek)) .genesis-docs-example__toggle {
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
   }

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -10,11 +10,11 @@
 </script>
 
 <script setup lang="ts">
-  // Context
-  import GnDocsExamplePeek from './GnDocsExamplePeek.vue'
-
   // Utilities
   import { shallowRef, toRef, useSlots } from 'vue'
+
+  // Context
+  import GnPeek from '../GnPeek/GnPeek.vue'
 
   defineOptions({ name: 'GnDocsExampleDescription' })
 
@@ -70,7 +70,7 @@
 
     <div v-if="truncated" aria-hidden="true" class="genesis-docs-example-description__fade" />
 
-    <GnDocsExamplePeek
+    <GnPeek
       v-if="hasContent"
       v-slot="{ expanded: open }"
       v-model:expanded="expanded"
@@ -78,7 +78,7 @@
       expanded-label="Collapse description"
     >
       {{ open ? 'Collapse' : 'Expand' }}
-    </GnDocsExamplePeek>
+    </GnPeek>
   </div>
 </template>
 
@@ -96,10 +96,10 @@
     color: var(--v0-on-surface-variant, rgb(0 0 0 / 0.6));
   }
 
-  /* GnDocsExamplePeek nudges itself further down when expanded (good for the
+  /* GnPeek nudges itself further down when expanded (good for the
      single-file code peek). The description pill should stay pinned to the
      border, so neutralize that drift here only. */
-  .genesis-docs-example-description :deep(.genesis-docs-example-peek[data-expanded]) {
+  .genesis-docs-example-description :deep(.genesis-peek[data-expanded]) {
     bottom: -0.75rem;
   }
 

--- a/packages/genesis/src/components/GnDocsExample/index.ts
+++ b/packages/genesis/src/components/GnDocsExample/index.ts
@@ -8,8 +8,6 @@ export type { GnDocsExampleDescriptionProps } from './GnDocsExampleDescription.v
 export { default as GnDocsExampleDescription } from './GnDocsExampleDescription.vue'
 export type { GnDocsExamplePanelProps } from './GnDocsExamplePanel.vue'
 export { default as GnDocsExamplePanel } from './GnDocsExamplePanel.vue'
-export type { GnDocsExamplePeekProps } from './GnDocsExamplePeek.vue'
-export { default as GnDocsExamplePeek } from './GnDocsExamplePeek.vue'
 export type { GnDocsExamplePreviewProps } from './GnDocsExamplePreview.vue'
 export { default as GnDocsExamplePreview } from './GnDocsExamplePreview.vue'
 export type { GnDocsExampleFile, GnDocsExampleTabsProps } from './GnDocsExampleTabs.vue'

--- a/packages/genesis/src/components/GnPeek/GnPeek.vue
+++ b/packages/genesis/src/components/GnPeek/GnPeek.vue
@@ -1,18 +1,19 @@
 <script lang="ts">
-  export interface GnDocsExamplePeekProps {
-    /** Force collapsed/expanded label */
+  export interface GnPeekProps {
+    /** Label shown while expanded */
     expandedLabel?: string
+    /** Label shown while collapsed */
     collapsedLabel?: string
   }
 </script>
 
 <script setup lang="ts">
-  defineOptions({ name: 'GnDocsExamplePeek' })
+  defineOptions({ name: 'GnPeek' })
 
   const {
     expandedLabel = 'Collapse',
     collapsedLabel = 'Expand',
-  } = defineProps<GnDocsExamplePeekProps>()
+  } = defineProps<GnPeekProps>()
 
   const expanded = defineModel<boolean>('expanded', { default: false })
 
@@ -25,7 +26,7 @@
   <button
     :aria-expanded="expanded ? 'true' : 'false'"
     :aria-label="expanded ? expandedLabel : collapsedLabel"
-    class="genesis-docs-example-peek"
+    class="genesis-peek"
     :data-expanded="expanded || undefined"
     type="button"
     @click="onToggle"
@@ -37,7 +38,7 @@
 </template>
 
 <style scoped>
-  .genesis-docs-example-peek {
+  .genesis-peek {
     position: absolute;
     inset-inline-start: 50%;
     bottom: -0.75rem;
@@ -59,11 +60,11 @@
     touch-action: manipulation;
   }
 
-  .genesis-docs-example-peek:hover {
+  .genesis-peek:hover {
     opacity: 0.85;
   }
 
-  .genesis-docs-example-peek[data-expanded] {
+  .genesis-peek[data-expanded] {
     bottom: -1.5rem;
   }
 </style>

--- a/packages/genesis/src/components/GnPeek/index.ts
+++ b/packages/genesis/src/components/GnPeek/index.ts
@@ -1,0 +1,2 @@
+export type { GnPeekProps } from './GnPeek.vue'
+export { default as GnPeek } from './GnPeek.vue'

--- a/packages/genesis/src/components/index.ts
+++ b/packages/genesis/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './GnActionButton'
 export * from './GnDocsExample'
 export * from './GnDotGrid'
+export * from './GnPeek'


### PR DESCRIPTION
Promotes the bottom-anchored expand/collapse pill out of `GnDocsExample` into a standalone, reusable **`GnPeek`** primitive (CSS class `genesis-peek`).

## Why
The peek pill was scoped to `GnDocsExample` but three call sites now want it: the single-file code peek, the description toggle, and the docs code-fence renderer. Reusing the `GnDocsExample`-namespaced sub-component for generic code blocks was a scoping smell — so the shared affordance becomes a top-level primitive.

## Changes
- **New** `GnPeek` / `GnPeekProps` exported from `@paper/genesis` (`v-model:expanded`, label props, default slot exposing `{ expanded }`).
- Removed `GnDocsExamplePeek` and its barrel exports; repointed `GnDocsExample` (single-file peek) and `GnDocsExampleDescription` to `GnPeek`, including the structural CSS selectors.
- Wired `GnPeek` into the docs code-fence renderer (`DocsMarkup`) so inline code blocks use the same peek pill for their expand affordance.
- Updated `SPEC.md` (tree, sub-component table, standalone `GnPeek` section).

Verified: genesis typecheck + tsdown build clean, full docs SSG build clean.