### PR TITLE
chore: bump local setup composite to node24 nested actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,8 +3,8 @@ description: pnpm, node, and install dependencies (assumes repo is already check
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
         cache: pnpm


### PR DESCRIPTION
`0/.github/actions/setup` is a repo-local composite (used 7× in `pr-checks.yml`) that nested `pnpm/action-setup@v4` + `actions/setup-node@v4` — both node20. Bumped both to `v6` (node24).

Sibling to #386, which repinned the *org* `vuetifyjs/setup-action` in the same file; this covers the local composite the org repin didn't touch. Inputs (`node-version: lts/*`, `cache: pnpm`) are unchanged across majors.