### PR TITLE
feat(genesis): complete GnPeek peek pill (bottom toggle, fixed position, chevron cue)

### DIFF
--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -90,8 +90,7 @@
       collapsed-label="Expand code"
       expanded-label="Collapse code"
     >
-      <span>{{ open ? 'Collapse' : 'Expand' }}</span>
-      <AppIcon :icon="open ? 'up' : 'down'" :size="14" />
+      {{ open ? 'Collapse' : 'Expand' }}
     </GnPeek>
   </div>
 </template>

--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -43,7 +43,7 @@
 </script>
 
 <template>
-  <div class="relative my-4" :class="shouldCollapse && !expanded && 'mb-8'">
+  <div class="relative my-4" :class="shouldCollapse && 'mb-8'">
     <div
       class="docs-markup relative group"
       :class="[
@@ -71,17 +71,6 @@
           show-wrap
           :title
         />
-
-        <button
-          v-if="shouldCollapse && expanded"
-          aria-label="Collapse code"
-          class="inline-flex items-center justify-center size-7 text-on-primary bg-primary rounded cursor-pointer transition-200 hover:bg-primary/85"
-          title="Collapse code"
-          type="button"
-          @click="expanded = false"
-        >
-          <AppIcon icon="fullscreen-exit" :size="16" />
-        </button>
       </div>
 
       <div
@@ -95,12 +84,14 @@
     </div>
 
     <GnPeek
-      v-if="shouldCollapse && !expanded"
+      v-if="shouldCollapse"
+      v-slot="{ expanded: open }"
       v-model:expanded="expanded"
       collapsed-label="Expand code"
+      expanded-label="Collapse code"
     >
-      <span>Expand</span>
-      <AppIcon icon="down" :size="14" />
+      <span>{{ open ? 'Collapse' : 'Expand' }}</span>
+      <AppIcon :icon="open ? 'up' : 'down'" :size="14" />
     </GnPeek>
   </div>
 </template>

--- a/packages/genesis/SPEC.md
+++ b/packages/genesis/SPEC.md
@@ -95,7 +95,7 @@ interface GnPeekProps {
 }
 ```
 
-`v-model:expanded` drives state; the default slot exposes `{ expanded }` for custom label/icon content (text-only by default).
+`v-model:expanded` drives state. The default slot exposes `{ expanded }` for the label; a separate `icon` slot defaults to an inline chevron that rotates 180° when expanded. Both slots are overridable.
 
 ## Icon strategy
 
@@ -105,8 +105,7 @@ Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
 |---|---|---|
 | `GnDocsExample` | `reset-icon` (single-file mode reset button) | refresh |
 | `GnDocsExampleTabs` | `reset-icon`, `combine-icon`, `split-icon` | refresh / unfold-less / unfold-more |
-
-`GnPeek` is text-only (default slot for label/icon content).
+| `GnPeek` | `icon` (chevron, rotates when expanded) | chevron-down |
 
 ```vue
 <GnDocsExampleTabs>

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleDescription.vue
@@ -96,13 +96,6 @@
     color: var(--v0-on-surface-variant, rgb(0 0 0 / 0.6));
   }
 
-  /* GnPeek nudges itself further down when expanded (good for the
-     single-file code peek). The description pill should stay pinned to the
-     border, so neutralize that drift here only. */
-  .genesis-docs-example-description :deep(.genesis-peek[data-expanded]) {
-    bottom: -0.75rem;
-  }
-
   .genesis-docs-example-description__title {
     margin: 0;
     font-size: 1.125rem;

--- a/packages/genesis/src/components/GnPeek/GnPeek.vue
+++ b/packages/genesis/src/components/GnPeek/GnPeek.vue
@@ -34,6 +34,20 @@
     <slot :expanded>
       {{ expanded ? expandedLabel : collapsedLabel }}
     </slot>
+
+    <slot :expanded name="icon">
+      <svg
+        aria-hidden="true"
+        class="genesis-peek__chevron"
+        fill="currentColor"
+        height="14"
+        viewBox="0 0 24 24"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
+      </svg>
+    </slot>
   </button>
 </template>
 
@@ -62,5 +76,13 @@
 
   .genesis-peek:hover {
     opacity: 0.85;
+  }
+
+  .genesis-peek__chevron {
+    transition: transform 0.15s;
+  }
+
+  .genesis-peek[data-expanded] .genesis-peek__chevron {
+    transform: rotate(180deg);
   }
 </style>

--- a/packages/genesis/src/components/GnPeek/GnPeek.vue
+++ b/packages/genesis/src/components/GnPeek/GnPeek.vue
@@ -56,15 +56,11 @@
     font: inherit;
     font-size: 0.75rem;
     cursor: pointer;
-    transition: opacity 0.15s, bottom 0.15s;
+    transition: opacity 0.15s;
     touch-action: manipulation;
   }
 
   .genesis-peek:hover {
     opacity: 0.85;
-  }
-
-  .genesis-peek[data-expanded] {
-    bottom: -1.5rem;
   }
 </style>


### PR DESCRIPTION
Follow-up to #362. That PR was squash-merged while it contained only the **first** commit (the initial `GnPeek` extraction); the three follow-up commits were pushed to the branch afterward and never landed on `master`, so they didn't deploy. This PR brings them in, cleanly rebased on current master.

## Restores
- **docs(DocsMarkup)** — move the code-block expand/collapse toggle to always sit at the bottom as the single `GnPeek` pill; drop the separate top-right collapse button (matches the GnDocsExample peek pattern).
- **refactor(genesis)** — hold the `GnPeek` pill at a constant offset across expand/collapse (remove the `[data-expanded]` downward nudge that's no longer needed).
- **feat(genesis)** — give `GnPeek` a default inline chevron (overridable `icon` slot) that rotates 180° when expanded, so docs code fences and gn-example peeks show the same cue. `DocsMarkup` drops its bespoke `AppIcon` chevron and uses the default.

Verified: genesis typecheck + docs SSG build clean.