### PR TITLE
fix(Button): suppress renderless aria-label and use ti() for solo default (WCAG 4.1.2)

### DIFF
--- a/.changeset/button-aria-label-330.md
+++ b/.changeset/button-aria-label-330.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Button): don't auto-set aria-label in renderless mode — in renderless mode the consumer owns the DOM and is responsible for the accessible name; the automatic icon-only fallback no longer overrides visible text in mixed-content renderless usages
+
+Also migrates the solo icon-only fallback to `locale.ti('Button.label') ?? 'Button'`, matching the inline accessible-name default every other component now ships, so an unconfigured app gets `"Button"` instead of the raw `Button.label` key.

--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -214,7 +214,7 @@
     'aria-disabled': isDisabled.value || isPassive.value,
     'aria-busy': isLoading.value ? true : undefined,
     'aria-pressed': group ? isSelected.value : undefined,
-    'aria-label': ariaLabel || (isSolo.value ? locale.t('Button.label') : undefined),
+    'aria-label': ariaLabel || (!renderless && isSolo.value ? (locale.ti('Button.label') ?? 'Button') : undefined),
     'tabindex': isDisabled.value ? -1 : 0,
     'data-loading': isLoading.value ? true : undefined,
     'data-passive': isPassive.value ? true : undefined,

--- a/packages/0/src/components/Button/index.test.ts
+++ b/packages/0/src/components/Button/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
+// Composables
+import { createLocalePlugin } from '#v0/composables'
+
 import { Button } from './index'
 
 // Utilities
@@ -609,7 +612,25 @@ describe('button', () => {
       })
 
       await nextTick()
-      expect(wrapper.find('button').attributes('aria-label')).toBeDefined()
+      expect(wrapper.find('button').attributes('aria-label')).toBe('Button')
+    })
+
+    it('should use the translated locale string for solo aria-label when registered', async () => {
+      const plugin = createLocalePlugin({
+        default: 'en',
+        messages: { en: { Button: { label: 'Knopf' } } },
+      })
+      const wrapper = mount(Button.Root, {
+        global: { plugins: [plugin] },
+        slots: {
+          default: () => h(Button.Icon as any, {}, {
+            default: () => h('span', '✕'),
+          }),
+        },
+      })
+
+      await nextTick()
+      expect(wrapper.find('button').attributes('aria-label')).toBe('Knopf')
     })
 
     it('should use explicit aria-label over default', async () => {
@@ -624,6 +645,32 @@ describe('button', () => {
 
       await nextTick()
       expect(wrapper.find('button').attributes('aria-label')).toBe('Close')
+    })
+
+    it('should not auto-set aria-label in renderless mode even when solo (regression #330)', async () => {
+      const wrapper = mount(Button.Root, {
+        props: { renderless: true },
+        slots: {
+          default: (p: any) =>
+            h('button', p.attrs, [
+              h(Button.Icon as any, {}, { default: () => h('span', '✕') }),
+            ]),
+        },
+      })
+
+      await nextTick()
+      expect(wrapper.find('button').attributes('aria-label')).toBeUndefined()
+    })
+
+    it('should not auto-set aria-label when button has visible text (no icon, non-renderless)', async () => {
+      const wrapper = mount(Button.Root, {
+        slots: {
+          default: () => h(Button.Content as any, {}, { default: () => 'Save & Next' }),
+        },
+      })
+
+      await nextTick()
+      expect(wrapper.find('button').attributes('aria-label')).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Supersedes #373.

In renderless mode the consumer owns the DOM and the accessible name, so Button no longer auto-sets an `aria-label` — the automatic icon-only fallback was overriding visible text in mixed-content renderless usages.

The icon-only **solo** fallback now resolves via `locale.ti('Button.label') ?? 'Button'`, matching the inline accessible-name default every other component adopted in #372 — an unconfigured app gets `"Button"` instead of the raw `Button.label` key, and a configured locale translation still wins.

### Why a new PR instead of #373
#373 carried the original renderless fix (thanks @sridhar-3009). Folding in the `ti()` migration requires master's `ti` API, and merging master into the fork branch tripped a `workflow` scope restriction on push. Reopened here on the org repo to land both together; #373 is closed in favor of this.

### Changes
- `ButtonRoot`: `ariaLabel || (!renderless && isSolo.value ? (locale.ti('Button.label') ?? 'Button') : undefined)`
- Tests: the #330 renderless regressions, a strengthened solo-default assertion (`'Button'`), and a configured-translation-override test
- Changeset (patch)

Closes #330