### PR TITLE
docs: derive feature counts from maturity.json

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -120,6 +120,7 @@ declare module 'vue' {
     DocsCodeActions: typeof import('./components/docs/DocsCodeActions.vue')['default']
     DocsCodeGroup: typeof import('./components/docs/DocsCodeGroup.vue')['default']
     DocsContact: typeof import('./components/docs/DocsContact.vue')['default']
+    DocsCount: typeof import('./components/docs/DocsCount.vue')['default']
     DocsDiscoveryStep: typeof import('./components/docs/DocsDiscoveryStep.vue')['default']
     DocsExample: typeof import('./components/docs/DocsExample.vue')['default']
     DocsExampleCodePane: typeof import('./components/docs/DocsExampleCodePane.vue')['default']

--- a/apps/docs/src/components/docs/DocsCount.vue
+++ b/apps/docs/src/components/docs/DocsCount.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+  import { MATURITY_COUNTS } from '@/constants/maturity'
+
+  // Types
+  import type { MaturityCountKey } from '@/constants/maturity'
+
+  const { type = 'total' } = defineProps<{
+    type?: MaturityCountKey
+  }>()
+</script>
+
+<template>{{ MATURITY_COUNTS[type] }}</template>

--- a/apps/docs/src/constants/maturity.ts
+++ b/apps/docs/src/constants/maturity.ts
@@ -1,3 +1,5 @@
+import maturityData from '#v0/maturity.json'
+
 /** Maturity ladder shared by DocsMaturity (roadmap matrix) and DocsPageFeatures (stability chip). */
 export type Level = 'draft' | 'preview' | 'stable' | 'mature' | 'deprecated'
 
@@ -41,3 +43,22 @@ export const MATURITY_LEVELS: Record<Level, LevelDisplay> = {
 }
 
 export const LEVEL_KEYS = Object.keys(MATURITY_LEVELS) as Level[]
+
+export type MaturityCountKey = 'composable' | 'component' | 'utility' | 'total'
+
+function countShipped (bucket: Record<string, MaturityEntry>): number {
+  return Object.values(bucket).filter(entry => entry.level !== 'draft').length
+}
+
+const data = maturityData as MaturityData
+const composable = countShipped(data.composables)
+const component = countShipped(data.components)
+const utility = countShipped(data.utilities)
+
+/** Counts of shipped (non-draft) features by type, derived from `maturity.json` — the single inventory source. */
+export const MATURITY_COUNTS: Record<MaturityCountKey, number> = {
+  composable,
+  component,
+  utility,
+  total: composable + component + utility,
+}

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -160,8 +160,8 @@ Hallucinated v0 APIs fail to compile. Run `vue-tsc --noEmit` (or `tsc --noEmit`)
 **llms.txt** contains categorized links to:
 
 - 10 guide pages (introduction, theming, accessibility, etc.)
-- 9 headless components (Atom, Avatar, Pagination, etc.)
-- 34 composables across 7 categories
+- <DocsCount type="component" /> headless components (Atom, Avatar, Pagination, etc.)
+- <DocsCount type="composable" /> composables across 7 categories
 - FAQ and contributing guides
 
 **llms-full.txt** includes the complete content of every documentation page, stripped of Vue components and frontmatter for cleaner LLM consumption.

--- a/apps/docs/src/pages/introduction/frequently-asked.md
+++ b/apps/docs/src/pages/introduction/frequently-asked.md
@@ -24,7 +24,7 @@ Have a question that isn't answered here? Try [Ask AI](/guide/essentials/using-t
 ::: faq
 ??? What is Vuetify0?
 
-Vuetify0 is a collection of headless UI primitives and composables for Vue 3. It provides unstyled, logic-focused building blocks that handle accessibility, keyboard navigation, and state management while giving you complete control over styling. The library includes 70 composables covering everything from selection patterns to form validation, plus ready-to-use headless components like Dialog, Tabs, and ExpansionPanel. Get started instantly with `pnpm create vuetify0`.
+Vuetify0 is a collection of headless UI primitives and composables for Vue 3. It provides unstyled, logic-focused building blocks that handle accessibility, keyboard navigation, and state management while giving you complete control over styling. The library includes <DocsCount type="composable" /> composables covering everything from selection patterns to form validation, plus ready-to-use headless components like Dialog, Tabs, and ExpansionPanel. Get started instantly with `pnpm create vuetify0`.
 
 ??? How is Vuetify0 different from Vuetify?
 


### PR DESCRIPTION
## Problem

Nothing in the docs counts the components/composables we offer. The inventory is machine-known (`maturity.json`, `virtual:api`) but never surfaced as a number, so the counts that *do* appear are hardcoded prose — and they've drifted:

- `frequently-asked.md`: "**70** composables"
- `guide/tooling/ai-tools.md`: "**9** headless components", "**34** composables across 7 categories"

Three surfaces, three different numbers — none correct.

## Change

A single derived source + an inline component, so these numbers can't go stale again.

- **`constants/maturity.ts`** — `MATURITY_COUNTS`, derived from `maturity.json` (the canonical inventory source), counting **shipped** features only (excludes `draft`). Reuses the `MaturityData`/`MaturityEntry` types already in that module.
- **`DocsCount.vue`** — tiny inline component: `<DocsCount type="composable" />` renders the live number. Usable anywhere in markdown prose.
- Replaced the three drifted prose numbers with `<DocsCount>`.

Rendered result (from a full `build:docs`):

| Surface | Before | After (live) |
|---|---|---|
| FAQ — composables | 70 | **71** |
| ai-tools — components | 9 | **40** |
| ai-tools — composables | 34 | **71** |

## Verification

- `pnpm build:docs` — clean; confirmed the inline component renders **inline** (mid-sentence and in list items) in the generated HTML.
- `vue-tsc -b --force` — touched files clean (the 7 remaining errors are pre-existing `build/*.ts` tsconfig-include quirks on master, unrelated).

## Decisions for review

- **"Offered" = non-draft.** Components count 40, not the 49 in `maturity.json` (9 are `draft`/planned). Flip the filter if you'd rather count planned too.
- **Source = `maturity.json`**, not `virtual:api` — it's the documented single source of truth and already typed here.
- **Scope kept tight:** left the homepage hero untouched (easy follow-up if you want a headline stat), and left "7 categories"/"10 guide pages" in ai-tools.md static (different metric). The stale `40 components / 70 composables / 24 utilities` in the v0 SKILL.md is a static skill file (can't host a component) — separate fix if wanted.
