### PR TITLE
fix(NumberField): pass parsed value to commit() to avoid stale model read

### DIFF
--- a/.changeset/number-field-vmodel-329.md
+++ b/.changeset/number-field-vmodel-329.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(NumberField): pass parsed value directly to commit() so typed values correctly propagate to the parent v-model on blur and Enter — avoids reading the stale model before Vue's reactivity round-trip completes

--- a/knip.json
+++ b/knip.json
@@ -142,9 +142,13 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
+    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
+  ],
+  "ignoreBinaries": [
+    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/knip.json
+++ b/knip.json
@@ -142,13 +142,9 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
-    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
-  ],
-  "ignoreBinaries": [
-    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/packages/0/src/components/NumberField/NumberFieldControl.vue
+++ b/packages/0/src/components/NumberField/NumberFieldControl.vue
@@ -102,7 +102,7 @@
   function onBlur () {
     const parsed = root.parse(text.value)
     root.value.value = parsed
-    root.commit()
+    root.commit(parsed)
     root.isFocused.value = false
     syncText()
   }
@@ -128,7 +128,7 @@
       Enter: () => {
         const parsed = root.parse(text.value)
         root.value.value = parsed
-        root.commit()
+        root.commit(parsed)
       },
     }
 

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -1563,9 +1563,7 @@ describe('numberField', () => {
       await wait()
       input.dispatchEvent(new FocusEvent('blur'))
       await wait()
-      // Either the v-model committed via onBlur, or it's still 5;
-      // cover the path itself, not the v-model bridge.
-      expect([42, 5]).toContain(model.value)
+      expect(model.value).toBe(42)
     })
 
     it('should commit on Enter key', async () => {
@@ -1583,9 +1581,43 @@ describe('numberField', () => {
       await wait()
       await controlEl().trigger('keydown', { key: 'Enter' })
       await wait()
-      // Cover the keydown Enter branch; commit may or may not propagate
-      // through happy-dom's input event chain.
-      expect([42, 5]).toContain(model.value)
+      expect(model.value).toBe(42)
+    })
+
+    it('should commit typed value to parent-bound v-model on blur (regression #329)', async () => {
+      const model = ref<number | null>(5)
+      const { controlEl, wait } = mountNumberField({
+        model,
+        props: { min: 0, max: 200 },
+      })
+      await wait()
+
+      await controlEl().trigger('focus')
+      const input = controlEl().element as HTMLInputElement
+      input.value = '100'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await wait()
+      input.dispatchEvent(new FocusEvent('blur'))
+      await wait()
+      expect(model.value).toBe(100)
+    })
+
+    it('should commit typed value to parent-bound v-model on Enter (regression #329)', async () => {
+      const model = ref<number | null>(5)
+      const { controlEl, wait } = mountNumberField({
+        model,
+        props: { min: 0, max: 200 },
+      })
+      await wait()
+
+      await controlEl().trigger('focus')
+      const input = controlEl().element as HTMLInputElement
+      input.value = '100'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await wait()
+      await controlEl().trigger('keydown', { key: 'Enter' })
+      await wait()
+      expect(model.value).toBe(100)
     })
 
     it('should leap on PageUp', async () => {

--- a/packages/0/src/composables/createNumberField/index.ts
+++ b/packages/0/src/composables/createNumberField/index.ts
@@ -82,8 +82,8 @@ export interface NumberFieldContext {
   formatValue: (value: number) => string
   /** Parse locale-formatted text to a number or null. */
   parse: (text: string) => number | null
-  /** Snap and optionally clamp the current value. */
-  commit: () => void
+  /** Snap and optionally clamp the current value. Pass `next` to avoid reading the stale model on the same tick as a write. */
+  commit: (next?: number | null) => void
 }
 
 export function createNumberField (options: NumberFieldOptions = {}): NumberFieldContext {
@@ -205,17 +205,20 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
     return Number.isNaN(result) ? null : result
   }
 
-  function commit (): void {
-    if (isNull(value.value)) return
-    if (!shouldClamp && (value.value < numeric.min || value.value > numeric.max)) {
+  function commit (next?: number | null): void {
+    // Use the provided value when available — avoids reading a stale model on
+    // the same tick as a write (parent-bound v-model hasn't round-tripped yet).
+    const val = arguments.length === 0 ? value.value : next as number | null
+    if (isNull(val)) return
+    if (!shouldClamp && (val < numeric.min || val > numeric.max)) {
       // Snap to nearest step without clamping to [min, max]
       if (numeric.step > 0 && Number.isFinite(numeric.min)) {
-        const steps = Math.round((value.value - numeric.min) / numeric.step)
+        const steps = Math.round((val - numeric.min) / numeric.step)
         value.value = numeric.min + steps * numeric.step
       }
       return
     }
-    value.value = numeric.snap(value.value)
+    value.value = numeric.snap(val)
   }
 
   return {


### PR DESCRIPTION
Fixes #329

## Problem

When a user types a value and blurs or presses Enter, `commit()` was called with no arguments and re-read `value.value` from the reactive model. Because the parent `v-model` write and Vue's reactivity round-trip hadn't completed yet, `value.value` still held the previous value — so the typed input was silently dropped.

## Fix

`commit()` now accepts an optional `next` parameter. Both `onBlur` and the Enter key handler pass the just-parsed value so `commit()` doesn't need to re-read the model on the same tick as a write.

```ts
// before
root.value.value = parsed
root.commit()          // reads value.value — stale!

// after
root.value.value = parsed
root.commit(parsed)    // uses parsed directly — correct
```

## Tests

- Tightened two existing tests that previously accepted either the old or new value (`expect([42, 5]).toContain(model.value)` → `expect(model.value).toBe(42)`)
- Added two regression tests that explicitly verify the typed value reaches the parent `v-model` on blur and Enter

## Checklist
- [x] `pnpm test:run` — 6249 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:fix` — clean
- [x] `pnpm repo:check` — clean