### PR TITLE
ci: harden changesets release pipeline (audit fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,16 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
+      # No registry-url on purpose: tokenless OIDC publishing (npm >= 11.5.1)
+      # resolves the public registry itself. Setting registry-url makes setup-node
+      # write an `.npmrc` `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line;
+      # with NODE_AUTH_TOKEN unset that empty token can 401 ("need: BASIC") instead
+      # of falling through to OIDC.
       - name: Set node
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,28 @@ pnpm changeset        # Author a changeset for your PR (run per change)
 pnpm release:prepare  # Pre-release validation (validate + build)
 # Publishing is automated: pushing to master opens a "Version Packages" PR;
 # merging it builds, publishes to npm via OIDC, and creates the GitHub releases.
+# Currently in PRE mode (beta dist-tag) — see "Releasing" below before cutting stable.
 
 # Repo health
 pnpm repo:check       # knip + sherif
 ```
+
+## Releasing
+
+Changesets-driven. Pushing to `master` opens/updates a "Version Packages" PR; merging it publishes to npm (tokenless OIDC) and mints the GitHub releases (`.github/workflows/release.yml`).
+
+- **Substrate** (`@vuetify/v0` + `@vuetify/paper`) is a `fixed` group: one shared version, one aggregate `v<version>` GitHub release.
+- **Design systems** (`@paper/*`, e.g. `@paper/genesis`) version and release independently, each on its own `name@version` release. Note `@paper/genesis` depends on `@vuetify/v0`, so a substrate **major** bump (e.g. `1.x` → `2.0.0`) leaves genesis's `^` range and changesets will also bump + republish genesis. That is expected — review it in the "Version Packages" PR before merging.
+
+### Exiting beta / cutting a stable release
+
+The repo is in changesets **pre mode** (`.changeset/pre.json`, `beta` dist-tag); every release is `…-beta.N` published under the `beta` tag. Before the first stable release:
+
+1. `pnpm changeset pre exit`
+2. Commit the removal of `.changeset/pre.json`
+3. Let the next "Version Packages" PR produce the clean `1.0.0`, then merge it
+
+Skipping `pre exit` ships `1.0.0-beta.N` (or mistags it) instead of a real `1.0.0`.
 
 ## Conventions
 

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -118,6 +118,17 @@ pnpm build            # Build packages
 4. Run `pnpm typecheck` to check types
 5. Run `pnpm test:run` to verify tests pass
 6. Write tests for new functionality
+7. Run `pnpm changeset` if you changed `packages/*` source (see [Changesets](#changesets))
+
+### Changesets
+
+Releases are managed with [Changesets](https://github.com/changesets/changesets). If your PR changes published source under `packages/*`, add a changeset so the change lands in the next release's version bump and changelog:
+
+```bash
+pnpm changeset
+```
+
+Pick the affected package(s), a bump type (`patch`/`minor`/`major`), and a short summary, then commit the generated `.changeset/*.md` alongside your code. `@vuetify/v0` and `@vuetify/paper` version in lockstep — selecting `@vuetify/v0` carries `@vuetify/paper` automatically; the `@paper/*` design systems version separately. Docs-only, chore, refactor, or CI PRs don't need one. A bot comments on every PR to remind you.
 
 ### PR Guidelines
 

--- a/apps/docs/src/stores/releases.ts
+++ b/apps/docs/src/stores/releases.ts
@@ -40,10 +40,14 @@ export const useReleasesStore = defineStore('releases', {
 
   actions: {
     format (release: GitHubRelease): Release {
+      // Substrate releases are `v<major>.x` — show the numeric-box icon for the
+      // major. Design-system releases are `@scope/name@<version>` (no single
+      // leading major to show) and fall back to a generic package icon.
+      const major = /^v(\d)/.exec(release.tag_name)
       return {
         ...release,
         props: {
-          prependIcon: `mdi-numeric-${release.tag_name.slice(1, 2)}-box`,
+          prependIcon: major ? `mdi-numeric-${major[1]}-box` : 'mdi-package-variant',
           title: release.tag_name,
         },
       }
@@ -96,7 +100,10 @@ export const useReleasesStore = defineStore('releases', {
       }
     },
     async find (tag: string): Promise<Release | undefined> {
-      if (!tag.startsWith('v')) tag = `v${tag}`
+      // Bare version numbers ("1.2.3") map to the substrate's `v` tag; scoped
+      // design-system tags ("@paper/genesis@1.2.3") and already-`v`-prefixed tags
+      // pass through unchanged.
+      if (!tag.startsWith('v') && !tag.includes('@')) tag = `v${tag}`
 
       const found = this.releases.find(release => release.tag_name === tag)
 

--- a/scripts/changeset-reminder.js
+++ b/scripts/changeset-reminder.js
@@ -30,13 +30,16 @@ This PR changes \`packages/*\` source but has no changeset, so it won't be in th
 pnpm changeset
 \`\`\`
 
-Pick the affected package(s) (\`@vuetify/v0\` carries \`@vuetify/paper\` automatically), a bump type, and a short summary, then commit the generated \`.changeset/*.md\`. Docs-only, chore, or CI PRs can ignore this.`
+Pick the affected package(s) — \`@vuetify/v0\` carries \`@vuetify/paper\` automatically; \`@paper/genesis\` (and other \`@paper/*\` design systems) version separately — a bump type, and a short summary, then commit the generated \`.changeset/*.md\`. Docs-only, chore, or CI PRs can ignore this.`
 const skip = `${MARKER}\nℹ️ No \`packages/*\` source changes detected — a changeset isn't required for this PR.`
 
 const body = hasChangeset ? found : (touchesSource ? missing : skip)
 
 const comments = JSON.parse(gh(['api', '--paginate', `repos/${repo}/issues/${pr}/comments`]))
-const existing = comments.find(comment => comment.body.includes(MARKER))
+// Match only this bot's own sticky comment: anchor the marker at the start (not a
+// substring) and require a Bot author, so a user comment quoting the marker can't
+// be hijacked/PATCHed in place of ours.
+const existing = comments.find(comment => comment.user?.type === 'Bot' && comment.body.startsWith(MARKER))
 
 if (existing) {
   // Keep the existing comment in sync (e.g. ⚠️ -> ✅ once a changeset is added).

--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -14,7 +14,7 @@
 // Driven by the changesets/action `publishedPackages` output. `gh` is
 // preinstalled on the runner and authenticates via GITHUB_TOKEN.
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 
 const SUBSTRATE = new Set(['@vuetify/v0', '@vuetify/paper'])
 
@@ -22,8 +22,13 @@ const published = JSON.parse(process.env.PUBLISHED_PACKAGES || '[]')
 const sha = process.env.GITHUB_SHA
 const version = Object.fromEntries(published.map(p => [p.name, p.version]))
 
-// Pull the `## <version>` block out of a changesets CHANGELOG.md.
+// Pull the `## <version>` block out of a changesets CHANGELOG.md. Returns '' when
+// the file is absent: a package can land in publishedPackages before its
+// CHANGELOG.md exists, and an unreadable changelog must NOT abort the release run
+// (npm publish has already succeeded by the time this script runs).
 function notes (changelog, value) {
+  if (!existsSync(changelog)) return ''
+
   const lines = readFileSync(changelog, 'utf8').split('\n')
   const start = lines.findIndex(line => line.trim() === `## ${value}`)
 
@@ -52,21 +57,43 @@ function exists (tag) {
 // `gh release create` mints the tag at `target` (the publish commit) and the
 // release together. Idempotent on re-run: an already-minted release is skipped
 // so a retry reconciles the missing ones instead of dying on the first 422.
-function release (tag, body, target) {
+// A prerelease version (anything carrying a `-`, e.g. `-beta.N`) is flagged
+// `--prerelease` so GitHub never marks a beta as the repo's "Latest release".
+function release (tag, body, target, prerelease) {
   if (exists(tag)) {
     console.log(`release ${tag} already exists, skipping`)
     return
   }
-  execFileSync('gh', ['release', 'create', tag, '--title', tag, '--notes', body || 'No release notes.', '--target', target], { stdio: 'inherit' })
+
+  const args = ['release', 'create', tag, '--title', tag, '--notes', body || 'No release notes.', '--target', target]
+  if (prerelease) args.push('--prerelease')
+  execFileSync('gh', args, { stdio: 'inherit' })
 }
 
-// Aggregate substrate release — v0 + paper share a version; v0's changelog is the body.
-const substrate = version['@vuetify/v0']
+const failures = []
+
+// Each release is isolated so one failure (e.g. an API hiccup) reports and is
+// retried on a re-run instead of aborting every release not yet minted.
+function mint (tag, body, target, prerelease) {
+  try {
+    release(tag, body, target, prerelease)
+  } catch (error) {
+    console.error(`::error::failed to create release ${tag}: ${error.message}`)
+    failures.push(tag)
+  }
+}
+
+// Aggregate substrate release — v0 + paper share a version. v0's changelog is the
+// body; paper's is the fallback for a paper-only recovery publish (where v0 was
+// already on npm). Keyed on either substrate package so the aggregate `v*` release
+// still mints if only one of the lockstep pair lands in publishedPackages.
+const substrate = version['@vuetify/v0'] ?? version['@vuetify/paper']
 if (substrate) {
-  let body = notes('packages/0/CHANGELOG.md', substrate)
-  const paper = version['@vuetify/paper']
-  if (paper) body += `\n\n---\n\`@vuetify/paper@${paper}\` shipped in lockstep.`
-  release(`v${substrate}`, body, sha)
+  let body = notes('packages/0/CHANGELOG.md', substrate) || notes('packages/paper/CHANGELOG.md', substrate)
+  if (version['@vuetify/v0'] && version['@vuetify/paper']) {
+    body += `\n\n---\n\`@vuetify/paper@${version['@vuetify/paper']}\` shipped in lockstep.`
+  }
+  mint(`v${substrate}`, body, sha, substrate.includes('-'))
 }
 
 // Each design system (@paper/*) releases independently on its own tag.
@@ -74,5 +101,12 @@ if (substrate) {
 for (const { name, version: value } of published) {
   if (SUBSTRATE.has(name)) continue
   const dir = name.split('/').pop()
-  release(`${name}@${value}`, notes(`packages/${dir}/CHANGELOG.md`, value), sha)
+  mint(`${name}@${value}`, notes(`packages/${dir}/CHANGELOG.md`, value), sha, value.includes('-'))
+}
+
+// Fail the step (after attempting every release) if any could not be minted, so a
+// partial GitHub-release run is visible rather than silently green.
+if (failures.length > 0) {
+  console.error(`::error::${failures.length} GitHub release(s) failed: ${failures.join(', ')}`)
+  process.exitCode = 1
 }

--- a/scripts/verify-published.js
+++ b/scripts/verify-published.js
@@ -6,6 +6,11 @@ import { execFileSync } from 'node:child_process'
 
 const published = JSON.parse(process.env.PUBLISHED_PACKAGES || '[]')
 
+// 8 attempts with linear backoff (5s,10s,…,35s) ~= 140s of tolerance. The publish
+// already succeeded at this point, so patience over npm propagation lag costs
+// nothing while failing fast costs a manual re-run.
+const ATTEMPTS = 8
+
 function sleep (ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
 }
@@ -15,14 +20,16 @@ let failed = false
 for (const { name, version } of published) {
   let found = false
 
-  for (let attempt = 1; attempt <= 5; attempt++) {
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
     try {
       execFileSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'ignore' })
       found = true
       break
     } catch {
-      console.log(`${name}@${version} not visible yet (attempt ${attempt}), retrying in 5s`)
-      sleep(5000)
+      if (attempt === ATTEMPTS) break
+      const wait = attempt * 5000
+      console.log(`${name}@${version} not visible yet (attempt ${attempt}/${ATTEMPTS}), retrying in ${wait / 1000}s`)
+      sleep(wait)
     }
   }
 


### PR DESCRIPTION
Addresses findings from an audit of the recent changesets release-pipeline overhaul (#364/#365/#368 + beta pre-mode). No `packages/*` source changed, so no changeset is required.

## Must-fix before the first real publish

- **OIDC vs. empty `_authToken` (REL-1)** — `release.yml` dropped `registry-url` from `setup-node`. With `registry-url` set and `NODE_AUTH_TOKEN` unset, the generated `.npmrc` carries an empty `_authToken` that can `401 (need: BASIC)` instead of falling through to tokenless OIDC. Still worth confirming on the first live publish that auth resolves via OIDC.
- **Beta releases marked "Latest" (GR-1 / REL-2 / PRE-2)** — `github-release.js` now passes `--prerelease` for any hyphenated (`-beta.N`) version, so a beta is never marked the repo's Latest release.

## Before cutting stable 1.0.0

- **Exit-pre-mode runbook (PRE-1)** — `CLAUDE.md` now documents `changeset pre exit` → commit `pre.json` removal → next Version Packages PR produces clean `1.0.0`.
- **`@paper/genesis` coupling** — kept the dependency edge (NOT added to `ignore`, which would remove genesis from the publish flow entirely). The auto-bump only fires at a substrate **major** bump and is reviewable in the Version Packages PR; documented in `CLAUDE.md`.

## Hardening

- **`github-release.js`** — `notes()` guards a missing `CHANGELOG.md` (no ENOENT abort after npm publish already landed); the aggregate substrate release is keyed on v0 *or* paper (paper-only recovery publish still mints); each release is isolated so one failure reports without aborting the rest.
- **`verify-published.js`** — retry ceiling raised to ~140s with linear backoff to ride out npm propagation lag; dropped the wasted final sleep.
- **`changeset-reminder.js`** — sticky-comment lookup now requires a Bot author + leading marker (a quoted marker can't hijack the PATCH); guidance mentions `@paper/*` design systems version separately.
- **`releases.ts` (docs)** — tolerate the new `@scope/name@version` design-system tags: numeric-box icon only for `v<major>` tags, and `find()` no longer force-prefixes scoped tags with `v`.
- **`contributing.md`** — documents the `pnpm changeset` step in the contributor flow.

## Verification

- `node --check` on all three scripts: clean
- `eslint` on changed JS/TS: clean
- Full `pnpm typecheck`/`build` not run here — worktree has no `node_modules`; CI will run them.