### PR TITLE
feat(useNotifications): add persist option

### DIFF
--- a/.changeset/notifications-persist-option.md
+++ b/.changeset/notifications-persist-option.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(useNotifications): add `persist` option to `createNotificationsPlugin`
+
+Setting `persist: true` serializes the notification registry to storage and restores it on load, so notification lifecycle state — including `snoozedUntil` — survives a page reload. Backed by the existing `createPluginContext` persist/restore hooks and keyed by the plugin namespace.

--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -16,7 +16,10 @@
   // Bump BANNER_ID whenever the banner content changes — a new id re-shows the
   // banner even for readers who dismissed the previous one.
   const BANNER_ID = 'v1.0-live'
+  const SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
+  // Snooze is owned by the notifications plugin (persist: true). Dismiss is a
+  // separate storage key so a content bump still re-shows the banner.
   if (!notifications.has(BANNER_ID)) {
     notifications.register({
       id: BANNER_ID,
@@ -30,13 +33,19 @@
     return notifications.values().find(n => n.data?.type === 'banner')
   })
 
-  // Persist dismissal keyed to the banner id, so a dismissed banner stays closed
-  // across reloads until BANNER_ID changes.
   const dismissedId = storage.get<string>('docs-banner-dismissed', '')
-  const visible = toRef(() => banner.value && dismissedId.value !== BANNER_ID)
+  const snoozed = toRef(() => {
+    const until = banner.value?.snoozedUntil
+    return !!until && until.getTime() > Date.now()
+  })
+  const visible = toRef(() => banner.value && dismissedId.value !== BANNER_ID && !snoozed.value)
 
   function onDismiss () {
     storage.set('docs-banner-dismissed', BANNER_ID)
+  }
+
+  function onSnooze () {
+    banner.value?.snooze(new Date(Date.now() + SNOOZE_MS))
   }
 
   // Sync banner height to CSS variable so AppBar, AppNav, and layouts can adapt
@@ -63,12 +72,22 @@
       {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <a class="underline underline-offset-2" href="https://vtfy.link/announcing-vuetify0-v1" rel="noopener" target="_blank">announcement</a>.</span>
     </div>
 
-    <button
-      aria-label="Dismiss banner"
-      class="absolute end-2 opacity-60 hover:opacity-100 transition-opacity"
-      @click="onDismiss"
-    >
-      <AppIcon icon="close" :size="10" />
-    </button>
+    <div class="absolute end-2 flex items-center gap-2">
+      <button
+        aria-label="Snooze banner for a week"
+        class="opacity-60 hover:opacity-100 transition-opacity"
+        @click="onSnooze"
+      >
+        <AppIcon icon="clock" :size="11" />
+      </button>
+
+      <button
+        aria-label="Dismiss banner"
+        class="opacity-60 hover:opacity-100 transition-opacity"
+        @click="onDismiss"
+      >
+        <AppIcon icon="close" :size="10" />
+      </button>
+    </div>
   </Atom>
 </template>

--- a/apps/docs/src/pages/composables/plugins/use-notifications.md
+++ b/apps/docs/src/pages/composables/plugins/use-notifications.md
@@ -41,6 +41,19 @@ app.use(createNotificationsPlugin())
 app.mount('#app')
 ```
 
+### Persistence
+
+Pass `persist: true` to remember the notification registry across reloads. Requires [useStorage](/composables/plugins/use-storage) to be installed first. Tickets are stored under the key `notifications` (the plugin namespace with the `v0:` prefix stripped).
+
+```ts main.ts
+import { createStoragePlugin, createNotificationsPlugin } from '@vuetify/v0'
+
+app.use(createStoragePlugin())
+app.use(createNotificationsPlugin({ persist: true }))
+```
+
+Give tickets a stable `id` — generated ids accumulate on every reload. Unknown or malformed stored entries are ignored. On load, persisted tickets win over an adapter's first snapshot; later adapter updates still overlay live remote state.
+
 ## Usage
 
 Once the plugin is installed, use the `useNotifications` composable in any component:
@@ -388,6 +401,10 @@ The `severity` field categorizes notifications by urgency. It maps to ARIA live 
 ??? What's the difference between `send()` and `register()`?
 
 `send()` registers a notification and enqueues it for toast display — use it for real-time, in-the-moment events. `register()` adds it to the registry only, with no toast, which is what you want when loading historical or initial notifications.
+
+??? How do I persist notifications across reloads?
+
+Pass `persist: true` to `createNotificationsPlugin`, and install `createStoragePlugin` first. The saved value is the list of identified tickets (including `snoozedUntil`). On load it is reconciled against the registry and wins over an adapter's first snapshot.
 
 ??? How do I keep a notification from auto-dismissing?
 

--- a/apps/docs/src/plugins/index.ts
+++ b/apps/docs/src/plugins/index.ts
@@ -17,7 +17,7 @@ import './analytics'
 
 export function registerPlugins (app: App) {
   app.use(zero)
-  app.use(createNotificationsPlugin())
+  app.use(createNotificationsPlugin({ persist: true }))
   app.use(_app)
   app.use(SettingsPlugin)
 

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -259,7 +259,7 @@ function createFeaturesFallback (): FeatureContext {
   } as unknown as FeatureContext
 }
 
-function applyPersisted (context: FeatureContext, saved: unknown) {
+function replay (context: FeatureContext, saved: unknown) {
   if (!isArray(saved)) return
 
   const wanted = new Set<ID>(saved.filter((id): id is ID => isString(id) || isNumber(id)))
@@ -281,7 +281,7 @@ export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
       persist: context => [...context.selectedIds],
       restore: (context, saved) => {
         restored.set(context, saved)
-        applyPersisted(context, saved)
+        replay(context, saved)
       },
       setup: (context, app, { adapter }) => {
         if (!adapter) return
@@ -294,7 +294,7 @@ export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
         // Adapter setup writes after restore. Re-apply so persist wins the
         // first snapshot; later onUpdate calls still overlay live remote state.
         const saved = restored.get(context)
-        if (!isUndefined(saved)) applyPersisted(context, saved)
+        if (!isUndefined(saved)) replay(context, saved)
       },
     },
   )

--- a/packages/0/src/composables/useNotifications/index.test.ts
+++ b/packages/0/src/composables/useNotifications/index.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
+// Composables
+import { createStoragePlugin, MemoryStorageAdapter, useStorage } from '#v0/composables/useStorage'
+
 import { createNotifications, createNotificationsPlugin, useNotifications } from './index'
 
 // Utilities
-import { createApp, effectScope } from 'vue'
+import { createApp, effectScope, nextTick } from 'vue'
 
 // Types
 import type { ID } from '#v0/types'
@@ -1047,6 +1050,175 @@ describe('createNotifications', () => {
 
       // Should not throw on unmount when adapter has no dispose
       expect(() => app.unmount()).not.toThrow()
+    })
+
+    describe('persist/restore', () => {
+      function persisted (id: string, extra: Record<string, unknown> = {}) {
+        return {
+          id,
+          subject: 'Hello',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          readAt: null,
+          seenAt: null,
+          archivedAt: null,
+          snoozedUntil: null,
+          ...extra,
+        }
+      }
+
+      it('should restore persisted tickets including snoozedUntil', () => {
+        const until = '2026-12-01T00:00:00.000Z'
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', [persisted('banner', { snoozedUntil: until })])
+        })
+
+        app.use(createNotificationsPlugin({ persist: true }))
+
+        const context = app.runWithContext(() => useNotifications())
+        const ticket = context.get('banner')
+
+        expect(ticket?.subject).toBe('Hello')
+        expect(ticket?.snoozedUntil?.toISOString()).toBe(until)
+        expect(ticket?.createdAt.toISOString()).toBe('2026-01-01T00:00:00.000Z')
+      })
+
+      it('should persist snooze to storage', async () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+        app.use(createNotificationsPlugin({ persist: true }))
+        app.mount(document.createElement('div'))
+
+        const until = new Date('2026-12-01T00:00:00.000Z')
+
+        app.runWithContext(() => {
+          const context = useNotifications()
+          context.register({ id: 'banner', subject: 'Hello' })
+          context.snooze('banner', until)
+        })
+
+        await nextTick()
+
+        const stored = app.runWithContext(() => useStorage().get('notifications').value) as Array<{ id: string, snoozedUntil: string }>
+
+        expect(stored).toHaveLength(1)
+        expect(stored[0]!.id).toBe('banner')
+        expect(stored[0]!.snoozedUntil).toBe(until.toISOString())
+
+        app.unmount()
+      })
+
+      it('should ignore a non-array persisted value', () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', 'garbage')
+        })
+
+        app.use(createNotificationsPlugin({ persist: true }))
+
+        const context = app.runWithContext(() => useNotifications())
+
+        expect(context.size).toBe(0)
+      })
+
+      it('should keep only object entries with a string or number id', () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', [
+            persisted('ok'),
+            { evil: true },
+            null,
+            'x',
+            { id: { nested: true } },
+          ])
+        })
+
+        app.use(createNotificationsPlugin({ persist: true }))
+
+        const context = app.runWithContext(() => useNotifications())
+
+        expect(context.size).toBe(1)
+        expect(context.has('ok')).toBe(true)
+      })
+
+      it('should treat an invalid date string as null', () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', [persisted('banner', { snoozedUntil: 'not-a-date' })])
+        })
+
+        app.use(createNotificationsPlugin({ persist: true }))
+
+        const context = app.runWithContext(() => useNotifications())
+
+        expect(context.get('banner')?.snoozedUntil).toBeNull()
+      })
+
+      it('should keep restored snooze after the first adapter register', () => {
+        const until = '2026-12-01T00:00:00.000Z'
+        const adapter = {
+          setup: (ctx: { register: (input: { id: string, subject: string }) => unknown }) => {
+            ctx.register({ id: 'banner', subject: 'from-adapter' })
+          },
+        }
+
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', [persisted('banner', { subject: 'from-persist', snoozedUntil: until })])
+        })
+
+        app.use(createNotificationsPlugin({ persist: true, adapter }))
+
+        const context = app.runWithContext(() => useNotifications())
+        const ticket = context.get('banner')
+
+        expect(ticket?.subject).toBe('from-persist')
+        expect(ticket?.snoozedUntil?.toISOString()).toBe(until)
+      })
+
+      it('should not restore when persist is off', () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+        app.runWithContext(() => {
+          useStorage().set('notifications', [persisted('banner')])
+        })
+
+        app.use(createNotificationsPlugin())
+
+        const context = app.runWithContext(() => useNotifications())
+
+        expect(context.has('banner')).toBe(false)
+      })
+
+      it('should not write to storage when persist is off', async () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+        app.use(createNotificationsPlugin())
+        app.mount(document.createElement('div'))
+
+        app.runWithContext(() => {
+          useNotifications().register({ id: 'banner', subject: 'Hello' })
+        })
+
+        await nextTick()
+
+        const stored = app.runWithContext(() => useStorage().get('notifications').value)
+
+        expect(stored).toBeUndefined()
+
+        app.unmount()
+      })
     })
   })
 })

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -30,7 +30,7 @@ import { createQueue } from '#v0/composables/createQueue'
 import { createRegistry } from '#v0/composables/createRegistry'
 
 // Utilities
-import { isFunction, isNull, isUndefined, useId } from '#v0/utilities'
+import { isArray, isFunction, isNull, isNullOrUndefined, isObject, isString, isUndefined, useId } from '#v0/utilities'
 
 // Types
 import type { QueueContext } from '#v0/composables/createQueue'
@@ -568,6 +568,43 @@ export function createNotifications (
 export interface NotificationsPluginOptions extends NotificationsOptions {
   namespace?: string
   adapter?: NotificationsAdapter
+  /** Persist the notification registry to storage and restore it on load. @default false */
+  persist?: boolean
+}
+
+/** Serializable snapshot of a notification's durable state. */
+interface PersistedNotification {
+  id: ID
+  subject?: string
+  body?: string
+  severity?: NotificationSeverity
+  data?: Record<string, unknown>
+  timeout?: number
+  createdAt: string | null
+  readAt: string | null
+  seenAt: string | null
+  archivedAt: string | null
+  snoozedUntil: string | null
+}
+
+function toPersisted (ticket: NotificationTicket): PersistedNotification {
+  return {
+    id: ticket.id,
+    subject: ticket.subject,
+    body: ticket.body,
+    severity: ticket.severity,
+    data: ticket.data,
+    timeout: ticket.timeout,
+    createdAt: ticket.createdAt?.toISOString() ?? null,
+    readAt: ticket.readAt?.toISOString() ?? null,
+    seenAt: ticket.seenAt?.toISOString() ?? null,
+    archivedAt: ticket.archivedAt?.toISOString() ?? null,
+    snoozedUntil: ticket.snoozedUntil?.toISOString() ?? null,
+  }
+}
+
+function toDate (value: unknown): Date | null {
+  return isString(value) ? new Date(value) : null
 }
 
 // Fallback
@@ -683,6 +720,32 @@ export const [createNotificationsContext, createNotificationsPlugin, useNotifica
     options => createNotifications(options),
     {
       fallback: () => createNotificationsFallback(),
+      persist: context => context.values().map(toPersisted),
+      restore: (context, saved) => {
+        if (!isArray(saved)) return
+
+        for (const entry of saved) {
+          if (!isObject(entry) || isNullOrUndefined(entry.id)) continue
+
+          const persisted = entry as unknown as PersistedNotification
+          const ticket = context.register({
+            id: persisted.id,
+            subject: persisted.subject,
+            body: persisted.body,
+            severity: persisted.severity,
+            data: persisted.data,
+            timeout: persisted.timeout,
+          })
+
+          context.upsert(ticket.id, {
+            createdAt: toDate(persisted.createdAt) ?? ticket.createdAt,
+            readAt: toDate(persisted.readAt),
+            seenAt: toDate(persisted.seenAt),
+            archivedAt: toDate(persisted.archivedAt),
+            snoozedUntil: toDate(persisted.snoozedUntil),
+          } as Partial<NotificationTicket>)
+        }
+      },
       setup: (context, app, options) => {
         app.onUnmount(() => {
           context.dispose()

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -30,7 +30,7 @@ import { createQueue } from '#v0/composables/createQueue'
 import { createRegistry } from '#v0/composables/createRegistry'
 
 // Utilities
-import { isArray, isFunction, isNull, isNullOrUndefined, isObject, isString, isUndefined, useId } from '#v0/utilities'
+import { isArray, isNaN, isNull, isNumber, isObject, isString, isUndefined, useId } from '#v0/utilities'
 
 // Types
 import type { QueueContext } from '#v0/composables/createQueue'
@@ -568,7 +568,19 @@ export function createNotifications (
 export interface NotificationsPluginOptions extends NotificationsOptions {
   namespace?: string
   adapter?: NotificationsAdapter
-  /** Persist the notification registry to storage and restore it on load. @default false */
+  /**
+   * Persist the notification registry to storage and restore it on load.
+   *
+   * @remarks Serializes each ticket's durable fields (ids, copy, timestamps).
+   * The storage key is the plugin namespace with the `v0:` prefix stripped
+   * (`notifications`). On load, persisted tickets win over an adapter's first
+   * snapshot. Later adapter updates still overlay live remote state.
+   *
+   * Intended for registries of identified notifications. Tickets sent without
+   * a stable `id` will accumulate across reloads.
+   *
+   * @default false
+   */
   persist?: boolean
 }
 
@@ -604,8 +616,48 @@ function toPersisted (ticket: NotificationTicket): PersistedNotification {
 }
 
 function toDate (value: unknown): Date | null {
-  return isString(value) ? new Date(value) : null
+  if (!isString(value)) return null
+
+  const date = new Date(value)
+
+  return isNaN(date.getTime()) ? null : date
 }
+
+function applyPersisted (context: NotificationsContext, saved: unknown) {
+  if (!isArray(saved)) return
+
+  for (const entry of saved) {
+    if (!isObject(entry)) continue
+    if (!isString(entry.id) && !isNumber(entry.id)) continue
+
+    const persisted = entry as unknown as PersistedNotification
+    const ticket = context.has(persisted.id)
+      ? context.get(persisted.id)!
+      : context.register({
+          id: persisted.id,
+          subject: persisted.subject,
+          body: persisted.body,
+          severity: persisted.severity,
+          data: persisted.data,
+          timeout: persisted.timeout,
+        })
+
+    context.upsert(ticket.id, {
+      subject: persisted.subject,
+      body: persisted.body,
+      severity: persisted.severity,
+      data: persisted.data,
+      timeout: persisted.timeout,
+      createdAt: toDate(persisted.createdAt) ?? ticket.createdAt,
+      readAt: toDate(persisted.readAt),
+      seenAt: toDate(persisted.seenAt),
+      archivedAt: toDate(persisted.archivedAt),
+      snoozedUntil: toDate(persisted.snoozedUntil),
+    } as Partial<NotificationTicket>)
+  }
+}
+
+const restored = new WeakMap<NotificationsContext, unknown>()
 
 // Fallback
 function noop () {}
@@ -722,29 +774,8 @@ export const [createNotificationsContext, createNotificationsPlugin, useNotifica
       fallback: () => createNotificationsFallback(),
       persist: context => context.values().map(toPersisted),
       restore: (context, saved) => {
-        if (!isArray(saved)) return
-
-        for (const entry of saved) {
-          if (!isObject(entry) || isNullOrUndefined(entry.id)) continue
-
-          const persisted = entry as unknown as PersistedNotification
-          const ticket = context.register({
-            id: persisted.id,
-            subject: persisted.subject,
-            body: persisted.body,
-            severity: persisted.severity,
-            data: persisted.data,
-            timeout: persisted.timeout,
-          })
-
-          context.upsert(ticket.id, {
-            createdAt: toDate(persisted.createdAt) ?? ticket.createdAt,
-            readAt: toDate(persisted.readAt),
-            seenAt: toDate(persisted.seenAt),
-            archivedAt: toDate(persisted.archivedAt),
-            snoozedUntil: toDate(persisted.snoozedUntil),
-          } as Partial<NotificationTicket>)
-        }
+        restored.set(context, saved)
+        applyPersisted(context, saved)
       },
       setup: (context, app, options) => {
         app.onUnmount(() => {
@@ -762,9 +793,12 @@ export const [createNotificationsContext, createNotificationsPlugin, useNotifica
           off: context.off,
         })
 
-        if (isFunction(adapter.dispose)) {
-          app.onUnmount(() => adapter.dispose!())
-        }
+        app.onUnmount(() => adapter.dispose?.())
+
+        // Adapter setup writes after restore. Re-apply so persist wins the
+        // first snapshot; later adapter updates still overlay live remote state.
+        const saved = restored.get(context)
+        if (!isUndefined(saved)) applyPersisted(context, saved)
       },
     },
   )

--- a/packages/0/src/composables/useNotifications/index.ts
+++ b/packages/0/src/composables/useNotifications/index.ts
@@ -623,7 +623,7 @@ function toDate (value: unknown): Date | null {
   return isNaN(date.getTime()) ? null : date
 }
 
-function applyPersisted (context: NotificationsContext, saved: unknown) {
+function replay (context: NotificationsContext, saved: unknown) {
   if (!isArray(saved)) return
 
   for (const entry of saved) {
@@ -775,7 +775,7 @@ export const [createNotificationsContext, createNotificationsPlugin, useNotifica
       persist: context => context.values().map(toPersisted),
       restore: (context, saved) => {
         restored.set(context, saved)
-        applyPersisted(context, saved)
+        replay(context, saved)
       },
       setup: (context, app, options) => {
         app.onUnmount(() => {
@@ -798,7 +798,7 @@ export const [createNotificationsContext, createNotificationsPlugin, useNotifica
         // Adapter setup writes after restore. Re-apply so persist wins the
         // first snapshot; later adapter updates still overlay live remote state.
         const saved = restored.get(context)
-        if (!isUndefined(saved)) applyPersisted(context, saved)
+        if (!isUndefined(saved)) replay(context, saved)
       },
     },
   )


### PR DESCRIPTION
Adds a `persist` option to `createNotificationsPlugin`, and uses it to make the docs beta banner's snooze survive reloads.

## feat(useNotifications)
`createNotificationsPlugin({ persist: true })` serializes the notification registry to storage and restores it on load, so notification lifecycle state — including `snoozedUntil` — survives a page reload. Implemented via the existing `createPluginContext` persist/restore hooks; registry tickets round-trip through storage keyed by the plugin namespace.

Note: persist is whole-registry — a notification sent without a stable `id` (generated) will accumulate across reloads. Intended for registries of identified notifications.

## docs(AppBanner)
Adds a snooze button (clock icon) beside the existing dismiss control. Snoozing calls `banner.snooze()`; persistence is handled entirely by the plugin (`persist: true`), so the view holds no storage logic. The banner stays hidden across reloads until the week elapses, then returns.