### PR TITLE
docs: normalize code actions across DocsMarkup and DocsExample

### DIFF
--- a/apps/docs/src/components/docs/DocsExampleCodePane.vue
+++ b/apps/docs/src/components/docs/DocsExampleCodePane.vue
@@ -32,6 +32,7 @@
 
   const settings = useSettings()
   const lineWrap = useSyncedRef(settings.lineWrap)
+  const size = settings.codeSize
 
   // Highlighting
   const highlightedCode = shallowRef<string>()
@@ -102,12 +103,14 @@
       class="absolute top-3 end-3 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100"
     >
       <DocsCodeActions
+        v-model:size="size"
         v-model:wrap="lineWrap"
         bin
         :code
         :language
         :playground="showPlayground"
         show-copy
+        show-size
         show-wrap
         :title="title || fileName"
       />

--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -32,6 +32,7 @@
 
   const settings = useSettings()
   const lineWrap = useSyncedRef(settings.lineWrap)
+  const size = settings.codeSize
 
   const decodedCode = toRef(() => decodeBase64(code))
 
@@ -61,6 +62,7 @@
 
       <div class="absolute top-3 end-3 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100">
         <DocsCodeActions
+          v-model:size="size"
           v-model:wrap="lineWrap"
           bin
           :bin-title
@@ -68,6 +70,7 @@
           :language
           :playground
           show-copy
+          show-size
           show-wrap
           :title
         />


### PR DESCRIPTION
Adds the existing code-size toggle to `DocsMarkup` and `DocsExample`'s code panes (`DocsExampleCodePane`), so all three code-block toolbars — `DocsMarkup`, `DocsExampleCodePane`, and the reference `DocsGenesisExample` — expose the identical action set: **copy · size · wrap · bin · playground**.

Size binds to the global `settings.codeSize` (the only thing driving `--docs-code-size` on `.app-shell`), so the toggle cycles small→medium→large and resizes every shiki surface, persisted to storage — matching the existing `DocsGenesisExample` wiring.

`DocsExample`'s separate orchestration toolbar (reset/playground/bin/combine) is intentionally untouched — it's not part of the shared code-action surface.