### PR TITLE
chore: bump coolify-action pin to node24 build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           VITE_API_SERVER_URL: ${{ vars.API_SERVER_URL }}
           VITE_GITHUB_SHA: ${{ github.sha }}
-      - uses: vuetifyjs/coolify-action@f24a3716773c4c238e67c4bf0319c410bafc52de # master
+      - uses: vuetifyjs/coolify-action@37a9c5a532f4c489e941d43edffd73fd2af00ec2 # master
         with:
           imageName: v0-docs
           dockerfilePath: ./apps/docs/Dockerfile

--- a/.github/workflows/playground-deploy.yml
+++ b/.github/workflows/playground-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
       - run: pnpm run build:play
-      - uses: vuetifyjs/coolify-action@f24a3716773c4c238e67c4bf0319c410bafc52de # master
+      - uses: vuetifyjs/coolify-action@37a9c5a532f4c489e941d43edffd73fd2af00ec2 # master
         with:
           imageName: v0-playground
           dockerfilePath: ./apps/playground/Dockerfile


### PR DESCRIPTION
The docs-deploy and playground-deploy steps pinned `vuetifyjs/coolify-action@f24a371`, whose nested `docker/login-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v6` all ran the deprecated **node20** runtime — triggering GitHub's node20 deprecation warning.

Bumps the pin to `37a9c5a`, which updates those nested actions to `v4`/`v6`/`v7` (node24). Inputs are unchanged.