### PR TITLE
docs(DocsPageFeatures): use blue for Stable, green for Mature

### DIFF
--- a/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
+++ b/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
@@ -217,8 +217,8 @@
   const phaseConfig = {
     draft: { icon: 'pencil', color: 'text-on-surface-variant', label: 'Draft' },
     preview: { icon: 'flask', color: 'text-warning', label: 'Preview' },
-    stable: { icon: 'check-circle', color: 'text-success', label: 'Stable' },
-    mature: { icon: 'shield-check', color: 'text-info', label: 'Mature' },
+    stable: { icon: 'check-circle', color: 'text-info', label: 'Stable' },
+    mature: { icon: 'shield-check', color: 'text-success', label: 'Mature' },
     deprecated: { icon: 'archive', color: 'text-error', label: 'Deprecated' },
   } as const
 


### PR DESCRIPTION
The page-meta maturity badge had the `stable` and `mature` colors swapped relative to the roadmap matrix (`DocsMaturity.vue`, the source of truth).

- **Stable** was green (`text-success`) → now blue (`text-info`)
- **Mature** was blue (`text-info`) → now green (`text-success`)

This matches `DocsMaturity.vue` (stable = `#3b82f6` blue, mature = `#22c55e` green). Swapping both avoids a color collision that recoloring only Stable would create.