### PR TITLE
docs(roadmap): milestone feature buckets

### DIFF
--- a/apps/docs/src/components/docs/DocsRoadmap.vue
+++ b/apps/docs/src/components/docs/DocsRoadmap.vue
@@ -6,12 +6,17 @@
   import DocsProgressBar from './DocsProgressBar.vue'
   import DocsSkeleton from './DocsSkeleton.vue'
 
+  import { MATURITY_LEVELS as levels } from '@/constants/maturity'
+
   // Stores
   import { type Milestone, type TimeHorizon, useRoadmapStore } from '@/stores/roadmap'
 
   // Utilities
   import { computed, onBeforeMount, watch } from 'vue'
-  import { useRoute, useRouter } from 'vue-router'
+  import { RouterLink, useRoute, useRouter } from 'vue-router'
+
+  // Types
+  import type { FeatureType } from '@/constants/roadmap-buckets'
 
   const route = useRoute()
   const router = useRouter()
@@ -24,6 +29,12 @@
     { key: 'later', label: 'Later', icon: 'telescope' },
     { key: 'done', label: 'Completed', icon: 'check-circle' },
   ]
+
+  const typeIcon: Record<FeatureType, string> = {
+    composable: 'code',
+    component: 'puzzle',
+    utility: 'typescript',
+  }
 
   const groupedMilestones = computed(() => {
     return horizons.map(h => ({
@@ -248,6 +259,26 @@
                       {{ line }}
                     </li>
                   </ul>
+                </div>
+
+                <!-- Planned features -->
+                <div v-if="milestone.features?.length" class="px-4 py-3 border-b border-divider">
+                  <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">Planned features</div>
+
+                  <div class="flex flex-wrap gap-2">
+                    <component
+                      :is="feature.level === 'draft' ? 'span' : RouterLink"
+                      v-for="feature in milestone.features"
+                      :key="feature.id"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline"
+                      :class="feature.level === 'draft' ? 'cursor-default' : 'hover:bg-surface-tint transition-colors'"
+                      :style="{ borderColor: levels[feature.level].color, color: levels[feature.level].color }"
+                      :to="feature.level !== 'draft' ? feature.path : undefined"
+                    >
+                      <AppIcon :icon="typeIcon[feature.type]" :size="12" />
+                      {{ feature.name }}
+                    </component>
+                  </div>
                 </div>
 
                 <!-- Loading issues -->

--- a/apps/docs/src/components/docs/DocsRoadmap.vue
+++ b/apps/docs/src/components/docs/DocsRoadmap.vue
@@ -12,7 +12,7 @@
   import { type Milestone, type TimeHorizon, useRoadmapStore } from '@/stores/roadmap'
 
   // Utilities
-  import { computed, onBeforeMount, watch } from 'vue'
+  import { computed, onBeforeMount, ref, watch } from 'vue'
   import { RouterLink, useRoute, useRouter } from 'vue-router'
 
   // Types
@@ -42,6 +42,25 @@
       milestones: store.byHorizon(h.key),
     })).filter(g => g.milestones.length > 0)
   })
+
+  // Cap the lower-priority horizons; user can reveal the rest per-section.
+  const CAP = 3
+  const showAll = ref<TimeHorizon[]>([])
+
+  function isCapped (key: TimeHorizon): boolean {
+    return key === 'later' || key === 'done'
+  }
+
+  function visible (group: { key: TimeHorizon, milestones: Milestone[] }): Milestone[] {
+    if (!isCapped(group.key) || showAll.value.includes(group.key)) return group.milestones
+    return group.milestones.slice(0, CAP)
+  }
+
+  function onShowAll (key: TimeHorizon): void {
+    showAll.value = showAll.value.includes(key)
+      ? showAll.value.filter(k => k !== key)
+      : [...showAll.value, key]
+  }
 
   function formatDate (date: string | null): string {
     if (!date) return 'No due date'
@@ -164,7 +183,7 @@
 
     <!-- Timeline -->
     <ExpansionPanel.Group v-else v-model="expanded" class="space-y-10" multiple>
-      <section v-for="group in groupedMilestones" :key="group.key">
+      <section v-for="group in groupedMilestones" :key="group.key" class="mb-4">
         <!-- Horizon Header -->
         <div class="flex items-center gap-3 mb-4">
           <div
@@ -185,7 +204,7 @@
         <!-- Timeline line + milestones -->
         <div class="relative ps-5 border-s-2 border-divider ms-5 space-y-6">
           <ExpansionPanel.Root
-            v-for="milestone in group.milestones"
+            v-for="milestone in visible(group)"
             :key="milestone.id"
             v-slot="{ isSelected }"
             as="article"
@@ -325,6 +344,15 @@
               </ExpansionPanel.Content>
             </div>
           </ExpansionPanel.Root>
+
+          <button
+            v-if="isCapped(group.key) && group.milestones.length > CAP"
+            class="ms-4 text-sm font-medium text-primary hover:underline"
+            type="button"
+            @click="onShowAll(group.key)"
+          >
+            {{ showAll.includes(group.key) ? 'Show less' : `View all (${group.milestones.length})` }}
+          </button>
         </div>
       </section>
     </ExpansionPanel.Group>

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -22,11 +22,11 @@ export interface ResolvedFeature {
  * is never edited for planning. Unknown ids are surfaced by `auditBuckets()`.
  */
 export const ROADMAP_BUCKETS: Record<string, string[]> = {
-  'v1.1.0': ['DataTable', 'DataGrid'],
+  'v1.1.0': ['DataTable', 'DataGrid', 'Alert'],
   'v1.2.0': ['Tour'],
   'v1.3.0': ['Virtualizer', 'Kanban', 'Otp'],
   'v1.4.0': ['TimePicker'],
-  'v1.5.0': ['DatePicker', 'DateRangePicker', 'Alert'],
+  'v1.5.0': ['DatePicker', 'DateRangePicker'],
 }
 
 function kebab (name: string): string {

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -1,0 +1,96 @@
+// Vuetify0
+import maturityData from '#v0/maturity.json'
+
+// Types
+import type { Level, MaturityData } from '@/constants/maturity'
+
+export type FeatureType = 'composable' | 'component' | 'utility'
+
+export interface ResolvedFeature {
+  id: string
+  name: string
+  type: FeatureType
+  category: string
+  level: Level
+  path: string
+}
+
+/**
+ * Roadmap bucket membership, keyed by GitHub milestone title. Values are
+ * `maturity.json` keys. This overlay is the single place to move a feature
+ * between milestones — `maturity.json` stays the stability source of truth and
+ * is never edited for planning. Unknown ids are surfaced by `auditBuckets()`.
+ */
+export const ROADMAP_BUCKETS: Record<string, string[]> = {
+  'v1.1.0': ['DataTable', 'DataGrid'],
+  'v1.2.0': ['Tour'],
+  'v1.3.0': ['Virtualizer', 'Kanban', 'Otp'],
+  'v1.4.0': ['TimePicker'],
+  'v1.5.0': ['DatePicker', 'DateRangePicker', 'Alert'],
+}
+
+function kebab (name: string): string {
+  return name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+const data = maturityData as MaturityData
+
+// Flatten maturity.json into a name -> feature lookup once at module load.
+const index = new Map<string, ResolvedFeature>()
+
+for (const [name, entry] of Object.entries(data.composables)) {
+  index.set(name, {
+    id: `composable-${name}`,
+    name,
+    type: 'composable',
+    category: entry.category,
+    level: entry.level,
+    path: `/composables/${entry.category}/${kebab(name)}`,
+  })
+}
+
+for (const [name, entry] of Object.entries(data.components)) {
+  index.set(name, {
+    id: `component-${name}`,
+    name,
+    type: 'component',
+    category: entry.category,
+    level: entry.level,
+    path: `/components/${entry.category}/${kebab(name)}`,
+  })
+}
+
+for (const [name, entry] of Object.entries(data.utilities)) {
+  index.set(name, {
+    id: `utility-${name}`,
+    name,
+    type: 'utility',
+    category: entry.category,
+    level: entry.level,
+    path: '/utilities',
+  })
+}
+
+/** Resolve a milestone title's bucket into its maturity-backed features. */
+export function featuresFor (title: string): ResolvedFeature[] {
+  const ids = ROADMAP_BUCKETS[title]
+  if (!ids) return []
+
+  const result: ResolvedFeature[] = []
+  for (const id of ids) {
+    const feature = index.get(id)
+    if (feature) result.push(feature)
+  }
+  return result
+}
+
+/** Bucket ids that no longer resolve against maturity.json (typos, renames). */
+export function auditBuckets (): string[] {
+  const unknown: string[] = []
+  for (const [title, ids] of Object.entries(ROADMAP_BUCKETS)) {
+    for (const id of ids) {
+      if (!index.has(id)) unknown.push(`${title}:${id}`)
+    }
+  }
+  return unknown
+}

--- a/apps/docs/src/stores/roadmap.ts
+++ b/apps/docs/src/stores/roadmap.ts
@@ -3,6 +3,7 @@
 import { createStorage, isArray, useLogger } from '@vuetify/v0'
 
 import { CACHE_TTL } from '@/constants/cache'
+import { type ResolvedFeature, auditBuckets, featuresFor } from '@/constants/roadmap-buckets'
 
 // Utilities
 import { defineStore } from 'pinia'
@@ -19,6 +20,7 @@ export interface Milestone extends GitHubMilestone {
   horizon: TimeHorizon
   issues?: GitHubIssue[]
   issuesLoading?: boolean
+  features?: ResolvedFeature[]
 }
 
 interface State {
@@ -91,10 +93,14 @@ export const useRoadmapStore = defineStore('roadmap', {
     async fetch () {
       if (this.milestones.length > 0) return // Already fetched
 
+      const unknown = auditBuckets()
+      if (unknown.length > 0) logger.warn('Roadmap bucket references unknown maturity ids', unknown)
+
       // Check cache first
       const cached = storage.get<Milestone[] | null>('milestones', null)
       if (isArray(cached.value)) {
-        this.milestones = cached.value
+        // Re-resolve features on read so bucket edits reflect without waiting for cache TTL.
+        this.milestones = cached.value.map(m => ({ ...m, features: featuresFor(m.title) }))
         return
       }
 
@@ -127,7 +133,7 @@ export const useRoadmapStore = defineStore('roadmap', {
         this.milestones = [
           ...assignHorizons(openMilestones),
           ...closedMilestones.map(m => ({ ...m, horizon: 'done' as TimeHorizon })),
-        ]
+        ].map(m => ({ ...m, features: featuresFor(m.title) }))
 
         storage.set('milestones', this.milestones)
       } catch (error: unknown) {

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -582,6 +582,10 @@
       "level": "draft",
       "category": "data"
     },
+    "DataTable": {
+      "level": "draft",
+      "category": "data"
+    },
     "Kanban": {
       "level": "draft",
       "category": "data"


### PR DESCRIPTION
Adds a planned-features overlay to the roadmap so each GitHub milestone card lists the components slated for it, resolved from `maturity.json`.

- New `apps/docs/src/constants/roadmap-buckets.ts` — bucket membership keyed by milestone title, with values being `maturity.json` keys. `featuresFor()` resolves them; `auditBuckets()` dev-warns on ids that no longer resolve (typo/rename drift).
- `stores/roadmap.ts` attaches resolved `features` to each milestone; `DocsRoadmap.vue` renders them as chips (draft = non-link, mirroring `DocsMaturity`).
- Adds `DataTable` as a `draft` component in `maturity.json` — only `DataGrid` existed, despite `createDataTable` being the older, foundational composable.

Membership lives in the overlay, so re-planning a milestone never touches `maturity.json`.