### PR TITLE
docs: update Temporal status to TC39 Stage 4 (ES2026)

### DIFF
--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -46,7 +46,7 @@ bun add @js-temporal/polyfill
 :::
 
 > [!TIP]
-> The Temporal API is a Stage 3 [TC39 proposal](https://github.com/tc39/proposal-temporal). The adapter prefers native Temporal and only falls back to the polyfill — once every runtime you target ships native support, the polyfill is no longer required.
+> The Temporal API reached [Stage 4](https://github.com/tc39/proposal-temporal) (finished) at TC39 in January 2026 and is part of ECMAScript 2026. The adapter prefers native Temporal and only falls back to the polyfill — once every runtime you target ships native support, the polyfill is no longer required.
 
 Then install the date plugin with an adapter:
 

--- a/apps/docs/src/pages/introduction/browser-support.md
+++ b/apps/docs/src/pages/introduction/browser-support.md
@@ -48,8 +48,10 @@ These features require the latest browser versions and may not work in all brows
 | [CSS Anchor Positioning](https://caniuse.com/css-anchor-positioning) | 125+ | 147+ | —[^safari-anchor] | 125+ | Properties ignored |
 | [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) | 114+ | 125+ | 17+ | 114+ | Optional chaining |
 | [Scrollend Event](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) | 112+ | 109+ | 18+ | 112+ | Falls back to scroll |
+| [Temporal](https://caniuse.com/temporal) | 144+ | 139+ | —[^safari-temporal] | 144+ | `@js-temporal/polyfill` |
 
 [^safari-anchor]: Safari support for CSS Anchor Positioning is not yet available; track at [WebKit Bug 286106](https://bugs.webkit.org/show_bug.cgi?id=286106). Firefox 147+ requires the beta channel.
+[^safari-temporal]: Temporal is not yet in stable Safari (available in Safari Technology Preview). `useDate`'s `V0DateAdapter` automatically uses the [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) peer when native Temporal is absent. The API reached TC39 Stage 4 (ES2026) in 2026.
 
 ### Well-Supported Features
 
@@ -161,6 +163,7 @@ Vuetify0 does not include polyfills to keep bundle sizes small. If you need to s
 - **ResizeObserver**: [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) · [caniuse](https://caniuse.com/resizeobserver)
 - **IntersectionObserver**: [intersection-observer](https://www.npmjs.com/package/intersection-observer) · [caniuse](https://caniuse.com/intersectionobserver)
 - **Dialog**: [dialog-polyfill](https://www.npmjs.com/package/dialog-polyfill) · [caniuse](https://caniuse.com/dialog)
+- **Temporal**: [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) · [caniuse](https://caniuse.com/temporal) — optional peer used by `useDate`'s `V0DateAdapter` when native Temporal is unavailable
 
 ## Testing Your Browser
 


### PR DESCRIPTION
Temporal advanced to TC39 Stage 4 (finished) and is part of ECMAScript 2026. Reconciles the docs that made time-sensitive claims about its status.

- **useDate page**: corrects the install TIP from "Stage 3 proposal" to "Stage 4 (finished), part of ES2026." Polyfill guidance unchanged — native engine support is still rolling out.
- **Browser Support page**: adds Temporal to the Cutting-Edge Features table (Chrome/Edge 144+, Firefox 139+, Safari Technology Preview) and to the Polyfills list, pointing at `@js-temporal/polyfill` — the optional peer `V0DateAdapter` already uses. Previously the page never mentioned Temporal despite useDate shipping the polyfill.

Descriptive references that simply say useDate "uses the Temporal API" were left as-is — they remain accurate regardless of stage.