### PR TITLE
feat(paper): add PaperIcon component and createIconPlugin for alias resolution

### DIFF
--- a/.changeset/paper-icon-system-107.md
+++ b/.changeset/paper-icon-system-107.md
@@ -1,0 +1,10 @@
+---
+"@vuetify/paper": minor
+---
+
+feat(paper): add `PaperIcon` component and `createIconPlugin` composable
+
+- `PaperIcon` — renderless icon component that resolves alias names through a `createTokens`-backed registry; design systems decide rendering (class on `<span>`, inline SVG, etc.)
+- `createIconPlugin({ close: 'i-mdi-close', ... })` — registers an icon set; call `provideIcons()` in the root component's `setup()`
+- `useIconTokens()` — composable to access the icon token context directly
+- Accessible by default: `aria-hidden="true"` on icon-only usage; set `label` prop to expose `role="img"` + `aria-label` instead

--- a/knip.json
+++ b/knip.json
@@ -22,13 +22,12 @@
         "src/pages/**/*.{vue,md}",
         "build/**/*.ts",
         "vite.config.*",
-        "src/examples/**/*.vue"
+        "src/examples/**/*.vue",
+        "src/examples/**/*.ts"
       ],
       "ignore": [
         "src/typed-router.d.ts",
-        "src/examples/guide/building-frameworks/my-ui/src/**/*.ts",
         "src/examples/guide/building-frameworks/my-ui/vite.config.ts",
-        "src/examples/composables/create-trinity/toasts.ts",
         "src/skillz/tours/**/index.ts"
       ],
       "paths": {
@@ -142,13 +141,9 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
-    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
-  ],
-  "ignoreBinaries": [
-    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/knip.json
+++ b/knip.json
@@ -142,9 +142,13 @@
     "**/*.d.ts"
   ],
   "ignoreDependencies": [
+    "@changesets/cli",
     "@js-temporal/polyfill",
     "@vue/repl",
     "@vuetify/paper"
+  ],
+  "ignoreBinaries": [
+    "changeset"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/packages/paper/src/components/Icon/Icon.vue
+++ b/packages/paper/src/components/Icon/Icon.vue
@@ -1,0 +1,56 @@
+<script lang="ts">
+  // Framework
+  import { Atom } from '@vuetify/v0'
+
+  // Composables
+  import { useIconTokens } from '#paper/composables/createIcon'
+
+  // Utilities
+  import { computed, toRef } from 'vue'
+
+  // Types
+  import type { IconProps, IconSlotProps } from './types'
+
+  export type { IconProps, IconSlotProps }
+</script>
+
+<script lang="ts" setup>
+  defineOptions({ name: 'PaperIcon' })
+
+  defineSlots<{
+    default: (props: IconSlotProps) => any
+  }>()
+
+  const { icon, label, as = 'span', renderless } = defineProps<IconProps>()
+
+  let tokens: ReturnType<typeof useIconTokens> | null = null
+  try {
+    tokens = useIconTokens()
+  } catch {}
+
+  const resolved = computed((): string => {
+    if (!tokens) return icon
+    const value = tokens.resolve(icon)
+    return typeof value === 'string' ? value : icon
+  })
+
+  const slotProps = toRef((): IconSlotProps => ({
+    icon: resolved.value,
+    attrs: {
+      'class': resolved.value,
+      'aria-hidden': label ? undefined : true,
+      'aria-label': label,
+      'role': label ? 'img' : undefined,
+    },
+  }))
+</script>
+
+<template>
+  <Atom
+    :as
+    :renderless
+    v-bind="slotProps.attrs"
+  >
+    <slot v-bind="slotProps" />
+  </Atom>
+</template>

--- a/packages/paper/src/components/Icon/Icon.vue
+++ b/packages/paper/src/components/Icon/Icon.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
   // Framework
   import { Atom } from '@vuetify/v0'
 
@@ -11,10 +11,6 @@
   // Types
   import type { IconProps, IconSlotProps } from './types'
 
-  export type { IconProps, IconSlotProps }
-</script>
-
-<script lang="ts" setup>
   defineOptions({ name: 'PaperIcon' })
 
   defineSlots<{

--- a/packages/paper/src/components/Icon/index.ts
+++ b/packages/paper/src/components/Icon/index.ts
@@ -1,0 +1,2 @@
+export { default as PaperIcon } from './Icon.vue'
+export type { IconProps, IconSlotProps } from './types'

--- a/packages/paper/src/components/Icon/types.ts
+++ b/packages/paper/src/components/Icon/types.ts
@@ -1,0 +1,20 @@
+import type { AtomProps } from '@vuetify/v0'
+
+export interface IconProps extends AtomProps {
+  /** Icon alias or class name */
+  icon: string
+  /** Accessible label. When omitted the icon is hidden from assistive tech. */
+  label?: string
+}
+
+export interface IconSlotProps {
+  /** Resolved icon value (alias → token value, or the original name if unregistered) */
+  icon: string
+  /** Attributes to spread onto the icon element */
+  attrs: {
+    'class': string
+    'aria-hidden': true | undefined
+    'aria-label': string | undefined
+    'role': 'img' | undefined
+  }
+}

--- a/packages/paper/src/components/Icon/types.ts
+++ b/packages/paper/src/components/Icon/types.ts
@@ -1,3 +1,4 @@
+// Types
 import type { AtomProps } from '@vuetify/v0'
 
 export interface IconProps extends AtomProps {

--- a/packages/paper/src/components/index.ts
+++ b/packages/paper/src/components/index.ts
@@ -1,1 +1,2 @@
+export * from './Icon'
 export * from './V0Paper'

--- a/packages/paper/src/composables/createIcon/index.ts
+++ b/packages/paper/src/composables/createIcon/index.ts
@@ -19,7 +19,10 @@
  * ```
  */
 
+// Framework
 import { createTokens, createTokensContext } from '@vuetify/v0'
+
+// Types
 import type { TokenCollection } from '@vuetify/v0'
 
 export const ICON_NAMESPACE = 'paper:icons'

--- a/packages/paper/src/composables/createIcon/index.ts
+++ b/packages/paper/src/composables/createIcon/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @module createIcon
+ *
+ * @remarks
+ * Icon token registry for Paper. Design systems register their icon set once
+ * (e.g. UnoCSS `i-mdi-*` class names) and Paper's `<PaperIcon>` component
+ * resolves alias names to the registered values at render time.
+ *
+ * @example
+ * ```ts
+ * // In your design system root component's setup():
+ * import { createIconPlugin } from '@vuetify/paper'
+ *
+ * const { provideIcons } = createIconPlugin({
+ *   close: 'i-mdi-close',
+ *   menu:  'i-mdi-menu',
+ * })
+ * provideIcons()
+ * ```
+ */
+
+import { createTokens, createTokensContext } from '@vuetify/v0'
+import type { TokenCollection } from '@vuetify/v0'
+
+export const ICON_NAMESPACE = 'paper:icons'
+
+export const [useIconTokens, provideIconContext] = createTokensContext({
+  namespace: ICON_NAMESPACE,
+  tokens: {},
+})
+
+export interface IconPluginOptions {
+  [alias: string]: string
+}
+
+export interface IconPlugin {
+  /** Call inside a Vue component's setup() to make icons available to descendants */
+  provideIcons: () => void
+  /** Raw icon alias map */
+  icons: IconPluginOptions
+}
+
+/**
+ * Creates an icon plugin backed by `createTokens` alias resolution.
+ *
+ * @example
+ * ```ts
+ * const { provideIcons } = createIconPlugin({
+ *   close: 'i-mdi-close',
+ *   menu:  'i-mdi-menu',
+ * })
+ * ```
+ */
+export function createIconPlugin (icons: IconPluginOptions): IconPlugin {
+  const context = createTokens(icons as TokenCollection)
+  return {
+    icons,
+    provideIcons () {
+      provideIconContext(context)
+    },
+  }
+}

--- a/packages/paper/src/composables/index.ts
+++ b/packages/paper/src/composables/index.ts
@@ -1,3 +1,4 @@
+export * from './createIcon'
 export * from './useBorder'
 export * from './useColor'
 export * from './useContrast'


### PR DESCRIPTION
Closes #107

## What

Implements the Paper icon system described in #107: a renderless `<PaperIcon>` component backed by `createTokens` alias resolution, with a `createIconPlugin` helper for registration.

## API

### `createIconPlugin(icons)` — design system setup

```ts
import { createIconPlugin } from '@vuetify/paper'

const icons = createIconPlugin({
  close: 'i-mdi-close',
  menu:  'i-mdi-menu',
  check: 'i-mdi-check',
})

// In root component's setup():
icons.provideIcons()
```

### `<PaperIcon>` — renderless component

```vue
<!-- Default: renders <span class="i-mdi-close" aria-hidden="true" /> -->
<PaperIcon icon="close" />

<!-- With label: exposes role="img" + aria-label for meaningful icons -->
<PaperIcon icon="close" label="Close dialog" />

<!-- Renderless: design system controls the element -->
<PaperIcon icon="close" renderless>
  <template #default="{ icon, attrs }">
    <span v-bind="attrs" />
  </template>
</PaperIcon>
```

Unregistered icon names pass through as-is (e.g. `icon="i-mdi-close"` works without registration).

### `useIconTokens()` — direct token access

```ts
const tokens = useIconTokens()
const resolved = tokens.resolve('close') // 'i-mdi-close'
```

## Architecture

- `createIconPlugin` calls `createTokens(icons)` to build a full token context with alias resolution, then uses `provideIconContext` (from `createTokensContext`) to provide it to descendants
- `PaperIcon` calls `useIconTokens()` with a try/catch so it works without a plugin (passes icon name through)
- Accessible by default: `aria-hidden="true"` on decorative icons; set `label` prop for meaningful icons

## Checklist
- [x] `pnpm typecheck` — clean (paper + v0 + genesis)
- [x] `pnpm test:run` — 6247 tests pass
- [x] `pnpm lint:fix` — clean
- [x] `pnpm repo:check` — clean