### PR TITLE
feat(useFeatures): add persist option

### DIFF
--- a/.changeset/features-persist-option.md
+++ b/.changeset/features-persist-option.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(useFeatures): add `persist` option to `createFeaturesPlugin`
+
+Setting `persist: true` saves the set of enabled feature flags to storage and reconciles them against the registered flags on load, so a user's feature toggles survive a page reload. Backed by the existing `createPluginContext` persist/restore hooks and keyed by the plugin namespace.

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { Atom, useBreakpoints, useFeatures, useStorage, useTheme } from '@vuetify/v0'
+  import { Atom, useBreakpoints, useTheme } from '@vuetify/v0'
 
   // Components
   import { Discovery } from '@/components/discovery'
@@ -14,7 +14,7 @@
   import { useAuthStore } from '@vuetify/auth'
 
   // Utilities
-  import { toRef, watch } from 'vue'
+  import { toRef } from 'vue'
   import { useRoute } from 'vue-router'
 
   // Types
@@ -24,22 +24,14 @@
 
   const auth = useAuthStore()
   const navigation = useNavigation()
-  const storage = useStorage()
   const route = useRoute()
 
   const isHomePage = toRef(() => route.path === '/')
 
   const breakpoints = useBreakpoints()
-  const features = useFeatures()
   const search = useSearch()
   const settings = useSettings()
   const theme = useTheme()
-
-  const devmode = features.get('devmode')!
-
-  watch(() => devmode.isSelected.value, isSelected => {
-    storage.set('devmode', isSelected)
-  })
 
   const darkLogo = 'https://cdn.vuetifyjs.com/docs/images/logos/vzero-logo-dark.svg'
   const lightLogo = 'https://cdn.vuetifyjs.com/docs/images/logos/vzero-logo-light.svg'

--- a/apps/docs/src/components/app/AppSettingsSheet.vue
+++ b/apps/docs/src/components/app/AppSettingsSheet.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { Avatar, useFeatures, useRtl, useStack, useStorage } from '@vuetify/v0'
+  import { Avatar, useFeatures, useRtl, useStack } from '@vuetify/v0'
 
   // Components
   import { Discovery } from '@/components/discovery'
@@ -19,7 +19,6 @@
   const auth = useAuthStore()
   const features = useFeatures()
   const rtl = useRtl()
-  const storage = useStorage()
   const settings = useSettings()
   const levelFilter = useLevelFilterContext()
   const stack = useStack()
@@ -59,10 +58,6 @@
   watch(sheetRef, el => {
     if (!el) return
     el.focus()
-  })
-
-  watch(() => devmode.isSelected.value, isSelected => {
-    storage.set('devmode', isSelected)
   })
 
   function onKeydown (e: KeyboardEvent) {

--- a/apps/docs/src/pages/composables/plugins/use-features.md
+++ b/apps/docs/src/pages/composables/plugins/use-features.md
@@ -380,7 +380,7 @@ Yes. Pass an array of adapters to `createFeaturesPlugin`; they initialize in ord
 
 ??? How do I persist a user's flag toggles across reloads?
 
-Pass `persist: true` to `createFeaturesPlugin`, and install `createStoragePlugin` first. The saved value is the list of enabled flag ids; on load it is reconciled against the registered flags.
+Pass `persist: true` to `createFeaturesPlugin`, and install `createStoragePlugin` first. The saved value is the list of enabled flag ids; on load it is reconciled against the registered flags, and wins over an adapter's first snapshot. Later adapter `onUpdate` calls still overlay live remote state.
 
 ??? Can I toggle or add a flag at runtime?
 

--- a/apps/docs/src/pages/composables/plugins/use-features.md
+++ b/apps/docs/src/pages/composables/plugins/use-features.md
@@ -46,6 +46,27 @@ app.use(
 app.mount('#app')
 ```
 
+### Persistence
+
+Pass `persist: true` to remember enabled flags across reloads. Requires [useStorage](/composables/plugins/use-storage) to be installed first. Selected flag ids are stored under the key `features` (the plugin namespace with the `v0:` prefix stripped).
+
+```ts main.ts
+import { createStoragePlugin, createFeaturesPlugin } from '@vuetify/v0'
+
+app.use(createStoragePlugin())
+app.use(
+  createFeaturesPlugin({
+    persist: true,
+    features: {
+      analytics: true,
+      debug_mode: false,
+    },
+  })
+)
+```
+
+Unknown or malformed stored ids are ignored, so a rename or removed flag cannot resurrect itself.
+
 ## Usage
 
 Once the plugin is installed, access feature flags and variations in any component:
@@ -356,6 +377,10 @@ Give the feature a `$variation` payload — `search: { $value: true, $variation:
 ??? Can I pull flags from more than one provider at once?
 
 Yes. Pass an array of adapters to `createFeaturesPlugin`; they initialize in order and their flags merge, with the last adapter winning on conflicting keys.
+
+??? How do I persist a user's flag toggles across reloads?
+
+Pass `persist: true` to `createFeaturesPlugin`, and install `createStoragePlugin` first. The saved value is the list of enabled flag ids; on load it is reconciled against the registered flags.
 
 ??? Can I toggle or add a flag at runtime?
 

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -27,9 +27,10 @@ export default function zero (app: App) {
 
   app.use(
     createFeaturesPlugin({
+      persist: true,
       features: {
         devmode: {
-          $value: IN_BROWSER ? localStorage.getItem('v0:devmode') === 'true' : false,
+          $value: false,
           $description: 'Enables development mode with additional logging and warnings',
         },
       },

--- a/packages/0/src/composables/useFeatures/index.test.ts
+++ b/packages/0/src/composables/useFeatures/index.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
+// Composables
+import { createStoragePlugin, MemoryStorageAdapter, useStorage } from '#v0/composables/useStorage'
+
 import { createFeatures, createFeaturesPlugin, useFeatures } from './index'
 
 // Utilities
-import { createApp, watchEffect } from 'vue'
+import { createApp, nextTick, watchEffect } from 'vue'
 
 // Types
 import type { FeaturesAdapterFlags, FeaturesAdapter } from './adapters'
@@ -724,6 +727,107 @@ describe('createFeaturesPlugin', () => {
 
       expect(dispose1).toHaveBeenCalled()
       expect(dispose2).toHaveBeenCalled()
+    })
+  })
+
+  describe('persist/restore', () => {
+    it('should restore persisted flag ids before setup', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        const storage = useStorage()
+        storage.set('features', ['feature-b'])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': true,
+            'feature-b': false,
+          },
+          persist: true,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-b')).toBe(true)
+      expect(context.selectedIds.has('feature-a')).toBe(false)
+    })
+
+    it('should auto-save selected flag ids when the selection changes', async () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': false,
+          },
+          persist: true,
+        }),
+      )
+      app.mount(document.createElement('div'))
+
+      app.runWithContext(() => {
+        const context = useFeatures()
+        context.select('feature-a')
+      })
+
+      await nextTick()
+
+      const stored = app.runWithContext(() => useStorage().get('features').value)
+
+      expect(stored).toEqual(['feature-a'])
+
+      app.unmount()
+    })
+
+    it('should ignore a non-array persisted value', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        const storage = useStorage()
+        storage.set('features', 'garbage')
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': true,
+          },
+          persist: true,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(true)
+    })
+
+    it('should ignore persisted ids that are not registered', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        const storage = useStorage()
+        storage.set('features', ['ghost', 'feature-a'])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': false,
+          },
+          persist: true,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(true)
+      expect(context.selectedIds.has('ghost')).toBe(false)
     })
   })
 })

--- a/packages/0/src/composables/useFeatures/index.test.ts
+++ b/packages/0/src/composables/useFeatures/index.test.ts
@@ -387,6 +387,23 @@ describe('createFeatures', () => {
       expect(context.variation('obj-feature')).toBe('blue')
     })
 
+    it('should leave selection alone when sync has only $variation', () => {
+      const context = createFeatures({
+        features: {
+          search: { $value: true, $variation: 'v1' },
+        },
+      })
+
+      expect(context.selectedIds.has('search')).toBe(true)
+
+      context.sync({
+        search: { $variation: 'v2' },
+      })
+
+      expect(context.selectedIds.has('search')).toBe(true)
+      expect(context.variation('search')).toBe('v2')
+    })
+
     it('should unselect object features with $value: false', () => {
       const context = createFeatures({
         features: {
@@ -878,6 +895,83 @@ describe('createFeaturesPlugin', () => {
       expect(stored).toEqual([])
 
       app.unmount()
+    })
+
+    it('should keep restored selection after the first adapter sync', () => {
+      const mockAdapter: FeaturesAdapter = {
+        setup: () => ({
+          'feature-a': false,
+          'feature-b': true,
+        }),
+      }
+
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        useStorage().set('features', ['feature-a'])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': false,
+            'feature-b': false,
+          },
+          persist: true,
+          adapter: mockAdapter,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(true)
+      expect(context.selectedIds.has('feature-b')).toBe(false)
+    })
+
+    it('should not restore when persist is off', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        useStorage().set('features', ['feature-b'])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': true,
+            'feature-b': false,
+          },
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(true)
+      expect(context.selectedIds.has('feature-b')).toBe(false)
+    })
+
+    it('should restore an empty selection', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        useStorage().set('features', [])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': true,
+          },
+          persist: true,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(false)
     })
 
     it('should not write to storage when persist is off', async () => {

--- a/packages/0/src/composables/useFeatures/index.test.ts
+++ b/packages/0/src/composables/useFeatures/index.test.ts
@@ -829,6 +829,81 @@ describe('createFeaturesPlugin', () => {
       expect(context.selectedIds.has('feature-a')).toBe(true)
       expect(context.selectedIds.has('ghost')).toBe(false)
     })
+
+    it('should keep only string or number ids from a mixed persisted array', () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+
+      app.runWithContext(() => {
+        const storage = useStorage()
+        storage.set('features', ['feature-a', 42, { evil: true }, null])
+      })
+
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': false,
+          },
+          persist: true,
+        }),
+      )
+
+      const context = app.runWithContext(() => useFeatures())
+
+      expect(context.selectedIds.has('feature-a')).toBe(true)
+      expect(context.selectedIds.has(42)).toBe(false)
+    })
+
+    it('should persist an empty selection when the last flag is cleared', async () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': true,
+          },
+          persist: true,
+        }),
+      )
+      app.mount(document.createElement('div'))
+
+      app.runWithContext(() => {
+        useFeatures().unselect('feature-a')
+      })
+
+      await nextTick()
+
+      const stored = app.runWithContext(() => useStorage().get('features').value)
+
+      expect(stored).toEqual([])
+
+      app.unmount()
+    })
+
+    it('should not write to storage when persist is off', async () => {
+      const app = createApp({ render: () => null })
+      app.use(createStoragePlugin({ adapter: new MemoryStorageAdapter() }))
+      app.use(
+        createFeaturesPlugin({
+          features: {
+            'feature-a': false,
+          },
+        }),
+      )
+      app.mount(document.createElement('div'))
+
+      app.runWithContext(() => {
+        useFeatures().select('feature-a')
+      })
+
+      await nextTick()
+
+      const stored = app.runWithContext(() => useStorage().get('features').value)
+
+      expect(stored).toBeUndefined()
+
+      app.unmount()
+    })
   })
 })
 

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -101,6 +101,16 @@ export interface FeaturePluginOptions extends FeatureContextOptions {
    * @remarks Adapters provide dynamic flag values from external services.
    */
   adapter?: MaybeArray<FeaturesAdapter>
+  /**
+   * Persist enabled feature flags to storage and restore them on load.
+   *
+   * @remarks Persists the set of selected flag ids, keyed by the plugin
+   * namespace. On load the selection is reconciled against the registered
+   * flags, so a user's toggles survive a page reload.
+   *
+   * @default false
+   */
+  persist?: boolean
 }
 
 /**
@@ -218,6 +228,16 @@ export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
     options => createFeatures(options),
     {
       fallback: () => createFeaturesFallback(),
+      persist: context => [...context.selectedIds],
+      restore: (context, saved) => {
+        if (!isArray(saved)) return
+
+        const wanted = new Set(saved)
+        for (const ticket of context.values()) {
+          if (wanted.has(ticket.id)) context.select(ticket.id)
+          else context.unselect(ticket.id)
+        }
+      },
       setup: (context, app, { adapter }) => {
         if (!adapter) return
 

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -33,7 +33,7 @@ import { createPluginContext } from '#v0/composables/createPlugin'
 import { createTokens } from '#v0/composables/createTokens'
 
 // Utilities
-import { isArray, isBoolean, isFunction, isNumber, isObject, isString } from '#v0/utilities'
+import { isArray, isBoolean, isNumber, isObject, isString, isUndefined } from '#v0/utilities'
 
 // Types
 import type { GroupContext, GroupTicket, GroupTicketInput } from '#v0/composables/createGroup'
@@ -66,6 +66,12 @@ export interface FeatureContext<
    *
    * @param id The feature ID.
    * @param fallback The fallback value if the feature has no variation.
+   *
+   * @example
+   * ```ts
+   * const features = useFeatures()
+   * features.variation('search', 'v1') // 'v2' or the fallback
+   * ```
    */
   variation: (id: ID, fallback?: unknown) => unknown
   /**
@@ -75,11 +81,36 @@ export interface FeatureContext<
    *
    * @remarks This updates existing flags and registers new ones.
    * Use this when adapter flags change to update the registry.
+   *
+   * @example
+   * ```ts
+   * features.sync({
+   *   checkout: true,
+   *   search: { $value: true, $variation: 'v2' },
+   * })
+   * ```
    */
   sync: (flags: FeaturesAdapterFlags) => void
-  /** Register a feature (accepts input type, returns output type) */
+  /**
+   * Register a feature (accepts input type, returns output type).
+   *
+   * @example
+   * ```ts
+   * features.register({ id: 'beta', value: false })
+   * ```
+   */
   register: (registration?: Partial<Z>) => E
-  /** Bulk-register multiple features in a single batch. */
+  /**
+   * Bulk-register multiple features in a single batch.
+   *
+   * @example
+   * ```ts
+   * features.onboard([
+   *   { id: 'beta', value: false },
+   *   { id: 'search', value: { $value: true, $variation: 'v2' } },
+   * ])
+   * ```
+   */
   onboard: (registrations: Partial<Z>[]) => E[]
 }
 
@@ -106,12 +137,20 @@ export interface FeaturePluginOptions extends FeatureContextOptions {
    *
    * @remarks Persists the set of selected flag ids. The storage key is the
    * plugin namespace with the `v0:` prefix stripped (`features`). On load the
-   * selection is reconciled against the registered flags, so a user's toggles
-   * survive a page reload.
+   * selection is reconciled against the registered flags and wins over an
+   * adapter's first snapshot. Later adapter updates still overlay live remote
+   * state.
    *
    * @default false
    */
   persist?: boolean
+}
+
+function isEnabled (value: unknown): boolean | undefined {
+  if (isBoolean(value)) return value
+  if (isObject(value) && isBoolean(value.$value)) return value.$value
+
+  return undefined
 }
 
 /**
@@ -160,14 +199,7 @@ export function createFeatures (_options: FeatureOptions = {}): FeatureContext {
 
     const ticket = registry.register(item as Partial<FeatureTicketInput>)
 
-    if (
-      (isBoolean(ticket.value) && ticket.value === true) || (
-        isObject(ticket.value) && (
-          isBoolean(ticket.value.$value) &&
-          ticket.value.$value === true
-        )
-      )
-    ) {
+    if (isEnabled(ticket.value) === true) {
       registry.select(ticket.id)
     }
 
@@ -179,17 +211,14 @@ export function createFeatures (_options: FeatureOptions = {}): FeatureContext {
       const existing = registry.get(id)
 
       if (existing) {
-        const shouldSelect = isBoolean(value)
-          ? value === true
-          : isObject(value) && isBoolean(value.$value) && value.$value === true
+        const enabled = isEnabled(value)
 
         registry.upsert(id, { value } as Partial<FeatureTicket>)
 
-        if (shouldSelect) {
+        if (enabled === true) {
           registry.select(id)
-        } else {
-          // Adapter sync is wholesale — drain directly so a disabled flag
-          // ticket still turns off when the external source says so.
+        } else if (enabled === false) {
+          // Explicit off — drain so a disabled ticket still turns off.
           registry.selectedIds.delete(id)
         }
       } else {
@@ -220,8 +249,28 @@ function createFeaturesFallback (): FeatureContext {
     variation: (_id: ID, fallback: unknown = null) => fallback,
     sync: () => {},
     onboard: () => [],
+    register: () => undefined as unknown as FeatureTicket,
+    select: () => {},
+    unselect: () => {},
+    get: () => undefined,
+    has: () => false,
+    selectedIds: new Set<ID>(),
+    values: () => [],
   } as unknown as FeatureContext
 }
+
+function applyPersisted (context: FeatureContext, saved: unknown) {
+  if (!isArray(saved)) return
+
+  const wanted = new Set<ID>(saved.filter((id): id is ID => isString(id) || isNumber(id)))
+
+  for (const ticket of context.values()) {
+    if (wanted.has(ticket.id)) context.select(ticket.id)
+    else context.unselect(ticket.id)
+  }
+}
+
+const restored = new WeakMap<FeatureContext, unknown>()
 
 export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
   createPluginContext<FeaturePluginOptions, FeatureContext>(
@@ -231,24 +280,21 @@ export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
       fallback: () => createFeaturesFallback(),
       persist: context => [...context.selectedIds],
       restore: (context, saved) => {
-        if (!isArray(saved)) return
-
-        const wanted = new Set(saved.filter(id => isString(id) || isNumber(id)))
-        for (const ticket of context.values()) {
-          if (wanted.has(ticket.id)) context.select(ticket.id)
-          else context.unselect(ticket.id)
-        }
+        restored.set(context, saved)
+        applyPersisted(context, saved)
       },
       setup: (context, app, { adapter }) => {
         if (!adapter) return
 
         for (const a of isArray(adapter) ? adapter : [adapter]) {
           context.sync(a.setup(flags => context.sync(flags)))
-
-          if (isFunction(a.dispose)) {
-            app.onUnmount(() => a.dispose!())
-          }
+          app.onUnmount(() => a.dispose?.())
         }
+
+        // Adapter setup writes after restore. Re-apply so persist wins the
+        // first snapshot; later onUpdate calls still overlay live remote state.
+        const saved = restored.get(context)
+        if (!isUndefined(saved)) applyPersisted(context, saved)
       },
     },
   )

--- a/packages/0/src/composables/useFeatures/index.ts
+++ b/packages/0/src/composables/useFeatures/index.ts
@@ -33,7 +33,7 @@ import { createPluginContext } from '#v0/composables/createPlugin'
 import { createTokens } from '#v0/composables/createTokens'
 
 // Utilities
-import { isArray, isBoolean, isFunction, isObject } from '#v0/utilities'
+import { isArray, isBoolean, isFunction, isNumber, isObject, isString } from '#v0/utilities'
 
 // Types
 import type { GroupContext, GroupTicket, GroupTicketInput } from '#v0/composables/createGroup'
@@ -104,9 +104,10 @@ export interface FeaturePluginOptions extends FeatureContextOptions {
   /**
    * Persist enabled feature flags to storage and restore them on load.
    *
-   * @remarks Persists the set of selected flag ids, keyed by the plugin
-   * namespace. On load the selection is reconciled against the registered
-   * flags, so a user's toggles survive a page reload.
+   * @remarks Persists the set of selected flag ids. The storage key is the
+   * plugin namespace with the `v0:` prefix stripped (`features`). On load the
+   * selection is reconciled against the registered flags, so a user's toggles
+   * survive a page reload.
    *
    * @default false
    */
@@ -232,7 +233,7 @@ export const [createFeaturesContext, createFeaturesPlugin, useFeatures] =
       restore: (context, saved) => {
         if (!isArray(saved)) return
 
-        const wanted = new Set(saved)
+        const wanted = new Set(saved.filter(id => isString(id) || isNumber(id)))
         for (const ticket of context.values()) {
           if (wanted.has(ticket.id)) context.select(ticket.id)
           else context.unselect(ticket.id)


### PR DESCRIPTION
Adds a `persist` option to `createFeaturesPlugin`, closing the gap that left `useFeatures` as the only user-state plugin without persistence (`useTheme`, `useRtl`, `useReducedMotion`, `useLocale` already have it).

## feat(useFeatures)
`createFeaturesPlugin({ persist: true })` saves the set of enabled feature flags to storage and reconciles them against the registered flags on load, so a user's toggles survive a reload. Implemented via the existing `createPluginContext` persist/restore hooks; the selected flag ids round-trip through storage keyed by the plugin namespace (`v0:features`).

## docs cleanup (the payoff)
The docs app was hand-rolling devmode persistence in **two** places — a manual `localStorage` read in `zero.ts` and a duplicated `watch(() => devmode.isSelected.value, …) → storage.set('devmode')` in both `AppBar.vue` and `AppSettingsSheet.vue`. All of it is removed in favor of `persist: true`.

Verified end-to-end on the docs app: toggling devmode writes `v0:features`, and a reload restores the selection (the devmode-gated `/health` nav link reappears).

Note: the storage key moves from the old `v0:devmode` boolean to `v0:features` (an id array), so an existing devmode toggle resets once on first load after upgrade.