### PR TITLE
ci: add per-PR changeset reminder

### DIFF
--- a/.github/workflows/changeset-reminder.yml
+++ b/.github/workflows/changeset-reminder.yml
@@ -1,0 +1,33 @@
+name: Changeset reminder
+
+# Nudges a PR that changes packages/* source but forgot `pnpm changeset`, so the
+# change isn't silently dropped from the next release's version bump + notes.
+#
+# Uses pull_request_target so the comment also posts on fork PRs (the default
+# GITHUB_TOKEN only gets pull-requests: write on forks via this event). SAFE:
+# checkout takes the trusted base branch (never the PR head), and the only thing
+# that runs is our own script, which reads the PR's file LIST through the API and
+# comments — no untrusted PR code is ever checked out or executed.
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: changeset-reminder-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6 # base branch (master) — trusted, NOT the PR head
+      - name: Changeset reminder
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: node scripts/changeset-reminder.js

--- a/scripts/changeset-reminder.js
+++ b/scripts/changeset-reminder.js
@@ -1,0 +1,47 @@
+// PR nudge: when a PR changes packages/* source but has no changeset, post — and
+// keep updated — a single sticky comment reminding the author to run
+// `pnpm changeset`, so the change isn't dropped from the next release.
+//
+// Driven by the changeset-reminder workflow (pull_request_target). Reads only the
+// PR's file LIST and comments via `gh`; it never checks out or runs PR code.
+import { execFileSync } from 'node:child_process'
+
+const repo = process.env.REPO
+const pr = process.env.PR
+const MARKER = '<!-- changeset-reminder -->'
+
+function gh (args, input) {
+  return execFileSync('gh', args, { encoding: 'utf8', input })
+}
+
+const files = JSON.parse(gh(['api', '--paginate', `repos/${repo}/pulls/${pr}/files`]))
+
+// A real changeset is a newly added .changeset/*.md that isn't the README.
+const hasChangeset = files.some(file => file.status === 'added' && /^\.changeset\/.+\.md$/.test(file.filename) && !file.filename.endsWith('/README.md'))
+const touchesSource = files.some(file => /^packages\/[^/]+\/src\//.test(file.filename))
+
+const found = `${MARKER}\n✅ **Changeset found** — this change will be included in the next release. Thanks!`
+const missing = `${MARKER}
+### ⚠️ No changeset found
+
+This PR changes \`packages/*\` source but has no changeset, so it won't be in the next release's version bump or notes. Add one:
+
+\`\`\`bash
+pnpm changeset
+\`\`\`
+
+Pick the affected package(s) (\`@vuetify/v0\` carries \`@vuetify/paper\` automatically), a bump type, and a short summary, then commit the generated \`.changeset/*.md\`. Docs-only, chore, or CI PRs can ignore this.`
+const skip = `${MARKER}\nℹ️ No \`packages/*\` source changes detected — a changeset isn't required for this PR.`
+
+const body = hasChangeset ? found : (touchesSource ? missing : skip)
+
+const comments = JSON.parse(gh(['api', '--paginate', `repos/${repo}/issues/${pr}/comments`]))
+const existing = comments.find(comment => comment.body.includes(MARKER))
+
+if (existing) {
+  // Keep the existing comment in sync (e.g. ⚠️ -> ✅ once a changeset is added).
+  gh(['api', '-X', 'PATCH', `repos/${repo}/issues/comments/${existing.id}`, '-F', 'body=@-'], body)
+} else if (touchesSource && !hasChangeset) {
+  // Only open a fresh thread when there's actually something to nudge about.
+  gh(['api', `repos/${repo}/issues/${pr}/comments`, '-F', 'body=@-'], body)
+}


### PR DESCRIPTION
Phase 3 of the Changesets migration: a per-PR nudge so contributors remember `pnpm changeset`, the one habit the new release flow depends on.

## What it does
A `pull_request_target` workflow posts and keeps updated a **single sticky comment** based on the PR's contents:
- **`packages/*/src` changed but no changeset** → ⚠️ a reminder with the `pnpm changeset` command
- **a changeset is present** → ✅ flips the same comment to "Changeset found"
- **no `packages/*` source changes** (docs/chore/CI) → stays silent — no comment

It only opens a thread when there's actually something to nudge about, and updates that one comment in place (no spam).

## Why `pull_request_target`
So the comment also posts on **fork PRs** — external contributors are exactly who won't know about changesets. The default `GITHUB_TOKEN` only gets `pull-requests: write` on forks through this event.

**Safe by design:** it checks out only the **trusted base branch** (never the PR head), runs **no PR code** (no `pnpm install`, no build), and reads the PR's file *list* via the API. The only PR-derived data is filenames, which are regex-tested, never executed or interpolated into a shell.

## Notes
- The comment logic lives in `scripts/changeset-reminder.js` (gh-driven, same house style as the release scripts); integration-tested across the missing / added / docs-only / update-existing cases.
- Not a blocking check — purely a nudge.
