### PR TITLE
fix(Button): suppress auto aria-label in renderless mode (WCAG 4.1.2)

### DIFF
--- a/.changeset/button-aria-label-330.md
+++ b/.changeset/button-aria-label-330.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Button): don't auto-set aria-label in renderless mode — in renderless mode the consumer owns the DOM and is responsible for the accessible name; the automatic icon-only fallback no longer overrides visible text in mixed-content renderless usages

--- a/knip.json
+++ b/knip.json
@@ -142,9 +142,13 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
+    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
+  ],
+  "ignoreBinaries": [
+    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/knip.json
+++ b/knip.json
@@ -142,13 +142,9 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
-    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
-  ],
-  "ignoreBinaries": [
-    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -214,7 +214,7 @@
     'aria-disabled': isDisabled.value || isPassive.value,
     'aria-busy': isLoading.value ? true : undefined,
     'aria-pressed': group ? isSelected.value : undefined,
-    'aria-label': ariaLabel || (isSolo.value ? locale.t('Button.label') : undefined),
+    'aria-label': ariaLabel || (!renderless && isSolo.value ? locale.t('Button.label') : undefined),
     'tabindex': isDisabled.value ? -1 : 0,
     'data-loading': isLoading.value ? true : undefined,
     'data-passive': isPassive.value ? true : undefined,

--- a/packages/0/src/components/Button/index.test.ts
+++ b/packages/0/src/components/Button/index.test.ts
@@ -625,6 +625,32 @@ describe('button', () => {
       await nextTick()
       expect(wrapper.find('button').attributes('aria-label')).toBe('Close')
     })
+
+    it('should not auto-set aria-label in renderless mode even when solo (regression #330)', async () => {
+      const wrapper = mount(Button.Root, {
+        props: { renderless: true },
+        slots: {
+          default: (p: any) =>
+            h('button', p.attrs, [
+              h(Button.Icon as any, {}, { default: () => h('span', '✕') }),
+            ]),
+        },
+      })
+
+      await nextTick()
+      expect(wrapper.find('button').attributes('aria-label')).toBeUndefined()
+    })
+
+    it('should not auto-set aria-label when button has visible text (no icon, non-renderless)', async () => {
+      const wrapper = mount(Button.Root, {
+        slots: {
+          default: () => h(Button.Content as any, {}, { default: () => 'Save & Next' }),
+        },
+      })
+
+      await nextTick()
+      expect(wrapper.find('button').attributes('aria-label')).toBeUndefined()
+    })
   })
 
   describe('hidden input', () => {


### PR DESCRIPTION
Fixes #330

> Note: The raw-key leak (`'Button.label'` instead of `'Button'`) is addressed separately in #372. This PR fixes the `isSolo` / renderless mismatch that causes the label to override visible text at all.

## Problem

In renderless mode (`renderless: true`), consumers own the full DOM — they write the button element and its content themselves. If they include `Button.Icon` in their rendering (to get icon slot-props), `Button.Icon.onMounted` detects `root.single.size === 0` (no `Button.Content` registered) and sets `isSolo = true`. That causes `ButtonRoot` to emit an `aria-label`, overriding the consumer's own visible text.

## Fix

One-line guard in `ButtonRoot.vue`:

```diff
- 'aria-label': ariaLabel || (isSolo.value ? locale.t('Button.label') : undefined),
+ 'aria-label': ariaLabel || (!renderless && isSolo.value ? locale.t('Button.label') : undefined),
```

In renderless mode the consumer is responsible for the accessible name — the component stays out of the way.

## Tests

Two new regression tests:
1. `renderless` + `Button.Icon` + no explicit `ariaLabel` → no `aria-label` attribute (was incorrectly emitted before)
2. Non-renderless + `Button.Content` (text) + no `Button.Icon` → no `aria-label` attribute (sanity check that text buttons never get a default label)

## Checklist
- [x] `pnpm test:run` — 6249 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:fix` — clean
- [x] `pnpm repo:check` — clean