### PR TITLE
chore: run type-strippable scripts with native node instead of tsx

### DIFF
--- a/apps/docs/build/generate-api-whitelist.ts
+++ b/apps/docs/build/generate-api-whitelist.ts
@@ -5,7 +5,7 @@
  * because the transformer runs client-side. This script generates
  * the lists from the filesystem at build time.
  *
- * Run manually: pnpm tsx apps/docs/build/generate-api-whitelist.ts
+ * Run manually: node apps/docs/build/generate-api-whitelist.ts
  * Or automatically via the Vite plugin in vite.config.ts
  */
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:bench:json": "vitest bench --run --outputJson apps/docs/public/benchmarks.json",
     "bench": "vitest --reporter=default bench",
     "metrics": "pnpm test:coverage && pnpm test:bench:json && node scripts/generate-metrics.js",
-    "skill": "tsx scripts/generate-skill.ts",
+    "skill": "node scripts/generate-skill.ts",
     "typecheck": "pnpm --filter=\"./packages/*\" typecheck",
     "typecheck:0": "pnpm --filter=\"./packages/0\" typecheck",
     "typecheck:paper": "pnpm --filter=\"./packages/paper\" typecheck",
@@ -40,7 +40,7 @@
     "changeset": "changeset",
     "release": "pnpm build && changeset publish",
     "release:prepare": "pnpm validate && pnpm build",
-    "postinstall": "tsx apps/docs/build/generate-api-whitelist.ts && node scripts/init-dev.js",
+    "postinstall": "node apps/docs/build/generate-api-whitelist.ts && node scripts/init-dev.js",
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
@@ -62,7 +62,6 @@
     "pkg-pr-new": "catalog:",
     "sherif": "catalog:",
     "simple-git-hooks": "catalog:",
-    "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "vue-tsc": "catalog:"

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "build": "pnpm build:tsdown && pnpm build:web-types",
     "build:tsdown": "tsdown",
-    "build:web-types": "tsx scripts/generate-web-types.ts",
-    "generate:web-types": "tsx scripts/generate-web-types.ts",
+    "build:web-types": "node scripts/generate-web-types.ts",
+    "generate:web-types": "node scripts/generate-web-types.ts",
     "typecheck": "vue-tsc --noEmit --incremental"
   },
   "publishConfig": {
@@ -133,7 +133,6 @@
     "launchdarkly-js-client-sdk": "catalog:",
     "posthog-js": "catalog:",
     "tsdown": "catalog:",
-    "tsx": "catalog:",
     "typescript": "catalog:",
     "unplugin-vue": "catalog:",
     "vue": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
       simple-git-hooks:
         specifier: 'catalog:'
         version: 2.13.1
-      tsx:
-        specifier: 'catalog:'
-        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -592,9 +589,6 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@tsdown/css@0.21.10)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
-      tsx:
-        specifier: 'catalog:'
-        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
Node 26 ships stable native TypeScript type-stripping, so the build/tooling scripts that `tsx` ran as a CLI loader now run under plain `node`. This drops the `[DEP0205] module.register() is deprecated` warning `tsx` emitted on every `pnpm install`, and removes a process-spawn dependency from the install path.

**Converted** (each verified type-strippable — erasable TS syntax only, ESM, runs clean under `node`):
- root `postinstall` + `skill`
- `packages/0` `build:web-types` + `generate:web-types`

With those gone, `tsx` is no longer referenced in the root or `packages/0` manifests, so it's dropped from both `devDependencies` (knip). `tsx` stays in `apps/docs` — `generate-tips.ts` still uses `tsx/esm/api` programmatically inside its Vite plugin.