### PR TITLE
docs: normalize component and composable page structure

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -117,6 +117,8 @@ Adapters let you swap the underlying implementation without changing your applic
 10. **FAQ** — `::: faq` container with `???` questions
 11. `<DocsApi />` — auto-generated API reference
 
+Providers that require plugin setup (`locale`, `scrim`) prepend an optional **Installation** section before **Usage**. Section order is canonical: pages omit sections they don't need but never reorder them. Bespoke H2 headings are folded to H3 under the nearest canonical parent — default **Recipes**; keyboard/ARIA content → **Accessibility**; limitations/gotchas → **FAQ**.
+
 ## Section Content Rules
 
 | Section | Component pages | Composable pages |
@@ -131,13 +133,20 @@ Adapters let you swap the underlying implementation without changing your applic
 1. **H1 title** — composable name
 2. `<DocsPageFeatures :frontmatter />`
 3. **Intro** — 1-2 sentences (see Page Intro rules)
-4. **Usage** — `` ```ts collapse `` `` block
-5. **Architecture** — Mermaid diagram showing composable hierarchy
-6. **Adapters** — if the composable accepts adapters
-7. **Reactivity** — table of reactive properties/methods
-8. **Examples** — `::: gn-example` with live demos
-9. **FAQ** — `::: faq` container
-10. `<DocsApi />` — auto-generated API reference
+4. **Installation** — plugins only; `createXPlugin` setup in `main.ts`
+5. **Usage** — `` ```ts collapse `` `` block
+6. **Context / DI** — provide/inject + `createXContext`, when present
+7. **Adapters** — if the composable accepts adapters (before **Architecture** — choosing an adapter is a setup-time decision)
+8. **Architecture** — Mermaid diagram showing composable hierarchy
+9. **Options** — config-object reference, when present
+10. **Reactivity** — table of reactive properties/methods
+11. **Examples** — `::: gn-example` with live demos
+12. **Recipes** — code fences or single-file `::: gn-example`, when present
+13. **Accessibility** — ARIA / keyboard, when the composable exposes an a11y surface
+14. **FAQ** — `::: faq` container
+15. `<DocsApi />` — auto-generated API reference
+
+Section order is canonical: pages omit sections they don't need but never reorder them. Bespoke H2 headings are folded to H3 under the nearest canonical parent (default **Recipes**).
 
 ## Examples
 

--- a/apps/docs/src/pages/components/actions/button.md
+++ b/apps/docs/src/pages/components/actions/button.md
@@ -53,36 +53,6 @@ The Button component renders as a native `<button>` by default (or an anchor, ro
 </template>
 ```
 
-## Interaction States
-
-Button supports four states that block click events. Each state has a distinct semantic meaning:
-
-| State | Click blocked | Focusable | Hoverable | Tab order | Use case |
-|-------|:---:|:---:|:---:|:---:|---|
-| **disabled** | Yes | No | No | Removed | Button is not applicable |
-| **readonly** | Yes | Yes | Yes | Kept | Display-only, no action needed |
-| **passive** | Yes | Yes | Yes | Kept | Temporarily unavailable |
-| **loading** | Yes | Yes | Yes | Kept | Waiting for async operation |
-
-::: gn-example
-/components/button/states
-:::
-
-### Data Attributes
-
-Each state sets a corresponding `data-*` attribute on the element for CSS styling:
-
-| Attribute | When set |
-|-----------|----------|
-| `data-disabled` | `disabled` prop is true |
-| `data-readonly` | `readonly` prop is true |
-| `data-passive` | `passive` prop is true |
-| `data-loading` | Loading grace period has elapsed |
-| `data-selected` | Button is selected in a group |
-
-> [!TIP]
-> `disabled` uses native `disabled` attribute and removes the button from tab order. `passive` uses `aria-disabled="true"` instead — the button stays focusable and screen readers announce it as disabled.
-
 ## Recipes
 
 ### Loading with Grace Period
@@ -166,6 +136,36 @@ Use `Button.HiddenInput` inside a group to submit toggle state with forms. It re
   </Form>
 </template>
 ```
+
+### Interaction States
+
+Button supports four states that block click events. Each state has a distinct semantic meaning:
+
+| State | Click blocked | Focusable | Hoverable | Tab order | Use case |
+|-------|:---:|:---:|:---:|:---:|---|
+| **disabled** | Yes | No | No | Removed | Button is not applicable |
+| **readonly** | Yes | Yes | Yes | Kept | Display-only, no action needed |
+| **passive** | Yes | Yes | Yes | Kept | Temporarily unavailable |
+| **loading** | Yes | Yes | Yes | Kept | Waiting for async operation |
+
+::: gn-example
+/components/button/states
+:::
+
+#### Data Attributes
+
+Each state sets a corresponding `data-*` attribute on the element for CSS styling:
+
+| Attribute | When set |
+|-----------|----------|
+| `data-disabled` | `disabled` prop is true |
+| `data-readonly` | `readonly` prop is true |
+| `data-passive` | `passive` prop is true |
+| `data-loading` | Loading grace period has elapsed |
+| `data-selected` | Button is selected in a group |
+
+> [!TIP]
+> `disabled` uses native `disabled` attribute and removes the button from tab order. `passive` uses `aria-disabled="true"` instead — the button stays focusable and screen readers announce it as disabled.
 
 ## Accessibility
 

--- a/apps/docs/src/pages/components/disclosure/dialog.md
+++ b/apps/docs/src/pages/components/disclosure/dialog.md
@@ -57,7 +57,7 @@ The Dialog component leverages the native `showModal()` API for proper modal beh
 </template>
 ```
 
-## Features
+## Recipes
 
 ### Click-Outside Dismissal
 
@@ -83,9 +83,11 @@ The `blocking` prop disables scrim-based dismissal entirely — the dialog can o
 </template>
 ```
 
-## Known Limitations
+## FAQ
 
-### Overlays inside a modal dialog (Snackbar, Tooltip, Popover)
+### Known Limitations
+
+#### Overlays inside a modal dialog (Snackbar, Tooltip, Popover)
 
 The native `<dialog>` element with `showModal()` promotes itself to the browser's **top layer** — a rendering surface that sits above all normal document content. This has one important consequence: any overlay rendered _outside_ the dialog (e.g., a `Snackbar.Portal` teleported to `body`, or a `Tooltip` inside a portal) will appear **below** the dialog, not above it.
 

--- a/apps/docs/src/pages/components/disclosure/popover.md
+++ b/apps/docs/src/pages/components/disclosure/popover.md
@@ -54,7 +54,7 @@ The Popover component leverages the CSS Anchor Positioning API to create popover
 </template>
 ```
 
-## Features
+## Recipes
 
 ### Positioning
 

--- a/apps/docs/src/pages/components/disclosure/tabs.md
+++ b/apps/docs/src/pages/components/disclosure/tabs.md
@@ -49,19 +49,7 @@ The Tabs component provides a compound pattern for building accessible tab inter
 </template>
 ```
 
-## Features
-
-### Keyboard Navigation
-
-The component implements full WAI-ARIA keyboard support. Keyboard behavior depends on the activation mode:
-
-| Key | Automatic | Manual |
-| - | - | - |
-| Arrow Left/Right (horizontal) | Moves focus **and** activates tab | Moves focus only |
-| Arrow Up/Down (vertical) | Moves focus **and** activates tab | Moves focus only |
-| Home | Focuses **and** activates first tab | Focuses first tab only |
-| End | Focuses **and** activates last tab | Focuses last tab only |
-| Enter/Space | — | Activates the focused tab |
+## Recipes
 
 ### Activation Modes
 
@@ -116,5 +104,19 @@ Set `enroll` to auto-select the first registered tab. Useful when tabs are rende
   </Tabs.Root>
 </template>
 ```
+
+## Accessibility
+
+### Keyboard Navigation
+
+The component implements full WAI-ARIA keyboard support. Keyboard behavior depends on the activation mode:
+
+| Key | Automatic | Manual |
+| - | - | - |
+| Arrow Left/Right (horizontal) | Moves focus **and** activates tab | Moves focus only |
+| Arrow Up/Down (vertical) | Moves focus **and** activates tab | Moves focus only |
+| Home | Focuses **and** activates first tab | Focuses first tab only |
+| End | Focuses **and** activates last tab | Focuses last tab only |
+| Enter/Space | — | Activates the focused tab |
 
 <DocsApi />

--- a/apps/docs/src/pages/components/primitives/atom.md
+++ b/apps/docs/src/pages/components/primitives/atom.md
@@ -117,7 +117,7 @@ In **element mode**, Atom renders the element and applies attrs to it. In **rend
 </template>
 ```
 
-## Guide
+## Architecture
 
 Atom is an advanced, low-level primitive that enables **polymorphic components**. A polymorphic component can render an element with default attributes applied, or go renderless and expose its functionality entirely through slot props. Most of the time you won't need Atom directly — it's there for when you're building your own components that need this flexibility.
 
@@ -191,6 +191,27 @@ In renderless mode, the component provides state and behavior through its slot p
 > [!TIP]
 > Any v0 component can be switched between rendered and renderless. Pass `renderless` to strip the wrapper. Pass `as="section"` to add one. This works on every component because they all use Atom underneath.
 
+## Examples
+
+::: gn-example
+/components/atom/AppButton.vue 1
+/components/atom/polymorphic.vue 2
+
+### Polymorphic Button
+
+The same `AppButton` component used two ways. In rendered mode, it outputs a `<button>` and applies attrs automatically — you just drop it in. In renderless mode, it outputs nothing — you provide your own element and bind the attrs from the slot.
+
+This is the core value of building on Atom: one component definition, two consumption patterns.
+
+| File | Role |
+|------|------|
+| `AppButton.vue` | Reusable button — extends `AtomProps`, builds `slotProps.attrs` with class and type, forwards through Atom |
+| `polymorphic.vue` | Demo — same component used rendered (3 variants) and renderless (consumer `<a>` with attrs from slot) |
+
+:::
+
+## Recipes
+
 ### Choosing a default element
 
 When you build a component on Atom, the first decision is: **should it render an element by default, or should it be renderless?**
@@ -252,25 +273,6 @@ When your component needs a reference to Atom's rendered DOM element — for mea
 ```
 
 This is how Pagination components register their elements for width measurement, and how Splitter accesses its root for pointer event coordinates. In renderless mode, `element` is `null` — there's no wrapper to reference.
-
-## Examples
-
-::: gn-example
-/components/atom/AppButton.vue 1
-/components/atom/polymorphic.vue 2
-
-### Polymorphic Button
-
-The same `AppButton` component used two ways. In rendered mode, it outputs a `<button>` and applies attrs automatically — you just drop it in. In renderless mode, it outputs nothing — you provide your own element and bind the attrs from the slot.
-
-This is the core value of building on Atom: one component definition, two consumption patterns.
-
-| File | Role |
-|------|------|
-| `AppButton.vue` | Reusable button — extends `AtomProps`, builds `slotProps.attrs` with class and type, forwards through Atom |
-| `polymorphic.vue` | Demo — same component used rendered (3 variants) and renderless (consumer `<a>` with attrs from slot) |
-
-:::
 
 ## Accessibility
 

--- a/apps/docs/src/pages/components/providers/group.md
+++ b/apps/docs/src/pages/components/providers/group.md
@@ -44,7 +44,7 @@ The Group component is a specialization of Selection that enforces multi-selecti
 </template>
 ```
 
-## Features
+## Recipes
 
 ### Batch Operations
 

--- a/apps/docs/src/pages/components/providers/locale.md
+++ b/apps/docs/src/pages/components/providers/locale.md
@@ -101,7 +101,9 @@ Nest `<Locale>` components to create layered locale contexts. Each card reads it
 > [!TIP] Scoped translations
 > `t()` and `n()` are fully scoped. A `<Locale locale="fr">` subtree resolves all translations against the French messages, even when nested inside another `<Locale>` override. Each scope is independent.
 
-## Renderless Mode
+## Recipes
+
+### Renderless Mode
 
 When `renderless` is set, the component does not render a wrapper element. Instead, it passes `attrs` (including `data-locale` and `lang`) via the slot scope for you to bind to your own element:
 

--- a/apps/docs/src/pages/components/providers/scrim.md
+++ b/apps/docs/src/pages/components/providers/scrim.md
@@ -75,7 +75,7 @@ When the topmost overlay has `blocking: true`, the scrim will not dismiss on cli
 </template>
 ```
 
-## Inline Rendering
+### Inline Rendering
 
 By default, Scrim teleports to `body`. Disable teleport for inline rendering:
 
@@ -88,7 +88,7 @@ By default, Scrim teleports to `body`. Disable teleport for inline rendering:
 </template>
 ```
 
-### Custom Stack Context
+#### Custom Stack Context
 
 For isolated overlay systems, create a custom stack and provide it via Vue's injection system:
 
@@ -107,7 +107,7 @@ For isolated overlay systems, create a custom stack and provide it via Vue's inj
 </template>
 ```
 
-### Transitions
+#### Transitions
 
 The default transition is `fade`. Customize with the `transition` prop:
 

--- a/apps/docs/src/pages/components/semantic/breadcrumbs.md
+++ b/apps/docs/src/pages/components/semantic/breadcrumbs.md
@@ -210,11 +210,11 @@ Override the ellipsis globally on Root or per-instance:
 </template>
 ```
 
-## Plugins
+### Plugins
 
 Breadcrumbs integrates with v0's plugin system for internationalization.
 
-### Locale
+#### Locale
 
 The Root renders the navigation landmark's `aria-label` as `ti('Breadcrumbs.label') ?? 'Breadcrumbs'`. When the Locale plugin resolves the `Breadcrumbs.label` key it uses your translation; without any configuration it falls back to the inline English default `"Breadcrumbs"`.
 

--- a/apps/docs/src/pages/composables/data/create-data-grid.md
+++ b/apps/docs/src/pages/composables/data/create-data-grid.md
@@ -58,32 +58,6 @@ grid.layout.hide('budget')    // exclude from the render set
 grid.layout.reset()            // restore initial layout
 ```
 
-## Architecture
-
-`createDataGrid` composes [createDataTable](/composables/data/create-data-table) — which owns the data pipeline (filter, sort, paginate) — with four grid modules: column layout, cell editing, row ordering ([createSortable](/composables/data/create-sortable)), and row spanning. Columns and rows are both onboarded through registries (`grid.columns.onboard(...)`, `grid.onboard(...)`) rather than passed as options, the same shape as createDataTable. Per-column config (`size`, `pinned`, `editable`, `validate`, `span`) rides on each column ticket, so layout, editing, and spanning read it straight off `grid.columns` and pick up columns onboarded at any time.
-
-```mermaid "createDataGrid Architecture"
-flowchart TD
-  createDataGrid:::primary --> table["createDataTable (pipeline)"]
-  createDataGrid --> layout["layout (grid.columns + createGroup)"]
-  createDataGrid --> editing["editing (createCellEditing)"]
-  createDataGrid --> ordering["rows (createSortable)"]
-  createDataGrid --> spanning["spans (createRowSpanning)"]
-  table --> adapter["DataTableAdapter (Client / Server / Virtual)"]
-  ordering -. "id sequence" .-> createDataGrid
-  layout --> pin["pin / resize / reorder"]
-  editing --> edit["edit / commit / cancel + validate"]
-  spanning --> span["computed span map (hidden cell tracking)"]
-```
-
-| Module | Built on | Purpose |
-| - | - | - |
-| `table` (spread) | `createDataTable` | Search, sort, filter, paginate, total — all v-modeled through |
-| `layout` | `grid.columns` + `createGroup` | Reads column order and config from the column registry; layers tri-region pinning, percentage sizing, delta-based resize, and visibility (`show` / `hide` / `toggle` / `all`) on top |
-| `editing` | internal factory | Click-to-edit lifecycle, per-column validation, dirty tracking |
-| `rows` | `createSortable` | Post-sort row reordering, layered in the grid's `items` projection over the sorted rows before pagination — not inside the adapter |
-| `spans` | computed map | Row span resolution and hidden-cell tracking |
-
 ## Adapters
 
 The grid uses the standard data table adapters — row ordering is layered above the pipeline, not inside it, so any [DataTableAdapter](/composables/data/create-data-table#adapters) works without modification.
@@ -149,6 +123,32 @@ const grid = createDataGrid({
 grid.columns.onboard(columns)
 grid.onboard(largeDataset.map(value => ({ id: value.id, value })))
 ```
+
+## Architecture
+
+`createDataGrid` composes [createDataTable](/composables/data/create-data-table) — which owns the data pipeline (filter, sort, paginate) — with four grid modules: column layout, cell editing, row ordering ([createSortable](/composables/data/create-sortable)), and row spanning. Columns and rows are both onboarded through registries (`grid.columns.onboard(...)`, `grid.onboard(...)`) rather than passed as options, the same shape as createDataTable. Per-column config (`size`, `pinned`, `editable`, `validate`, `span`) rides on each column ticket, so layout, editing, and spanning read it straight off `grid.columns` and pick up columns onboarded at any time.
+
+```mermaid "createDataGrid Architecture"
+flowchart TD
+  createDataGrid:::primary --> table["createDataTable (pipeline)"]
+  createDataGrid --> layout["layout (grid.columns + createGroup)"]
+  createDataGrid --> editing["editing (createCellEditing)"]
+  createDataGrid --> ordering["rows (createSortable)"]
+  createDataGrid --> spanning["spans (createRowSpanning)"]
+  table --> adapter["DataTableAdapter (Client / Server / Virtual)"]
+  ordering -. "id sequence" .-> createDataGrid
+  layout --> pin["pin / resize / reorder"]
+  editing --> edit["edit / commit / cancel + validate"]
+  spanning --> span["computed span map (hidden cell tracking)"]
+```
+
+| Module | Built on | Purpose |
+| - | - | - |
+| `table` (spread) | `createDataTable` | Search, sort, filter, paginate, total — all v-modeled through |
+| `layout` | `grid.columns` + `createGroup` | Reads column order and config from the column registry; layers tri-region pinning, percentage sizing, delta-based resize, and visibility (`show` / `hide` / `toggle` / `all`) on top |
+| `editing` | internal factory | Click-to-edit lifecycle, per-column validation, dirty tracking |
+| `rows` | `createSortable` | Post-sort row reordering, layered in the grid's `items` projection over the sorted rows before pagination — not inside the adapter |
+| `spans` | computed map | Row span resolution and hidden-cell tracking |
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/data/create-data-table.md
+++ b/apps/docs/src/pages/composables/data/create-data-table.md
@@ -65,41 +65,6 @@ table.columns.unregister('actions')
 table.columns.clear()
 ```
 
-## Reactivity
-
-| Property / Method | Reactive | Notes |
-| - | :-: | - |
-| `items` | <AppSuccessIcon /> | Computed — final visible items (projected from registry tickets) |
-| `allItems` | <AppSuccessIcon /> | Computed — every registered row, unfiltered/unsorted |
-| `filteredItems` | <AppSuccessIcon /> | Computed — items after filtering |
-| `sortedItems` | <AppSuccessIcon /> | Computed — items after filter + sort |
-| `columns` | <AppSuccessIcon /> | RegistryContext — reactive column registry (`columns.values()` drives `leaves` and `headers`) |
-| `leaves` | <AppSuccessIcon /> | Computed — leaf columns (no children) used by the data pipeline |
-| `headers` | <AppSuccessIcon /> | Computed — 2D header grid with colspan/rowspan for rendering thead |
-| `query` | <AppSuccessIcon /> | ShallowRef — current search query (readonly) |
-| `sort.columns` | <AppSuccessIcon /> | Computed — current sort entries |
-| `pagination.page` | <AppSuccessIcon /> | ShallowRef — current page |
-| `pagination.items` | <AppSuccessIcon /> | Computed — visible page buttons |
-| `selection.selectedIds` | <AppSuccessIcon /> | `shallowReactive(Set)` — currently selected row IDs |
-| `selection.isAllSelected` | <AppSuccessIcon /> | Computed — all in scope selected |
-| `selection.isMixed` | <AppSuccessIcon /> | Computed — some but not all selected |
-| `expansion.expandedIds` | <AppSuccessIcon /> | `shallowReactive(Set)` — currently expanded row IDs |
-| `grouping.groups` | <AppSuccessIcon /> | Computed — grouped items |
-| `total` | <AppSuccessIcon /> | Computed — total row count |
-| `loading` | <AppSuccessIcon /> | Computed — adapter loading state |
-| `error` | <AppSuccessIcon /> | Computed — adapter error state |
-| `register(input)` | — | Method — adds a single row ticket, mutates the row registry (downstream refs recompute) |
-| `onboard(inputs)` | — | Method — bulk register rows |
-| `unregister(id)` | — | Method — removes a row ticket by id |
-| `upsert(id, patch)` | — | Method — replaces a row's value; the pipeline re-runs. The sanctioned row-update path — mutating `ticket.value` in place does not re-run the pipeline |
-| `clear()` | — | Method — wipes every row ticket (useful before re-fetching server data) |
-| `columns.register(input)` | — | Method — adds a single column ticket (reactively updates `leaves`, `headers`, sort group, filter pipeline) |
-| `columns.onboard(inputs)` | — | Method — bulk register columns |
-| `columns.unregister(id)` | — | Method — removes a column by id; drops it from sort state |
-| `columns.clear()` | — | Method — wipes every column |
-
-The row registry itself is non-reactive for performance — registering ten thousand rows allocates no per-row proxies. Mutations propagate to the pipeline through registry events, so always iterate rows via `items` / `allItems` (or the other pipeline refs) in templates and computeds, never via raw `table.values()`, and update a row via `table.upsert(id, { value })` rather than mutating the row object in place. The column registry stays fully reactive.
-
 ## Adapters
 
 Adapters control the data pipeline strategy. Pass one via the `adapter` option.
@@ -238,7 +203,122 @@ const virtual = createVirtual(table.items, { itemHeight: 40 })
 > table.register({ id, value })
 > ```
 
-## Features
+## Reactivity
+
+| Property / Method | Reactive | Notes |
+| - | :-: | - |
+| `items` | <AppSuccessIcon /> | Computed — final visible items (projected from registry tickets) |
+| `allItems` | <AppSuccessIcon /> | Computed — every registered row, unfiltered/unsorted |
+| `filteredItems` | <AppSuccessIcon /> | Computed — items after filtering |
+| `sortedItems` | <AppSuccessIcon /> | Computed — items after filter + sort |
+| `columns` | <AppSuccessIcon /> | RegistryContext — reactive column registry (`columns.values()` drives `leaves` and `headers`) |
+| `leaves` | <AppSuccessIcon /> | Computed — leaf columns (no children) used by the data pipeline |
+| `headers` | <AppSuccessIcon /> | Computed — 2D header grid with colspan/rowspan for rendering thead |
+| `query` | <AppSuccessIcon /> | ShallowRef — current search query (readonly) |
+| `sort.columns` | <AppSuccessIcon /> | Computed — current sort entries |
+| `pagination.page` | <AppSuccessIcon /> | ShallowRef — current page |
+| `pagination.items` | <AppSuccessIcon /> | Computed — visible page buttons |
+| `selection.selectedIds` | <AppSuccessIcon /> | `shallowReactive(Set)` — currently selected row IDs |
+| `selection.isAllSelected` | <AppSuccessIcon /> | Computed — all in scope selected |
+| `selection.isMixed` | <AppSuccessIcon /> | Computed — some but not all selected |
+| `expansion.expandedIds` | <AppSuccessIcon /> | `shallowReactive(Set)` — currently expanded row IDs |
+| `grouping.groups` | <AppSuccessIcon /> | Computed — grouped items |
+| `total` | <AppSuccessIcon /> | Computed — total row count |
+| `loading` | <AppSuccessIcon /> | Computed — adapter loading state |
+| `error` | <AppSuccessIcon /> | Computed — adapter error state |
+| `register(input)` | — | Method — adds a single row ticket, mutates the row registry (downstream refs recompute) |
+| `onboard(inputs)` | — | Method — bulk register rows |
+| `unregister(id)` | — | Method — removes a row ticket by id |
+| `upsert(id, patch)` | — | Method — replaces a row's value; the pipeline re-runs. The sanctioned row-update path — mutating `ticket.value` in place does not re-run the pipeline |
+| `clear()` | — | Method — wipes every row ticket (useful before re-fetching server data) |
+| `columns.register(input)` | — | Method — adds a single column ticket (reactively updates `leaves`, `headers`, sort group, filter pipeline) |
+| `columns.onboard(inputs)` | — | Method — bulk register columns |
+| `columns.unregister(id)` | — | Method — removes a column by id; drops it from sort state |
+| `columns.clear()` | — | Method — wipes every column |
+
+The row registry itself is non-reactive for performance — registering ten thousand rows allocates no per-row proxies. Mutations propagate to the pipeline through registry events, so always iterate rows via `items` / `allItems` (or the other pipeline refs) in templates and computeds, never via raw `table.values()`, and update a row via `table.upsert(id, { value })` rather than mutating the row object in place. The column registry stays fully reactive.
+
+## Examples
+
+::: gn-example
+/composables/create-data-table/basic/BasicTable.vue
+/composables/create-data-table/basic/columns.ts
+/composables/create-data-table/basic/data.ts
+
+### Basic Data Table
+
+A three-column table of 8 users — name, email, role — with a live search input, sortable column headers, and prev/next pagination at 5 rows per page.
+
+`columns.ts` marks all three columns `sortable: true` and the name and email columns `filterable: true`. The table is created with `{ pagination: { itemsPerPage: 5 } }`, then rows are onboarded in one `table.onboard(users.map(...))` call. From that point, the template reads `table.items.value` directly — the pipeline (filter → sort → paginate) runs automatically on every `table.search()` or `table.sort.toggle()` call.
+
+The sort header uses a local `arrow()` helper that reads `table.sort.direction(id)` to pick `↑`, `↓`, or an empty string. No external sort-state variable is needed; the table owns it. The pagination row reads `table.pagination.isFirst.value` and `table.pagination.isLast.value` to disable the boundary buttons, and reads `table.pagination.page.value` and `table.pagination.pages` for the `n / total` counter.
+
+| File | Role |
+|------|------|
+| `BasicTable.vue` | Table with search input, sortable headers, and pagination |
+| `columns.ts` | Column definitions — sortable and filterable flags per column |
+| `data.ts` | 8-user dataset with id, name, email, and role |
+
+:::
+
+::: gn-example
+/composables/create-data-table/server/ServerTable.vue
+/composables/create-data-table/server/columns.ts
+/composables/create-data-table/server/api.ts
+
+### Server Adapter
+
+A data table backed by a simulated API. The `ServerDataTableAdapter` delegates all filtering, sorting, and pagination to the server — the client only renders what it receives.
+
+| File | Role |
+|------|------|
+| `ServerTable.vue` | Table with loading state, search, sort, and pagination |
+| `columns.ts` | Column definitions |
+| `api.ts` | Simulated server with `fetchPage()` that filters/sorts/paginates a dataset |
+
+The key difference from the client-side adapter is that the client never holds the full dataset. Instead, `total` and `loading` refs are passed to `ServerDataTableAdapter` so the table knows the full dataset size for pagination without materializing it locally. A `watch` on `[table.query, table.sort.columns, table.pagination.page]` fires `fetchPage()` whenever the user interacts — the handler calls `table.clear()` then `table.onboard(page.items)` to swap in the new result set. The simulated `api.ts` applies search, sort, and pagination server-side, returning only the current page.
+
+:::
+
+::: gn-example
+/composables/create-data-table/features/FeaturesTable.vue
+/composables/create-data-table/features/columns.ts
+/composables/create-data-table/features/data.ts
+
+### Grouping, Selection & Custom Sort
+
+A grouped table with row selection, custom numeric sort, and salary range filtering. Rows with `active: false` cannot be selected.
+
+| File | Role |
+|------|------|
+| `FeaturesTable.vue` | Grouped table with checkboxes, collapsible groups, and status badges |
+| `columns.ts` | Columns with custom `sort` (numeric) and `filter` (range queries like `>100000`) |
+| `data.ts` | Employee dataset with departments, salaries, and active status |
+
+`groupBy: 'department'` groups rows automatically — `openAll: true` opens all groups on creation. `table.grouping.isOpen(key)` checks visibility and `toggle(key)` flips it, so collapsible group rows render with no extra state variable. `itemSelectable: 'active'` disables checkboxes for inactive employees — the field name is a key into the row's value object and the table reads it directly. `mandate: true` ensures a sort column is always active (the sort never clears to unsorted on repeated clicks). The salary column's custom `filter` function parses range operators (`>100000`, `<80000`) so the search box doubles as a range query field.
+
+:::
+
+::: gn-example
+/composables/create-data-table/virtual/VirtualTable.vue
+/composables/create-data-table/virtual/columns.ts
+/composables/create-data-table/virtual/data.ts
+
+### Virtual Scrolling
+
+A table with 1,000 rows rendered through `createVirtual`. The `VirtualDataTableAdapter` skips pagination — all filtered/sorted items are passed directly to the virtual scroller.
+
+| File | Role |
+|------|------|
+| `VirtualTable.vue` | Virtual-scrolled table with sticky header and sort controls |
+| `columns.ts` | Column definitions with custom numeric sort for the score column |
+| `data.ts` | Generator that creates 1,000 sample user records |
+
+`VirtualDataTableAdapter` performs client-side filter and sort but skips pagination slicing — `table.items` holds all sorted rows. `createVirtual(table.items, { itemHeight: 40 })` then virtualizes at the rendering layer: only the rows in the current viewport window are mounted. The sticky `<thead>` stays visible while scrolling through virtual rows. The stats line shows rendered vs. filtered vs. total counts so the windowing effect is visible. For larger datasets at variable row heights, see `resize(index, height)` in [createVirtual](/composables/data/create-virtual).
+
+:::
+
+## Recipes
 
 ### Sorting
 
@@ -373,85 +453,5 @@ table.grouping.isOpen('Engineering')
 table.grouping.openAll()
 table.grouping.closeAll()
 ```
-
-## Examples
-
-::: gn-example
-/composables/create-data-table/basic/BasicTable.vue
-/composables/create-data-table/basic/columns.ts
-/composables/create-data-table/basic/data.ts
-
-### Basic Data Table
-
-A three-column table of 8 users — name, email, role — with a live search input, sortable column headers, and prev/next pagination at 5 rows per page.
-
-`columns.ts` marks all three columns `sortable: true` and the name and email columns `filterable: true`. The table is created with `{ pagination: { itemsPerPage: 5 } }`, then rows are onboarded in one `table.onboard(users.map(...))` call. From that point, the template reads `table.items.value` directly — the pipeline (filter → sort → paginate) runs automatically on every `table.search()` or `table.sort.toggle()` call.
-
-The sort header uses a local `arrow()` helper that reads `table.sort.direction(id)` to pick `↑`, `↓`, or an empty string. No external sort-state variable is needed; the table owns it. The pagination row reads `table.pagination.isFirst.value` and `table.pagination.isLast.value` to disable the boundary buttons, and reads `table.pagination.page.value` and `table.pagination.pages` for the `n / total` counter.
-
-| File | Role |
-|------|------|
-| `BasicTable.vue` | Table with search input, sortable headers, and pagination |
-| `columns.ts` | Column definitions — sortable and filterable flags per column |
-| `data.ts` | 8-user dataset with id, name, email, and role |
-
-:::
-
-::: gn-example
-/composables/create-data-table/server/ServerTable.vue
-/composables/create-data-table/server/columns.ts
-/composables/create-data-table/server/api.ts
-
-### Server Adapter
-
-A data table backed by a simulated API. The `ServerDataTableAdapter` delegates all filtering, sorting, and pagination to the server — the client only renders what it receives.
-
-| File | Role |
-|------|------|
-| `ServerTable.vue` | Table with loading state, search, sort, and pagination |
-| `columns.ts` | Column definitions |
-| `api.ts` | Simulated server with `fetchPage()` that filters/sorts/paginates a dataset |
-
-The key difference from the client-side adapter is that the client never holds the full dataset. Instead, `total` and `loading` refs are passed to `ServerDataTableAdapter` so the table knows the full dataset size for pagination without materializing it locally. A `watch` on `[table.query, table.sort.columns, table.pagination.page]` fires `fetchPage()` whenever the user interacts — the handler calls `table.clear()` then `table.onboard(page.items)` to swap in the new result set. The simulated `api.ts` applies search, sort, and pagination server-side, returning only the current page.
-
-:::
-
-::: gn-example
-/composables/create-data-table/features/FeaturesTable.vue
-/composables/create-data-table/features/columns.ts
-/composables/create-data-table/features/data.ts
-
-### Grouping, Selection & Custom Sort
-
-A grouped table with row selection, custom numeric sort, and salary range filtering. Rows with `active: false` cannot be selected.
-
-| File | Role |
-|------|------|
-| `FeaturesTable.vue` | Grouped table with checkboxes, collapsible groups, and status badges |
-| `columns.ts` | Columns with custom `sort` (numeric) and `filter` (range queries like `>100000`) |
-| `data.ts` | Employee dataset with departments, salaries, and active status |
-
-`groupBy: 'department'` groups rows automatically — `openAll: true` opens all groups on creation. `table.grouping.isOpen(key)` checks visibility and `toggle(key)` flips it, so collapsible group rows render with no extra state variable. `itemSelectable: 'active'` disables checkboxes for inactive employees — the field name is a key into the row's value object and the table reads it directly. `mandate: true` ensures a sort column is always active (the sort never clears to unsorted on repeated clicks). The salary column's custom `filter` function parses range operators (`>100000`, `<80000`) so the search box doubles as a range query field.
-
-:::
-
-::: gn-example
-/composables/create-data-table/virtual/VirtualTable.vue
-/composables/create-data-table/virtual/columns.ts
-/composables/create-data-table/virtual/data.ts
-
-### Virtual Scrolling
-
-A table with 1,000 rows rendered through `createVirtual`. The `VirtualDataTableAdapter` skips pagination — all filtered/sorted items are passed directly to the virtual scroller.
-
-| File | Role |
-|------|------|
-| `VirtualTable.vue` | Virtual-scrolled table with sticky header and sort controls |
-| `columns.ts` | Column definitions with custom numeric sort for the score column |
-| `data.ts` | Generator that creates 1,000 sample user records |
-
-`VirtualDataTableAdapter` performs client-side filter and sort but skips pagination slicing — `table.items` holds all sorted rows. `createVirtual(table.items, { itemHeight: 40 })` then virtualizes at the rendering layer: only the rows in the current viewport window are mounted. The sticky `<thead>` stays visible while scrolling through virtual rows. The stats line shows rendered vs. filtered vs. total counts so the windowing effect is visible. For larger datasets at variable row heights, see `resize(index, height)` in [createVirtual](/composables/data/create-virtual).
-
-:::
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/data/create-filter.md
+++ b/apps/docs/src/pages/composables/data/create-filter.md
@@ -71,6 +71,18 @@ const { items: filtered } = filter.apply(query, products)
 
 Returns the standard trinity `[useSearchFilter, provideSearchFilter, searchFilter]`. The third element gives standalone access without injection — useful for testing and server-side use.
 
+## Architecture
+
+`createFilter` provides pure filtering logic with context support:
+
+```mermaid "Filter Flow"
+flowchart LR
+  query[query ref] --> apply
+  items[items ref] --> apply
+  filter[createFilter]:::primary --> apply
+  apply --> computed[filtered items]
+```
+
 ## Options
 
 | Option | Type | Default | Notes |
@@ -93,29 +105,7 @@ const filter = createFilter({
 })
 ```
 
-## Architecture
-
-`createFilter` provides pure filtering logic with context support:
-
-```mermaid "Filter Flow"
-flowchart LR
-  query[query ref] --> apply
-  items[items ref] --> apply
-  filter[createFilter]:::primary --> apply
-  apply --> computed[filtered items]
-```
-
-## Reactivity
-
-| Property/Method | Reactive | Notes |
-| - | :-: | - |
-| `query` | <AppSuccessIcon /> | ShallowRef, updated on each `apply()` |
-| `items` (from apply) | <AppSuccessIcon /> | Computed, filters reactively |
-
-> [!TIP] Reactive filtering
-> Both the query and items passed to `apply()` can be reactive. The filtered result automatically updates when either changes.
-
-## Filter Modes
+### Filter Modes
 
 When the query is an array, each mode controls how multiple queries are matched against item values:
 
@@ -128,6 +118,16 @@ When the query is an array, each mode controls how multiple queries are matched 
 
 > [!TIP] some vs union
 > `some` and `union` both pass when any query matches, but `some` checks each value independently while `union` joins all values into a single string. The difference matters when a match spans multiple fields.
+
+## Reactivity
+
+| Property/Method | Reactive | Notes |
+| - | :-: | - |
+| `query` | <AppSuccessIcon /> | ShallowRef, updated on each `apply()` |
+| `items` (from apply) | <AppSuccessIcon /> | Computed, filters reactively |
+
+> [!TIP] Reactive filtering
+> Both the query and items passed to `apply()` can be reactive. The filtered result automatically updates when either changes.
 
 ## Examples
 

--- a/apps/docs/src/pages/composables/forms/create-combobox.md
+++ b/apps/docs/src/pages/composables/forms/create-combobox.md
@@ -51,62 +51,9 @@ combobox.query.value = 'ch'
 // combobox.filtered.value === Set { 'cherry' }
 ```
 
-## Architecture
+## Context / DI
 
-`createCombobox` orchestrates four independent primitives without extending their chains — it composes them. The adapter translates queries into a filtered set; virtual focus uses that set to skip hidden items.
-
-```mermaid "createCombobox Architecture"
-flowchart TD
-  createSelection["createSelection"]
-  useVirtualFocus["useVirtualFocus"]
-  usePopover["usePopover"]
-  Adapter["ClientComboboxAdapter / ServerComboboxAdapter"]
-  createCombobox["createCombobox"]:::primary
-  query["query (ShallowRef)"]
-  pristine["pristine (ShallowRef)"]
-  filtered["filtered (Ref<Set>)"]
-
-  createSelection --> createCombobox
-  useVirtualFocus --> createCombobox
-  usePopover --> createCombobox
-  Adapter --> createCombobox
-  createCombobox --> query
-  createCombobox --> pristine
-  createCombobox --> filtered
-```
-
-## Reactivity
-
-| Property | Type | Reactive | Notes |
-| - | - | :-: | - |
-| `query` | `ShallowRef<string>` | <AppSuccessIcon /> | Current input text |
-| `pristine` | `ShallowRef<boolean>` | <AppSuccessIcon /> | `true` after selection; `false` once user types |
-| `filtered` | `Ref<Set<ID>>` | <AppSuccessIcon /> | IDs that pass the current filter |
-| `isEmpty` | `Ref<boolean>` | <AppSuccessIcon /> | `true` when filtered set is empty |
-| `isLoading` | `ShallowRef<boolean>` | <AppSuccessIcon /> | Forwarded from adapter |
-| `isOpen` | `ShallowRef<boolean>` | <AppSuccessIcon /> | Popover open state |
-| `selection` | `SelectionContext` | — | Full selection API |
-| `popover` | `PopoverReturn` | — | Popover positioning API |
-| `cursor` | `VirtualFocusReturn` | — | Keyboard focus API |
-| `inputEl` | `ShallowRef<HTMLElement \| null>` | <AppSuccessIcon /> | Reference to the `<input>` element |
-
-## Options
-
-```ts
-interface ComboboxOptions {
-  multiple?: MaybeRefOrGetter<boolean>   // Enable multi-select
-  mandatory?: MaybeRefOrGetter<boolean>  // Prevent deselecting last item
-  disabled?: MaybeRefOrGetter<boolean>   // Disable all interaction
-  strict?: MaybeRefOrGetter<boolean>     // Revert query on close if no match
-  adapter?: ComboboxAdapter              // Filtering strategy (default: ClientComboboxAdapter)
-  displayValue?: (value: unknown) => string  // Format selected value for display in input
-  id?: string                            // Base ID for ARIA attributes
-  name?: string                          // Hidden input name for form submission
-  form?: string                          // Associated form ID
-}
-```
-
-## Context Object
+### Context Object
 
 `createCombobox` returns a `ComboboxContext` with the following API surface:
 
@@ -125,6 +72,26 @@ interface ComboboxOptions {
 | `disabled` | `MaybeRefOrGetter<boolean>` | Disabled option ref |
 | `name` | `string \| undefined` | Form field name |
 | `form` | `string \| undefined` | Associated form ID |
+
+### Dependency Injection
+
+Use `createComboboxContext` to get a DI-aware trinity for component-based setups:
+
+```ts
+import { createComboboxContext, useCombobox } from '@vuetify/v0'
+
+// In a Root component
+const [useMyCombobox, provideMyCombobox, context] = createComboboxContext({
+  namespace: 'my-combobox',
+  strict: true,
+})
+provideMyCombobox(context)
+
+// In any child component
+const combobox = useCombobox('my-combobox')
+```
+
+`useCombobox(namespace?)` injects the nearest combobox context (default namespace: `'v0:combobox'`).
 
 ## Adapters
 
@@ -180,61 +147,60 @@ watch(query, async q => {
 > [!TIP]
 > See the [Combobox server example](/components/forms/combobox#server-side-filtering) for a complete integration.
 
-## Strict Mode
+## Architecture
 
-When `strict: true`, closing the dropdown without an active selection reverts the query:
+`createCombobox` orchestrates four independent primitives without extending their chains — it composes them. The adapter translates queries into a filtered set; virtual focus uses that set to skip hidden items.
 
-- If an item is selected, `query` resets to that item's label.
-- If nothing is selected, `query` resets to `''`.
+```mermaid "createCombobox Architecture"
+flowchart TD
+  createSelection["createSelection"]
+  useVirtualFocus["useVirtualFocus"]
+  usePopover["usePopover"]
+  Adapter["ClientComboboxAdapter / ServerComboboxAdapter"]
+  createCombobox["createCombobox"]:::primary
+  query["query (ShallowRef)"]
+  pristine["pristine (ShallowRef)"]
+  filtered["filtered (Ref<Set>)"]
 
-Non-strict mode (default) leaves whatever text the user typed in place.
-
-> [!TIP]
-> `aria-autocomplete="both"` is set automatically on the input when `strict` is enabled, per the WAI-ARIA combobox pattern.
-
-## Pristine Flag
-
-`pristine` tracks whether the query reflects the current selection or is a live filter:
-
-- Starts as `true` (no user input yet).
-- Becomes `false` when the user types — the adapter receives the raw query.
-- Resets to `true` after a selection (`select(id)`), so reopening the dropdown always shows all items instead of the previous typed query.
-
-```ts
-// The adapter receives `search`, not `query` directly
-const search = toRef(() => pristine.value ? '' : query.value)
-const { filtered } = adapter.setup({ query: search, items })
+  createSelection --> createCombobox
+  useVirtualFocus --> createCombobox
+  usePopover --> createCombobox
+  Adapter --> createCombobox
+  createCombobox --> query
+  createCombobox --> pristine
+  createCombobox --> filtered
 ```
 
-## Multi-Select Behavior
-
-In `multiple` mode, `select(id)` differs from single mode:
-
-- Toggles the item (select → deselect on second click) via `selection.toggle()`.
-- Clears the query so the user can search for the next item.
-- Keeps the dropdown open.
-- Highlights the clicked item via `cursor.highlight(id)` so ArrowDown continues from that position.
-- Refocuses the input so keyboard navigation continues immediately.
-
-## Dependency Injection
-
-Use `createComboboxContext` to get a DI-aware trinity for component-based setups:
+## Options
 
 ```ts
-import { createComboboxContext, useCombobox } from '@vuetify/v0'
-
-// In a Root component
-const [useMyCombobox, provideMyCombobox, context] = createComboboxContext({
-  namespace: 'my-combobox',
-  strict: true,
-})
-provideMyCombobox(context)
-
-// In any child component
-const combobox = useCombobox('my-combobox')
+interface ComboboxOptions {
+  multiple?: MaybeRefOrGetter<boolean>   // Enable multi-select
+  mandatory?: MaybeRefOrGetter<boolean>  // Prevent deselecting last item
+  disabled?: MaybeRefOrGetter<boolean>   // Disable all interaction
+  strict?: MaybeRefOrGetter<boolean>     // Revert query on close if no match
+  adapter?: ComboboxAdapter              // Filtering strategy (default: ClientComboboxAdapter)
+  displayValue?: (value: unknown) => string  // Format selected value for display in input
+  id?: string                            // Base ID for ARIA attributes
+  name?: string                          // Hidden input name for form submission
+  form?: string                          // Associated form ID
+}
 ```
 
-`useCombobox(namespace?)` injects the nearest combobox context (default namespace: `'v0:combobox'`).
+## Reactivity
+
+| Property | Type | Reactive | Notes |
+| - | - | :-: | - |
+| `query` | `ShallowRef<string>` | <AppSuccessIcon /> | Current input text |
+| `pristine` | `ShallowRef<boolean>` | <AppSuccessIcon /> | `true` after selection; `false` once user types |
+| `filtered` | `Ref<Set<ID>>` | <AppSuccessIcon /> | IDs that pass the current filter |
+| `isEmpty` | `Ref<boolean>` | <AppSuccessIcon /> | `true` when filtered set is empty |
+| `isLoading` | `ShallowRef<boolean>` | <AppSuccessIcon /> | Forwarded from adapter |
+| `isOpen` | `ShallowRef<boolean>` | <AppSuccessIcon /> | Popover open state |
+| `selection` | `SelectionContext` | — | Full selection API |
+| `popover` | `PopoverReturn` | — | Popover positioning API |
+| `cursor` | `VirtualFocusReturn` | — | Keyboard focus API |
+| `inputEl` | `ShallowRef<HTMLElement \| null>` | <AppSuccessIcon /> | Reference to the `<input>` element |
 
 ## Examples
 
@@ -257,5 +223,43 @@ ARIA wiring is manual but mechanical: `role="combobox"`, `aria-controls`, `aria-
 | `CountryAutocomplete.vue` | Renders the input and listbox; owns the keyboard and input events |
 | `country-autocomplete.vue` | Wires the composable to the component and shows the selected-value panel |
 :::
+
+## Recipes
+
+### Strict Mode
+
+When `strict: true`, closing the dropdown without an active selection reverts the query:
+
+- If an item is selected, `query` resets to that item's label.
+- If nothing is selected, `query` resets to `''`.
+
+Non-strict mode (default) leaves whatever text the user typed in place.
+
+> [!TIP]
+> `aria-autocomplete="both"` is set automatically on the input when `strict` is enabled, per the WAI-ARIA combobox pattern.
+
+### Pristine Flag
+
+`pristine` tracks whether the query reflects the current selection or is a live filter:
+
+- Starts as `true` (no user input yet).
+- Becomes `false` when the user types — the adapter receives the raw query.
+- Resets to `true` after a selection (`select(id)`), so reopening the dropdown always shows all items instead of the previous typed query.
+
+```ts
+// The adapter receives `search`, not `query` directly
+const search = toRef(() => pristine.value ? '' : query.value)
+const { filtered } = adapter.setup({ query: search, items })
+```
+
+### Multi-Select Behavior
+
+In `multiple` mode, `select(id)` differs from single mode:
+
+- Toggles the item (select → deselect on second click) via `selection.toggle()`.
+- Clears the query so the user can search for the next item.
+- Keeps the dropdown open.
+- Highlights the clicked item via `cursor.highlight(id)` so ArrowDown continues from that position.
+- Refocuses the input so keyboard navigation continues immediately.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/forms/create-form.md
+++ b/apps/docs/src/pages/composables/forms/create-form.md
@@ -108,13 +108,6 @@ await form.submit()
 
 Validations inside the component tree auto-register with the provided form — no manual `form.register()` needed.
 
-## Options
-
-| Option | Type | Default | Notes |
-| - | - | - | - |
-| `disabled` | `MaybeRefOrGetter<boolean>` | `false` | When truthy, child components should disable interaction. Read via `form.disabled` |
-| `readonly` | `MaybeRefOrGetter<boolean>` | `false` | When truthy, child components should prevent editing. Read via `form.readonly` |
-
 ## Architecture
 
 `createForm` is a pure registry. Validations register with it for coordination:
@@ -127,6 +120,13 @@ flowchart TD
   createForm --> aggregate[isValid / isValidating]
   createForm --> state[disabled / readonly]
 ```
+
+## Options
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `disabled` | `MaybeRefOrGetter<boolean>` | `false` | When truthy, child components should disable interaction. Read via `form.disabled` |
+| `readonly` | `MaybeRefOrGetter<boolean>` | `false` | When truthy, child components should prevent editing. Read via `form.readonly` |
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/forms/create-input.md
+++ b/apps/docs/src/pages/composables/forms/create-input.md
@@ -72,6 +72,28 @@ graph TD
     D --> J[descriptionId / errorId]
 ```
 
+### Generic Types
+
+createInput is generic over the value type:
+
+```ts no-filename
+// String (default) — for text inputs
+createInput({ value: ref('') })
+
+// Number | null — for numeric inputs
+createInput<number | null>({
+  value: ref<number | null>(null),
+  dirty: v => v !== null,
+  equals: (a, b) => Object.is(a, b),
+})
+
+// ID | ID[] — for select inputs
+createInput<ID | ID[]>({
+  value: ref<ID[]>([]),
+  dirty: v => Array.isArray(v) ? v.length > 0 : v != null,
+})
+```
+
 ## Reactivity
 
 | Property | Type | Description |
@@ -95,28 +117,6 @@ graph TD
 
 > [!TIP]
 > `isDirty` and `isPristine` are not inverses. A pre-filled form field is dirty AND pristine. A cleared field is not-dirty AND not-pristine.
-
-## Generic Types
-
-createInput is generic over the value type:
-
-```ts no-filename
-// String (default) — for text inputs
-createInput({ value: ref('') })
-
-// Number | null — for numeric inputs
-createInput<number | null>({
-  value: ref<number | null>(null),
-  dirty: v => v !== null,
-  equals: (a, b) => Object.is(a, b),
-})
-
-// ID | ID[] — for select inputs
-createInput<ID | ID[]>({
-  value: ref<ID[]>([]),
-  dirty: v => Array.isArray(v) ? v.length > 0 : v != null,
-})
-```
 
 ## Examples
 

--- a/apps/docs/src/pages/composables/forms/create-otp.md
+++ b/apps/docs/src/pages/composables/forms/create-otp.md
@@ -60,6 +60,19 @@ flowchart TD
 
 Layer 2 orchestrator. Aggregates createInput for validation, dirty tracking, and ARIA wiring. No registry, no focus traversal, no observers — rendering, per-element refs, and keyboard wiring are the consumer's responsibility.
 
+## Options
+
+### Patterns
+
+| Pattern | Matches |
+| - | - |
+| `'numeric'` | `[0-9]` |
+| `'alphanumeric'` | `[a-zA-Z0-9]` |
+| `'alphabetic'` | `[a-zA-Z]` |
+| `RegExp` | Custom; tested per character |
+
+`accepts(char)` is the single point of truth and is reactive through `MaybeRefOrGetter` — toggle modes at runtime and every helper respects the new pattern on the next call.
+
 ## Reactivity
 
 | Property | Type | Reactive | Description |
@@ -75,17 +88,6 @@ Layer 2 orchestrator. Aggregates createInput for validation, dirty tracking, and
 | `accepts(char)` | `(char: string) => boolean` | — | Pattern test, exposed so consumers can guard `beforeinput`. |
 
 Every helper is gated on the configured `disabled` and `readonly` options, and on the internal pending state while an async `onComplete` is in flight.
-
-## Patterns
-
-| Pattern | Matches |
-| - | - |
-| `'numeric'` | `[0-9]` |
-| `'alphanumeric'` | `[a-zA-Z0-9]` |
-| `'alphabetic'` | `[a-zA-Z]` |
-| `RegExp` | Custom; tested per character |
-
-`accepts(char)` is the single point of truth and is reactive through `MaybeRefOrGetter` — toggle modes at runtime and every helper respects the new pattern on the next call.
 
 ## Examples
 

--- a/apps/docs/src/pages/composables/foundation/create-plugin.md
+++ b/apps/docs/src/pages/composables/foundation/create-plugin.md
@@ -61,7 +61,26 @@ app.use(createAnalyticsPlugin({ trackPageviews: true }))
 </script>
 ```
 
-## Low-level API
+## Architecture
+
+`createPlugin` wraps `createContext` for Vue plugin registration:
+
+```mermaid "Plugin Architecture"
+flowchart LR
+  subgraph Plugin
+    A[namespace]
+    B[provide]
+    C[setup]
+  end
+
+  createContext --> B
+  A --> install
+  B --> install
+  C --> install
+  install --> app.runWithContext
+```
+
+### Low-level API
 
 Use `createPlugin` directly when you need fine-grained control over plugin setup, or when composing with existing `createContext` instances:
 
@@ -93,95 +112,6 @@ export function createMyPlugin () {
 
 > [!TIP]
 > The **setup** and **provide** hooks are separated for semantic purposes — `provide` is for DI context, `setup` is for side effects (watchers, adapters, globals).
-
-## Architecture
-
-`createPlugin` wraps `createContext` for Vue plugin registration:
-
-```mermaid "Plugin Architecture"
-flowchart LR
-  subgraph Plugin
-    A[namespace]
-    B[provide]
-    C[setup]
-  end
-
-  createContext --> B
-  A --> install
-  B --> install
-  C --> install
-  install --> app.runWithContext
-```
-
-## Persistence
-
-Plugins can automatically save and restore state across page reloads using `useStorage`. Add `persist` and `restore` hooks to the plugin config, then consumers opt in with `persist: true`.
-
-### Plugin author
-
-Define what to save and how to restore in the `createPluginContext` config:
-
-```ts collapse no-filename
-import { createPluginContext } from '@vuetify/v0'
-
-export const [createThemeContext, createThemePlugin, useTheme] =
-  createPluginContext('v0:theme', createTheme, {
-    setup: (context, app, options) => {
-      // adapter setup...
-    },
-    // Return the value to save — called reactively
-    persist: ctx => ctx.selectedId.value,
-    // Apply saved value on load — called before setup
-    restore: (ctx, saved) => ctx.select(saved),
-  })
-```
-
-### Consumer
-
-```ts no-filename
-app.use(createThemePlugin({ persist: true }))
-```
-
-When `persist: true` is passed, the plugin automatically:
-
-1. Reads from `useStorage` using the plugin namespace as key
-2. Calls `restore` with the saved value before `setup` runs
-3. Watches the `persist` return value and writes changes to storage
-
-> [!TIP]
-> The `default` option becomes the true default — it's only used when no persisted value exists.
-
-### Lifecycle
-
-```mermaid "Persist Lifecycle"
-flowchart LR
-  A[provide] --> B[restore]
-  B --> C[setup]
-  C --> D["watch(persist)"]
-```
-
-The critical ordering is **restore before setup**. This means adapters (like the theme CSS variable injector) see the correct restored state on their first run — no flash of wrong values.
-
-### Hook signatures
-
-```ts
-interface PluginContextConfig<O, E> {
-  /** Return the value to persist — called reactively inside a watch source */
-  persist?: (context: E) => unknown
-  /** Restore previously persisted state — called before setup */
-  restore?: (context: E, saved: unknown) => void
-}
-```
-
-The `persist` return value is stored under the plugin namespace key (e.g. `v0:theme`). `restore` receives whatever was stored — cast to the expected type inside the hook.
-
-### Built-in support
-
-| Plugin | Persists | Storage key |
-|--------|----------|-------------|
-| `createThemePlugin` | Selected theme ID | `v0:theme` |
-| `createRtlPlugin` | RTL direction | `v0:rtl` |
-| `createLocalePlugin` | Selected locale | `v0:locale` |
 
 ## Examples
 
@@ -224,5 +154,77 @@ graph LR
 - Consumers import only from `plugin.ts`, never from the Provider
 
 :::
+
+## Recipes
+
+### Persistence
+
+Plugins can automatically save and restore state across page reloads using `useStorage`. Add `persist` and `restore` hooks to the plugin config, then consumers opt in with `persist: true`.
+
+#### Plugin author
+
+Define what to save and how to restore in the `createPluginContext` config:
+
+```ts collapse no-filename
+import { createPluginContext } from '@vuetify/v0'
+
+export const [createThemeContext, createThemePlugin, useTheme] =
+  createPluginContext('v0:theme', createTheme, {
+    setup: (context, app, options) => {
+      // adapter setup...
+    },
+    // Return the value to save — called reactively
+    persist: ctx => ctx.selectedId.value,
+    // Apply saved value on load — called before setup
+    restore: (ctx, saved) => ctx.select(saved),
+  })
+```
+
+#### Consumer
+
+```ts no-filename
+app.use(createThemePlugin({ persist: true }))
+```
+
+When `persist: true` is passed, the plugin automatically:
+
+1. Reads from `useStorage` using the plugin namespace as key
+2. Calls `restore` with the saved value before `setup` runs
+3. Watches the `persist` return value and writes changes to storage
+
+> [!TIP]
+> The `default` option becomes the true default — it's only used when no persisted value exists.
+
+#### Lifecycle
+
+```mermaid "Persist Lifecycle"
+flowchart LR
+  A[provide] --> B[restore]
+  B --> C[setup]
+  C --> D["watch(persist)"]
+```
+
+The critical ordering is **restore before setup**. This means adapters (like the theme CSS variable injector) see the correct restored state on their first run — no flash of wrong values.
+
+#### Hook signatures
+
+```ts
+interface PluginContextConfig<O, E> {
+  /** Return the value to persist — called reactively inside a watch source */
+  persist?: (context: E) => unknown
+  /** Restore previously persisted state — called before setup */
+  restore?: (context: E, saved: unknown) => void
+}
+```
+
+The `persist` return value is stored under the plugin namespace key (e.g. `v0:theme`). `restore` receives whatever was stored — cast to the expected type inside the hook.
+
+#### Built-in support
+
+| Plugin | Persists | Storage key |
+|--------|----------|-------------|
+| `createThemePlugin` | Selected theme ID | `v0:theme` |
+| `createRtlPlugin` | RTL direction | `v0:rtl` |
+| `createLocalePlugin` | Selected locale | `v0:locale` |
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/foundation/create-trinity.md
+++ b/apps/docs/src/pages/composables/foundation/create-trinity.md
@@ -82,7 +82,7 @@ flowchart LR
   C --> Fallback
 ```
 
-## Plugin Trinity
+### Plugin Trinity
 
 When building a Vue plugin, use [`createPluginContext`](/composables/foundation/create-plugin) instead of wiring `createContext + createTrinity` manually. It generates the same trinity tuple from a factory function with far less boilerplate:
 

--- a/apps/docs/src/pages/composables/plugins/use-breakpoints.md
+++ b/apps/docs/src/pages/composables/plugins/use-breakpoints.md
@@ -148,7 +148,9 @@ The composable reads its instance once and exposes derived refs; the presentatio
 | `responsive-dashboard.vue` | Entry that renders the breakpoint instrument strip and wires the composable to the grid |
 :::
 
-## SSR Support
+## Recipes
+
+### SSR Support
 
 By default, useBreakpoints returns `xs` / width `0` on the server. Pass `ssr` options to render at a known viewport size:
 

--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -237,76 +237,7 @@ The `formatByString()` method supports these tokens:
 | `A` | AM/PM | AM |
 | `a` | am/pm | am |
 
-## Reactivity
-
-The date context provides minimal reactivity, with the adapter being a static instance.
-
-| Property | Reactive | Notes |
-| - | :-: | - |
-| `locale` | <AppSuccessIcon /> | Computed from `useLocale` if available |
-| `adapter` | <AppErrorIcon /> | Static adapter instance |
-
-## Examples
-
-The following example builds a complete, interactive date surface from adapter calls alone — no DatePicker component required.
-
-::: gn-example
-/composables/use-date/useCalendar.ts 1
-/composables/use-date/CalendarGrid.vue 2
-/composables/use-date/month-calendar.vue 3
-
-### Interactive month calendar
-
-A navigable month grid with click-to-select, built entirely from the adapter. `useCalendar.ts` calls `useDate()` once and owns all the date math: `getWeekArray()` produces the 2D week grid, `getWeekdays('narrow')` drives the column headers, `getPreviousMonth()` and `getNextMonth()` handle navigation, and `isSameDay()` / `isSameMonth()` power the today ring, the selected fill, and the greyed-out overflow cells. The grid renders as many week rows as the month spans — four to six — straight from `getWeekArray()`, so every in-month day stays visible and the calendar never truncates a long month or borrows days from the wrong neighbouring week.
-
-The composable precomputes each `weeks` cell into a flat `{ date, day, today, selected, outside }` record, so `CalendarGrid.vue` renders the surface from plain props — `weekdays`, `weeks`, `monthYear`, plus the `prev`, `next`, `today`, and `select` callbacks — without ever touching the adapter directly. The entry instantiates the calendar once and reads `selectedLabel` and `locale` for the summary panel. This is the structural half of the adapter interface — building and navigating grids — rather than the formatting presets shown in the Usage example above.
-
-Reach for this pattern when building a DatePicker, DateRangePicker, or any calendar surface where the adapter should own the grid layout. The adapter is locale-aware by default: `getWeekdays` and the month name both respond to the locale set at plugin install time, so switching the active locale via [useLocale](/composables/plugins/use-locale) reformats the calendar with no extra code. See the locale integration section below for how the two plugins sync.
-
-| File | Role |
-|------|------|
-| `useCalendar.ts` | Wraps `useDate()`; owns month/selection state and exposes weekday labels, precomputed week cells, and navigation callbacks |
-| `CalendarGrid.vue` | Renders the weekday headers and day buttons from its props; styles today, selected, and outside-month cells via data attributes |
-| `month-calendar.vue` | Entry point — instantiates the calendar, wires it to the grid, and shows the selected date and active locale |
-:::
-
-## Locale Integration
-
-When `useLocale` is available, `useDate` automatically syncs with the selected locale:
-
-```ts src/main.ts
-import { createApp } from 'vue'
-import { V0DateAdapter } from '@vuetify/v0/date'
-import { createLocalePlugin, createDatePlugin } from '@vuetify/v0'
-
-const app = createApp(App)
-
-// Install locale plugin first
-app.use(
-  createLocalePlugin({
-    default: 'en',
-    messages: {
-      en: { /* ... */ },
-      de: { /* ... */ },
-    }
-  })
-)
-
-// Date plugin will auto-sync with locale
-app.use(
-  createDatePlugin({
-    adapter: new V0DateAdapter(),
-    locales: {
-      en: 'en-US',  // Map short codes to Intl locales
-      de: 'de-DE',
-    }
-  })
-)
-```
-
-When switching locales via `useLocale`, the date adapter automatically updates its formatting locale.
-
-## Custom Adapters
+### Custom Adapters
 
 The adapter pattern decouples date operations from the underlying library. When you call `adapter.format()`, the request flows through the provided adapter to its underlying date library:
 
@@ -402,11 +333,84 @@ app.use(
 > }
 > ```
 
-## Known Limitations
+## Reactivity
+
+The date context provides minimal reactivity, with the adapter being a static instance.
+
+| Property | Reactive | Notes |
+| - | :-: | - |
+| `locale` | <AppSuccessIcon /> | Computed from `useLocale` if available |
+| `adapter` | <AppErrorIcon /> | Static adapter instance |
+
+## Examples
+
+The following example builds a complete, interactive date surface from adapter calls alone — no DatePicker component required.
+
+::: gn-example
+/composables/use-date/useCalendar.ts 1
+/composables/use-date/CalendarGrid.vue 2
+/composables/use-date/month-calendar.vue 3
+
+### Interactive month calendar
+
+A navigable month grid with click-to-select, built entirely from the adapter. `useCalendar.ts` calls `useDate()` once and owns all the date math: `getWeekArray()` produces the 2D week grid, `getWeekdays('narrow')` drives the column headers, `getPreviousMonth()` and `getNextMonth()` handle navigation, and `isSameDay()` / `isSameMonth()` power the today ring, the selected fill, and the greyed-out overflow cells. The grid renders as many week rows as the month spans — four to six — straight from `getWeekArray()`, so every in-month day stays visible and the calendar never truncates a long month or borrows days from the wrong neighbouring week.
+
+The composable precomputes each `weeks` cell into a flat `{ date, day, today, selected, outside }` record, so `CalendarGrid.vue` renders the surface from plain props — `weekdays`, `weeks`, `monthYear`, plus the `prev`, `next`, `today`, and `select` callbacks — without ever touching the adapter directly. The entry instantiates the calendar once and reads `selectedLabel` and `locale` for the summary panel. This is the structural half of the adapter interface — building and navigating grids — rather than the formatting presets shown in the Usage example above.
+
+Reach for this pattern when building a DatePicker, DateRangePicker, or any calendar surface where the adapter should own the grid layout. The adapter is locale-aware by default: `getWeekdays` and the month name both respond to the locale set at plugin install time, so switching the active locale via [useLocale](/composables/plugins/use-locale) reformats the calendar with no extra code. See the locale integration section below for how the two plugins sync.
+
+| File | Role |
+|------|------|
+| `useCalendar.ts` | Wraps `useDate()`; owns month/selection state and exposes weekday labels, precomputed week cells, and navigation callbacks |
+| `CalendarGrid.vue` | Renders the weekday headers and day buttons from its props; styles today, selected, and outside-month cells via data attributes |
+| `month-calendar.vue` | Entry point — instantiates the calendar, wires it to the grid, and shows the selected date and active locale |
+:::
+
+## Recipes
+
+### Locale Integration
+
+When `useLocale` is available, `useDate` automatically syncs with the selected locale:
+
+```ts src/main.ts
+import { createApp } from 'vue'
+import { V0DateAdapter } from '@vuetify/v0/date'
+import { createLocalePlugin, createDatePlugin } from '@vuetify/v0'
+
+const app = createApp(App)
+
+// Install locale plugin first
+app.use(
+  createLocalePlugin({
+    default: 'en',
+    messages: {
+      en: { /* ... */ },
+      de: { /* ... */ },
+    }
+  })
+)
+
+// Date plugin will auto-sync with locale
+app.use(
+  createDatePlugin({
+    adapter: new V0DateAdapter(),
+    locales: {
+      en: 'en-US',  // Map short codes to Intl locales
+      de: 'de-DE',
+    }
+  })
+)
+```
+
+When switching locales via `useLocale`, the date adapter automatically updates its formatting locale.
+
+## FAQ
+
+### Known Limitations
 
 - **parse() format parameter**: The `parse()` method's format parameter is currently ignored. The Temporal API doesn't provide built-in format parsing. The method delegates to `date()` which handles ISO 8601 strings. For custom format parsing, use a library like date-fns or luxon with a custom adapter.
 
-### SSR and Hydration
+#### SSR and Hydration
 
 > [!WARNING]
 > Date formatting can cause hydration mismatches in SSR applications. Server and client environments may produce different formatted output due to timezone differences.

--- a/apps/docs/src/pages/composables/plugins/use-hydration.md
+++ b/apps/docs/src/pages/composables/plugins/use-hydration.md
@@ -89,19 +89,6 @@ All properties are `Readonly<ShallowRef>` and update when the root component mou
 | `isHydrated` | `ShallowRef<boolean>` | True after root component mounts |
 | `isSettled` | `ShallowRef<boolean>` | True after next tick post-hydration |
 
-## Fallback Hydration
-
-When `useHydration()` is called without the plugin installed (no `createHydrationPlugin` in your app), it returns a fallback context where `isHydrated` and `isSettled` are **immediately `true`**. This means components that conditionally render based on `isHydrated` work correctly in client-only apps without any plugin setup.
-
-```ts no-filename
-// Without plugin: isHydrated.value === true immediately
-// With plugin:    isHydrated.value starts false, becomes true after mount
-const { isHydrated } = useHydration()
-```
-
-> [!TIP]
-> The fallback is also what SSR-aware composables like `useResizeObserver` use internally — they call `useHydration()` to defer observation until after hydration, but work correctly even in environments where the plugin isn't installed.
-
 ## Examples
 
 ::: gn-example
@@ -116,5 +103,20 @@ The example uses `createLoggerContext` internally — just `createHydrationPlugi
 Reach for `isSettled` (not just `isHydrated`) as the gate for CSS transitions and animations: `isHydrated` fires on mount, but the browser hasn't painted yet at that point, so transition classes applied immediately are suppressed. `isSettled` fires one tick later, after paint, and avoids the flash.
 
 :::
+
+## Recipes
+
+### Fallback Hydration
+
+When `useHydration()` is called without the plugin installed (no `createHydrationPlugin` in your app), it returns a fallback context where `isHydrated` and `isSettled` are **immediately `true`**. This means components that conditionally render based on `isHydrated` work correctly in client-only apps without any plugin setup.
+
+```ts no-filename
+// Without plugin: isHydrated.value === true immediately
+// With plugin:    isHydrated.value starts false, becomes true after mount
+const { isHydrated } = useHydration()
+```
+
+> [!TIP]
+> The fallback is also what SSR-aware composables like `useResizeObserver` use internally — they call `useHydration()` to defer observation until after hydration, but work correctly even in environments where the plugin isn't installed.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-locale.md
+++ b/apps/docs/src/pages/composables/plugins/use-locale.md
@@ -78,99 +78,6 @@ Once the plugin is installed, use the `useLocale` composable in any component:
 </template>
 ```
 
-## Translation
-
-Look up a message key with `t()` or `ti()`. Both run the same pipeline — selected locale, then the `fallback` locale, then placeholder interpolation — and differ only in what they return when the key is missing.
-
-| Method | On a miss | Reach for it when |
-| - | - | - |
-| `t(key, ...params)` | Echoes the raw `key` back | A visible string is always wanted and the key itself is an acceptable last resort |
-| `ti(key, ...params)` | Returns `undefined` | You want to supply your own fallback string inline |
-
-### Translate if exists
-
-`ti()` ("translate if exists") never echoes the key. Pair it with the nullish-coalescing operator to provide an inline default — the pattern every v0 component uses for its accessible names:
-
-```vue no-filename TranslateIfExists
-<script setup lang="ts">
-  import { useLocale } from '@vuetify/v0'
-
-  const locale = useLocale()
-</script>
-
-<template>
-  <nav :aria-label="locale.ti('Pagination.label') ?? 'Pagination'">
-    ...
-  </nav>
-</template>
-```
-
-When an app installs the Locale plugin with a `Pagination.label` translation, the component uses it; when an app installs no locale messages at all, the component still renders a real English accessible name (`'Pagination'`) and satisfies [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). Because the default lives at the call site, no English strings are bundled into the runtime fallback — calling `t('Pagination.label')` on the same missing key would render the literal `'Pagination.label'`, which is exactly the unhelpful output `ti()` avoids.
-
-### Bundled English messages
-
-The inline `ti(key) ?? '...'` idiom keeps a sensible default at each call site. If you would rather register full, centralized English coverage for v0's own component keys, import the optional `@vuetify/v0/locale/messages/en` map. It is a plain object of every key v0 components look up, and it is never pulled into the runtime unless you import it:
-
-```ts main.ts
-import en from '@vuetify/v0/locale/messages/en'
-import { createLocalePlugin } from '@vuetify/v0'
-
-app.use(
-  createLocalePlugin({
-    messages: { en },
-    default: 'en',
-  })
-)
-```
-
-Use it as a starting point for a new translation — copy the shape, swap the values for your language — or register it as-is to give every v0 component a complete English baseline.
-
-## Architecture
-
-`useLocale` extends `createSingle` for locale selection with message interpolation:
-
-```mermaid "Locale Hierarchy"
-flowchart TD
-  createRegistry --> createModel
-  createModel --> createSelection
-  createSelection --> createSingle
-  createSingle --> useLocale
-  Adapter --> useLocale
-```
-
-## Reactivity
-
-Locale selection is reactive via `createSingle`. Translation methods return static strings.
-
-| Property | Reactive | Notes |
-| - | :-: | - |
-| `selectedId` | <AppSuccessIcon /> | Current locale ID |
-| `selectedItem` | <AppSuccessIcon /> | Current locale ticket |
-| `selectedValue` | <AppSuccessIcon /> | Current locale value |
-| `selectedIndex` | <AppSuccessIcon /> | Index in registry |
-
-## Examples
-
-::: gn-example
-/composables/use-locale/LocaleScope.vue 1
-/composables/use-locale/LocalePanel.vue 2
-/composables/use-locale/locale-scopes.vue 3
-
-### Nested Locale Scopes
-
-`createLocaleContext` provides a locale to a subtree via provide/inject instead of installing it app-wide. Because every scope provides under the same injection key, a nested scope shadows its parent: a consumer reads the nearest provider above it, so an embedded widget can run an entirely different language and message set than the page around it. Here the outer shell defaults to English (with Spanish and Japanese) while the inner checkout widget defaults to French (with German), and switching one panel's language never touches the other.
-
-`LocaleScope.vue` is a thin provider — it calls `createLocaleContext` with a `default` locale and a `messages` dictionary, then renders its slot. `LocalePanel.vue` is the consumer: it calls `useLocale()` to resolve whichever scope wraps it and exercises every form the built-in `V0LocaleAdapter` supports — named replacement (`{ name }`), positional replacement (`{0}`), multi-placeholder (`{ count, total }`), and nested key lookup (`nav.home`). The amount line nests `locale.n()` inside `locale.t()`, so the number is formatted by `Intl.NumberFormat` for the active locale before being interpolated into the translated string.
-
-Reach for scoped contexts over the app-wide [Installation](#installation) plugin when sections of a page need independent locales — multi-tenant dashboards, embedded third-party widgets, or isolated docs demos. For a vue-i18n integration or a custom adapter, see the Adapters section below. For component-level locale overrides, see the [Locale](/components/providers/locale) component.
-
-| File | Role |
-|------|------|
-| `LocaleScope.vue` | Provider — creates a locale context from `default` + `messages` props and provides it to its slot |
-| `LocalePanel.vue` | Consumer — injects `useLocale()` and renders the switcher, translations, and number format |
-| `locale-scopes.vue` | Entry — nests a widget scope inside the app scope to show the two read independently |
-:::
-
 ## Adapters
 
 Adapters let you swap the underlying i18n implementation without changing your application code.
@@ -301,5 +208,100 @@ abstract class LocaleAdapter {
   abstract n (value: number): string
 }
 ```
+
+## Architecture
+
+`useLocale` extends `createSingle` for locale selection with message interpolation:
+
+```mermaid "Locale Hierarchy"
+flowchart TD
+  createRegistry --> createModel
+  createModel --> createSelection
+  createSelection --> createSingle
+  createSingle --> useLocale
+  Adapter --> useLocale
+```
+
+## Reactivity
+
+Locale selection is reactive via `createSingle`. Translation methods return static strings.
+
+| Property | Reactive | Notes |
+| - | :-: | - |
+| `selectedId` | <AppSuccessIcon /> | Current locale ID |
+| `selectedItem` | <AppSuccessIcon /> | Current locale ticket |
+| `selectedValue` | <AppSuccessIcon /> | Current locale value |
+| `selectedIndex` | <AppSuccessIcon /> | Index in registry |
+
+## Examples
+
+::: gn-example
+/composables/use-locale/LocaleScope.vue 1
+/composables/use-locale/LocalePanel.vue 2
+/composables/use-locale/locale-scopes.vue 3
+
+### Nested Locale Scopes
+
+`createLocaleContext` provides a locale to a subtree via provide/inject instead of installing it app-wide. Because every scope provides under the same injection key, a nested scope shadows its parent: a consumer reads the nearest provider above it, so an embedded widget can run an entirely different language and message set than the page around it. Here the outer shell defaults to English (with Spanish and Japanese) while the inner checkout widget defaults to French (with German), and switching one panel's language never touches the other.
+
+`LocaleScope.vue` is a thin provider — it calls `createLocaleContext` with a `default` locale and a `messages` dictionary, then renders its slot. `LocalePanel.vue` is the consumer: it calls `useLocale()` to resolve whichever scope wraps it and exercises every form the built-in `V0LocaleAdapter` supports — named replacement (`{ name }`), positional replacement (`{0}`), multi-placeholder (`{ count, total }`), and nested key lookup (`nav.home`). The amount line nests `locale.n()` inside `locale.t()`, so the number is formatted by `Intl.NumberFormat` for the active locale before being interpolated into the translated string.
+
+Reach for scoped contexts over the app-wide [Installation](#installation) plugin when sections of a page need independent locales — multi-tenant dashboards, embedded third-party widgets, or isolated docs demos. For a vue-i18n integration or a custom adapter, see the Adapters section below. For component-level locale overrides, see the [Locale](/components/providers/locale) component.
+
+| File | Role |
+|------|------|
+| `LocaleScope.vue` | Provider — creates a locale context from `default` + `messages` props and provides it to its slot |
+| `LocalePanel.vue` | Consumer — injects `useLocale()` and renders the switcher, translations, and number format |
+| `locale-scopes.vue` | Entry — nests a widget scope inside the app scope to show the two read independently |
+:::
+
+## Recipes
+
+### Translation
+
+Look up a message key with `t()` or `ti()`. Both run the same pipeline — selected locale, then the `fallback` locale, then placeholder interpolation — and differ only in what they return when the key is missing.
+
+| Method | On a miss | Reach for it when |
+| - | - | - |
+| `t(key, ...params)` | Echoes the raw `key` back | A visible string is always wanted and the key itself is an acceptable last resort |
+| `ti(key, ...params)` | Returns `undefined` | You want to supply your own fallback string inline |
+
+#### Translate if exists
+
+`ti()` ("translate if exists") never echoes the key. Pair it with the nullish-coalescing operator to provide an inline default — the pattern every v0 component uses for its accessible names:
+
+```vue no-filename TranslateIfExists
+<script setup lang="ts">
+  import { useLocale } from '@vuetify/v0'
+
+  const locale = useLocale()
+</script>
+
+<template>
+  <nav :aria-label="locale.ti('Pagination.label') ?? 'Pagination'">
+    ...
+  </nav>
+</template>
+```
+
+When an app installs the Locale plugin with a `Pagination.label` translation, the component uses it; when an app installs no locale messages at all, the component still renders a real English accessible name (`'Pagination'`) and satisfies [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). Because the default lives at the call site, no English strings are bundled into the runtime fallback — calling `t('Pagination.label')` on the same missing key would render the literal `'Pagination.label'`, which is exactly the unhelpful output `ti()` avoids.
+
+#### Bundled English messages
+
+The inline `ti(key) ?? '...'` idiom keeps a sensible default at each call site. If you would rather register full, centralized English coverage for v0's own component keys, import the optional `@vuetify/v0/locale/messages/en` map. It is a plain object of every key v0 components look up, and it is never pulled into the runtime unless you import it:
+
+```ts main.ts
+import en from '@vuetify/v0/locale/messages/en'
+import { createLocalePlugin } from '@vuetify/v0'
+
+app.use(
+  createLocalePlugin({
+    messages: { en },
+    default: 'en',
+  })
+)
+```
+
+Use it as a starting point for a new translation — copy the shape, swap the values for your language — or register it as-is to give every v0 component a complete English baseline.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-logger.md
+++ b/apps/docs/src/pages/composables/plugins/use-logger.md
@@ -65,21 +65,6 @@ Once the plugin is installed, use the `useLogger` composable in any component:
 </template>
 ```
 
-## Scoped logging
-
-When several composables share the app-level logger, their output blends together with no easy way to tell which one emitted what. Pass a scope key to `useLogger` to tag every message from that caller with a `[scope]` segment, layered after the plugin prefix:
-
-```ts no-filename
-import { useLogger } from '@vuetify/v0'
-
-const logger = useLogger('createKanban')
-
-logger.warn('drop rejected')
-// → [v0 warn] [createKanban] drop rejected
-```
-
-`useLogger()` with no argument is unchanged — it returns the plugin-configured logger as-is. A scoped logger shares the plugin's level, enabled state, and adapter; only the message prefix differs, so re-leveling or disabling the shared logger affects every scope. A blank scope key is treated as no scope. Without a plugin installed, `useLogger` falls back to a console logger and still appends the `[scope]` segment, so output stays attributable.
-
 ## Adapters
 
 Adapters let you swap the underlying logging implementation without changing your application code.
@@ -257,5 +242,22 @@ Reach for this shape when several components need to log through one shared, run
 | `LogConsole.vue` | Injects the shared logger with `useLogger()` to emit, renders the level controls, toggle, and output panel |
 | `log-console.vue` | Entry that wires the composable state into the console and adds the usage hint |
 :::
+
+## Recipes
+
+### Scoped logging
+
+When several composables share the app-level logger, their output blends together with no easy way to tell which one emitted what. Pass a scope key to `useLogger` to tag every message from that caller with a `[scope]` segment, layered after the plugin prefix:
+
+```ts no-filename
+import { useLogger } from '@vuetify/v0'
+
+const logger = useLogger('createKanban')
+
+logger.warn('drop rejected')
+// → [v0 warn] [createKanban] drop rejected
+```
+
+`useLogger()` with no argument is unchanged — it returns the plugin-configured logger as-is. A scoped logger shares the plugin's level, enabled state, and adapter; only the message prefix differs, so re-leveling or disabling the shared logger affects every scope. A blank scope key is treated as no scope. Without a plugin installed, `useLogger` falls back to a console logger and still appends the `[scope]` segment, so output stays attributable.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-notifications.md
+++ b/apps/docs/src/pages/composables/plugins/use-notifications.md
@@ -75,114 +75,6 @@ Once the plugin is installed, use the `useNotifications` composable in any compo
 </template>
 ```
 
-## Architecture
-
-`createNotifications` layers notification semantics on top of the registry and queue primitives, with plugin installation via `createPluginContext`:
-
-```mermaid "Notification Architecture"
-flowchart TB
-  subgraph Primitives
-    Registry[createRegistry]
-    Queue[createQueue]
-  end
-
-  subgraph Notifications
-    Core[createNotifications]
-    Plugin[createNotificationsPlugin]
-    Use[useNotifications]
-  end
-
-  subgraph Integration
-    Adapter["Adapter (Knock, Novu)"]
-    Events["Events (notification:read, etc.)"]
-  end
-
-  Registry --> Core
-  Queue --> Core
-  Core --> Plugin
-  Plugin --> Use
-  Adapter -.->|inbound: send| Core
-  Core -.->|outbound: events| Events
-  Events -.-> Adapter
-```
-
-## Severity Levels
-
-The `severity` field categorizes notifications by urgency. It maps to ARIA live region roles automatically:
-
-| Value | ARIA role | Use for |
-|-------|-----------|---------|
-| `'error'` | `role="alert"` | Failures, errors, destructive outcomes |
-| `'warning'` | `role="alert"` | Degraded state, approaching limits |
-| `'info'` | `role="status"` | Neutral updates, background activity |
-| `'success'` | `role="status"` | Completed actions, positive outcomes |
-
-`NotificationSeverity` is extensible — custom values like `'critical'` are accepted with autocomplete for the four defaults.
-
-## API
-
-| Method | Description |
-|--------|-------------|
-| `send(input)` | Create notification + enqueue for toast display |
-| `register(input)` | Create notification in registry only (no toast). Use for historical items |
-| `queue` | Queue context — `queue.values()`, `queue.pause()`, `queue.resume()` |
-| `read(id)` / `unread(id)` | Toggle read state |
-| `seen(id)` | Mark as seen |
-| `archive(id)` / `unarchive(id)` | Toggle archive state |
-| `snooze(id, until)` / `wake(id)` | Snooze with expiry |
-| `readAll()` / `archiveAll()` | Bulk operations |
-| `onboard(items)` | Bulk-register enriched notifications into registry (no toast) |
-| `clear()` | Remove all notifications from the registry |
-| `dispose()` | Tear down event listeners and clear the registry |
-
-## Examples
-
-::: gn-example
-/composables/use-notifications/context.ts 1
-/composables/use-notifications/NotificationProvider.vue 2
-/composables/use-notifications/NotificationConsumer.vue 3
-/composables/use-notifications/inbox.vue 4
-@import @mdi/js
-
-### Notification Center
-
-A single `createNotifications` instance powering four notification surfaces through the `data.type` field:
-
-| Surface | Type | Behavior |
-|---------|------|----------|
-| **Banner** | `'banner'` | Persistent, dismissible, max 1 visible. System announcements, trial expiry |
-| **Toast** | `'toast'` | Auto-dismissing via `timeout`. Action feedback: "Changes saved" |
-| **Inline** | `'inline'` | Contextual, embedded in page content. Rate limits, degraded service |
-| **Inbox** | `'inbox'` or none | Full lifecycle — read, archive, snooze. Collaboration, CI alerts |
-
-The `data` bag drives routing — the composable doesn't care how notifications render. Each surface filters `items` by `data.type`.
-
-| File | Role |
-|------|------|
-| `context.ts` | Wraps `createNotifications` with `createContext` for provide/inject |
-| `NotificationProvider.vue` | Renders all surfaces: banners, inbox dropdown, snackbar stack |
-| `NotificationConsumer.vue` | Triggers notifications — simulates real app events |
-| `inbox.vue` | Entry point wiring provider and consumer |
-
-Click **Simulate Event** repeatedly to cycle through banner, snackbar, and inbox notifications. Open the **Inbox** to interact with read/archive/snooze. Notice how `seen` (badge count) and `read` (visual weight) are distinct — mirroring GitHub and Slack.
-
-```mermaid "Notification Lifecycle"
-stateDiagram-v2
-  [*] --> Unseen: send()
-  Unseen --> Unread: inbox opened (seen)
-  Unread --> Read: mark read
-  Read --> Unread: mark unread
-  Read --> Archived: archive
-  Unread --> Archived: archive
-  Unread --> Snoozed: snooze(until)
-  Snoozed --> Unread: wake
-  Read --> [*]: dismiss()
-  Unread --> [*]: dismiss()
-  Archived --> [*]: dismiss()
-```
-
-:::
-
 ## Adapters
 
 Adapters let you swap the underlying notification service without changing your application code.
@@ -376,5 +268,117 @@ app.use(createNotificationsPlugin<AppNotification>({ adapter: new MyBackendAdapt
 Custom fields are preserved on the ticket and accessible anywhere you inject the notifications context.
 
 > [!ASKAI] How do I write a custom adapter for my backend?
+
+## Architecture
+
+`createNotifications` layers notification semantics on top of the registry and queue primitives, with plugin installation via `createPluginContext`:
+
+```mermaid "Notification Architecture"
+flowchart TB
+  subgraph Primitives
+    Registry[createRegistry]
+    Queue[createQueue]
+  end
+
+  subgraph Notifications
+    Core[createNotifications]
+    Plugin[createNotificationsPlugin]
+    Use[useNotifications]
+  end
+
+  subgraph Integration
+    Adapter["Adapter (Knock, Novu)"]
+    Events["Events (notification:read, etc.)"]
+  end
+
+  Registry --> Core
+  Queue --> Core
+  Core --> Plugin
+  Plugin --> Use
+  Adapter -.->|inbound: send| Core
+  Core -.->|outbound: events| Events
+  Events -.-> Adapter
+```
+
+## Reactivity
+
+### API
+
+| Method | Description |
+|--------|-------------|
+| `send(input)` | Create notification + enqueue for toast display |
+| `register(input)` | Create notification in registry only (no toast). Use for historical items |
+| `queue` | Queue context — `queue.values()`, `queue.pause()`, `queue.resume()` |
+| `read(id)` / `unread(id)` | Toggle read state |
+| `seen(id)` | Mark as seen |
+| `archive(id)` / `unarchive(id)` | Toggle archive state |
+| `snooze(id, until)` / `wake(id)` | Snooze with expiry |
+| `readAll()` / `archiveAll()` | Bulk operations |
+| `onboard(items)` | Bulk-register enriched notifications into registry (no toast) |
+| `clear()` | Remove all notifications from the registry |
+| `dispose()` | Tear down event listeners and clear the registry |
+
+## Examples
+
+::: gn-example
+/composables/use-notifications/context.ts 1
+/composables/use-notifications/NotificationProvider.vue 2
+/composables/use-notifications/NotificationConsumer.vue 3
+/composables/use-notifications/inbox.vue 4
+@import @mdi/js
+
+### Notification Center
+
+A single `createNotifications` instance powering four notification surfaces through the `data.type` field:
+
+| Surface | Type | Behavior |
+|---------|------|----------|
+| **Banner** | `'banner'` | Persistent, dismissible, max 1 visible. System announcements, trial expiry |
+| **Toast** | `'toast'` | Auto-dismissing via `timeout`. Action feedback: "Changes saved" |
+| **Inline** | `'inline'` | Contextual, embedded in page content. Rate limits, degraded service |
+| **Inbox** | `'inbox'` or none | Full lifecycle — read, archive, snooze. Collaboration, CI alerts |
+
+The `data` bag drives routing — the composable doesn't care how notifications render. Each surface filters `items` by `data.type`.
+
+| File | Role |
+|------|------|
+| `context.ts` | Wraps `createNotifications` with `createContext` for provide/inject |
+| `NotificationProvider.vue` | Renders all surfaces: banners, inbox dropdown, snackbar stack |
+| `NotificationConsumer.vue` | Triggers notifications — simulates real app events |
+| `inbox.vue` | Entry point wiring provider and consumer |
+
+Click **Simulate Event** repeatedly to cycle through banner, snackbar, and inbox notifications. Open the **Inbox** to interact with read/archive/snooze. Notice how `seen` (badge count) and `read` (visual weight) are distinct — mirroring GitHub and Slack.
+
+```mermaid "Notification Lifecycle"
+stateDiagram-v2
+  [*] --> Unseen: send()
+  Unseen --> Unread: inbox opened (seen)
+  Unread --> Read: mark read
+  Read --> Unread: mark unread
+  Read --> Archived: archive
+  Unread --> Archived: archive
+  Unread --> Snoozed: snooze(until)
+  Snoozed --> Unread: wake
+  Read --> [*]: dismiss()
+  Unread --> [*]: dismiss()
+  Archived --> [*]: dismiss()
+```
+
+:::
+
+## Recipes
+
+### Severity Levels
+
+The `severity` field categorizes notifications by urgency. It maps to ARIA live region roles automatically:
+
+| Value | ARIA role | Use for |
+|-------|-----------|---------|
+| `'error'` | `role="alert"` | Failures, errors, destructive outcomes |
+| `'warning'` | `role="alert"` | Degraded state, approaching limits |
+| `'info'` | `role="status"` | Neutral updates, background activity |
+| `'success'` | `role="status"` | Completed actions, positive outcomes |
+
+`NotificationSeverity` is extensible — custom values like `'critical'` are accepted with autocomplete for the four defaults.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-reduced-motion.md
+++ b/apps/docs/src/pages/composables/plugins/use-reduced-motion.md
@@ -54,45 +54,6 @@ motion.select('never') // force full motion
 motion.select('system') // follow the OS setting
 ```
 
-## Modes
-
-The `selectedMode` decides how the OS preference is interpreted.
-
-| Mode | Behavior |
-| - | - |
-| `system` | Follow `prefers-reduced-motion` (default) |
-| `always` | Force `isReduced` to `true`, ignoring the OS |
-| `never` | Force `isReduced` to `false`, ignoring the OS |
-
-> [!WARNING]
-> `never` forces full motion on users whose OS asked for less — it also flips the body attribute to `no-preference`, so your own reduce styles stop matching. Reserve it for an explicit, user-driven control (e.g. a settings toggle), never an app-wide default.
-
-Need the raw OS preference regardless of `selectedMode`? Call [usePrefersReducedMotion](/composables/system/use-media-query) directly.
-
-### Persisting the override
-
-Pass `persist: true` to remember a user's manual override across reloads. This requires the storage plugin to be installed:
-
-```ts main.ts
-import { createStoragePlugin, createReducedMotionPlugin } from '@vuetify/v0'
-
-app.use(createStoragePlugin())
-app.use(createReducedMotionPlugin({ persist: true }))
-```
-
-## Architecture
-
-`useReducedMotion` uses the plugin pattern with a media-query core and a DOM adapter:
-
-```mermaid "Reduced Motion Plugin"
-flowchart LR
-  plugin[createReducedMotionPlugin] --> context[createReducedMotion]
-  context --> media[usePrefersReducedMotion]
-  context --> adapter[ReducedMotionAdapter]
-  adapter --> body[body data attribute/browser]
-  adapter --> unhead[unhead bodyAttrs/server]
-```
-
 ## Adapters
 
 Adapters control how the reduced-motion state is applied to the DOM. The default writes a body data attribute in the browser and renders the same attribute via [@unhead](https://unhead.unjs.io/) on the server, so the attribute is present in the initial HTML reflecting the configured mode — correct for `always` and `never`; in the default `system` mode the server cannot know the OS preference and renders `no-preference`.
@@ -129,7 +90,70 @@ class ClassReducedMotionAdapter extends ReducedMotionAdapter {
 app.use(createReducedMotionPlugin({ adapter: new ClassReducedMotionAdapter() }))
 ```
 
-## Standalone Usage
+## Architecture
+
+`useReducedMotion` uses the plugin pattern with a media-query core and a DOM adapter:
+
+```mermaid "Reduced Motion Plugin"
+flowchart LR
+  plugin[createReducedMotionPlugin] --> context[createReducedMotion]
+  context --> media[usePrefersReducedMotion]
+  context --> adapter[ReducedMotionAdapter]
+  adapter --> body[body data attribute/browser]
+  adapter --> unhead[unhead bodyAttrs/server]
+```
+
+## Reactivity
+
+| Property | Reactive | Notes |
+| - | :-: | - |
+| `selectedMode` | <AppSuccessIcon /> | Active override mode (`'system' \| 'always' \| 'never'`) |
+| `isReduced` | <AppSuccessIcon /> | `true` when motion should be minimized, considering `selectedMode` |
+| `select(mode)` | <AppErrorIcon /> | Set the active mode |
+| `dispose()` | <AppErrorIcon /> | Stop the OS media-query subscription |
+
+## Examples
+
+::: gn-example
+/composables/use-reduced-motion/basic
+
+### Mode Switching
+
+Toggle between the three modes and watch `isReduced` flip. The bouncing dot stops the moment motion is reduced — either because the OS reports `prefers-reduced-motion: reduce` in `system` mode, or because `always` forces it.
+
+The raw OS readout — pulled from `usePrefersReducedMotion` — shows what the system reports independent of the override. Surface it in a settings panel so users can compare their system preference against what the app is actually applying.
+
+:::
+
+## Recipes
+
+### Modes
+
+The `selectedMode` decides how the OS preference is interpreted.
+
+| Mode | Behavior |
+| - | - |
+| `system` | Follow `prefers-reduced-motion` (default) |
+| `always` | Force `isReduced` to `true`, ignoring the OS |
+| `never` | Force `isReduced` to `false`, ignoring the OS |
+
+> [!WARNING]
+> `never` forces full motion on users whose OS asked for less — it also flips the body attribute to `no-preference`, so your own reduce styles stop matching. Reserve it for an explicit, user-driven control (e.g. a settings toggle), never an app-wide default.
+
+Need the raw OS preference regardless of `selectedMode`? Call [usePrefersReducedMotion](/composables/system/use-media-query) directly.
+
+#### Persisting the override
+
+Pass `persist: true` to remember a user's manual override across reloads. This requires the storage plugin to be installed:
+
+```ts main.ts
+import { createStoragePlugin, createReducedMotionPlugin } from '@vuetify/v0'
+
+app.use(createStoragePlugin())
+app.use(createReducedMotionPlugin({ persist: true }))
+```
+
+### Standalone Usage
 
 Use `createReducedMotion` to create a raw context without the plugin system — useful for testing or embedding in another composable. The standalone context does not set the body data attribute:
 
@@ -147,16 +171,7 @@ Inside a component or effect scope, cleanup is automatic; outside any scope, cal
 
 When `useReducedMotion` is called without an installed plugin, it returns a no-op fallback (`isReduced` is `false`, `select` does nothing), so consuming code never throws.
 
-## Reactivity
-
-| Property | Reactive | Notes |
-| - | :-: | - |
-| `selectedMode` | <AppSuccessIcon /> | Active override mode (`'system' \| 'always' \| 'never'`) |
-| `isReduced` | <AppSuccessIcon /> | `true` when motion should be minimized, considering `selectedMode` |
-| `select(mode)` | <AppErrorIcon /> | Set the active mode |
-| `dispose()` | <AppErrorIcon /> | Stop the OS media-query subscription |
-
-## Styling
+### Styling
 
 When installed, the plugin sets `data-reduced-motion="reduce" | "no-preference"` on `document.body` (and renders it server-side via [@unhead](https://unhead.unjs.io/), reflecting the configured mode), so stylesheets can respond without any JavaScript:
 
@@ -177,18 +192,5 @@ In the default `system` mode the server cannot read the OS preference, so the in
   /* same reductions — covers first paint before the plugin runs */
 }
 ```
-
-## Examples
-
-::: gn-example
-/composables/use-reduced-motion/basic
-
-### Mode Switching
-
-Toggle between the three modes and watch `isReduced` flip. The bouncing dot stops the moment motion is reduced — either because the OS reports `prefers-reduced-motion: reduce` in `system` mode, or because `always` forces it.
-
-The raw OS readout — pulled from `usePrefersReducedMotion` — shows what the system reports independent of the override. Surface it in a settings panel so users can compare their system preference against what the app is actually applying.
-
-:::
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-rtl.md
+++ b/apps/docs/src/pages/composables/plugins/use-rtl.md
@@ -64,13 +64,6 @@ rtl.toggle() // Now true (RTL)
 rtl.isRtl.value = false // Back to LTR
 ```
 
-## Reactivity
-
-| Property | Type | Description |
-| - | - | - |
-| `isRtl` | `Ref<boolean>` | Writable ref — `true` for RTL, `false` for LTR |
-| `toggle` | `() => void` | Flips the current direction |
-
 ## Adapters
 
 Adapters let you swap the underlying `dir` attribute management without changing your application code.
@@ -116,7 +109,31 @@ abstract class RtlAdapter {
 }
 ```
 
-## Standalone Usage
+## Reactivity
+
+| Property | Type | Description |
+| - | - | - |
+| `isRtl` | `Ref<boolean>` | Writable ref — `true` for RTL, `false` for LTR |
+| `toggle` | `() => void` | Flips the current direction |
+
+## Examples
+
+::: gn-example
+/composables/use-rtl/direction-toggle
+
+### Direction Toggle
+
+A live RTL/LTR switcher that calls `toggle()` from `useRtl()` and binds the resulting direction string to a container's `dir` attribute. Because `isRtl` is a writable ref, the template derives `direction` via `toRef(() => isRtl.value ? 'rtl' : 'ltr')` and uses it both for the `dir` prop and for conditionally rendering Arabic vs. English copy.
+
+The card inside the panel demonstrates how the browser's native bidirectional layout engine handles the flip: the avatar, name, and action buttons all reflow without any CSS overrides because they're positioned with flexbox and the `dir` attribute propagates automatically to descendants. This is the cheapest way to test whether your own components are already direction-aware — no special `rtl:` variants or logical properties needed if the flex container gets the right `dir`.
+
+Reach for `useRtl()` when you need to read or imperatively change the active direction from script. For locale-linked RTL (e.g. Arabic or Hebrew auto-sets `isRtl`), wire a watcher between `useLocale().selectedId` and `isRtl` inside a custom adapter. For subtree-scoped direction that is isolated from the app-level flag, see `createRtlContext` in the Subtree Overrides section above.
+
+:::
+
+## Recipes
+
+### Standalone Usage
 
 Use `createRtl` to create a raw RTL context without the plugin system — useful for testing or embedding in other composables:
 
@@ -131,11 +148,11 @@ rtl.isRtl.value  // false
 
 `createRtl` accepts `default?: boolean` (initial direction) and returns `{ isRtl: ShallowRef<boolean>, toggle: () => void }`. No `app` is required.
 
-## Styling
+### Styling
 
 The `dir` attribute set by the adapter enables three approaches to direction-aware styling with utility classes:
 
-### Logical Properties (preferred)
+#### Logical Properties (preferred)
 
 CSS logical properties automatically flip based on `dir`. Use these by default:
 
@@ -159,7 +176,7 @@ CSS logical properties automatically flip based on `dir`. Use these by default:
 > [!TIP]
 > The utility class names above use UnoCSS `presetWind4` / Tailwind v4 syntax. Exact class names may vary depending on your CSS framework or preset — the underlying CSS logical properties are the same.
 
-### Direction Variants
+#### Direction Variants
 
 For cases logical properties can't handle (like `translate-x`), use the bare class as the LTR default and the `rtl:` variant as the override:
 
@@ -173,7 +190,7 @@ For cases logical properties can't handle (like `translate-x`), use the bare cla
 > [!TIP]
 > Avoid the `ltr:` variant — it only applies when an ancestor has an explicit `dir="ltr"` attribute, not as the default. Use the bare utility class for LTR behavior and `rtl:` for the RTL override.
 
-### Symmetric Shorthand
+#### Symmetric Shorthand
 
 When both sides use the same value, use `inset-x-*` instead of `left-* right-*`:
 
@@ -185,7 +202,7 @@ When both sides use the same value, use `inset-x-*` instead of `left-* right-*`:
 <div class="fixed inset-x-0 top-0">...</div>
 ```
 
-## Subtree Overrides
+### Subtree Overrides
 
 Use `createRtlContext` to scope direction to a subtree — isolated from the app-level direction:
 
@@ -221,20 +238,5 @@ export const [useLocalRtl, provideLocalRtl, localRtl] =
 
 > [!TIP]
 > Direction is independent from locale. To connect them (e.g., Arabic → RTL), use a custom adapter that watches `useLocale().selectedId` and sets `isRtl` based on a language→direction mapping.
-
-## Examples
-
-::: gn-example
-/composables/use-rtl/direction-toggle
-
-### Direction Toggle
-
-A live RTL/LTR switcher that calls `toggle()` from `useRtl()` and binds the resulting direction string to a container's `dir` attribute. Because `isRtl` is a writable ref, the template derives `direction` via `toRef(() => isRtl.value ? 'rtl' : 'ltr')` and uses it both for the `dir` prop and for conditionally rendering Arabic vs. English copy.
-
-The card inside the panel demonstrates how the browser's native bidirectional layout engine handles the flip: the avatar, name, and action buttons all reflow without any CSS overrides because they're positioned with flexbox and the `dir` attribute propagates automatically to descendants. This is the cheapest way to test whether your own components are already direction-aware — no special `rtl:` variants or logical properties needed if the flex container gets the right `dir`.
-
-Reach for `useRtl()` when you need to read or imperatively change the active direction from script. For locale-linked RTL (e.g. Arabic or Hebrew auto-sets `isRtl`), wire a watcher between `useLocale().selectedId` and `isRtl` inside a custom adapter. For subtree-scoped direction that is isolated from the app-level flag, see `createRtlContext` in the Subtree Overrides section above.
-
-:::
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/plugins/use-rules.md
+++ b/apps/docs/src/pages/composables/plugins/use-rules.md
@@ -159,11 +159,13 @@ The controls let you trigger validation, prefill valid or invalid data, and rese
 
 :::
 
-## Standard Schema
+## Recipes
+
+### Standard Schema
 
 `useRules` supports [Standard Schema](https://standardschema.dev/) — a universal interface for validation libraries. Pass schema objects directly in `rules` arrays alongside alias strings and inline functions — `resolve()` auto-detects and wraps them.
 
-### Zod
+#### Zod
 
 ```vue
 <script setup lang="ts">
@@ -185,7 +187,7 @@ The controls let you trigger validation, prefill valid or invalid data, and rese
 </script>
 ```
 
-### Valibot
+#### Valibot
 
 ```vue
 <script setup lang="ts">
@@ -201,7 +203,7 @@ The controls let you trigger validation, prefill valid or invalid data, and rese
 </script>
 ```
 
-### ArkType
+#### ArkType
 
 ```vue
 <script setup lang="ts">
@@ -220,7 +222,7 @@ The controls let you trigger validation, prefill valid or invalid data, and rese
 > [!TIP]
 > Schema objects produce async rules. `createValidation` handles this transparently — no special handling needed in components.
 
-### Compatible Libraries
+#### Compatible Libraries
 
 Any library that implements the [Standard Schema v1 spec](https://standardschema.dev/) works out of the box:
 
@@ -230,7 +232,7 @@ Any library that implements the [Standard Schema v1 spec](https://standardschema
 | [Valibot](https://valibot.dev/) | v1.0+ | `import * as v from 'valibot'` |
 | [ArkType](https://arktype.io/) | v2.0+ | `import { type } from 'arktype'` |
 
-### isStandardSchema()
+#### isStandardSchema()
 
 `isStandardSchema(value)` is exported for use in custom rule factories. Returns `true` if the value implements the Standard Schema v1 interface (`~standard.version === 1`):
 

--- a/apps/docs/src/pages/composables/plugins/use-stack.md
+++ b/apps/docs/src/pages/composables/plugins/use-stack.md
@@ -138,7 +138,9 @@ Open multiple overlays to see z-index layering in action. This pattern applies d
 
 :::
 
-## Scrim Integration
+## Recipes
+
+### Scrim Integration
 
 Use the `Scrim` component alongside `useStack` to provide a backdrop for your overlays. The Scrim automatically positions itself below the topmost overlay:
 

--- a/apps/docs/src/pages/composables/plugins/use-storage.md
+++ b/apps/docs/src/pages/composables/plugins/use-storage.md
@@ -64,45 +64,6 @@ Once the plugin is installed, use the `useStorage` composable in any component:
 </template>
 ```
 
-## Standalone Usage
-
-Use `createStorage` directly without the plugin system for standalone or module-level caching:
-
-```ts collapse no-filename createStorage
-import { createStorage } from '@vuetify/v0'
-
-const storage = createStorage({ prefix: 'myapp:' })
-
-storage.set('theme', 'dark')
-
-const theme = storage.get('theme', 'light')
-
-console.log(theme.value) // 'dark'
-```
-
-### TTL (Time-to-Live)
-
-Set a `ttl` option (in milliseconds) to automatically expire cached entries. Expired entries return the default value on `get()` and are removed from storage.
-
-```ts collapse no-filename TTL
-import { createStorage } from '@vuetify/v0'
-
-// Cache expires after 5 minutes
-const cache = createStorage({
-  prefix: 'api-cache:',
-  ttl: 5 * 60 * 1000,
-})
-
-// Store fetched data — automatically timestamped
-cache.set('users', await fetchUsers())
-
-// Later reads return the default if expired
-const users = cache.get('users', [])
-```
-
-> [!TIP] How TTL works
-> When `ttl` is set, values are internally wrapped as `{ __ttl, __v, __t }` with a timestamp. On `get()`, if the entry is older than the TTL, it is treated as absent and removed from storage. Non-TTL entries stored previously are read normally.
-
 ## Adapters
 
 Adapters let you swap the underlying storage backend without changing your application code.
@@ -161,5 +122,46 @@ The example uses `MemoryStorageAdapter` for isolation; swapping in `localStorage
 | `SettingsPanel.vue` | Presentational panel built on `Input` and `Button` that binds the settings and triggers the save and forget actions |
 | `settings-panel.vue` | Entry that instantiates the composable, wires it to the panel, and renders the live stored snapshot |
 :::
+
+## Recipes
+
+### Standalone Usage
+
+Use `createStorage` directly without the plugin system for standalone or module-level caching:
+
+```ts collapse no-filename createStorage
+import { createStorage } from '@vuetify/v0'
+
+const storage = createStorage({ prefix: 'myapp:' })
+
+storage.set('theme', 'dark')
+
+const theme = storage.get('theme', 'light')
+
+console.log(theme.value) // 'dark'
+```
+
+#### TTL (Time-to-Live)
+
+Set a `ttl` option (in milliseconds) to automatically expire cached entries. Expired entries return the default value on `get()` and are removed from storage.
+
+```ts collapse no-filename TTL
+import { createStorage } from '@vuetify/v0'
+
+// Cache expires after 5 minutes
+const cache = createStorage({
+  prefix: 'api-cache:',
+  ttl: 5 * 60 * 1000,
+})
+
+// Store fetched data — automatically timestamped
+cache.set('users', await fetchUsers())
+
+// Later reads return the default if expired
+const users = cache.get('users', [])
+```
+
+> [!TIP] How TTL works
+> When `ttl` is set, values are internally wrapped as `{ __ttl, __v, __t }` with a timestamp. On `get()`, if the entry is older than the TTL, it is treated as absent and removed from storage. Non-TTL entries stored previously are read normally.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/reactivity/use-proxy-registry.md
+++ b/apps/docs/src/pages/composables/reactivity/use-proxy-registry.md
@@ -65,6 +65,21 @@ flowchart LR
 > [!TIP] Deep vs shallow
 > Pass `{ deep: true }` for `reactive()`, or omit for `shallowReactive()` (default). Shallow is more performant when ticket internals don't need tracking.
 
+## Examples
+
+::: gn-example
+/composables/use-proxy-registry/notification-center
+
+### Notification Center
+
+A notification center that manages an event-sourced list of items through `createRegistry` with `events: true` and exposes them reactively to the template via `useProxyRegistry`. Three notifications are seeded with `onboard()` on mount; the + Add button calls `registry.register()` with a random message and type; clicking the mail icon calls `registry.upsert()` to flip the `read` flag; dismiss calls `registry.unregister()`. The template iterates `proxy.values` — a reactive array that updates automatically on every registry mutation without any manual `watch` or event subscription in the component.
+
+The debug panel at the top shows `proxy.size`, `proxy.keys`, and a `toRef`-derived `unread` count, making the reactivity boundary visible: all three update the moment the registry changes, driven entirely by the event bridge `useProxyRegistry` installs. The unread badge on the header demonstrates that derived values — computed from `proxy.values` via `toRef` — are also reactive without extra wiring.
+
+Use `useProxyRegistry` any time a registry's contents need to drive a `v-for` or a reactive count in a template. The alternative — `reactive: true` on the registry — carries a subtle cache-invalidation footgun (see the FAQ) that `useProxyRegistry` avoids entirely by listening to events rather than relying on Vue's dep tracking of the internal Map. For selection composables like `createSingle` or `createGroup`, pass the selection instance directly since they extend `createRegistry` and support `events: true` the same way.
+
+:::
+
 ## FAQ
 
 ::: faq
@@ -185,21 +200,6 @@ selection.selectedIds // Set of selected IDs
 ```
 
 The proxy only exposes registry properties. For reactive selection state, use the selection instance directly or create a custom reactive wrapper.
-:::
-
-## Examples
-
-::: gn-example
-/composables/use-proxy-registry/notification-center
-
-### Notification Center
-
-A notification center that manages an event-sourced list of items through `createRegistry` with `events: true` and exposes them reactively to the template via `useProxyRegistry`. Three notifications are seeded with `onboard()` on mount; the + Add button calls `registry.register()` with a random message and type; clicking the mail icon calls `registry.upsert()` to flip the `read` flag; dismiss calls `registry.unregister()`. The template iterates `proxy.values` — a reactive array that updates automatically on every registry mutation without any manual `watch` or event subscription in the component.
-
-The debug panel at the top shows `proxy.size`, `proxy.keys`, and a `toRef`-derived `unread` count, making the reactivity boundary visible: all three update the moment the registry changes, driven entirely by the event bridge `useProxyRegistry` installs. The unread badge on the header demonstrates that derived values — computed from `proxy.values` via `toRef` — are also reactive without extra wiring.
-
-Use `useProxyRegistry` any time a registry's contents need to drive a `v-for` or a reactive count in a template. The alternative — `reactive: true` on the registry — carries a subtle cache-invalidation footgun (see the FAQ) that `useProxyRegistry` avoids entirely by listening to events rather than relying on Vue's dep tracking of the internal Map. For selection composables like `createSingle` or `createGroup`, pass the selection instance directly since they extend `createRegistry` and support `events: true` the same way.
-
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/registration/create-queue.md
+++ b/apps/docs/src/pages/composables/registration/create-queue.md
@@ -76,7 +76,9 @@ flowchart TD
   createQueue --> first[first item active]
 ```
 
-## Timeout Behavior
+## Options
+
+### Timeout Behavior
 
 The `timeout` option controls how long a ticket stays in the queue before auto-removal:
 

--- a/apps/docs/src/pages/composables/registration/create-timeline.md
+++ b/apps/docs/src/pages/composables/registration/create-timeline.md
@@ -65,12 +65,6 @@ timeline.register({ id: 'action-1', value: 'Created item' })
 timeline.undo()
 ```
 
-## Options
-
-| Option | Type | Default | Notes |
-| - | - | - | - |
-| `size` | `number` | `10` | Maximum number of entries in the active timeline. When exceeded, the oldest entry moves to an internal overflow buffer — it remains accessible via `undo()` but no longer counts against the limit |
-
 ## Architecture
 
 `createTimeline` extends `createRegistry` with bounded history and overflow management:
@@ -82,6 +76,12 @@ flowchart TD
   createTimeline --> overflow[overflow buffer]
   createTimeline --> cursor[history cursor]
 ```
+
+## Options
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `size` | `number` | `10` | Maximum number of entries in the active timeline. When exceeded, the oldest entry moves to an internal overflow buffer — it remains accessible via `undo()` but no longer counts against the limit |
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/registration/create-tokens.md
+++ b/apps/docs/src/pages/composables/registration/create-tokens.md
@@ -83,6 +83,18 @@ const tokens = useTokens()
 tokens.resolve('colors.primary')  // '#3b82f6'
 ```
 
+## Architecture
+
+`createTokens` extends `createRegistry` and powers token-based systems:
+
+```mermaid "Tokens Hierarchy"
+flowchart TD
+  createTokens --> useTheme
+  createTokens --> useLocale
+  createTokens --> useFeatures
+  createTokens --> usePermissions
+```
+
 ## Options
 
 ### createTokens
@@ -100,18 +112,6 @@ Accepts all `createTokens` options plus:
 | - | - | - | - |
 | `namespace` | `string` | — | DI namespace string (e.g. `'my:tokens'`) |
 | `tokens` | `TokenCollection` | — | Initial token collection registered when the context is created |
-
-## Architecture
-
-`createTokens` extends `createRegistry` and powers token-based systems:
-
-```mermaid "Tokens Hierarchy"
-flowchart TD
-  createTokens --> useTheme
-  createTokens --> useLocale
-  createTokens --> useFeatures
-  createTokens --> usePermissions
-```
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/selection/create-nested.md
+++ b/apps/docs/src/pages/composables/selection/create-nested.md
@@ -46,6 +46,27 @@ tree.open('root')
 tree.select('child-1')
 ```
 
+## Context / DI
+
+### Context Pattern
+
+Use with Vue's provide/inject for component trees:
+
+```ts
+import { createNestedContext } from '@vuetify/v0'
+
+// Create a trinity
+const [useTree, provideTree, defaultTree] = createNestedContext({
+  namespace: 'my-tree',
+})
+
+// In parent component
+provideTree()
+
+// In child components
+const tree = useTree()
+```
+
 ## Architecture
 
 `createNested` extends `createGroup` with hierarchical tree management:
@@ -60,47 +81,6 @@ flowchart TD
   createNested --> parents[parents Map]
   createNested --> openedIds[openedIds Set]
 ```
-
-## Reactivity
-
-`createNested` uses **shallowReactive** for tree state, making structural changes reactive while keeping traversal methods non-reactive for performance.
-
-| Property/Method | Reactive | Notes |
-| - | :-: | - |
-| `children` | <AppSuccessIcon /> | ShallowReactive Map |
-| `parents` | <AppSuccessIcon /> | ShallowReactive Map |
-| `openedIds` | <AppSuccessIcon /> | ShallowReactive Set |
-| `openedItems` | <AppSuccessIcon /> | Computed from openedIds |
-| `rootIds` | <AppSuccessIcon /> | ShallowReactive Set — IDs of all top-level (parentless) nodes |
-| `roots` | <AppSuccessIcon /> | Computed, root nodes |
-| `leaves` | <AppSuccessIcon /> | Computed, leaf nodes |
-| `ticket.isOpen` | <AppSuccessIcon /> | Ref via toRef() |
-| `ticket.isLeaf` | <AppSuccessIcon /> | Ref via toRef() |
-| `ticket.depth` | <AppSuccessIcon /> | Ref via toRef() |
-
-## Examples
-
-::: gn-example
-/composables/create-nested/context.ts 1
-/composables/create-nested/FileTreeProvider.vue 2
-/composables/create-nested/FileTreeExplorer.vue 3
-/composables/create-nested/file-explorer.vue 4
-
-### File Tree Explorer
-
-A file-tree explorer split across the provider/consumer pattern, showing how `createNested` coordinates expand/collapse state and cascading selection over a hierarchy. `context.ts` is the only file that touches the composable: it pairs `createNested({ selection: 'cascade' })` with a `createContext` tuple, declares the per-node `FileMeta` (a label plus a `folder`/`file` kind stored as the ticket `value`), and exposes a typed `toRegistration` mapper that turns a plain nested `FileNode[]` into the recursive `children` shape `onboard()` expects. `FileTreeProvider.vue` instantiates the tree, batch-registers the whole structure with one `onboard()` call, opens the root, and provides the context augmented with a typed `meta(id)` reader and a `stats` computed. `FileTreeExplorer.vue` injects that context and renders the UI without ever knowing how the tree was built.
-
-The consumer flattens the tree for rendering with a small `walk()` helper that reads `children.get(id)` and short-circuits wherever `opened(id)` is false, so collapsed branches contribute nothing to the visible list; `getDepth(id)` then drives left-padding, so indentation needs no extra bookkeeping. Selection is the headline: each row uses a standalone [Checkbox](/components/forms/checkbox) bound to `selected(id)` with `:indeterminate="mixed(id)"`, and clicking it calls `toggle(id)`. Because the instance runs in cascade mode, toggling a folder selects or clears every descendant while ancestors automatically resolve to selected, mixed, or empty — the indeterminate dash you see on a partially-selected folder is maintained entirely by the composable, not by the example. `expandAll()` and `collapseAll()` wire straight to the toolbar.
-
-Reach for this pattern when you need a file browser, sidebar nav, or category picker where branches expand independently and a parent's checkbox should reflect its children. The provider/consumer split keeps the consumer reusable against any context that satisfies the interface. For flat multi-select without hierarchy, [createGroup](/composables/selection/create-group) is lighter; for a batteries-included tree with focus and ARIA wired up, see the [Treeview](/components/disclosure/treeview) component. Switch the `selection` option to `independent` or `leaf` to change how toggling a folder propagates.
-
-| File | Role |
-|------|------|
-| `context.ts` | Creates the nested instance and `createContext` tuple, defines `FileMeta` plus the `toRegistration` mapper and `source` data |
-| `FileTreeProvider.vue` | Instantiates the tree, batch-registers via `onboard()`, and provides the context with `meta()` and `stats` |
-| `FileTreeExplorer.vue` | Consumes the context to render rows, drive cascade selection, and flatten visible nodes |
-| `file-explorer.vue` | Entry point composing the provider around the explorer |
-:::
 
 ## Options
 
@@ -184,9 +164,73 @@ const flat = createNested({ selection: 'independent' })
 const picker = createNested({ selection: 'leaf' })
 ```
 
-## Selection Modes
+## Reactivity
 
-### Cascade Mode (Default)
+`createNested` uses **shallowReactive** for tree state, making structural changes reactive while keeping traversal methods non-reactive for performance.
+
+| Property/Method | Reactive | Notes |
+| - | :-: | - |
+| `children` | <AppSuccessIcon /> | ShallowReactive Map |
+| `parents` | <AppSuccessIcon /> | ShallowReactive Map |
+| `openedIds` | <AppSuccessIcon /> | ShallowReactive Set |
+| `openedItems` | <AppSuccessIcon /> | Computed from openedIds |
+| `rootIds` | <AppSuccessIcon /> | ShallowReactive Set — IDs of all top-level (parentless) nodes |
+| `roots` | <AppSuccessIcon /> | Computed, root nodes |
+| `leaves` | <AppSuccessIcon /> | Computed, leaf nodes |
+| `ticket.isOpen` | <AppSuccessIcon /> | Ref via toRef() |
+| `ticket.isLeaf` | <AppSuccessIcon /> | Ref via toRef() |
+| `ticket.depth` | <AppSuccessIcon /> | Ref via toRef() |
+
+### Ticket Properties
+
+Each registered node receives additional properties:
+
+```ts
+const node = tree.register({ id: 'node', value: 'Node', parentId: 'root' })
+
+// Reactive refs
+node.isOpen.value      // boolean - is this node open?
+node.isLeaf.value      // boolean - has no children?
+node.depth.value       // number - depth in tree (0 = root)
+
+// Methods
+node.open()            // Open this node
+node.close()           // Close this node
+node.flip()            // Flip open/closed state
+node.getPath()         // Get path from root to this node
+node.getAncestors()    // Get all ancestors
+node.getDescendants()  // Get all descendants
+```
+
+## Examples
+
+::: gn-example
+/composables/create-nested/context.ts 1
+/composables/create-nested/FileTreeProvider.vue 2
+/composables/create-nested/FileTreeExplorer.vue 3
+/composables/create-nested/file-explorer.vue 4
+
+### File Tree Explorer
+
+A file-tree explorer split across the provider/consumer pattern, showing how `createNested` coordinates expand/collapse state and cascading selection over a hierarchy. `context.ts` is the only file that touches the composable: it pairs `createNested({ selection: 'cascade' })` with a `createContext` tuple, declares the per-node `FileMeta` (a label plus a `folder`/`file` kind stored as the ticket `value`), and exposes a typed `toRegistration` mapper that turns a plain nested `FileNode[]` into the recursive `children` shape `onboard()` expects. `FileTreeProvider.vue` instantiates the tree, batch-registers the whole structure with one `onboard()` call, opens the root, and provides the context augmented with a typed `meta(id)` reader and a `stats` computed. `FileTreeExplorer.vue` injects that context and renders the UI without ever knowing how the tree was built.
+
+The consumer flattens the tree for rendering with a small `walk()` helper that reads `children.get(id)` and short-circuits wherever `opened(id)` is false, so collapsed branches contribute nothing to the visible list; `getDepth(id)` then drives left-padding, so indentation needs no extra bookkeeping. Selection is the headline: each row uses a standalone [Checkbox](/components/forms/checkbox) bound to `selected(id)` with `:indeterminate="mixed(id)"`, and clicking it calls `toggle(id)`. Because the instance runs in cascade mode, toggling a folder selects or clears every descendant while ancestors automatically resolve to selected, mixed, or empty — the indeterminate dash you see on a partially-selected folder is maintained entirely by the composable, not by the example. `expandAll()` and `collapseAll()` wire straight to the toolbar.
+
+Reach for this pattern when you need a file browser, sidebar nav, or category picker where branches expand independently and a parent's checkbox should reflect its children. The provider/consumer split keeps the consumer reusable against any context that satisfies the interface. For flat multi-select without hierarchy, [createGroup](/composables/selection/create-group) is lighter; for a batteries-included tree with focus and ARIA wired up, see the [Treeview](/components/disclosure/treeview) component. Switch the `selection` option to `independent` or `leaf` to change how toggling a folder propagates.
+
+| File | Role |
+|------|------|
+| `context.ts` | Creates the nested instance and `createContext` tuple, defines `FileMeta` plus the `toRegistration` mapper and `source` data |
+| `FileTreeProvider.vue` | Instantiates the tree, batch-registers via `onboard()`, and provides the context with `meta()` and `stats` |
+| `FileTreeExplorer.vue` | Consumes the context to render rows, drive cascade selection, and flatten visible nodes |
+| `file-explorer.vue` | Entry point composing the provider around the explorer |
+:::
+
+## Recipes
+
+### Selection Modes
+
+#### Cascade Mode (Default)
 
 Selection propagates through the hierarchy:
 
@@ -211,7 +255,7 @@ tree.select('child-1')
 - **Some children selected** → Parent becomes mixed
 - **No children selected** → Parent becomes unselected (not mixed)
 
-### Independent Mode
+#### Independent Mode
 
 Each node is selected independently with no cascading:
 
@@ -222,7 +266,7 @@ tree.select('parent')
 // Only 'parent' is selected, children unchanged
 ```
 
-### Leaf Mode
+#### Leaf Mode
 
 Only leaf nodes can be selected. Selecting a parent selects all leaf descendants:
 
@@ -234,9 +278,9 @@ tree.select('folder')
 // 'folder' itself is not in selectedIds
 ```
 
-## Convenience Methods
+### Convenience Methods
 
-### Expand/Collapse All
+#### Expand/Collapse All
 
 ```ts
 // Open all non-leaf nodes
@@ -246,7 +290,7 @@ tree.expandAll()
 tree.collapseAll()
 ```
 
-### Data Transformation
+#### Data Transformation
 
 Convert tree to flat array for serialization or API consumption:
 
@@ -258,7 +302,7 @@ const flat = tree.toFlat()
 console.log(JSON.stringify(flat))
 ```
 
-## Inline Children Registration
+### Inline Children Registration
 
 Define children directly when registering items:
 
@@ -283,7 +327,7 @@ tree.onboard([
 ])
 ```
 
-## Cascade Unregister
+### Cascade Unregister
 
 Remove a node and optionally all its descendants:
 
@@ -296,46 +340,6 @@ tree.unregister('parent', true)
 
 // Batch removal with cascade
 tree.offboard(['node-1', 'node-2'], true)
-```
-
-## Ticket Properties
-
-Each registered node receives additional properties:
-
-```ts
-const node = tree.register({ id: 'node', value: 'Node', parentId: 'root' })
-
-// Reactive refs
-node.isOpen.value      // boolean - is this node open?
-node.isLeaf.value      // boolean - has no children?
-node.depth.value       // number - depth in tree (0 = root)
-
-// Methods
-node.open()            // Open this node
-node.close()           // Close this node
-node.flip()            // Flip open/closed state
-node.getPath()         // Get path from root to this node
-node.getAncestors()    // Get all ancestors
-node.getDescendants()  // Get all descendants
-```
-
-## Context Pattern
-
-Use with Vue's provide/inject for component trees:
-
-```ts
-import { createNestedContext } from '@vuetify/v0'
-
-// Create a trinity
-const [useTree, provideTree, defaultTree] = createNestedContext({
-  namespace: 'my-tree',
-})
-
-// In parent component
-provideTree()
-
-// In child components
-const tree = useTree()
 ```
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/system/use-click-outside.md
+++ b/apps/docs/src/pages/composables/system/use-click-outside.md
@@ -55,25 +55,6 @@ flowchart TD
   useClickOutside --> Popovers
 ```
 
-## Multiple Targets
-
-Pass an array of refs to ignore clicks inside any of them:
-
-```ts
-import { useClickOutside } from '@vuetify/v0'
-import { useTemplateRef } from 'vue'
-
-const trigger = useTemplateRef('trigger')
-const panel = useTemplateRef('panel')
-
-// Clicks inside EITHER trigger or panel are ignored
-useClickOutside([trigger, panel], () => {
-  console.log('Clicked outside both elements')
-})
-```
-
-The `target` parameter accepts `MaybeArray<ClickOutsideTarget>` — a single ref/getter or an array of refs/getters.
-
 ## Options
 
 | Option | Type | Default | Description |
@@ -113,5 +94,26 @@ The example uses `useClickOutside` in its simplest form: one ref target and one 
 Reach for this when dismissing a popover, dropdown, or context menu on outside click. For elements where the event target doesn't reliably reflect DOM containment — such as native `<dialog>` backdrops — pass `{ bounds: true }` to switch to bounding-rect detection instead.
 
 :::
+
+## Recipes
+
+### Multiple Targets
+
+Pass an array of refs to ignore clicks inside any of them:
+
+```ts
+import { useClickOutside } from '@vuetify/v0'
+import { useTemplateRef } from 'vue'
+
+const trigger = useTemplateRef('trigger')
+const panel = useTemplateRef('panel')
+
+// Clicks inside EITHER trigger or panel are ignored
+useClickOutside([trigger, panel], () => {
+  console.log('Clicked outside both elements')
+})
+```
+
+The `target` parameter accepts `MaybeArray<ClickOutsideTarget>` — a single ref/getter or an array of refs/getters.
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/system/use-delay.md
+++ b/apps/docs/src/pages/composables/system/use-delay.md
@@ -93,13 +93,15 @@ Reach for this pattern when you want a tooltip or popover that respects hover in
 
 :::
 
-## Key Features
+## Recipes
 
-### Lifecycle Vocabulary
+### Key Features
+
+#### Lifecycle Vocabulary
 
 `useDelay` exposes the same lifecycle surface as `useTimer` (`start`, `stop`, `pause`, `resume`, `isActive`, `isPaused`, `remaining`) and adds an `isOpening` direction flag. Consumers that already know `useTimer` get the same shape with one extra dimension — direction.
 
-### Reactive Delays
+#### Reactive Delays
 
 `openDelay` and `closeDelay` accept any `MaybeRefOrGetter<number>`. Resolution happens when `start()` is called, so updates after start do not affect the in-flight delay.
 
@@ -114,7 +116,7 @@ const delay = useDelay({
 })
 ```
 
-### Minimum Delay Floor
+#### Minimum Delay Floor
 
 Pass `minDelay` to `start()` to enforce a floor on the resolved delay. Useful for transient feedback like toasts where the close delay must not be shorter than the time the content has been visible.
 
@@ -126,7 +128,7 @@ await delay.start(true)
 await delay.start(false, { minDelay: 500 })
 ```
 
-### Re-Start Behavior
+#### Re-Start Behavior
 
 Calling `start()` while another delay is pending cancels the previous timer and resolves the previous promise with the *new* direction. Awaiting code sees a single source of truth — the latest intent — instead of stale resolutions.
 
@@ -136,7 +138,7 @@ delay.start(true)
 delay.start(false) // previous promise resolves false, new close delay begins
 ```
 
-### Pause and Resume
+#### Pause and Resume
 
 Pause preserves the remaining delay; resume continues from where pause left off. Useful for hover-driven UI where the user briefly interacts with the panel itself and you don't want the auto-close timer to keep counting.
 
@@ -152,7 +154,7 @@ delay.pause() // remaining ≈ 700ms
 delay.resume() // fires after ~700 more ms
 ```
 
-### Automatic Cleanup
+#### Automatic Cleanup
 
 The pending timer clears on scope disposal — no manual cleanup needed.
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -67,45 +67,6 @@ Call `useDragDrop` once per scope and pass the returned context to children that
 </template>
 ```
 
-## Architecture
-
-The factory owns four pieces of state (`draggables`, `zones`, `active`, `isDragging`) plus a public `cancel()` action, and three extension points (adapters, plugins, lifecycle hooks). Pointer and keyboard adapters observe the DOM and emit a four-call lifecycle (`start`, `move`, `drop`, `cancel`); the factory pipes those through per-ticket and global hooks before mutating `active`.
-
-```mermaid "useDragDrop architecture"
-flowchart TD
-  subgraph factory["useDragDrop()"]
-    direction TB
-    draggables[("draggables<br/>(createRegistry)")]
-    zones[("zones<br/>(createRegistry)")]
-    active["active<br/>(ShallowRef)"]
-  end
-
-  subgraph adapters["Adapters (pluggable)"]
-    pointer["PointerAdapter"]
-    keyboard["KeyboardAdapter"]
-  end
-
-  subgraph hooks["Lifecycle hooks"]
-    direction TB
-    onBeforeStart
-    onMove
-    onBeforeDrop
-    onDrop
-    onCancel
-  end
-
-  child1["&lt;Card /&gt;<br/>dnd.draggables.register"] --> draggables
-  child2["&lt;Column /&gt;<br/>dnd.zones.register"] --> zones
-
-  pointer -->|emit| factory
-  keyboard -->|emit| factory
-  factory --> hooks
-  hooks --> active
-
-  active -->|reactive| child1
-  active -->|reactive| child2
-```
-
 ## Adapters
 
 Adapters are pluggable input layers: an adapter observes the DOM (or any other input source) and emits the four lifecycle events the factory consumes. Default adapters are installed automatically.
@@ -190,6 +151,45 @@ class TouchAdapter<Z extends DragType = DragType> extends DragDropAdapter<Z> {
 ```
 
 `context.emit` exposes `start(source, origin, via)`, `move(point)`, `drop()`, and `cancel()` — call these as input arrives. Adapters declare their own `via` value (typed as `DragVia`) so consumers reading `active.value.via` can distinguish the input source. `DragVia` is `Extensible<'pointer' | 'keyboard'>` — additional modalities (e.g. `'touch'`, `'gamepad'`) flow through without type-level coordination.
+
+## Architecture
+
+The factory owns four pieces of state (`draggables`, `zones`, `active`, `isDragging`) plus a public `cancel()` action, and three extension points (adapters, plugins, lifecycle hooks). Pointer and keyboard adapters observe the DOM and emit a four-call lifecycle (`start`, `move`, `drop`, `cancel`); the factory pipes those through per-ticket and global hooks before mutating `active`.
+
+```mermaid "useDragDrop architecture"
+flowchart TD
+  subgraph factory["useDragDrop()"]
+    direction TB
+    draggables[("draggables<br/>(createRegistry)")]
+    zones[("zones<br/>(createRegistry)")]
+    active["active<br/>(ShallowRef)"]
+  end
+
+  subgraph adapters["Adapters (pluggable)"]
+    pointer["PointerAdapter"]
+    keyboard["KeyboardAdapter"]
+  end
+
+  subgraph hooks["Lifecycle hooks"]
+    direction TB
+    onBeforeStart
+    onMove
+    onBeforeDrop
+    onDrop
+    onCancel
+  end
+
+  child1["&lt;Card /&gt;<br/>dnd.draggables.register"] --> draggables
+  child2["&lt;Column /&gt;<br/>dnd.zones.register"] --> zones
+
+  pointer -->|emit| factory
+  keyboard -->|emit| factory
+  factory --> hooks
+  hooks --> active
+
+  active -->|reactive| child1
+  active -->|reactive| child2
+```
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/system/use-hotkey.md
+++ b/apps/docs/src/pages/composables/system/use-hotkey.md
@@ -63,7 +63,21 @@ The `useHotkey` composable registers hotkey handlers on the window with automati
 </template>
 ```
 
-## Key Aliases
+## Architecture
+
+`useHotkey` builds on `useEventListener` for keyboard event handling:
+
+```mermaid "Hotkey Hierarchy"
+flowchart TD
+  useEventListener --> useHotkey
+  useHotkey --> Combinations["ctrl+k, cmd+s"]
+  useHotkey --> Sequences["g-h, g-i"]
+  useHotkey --> Components["Command Palette, Shortcuts"]
+```
+
+## Options
+
+### Key Aliases
 
 Key strings are normalized before matching, so you can use human-friendly names instead of exact `KeyboardEvent.key` values:
 
@@ -89,18 +103,6 @@ useHotkey('esc', close)
 
 useHotkey('ctrl+plus', zoomIn)   // matches Ctrl ++
 useHotkey('cmd+minus', zoomOut)  // matches Cmd +-
-```
-
-## Architecture
-
-`useHotkey` builds on `useEventListener` for keyboard event handling:
-
-```mermaid "Hotkey Hierarchy"
-flowchart TD
-  useEventListener --> useHotkey
-  useHotkey --> Combinations["ctrl+k, cmd+s"]
-  useHotkey --> Sequences["g-h, g-i"]
-  useHotkey --> Components["Command Palette, Shortcuts"]
 ```
 
 ## Reactivity

--- a/apps/docs/src/pages/composables/system/use-lazy.md
+++ b/apps/docs/src/pages/composables/system/use-lazy.md
@@ -82,7 +82,9 @@ This is the canonical pattern for tabbed dashboards, wizard steps, and any layou
 
 :::
 
-## Delay
+## Recipes
+
+### Delay
 
 Use the `delay` option to defer the first mount by a fixed number of milliseconds. This prevents a flash of content for operations that complete very quickly:
 
@@ -91,7 +93,7 @@ const { hasContent } = useLazy(isOpen, { delay: 200 })
 // Content only mounts if isOpen stays true for 200ms
 ```
 
-## Eager Mode
+### Eager Mode
 
 Use the `eager` option to render content immediately without waiting for activation:
 
@@ -109,7 +111,7 @@ const { hasContent } = useLazy(isOpen, {
 })
 ```
 
-## Transition Integration
+### Transition Integration
 
 The `onAfterLeave` callback resets the lazy state after the leave transition completes (unless eager mode is enabled):
 

--- a/apps/docs/src/pages/composables/system/use-presence.md
+++ b/apps/docs/src/pages/composables/system/use-presence.md
@@ -43,14 +43,6 @@ const { isMounted, isPresent, isLeaving, state, done } = usePresence({
 // done() — call when exit animation finishes
 ```
 
-## Options
-
-| Option | Type | Default | Notes |
-| - | - | - | - |
-| `present` | `MaybeRefOrGetter<boolean>` | — | Required. Drives visibility — when truthy, content enters; when falsy, begins leaving |
-| `lazy` | `boolean` | `false` | Delay first mount until `present` is `true` for the first time |
-| `immediate` | `boolean` | `true` | Auto-resolve the `leaving` state on the next tick if `done()` is not called. Set to `false` for JS-driven animations that need full timing control |
-
 ## Architecture
 
 ```mermaid "usePresence State Machine"
@@ -62,6 +54,14 @@ stateDiagram-v2
   leaving --> unmounted: done()
   leaving --> present: present = true (re-entry)
 ```
+
+## Options
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `present` | `MaybeRefOrGetter<boolean>` | — | Required. Drives visibility — when truthy, content enters; when falsy, begins leaving |
+| `lazy` | `boolean` | `false` | Delay first mount until `present` is `true` for the first time |
+| `immediate` | `boolean` | `true` | Auto-resolve the `leaving` state on the next tick if `done()` is not called. Set to `false` for JS-driven animations that need full timing control |
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/system/use-raf.md
+++ b/apps/docs/src/pages/composables/system/use-raf.md
@@ -73,9 +73,11 @@ A tall scrollable container that tracks three metrics — `scrollTop` in pixels,
 
 :::
 
-## Key Features
+## Recipes
 
-### Cancel-Then-Request Pattern
+### Key Features
+
+#### Cancel-Then-Request Pattern
 
 Each call cancels any pending frame before requesting a new one. This deduplicates rapid calls, ensuring only the latest request executes:
 
@@ -90,7 +92,7 @@ update()
 update()
 ```
 
-### Automatic Cleanup
+#### Automatic Cleanup
 
 The composable automatically cancels pending frames when the Vue scope is disposed (component unmount, effect scope stop):
 
@@ -99,7 +101,7 @@ The composable automatically cancels pending frames when the Vue scope is dispos
 const update = useRaf(callback)
 ```
 
-### SSR Safe
+#### SSR Safe
 
 The composable is a no-op in non-browser environments. `isActive` always returns `false` during SSR.
 

--- a/apps/docs/src/pages/composables/system/use-roving-focus.md
+++ b/apps/docs/src/pages/composables/system/use-roving-focus.md
@@ -66,7 +66,19 @@ Keyboard navigation for composite widgets where arrow keys move focus between it
 </template>
 ```
 
-## useRovingFocus vs useVirtualFocus
+## Architecture
+
+`useRovingFocus` builds on `useEventListener` for keydown handling. It is a standalone composable — not part of the registry/selection hierarchy — making it composable alongside `createSingle` or `createSelection` for widgets that separate focus from selection (e.g., listboxes, selects).
+
+```mermaid "Roving Focus Architecture"
+flowchart TD
+  useEventListener --> useRovingFocus
+  useRovingFocus --> Linear["Linear: toolbar, menu, tabs"]
+  useRovingFocus --> Grid["Grid: calendar, color picker, data table"]
+  useRovingFocus --> Composed["+ createSingle = listbox/select"]
+```
+
+### useRovingFocus vs useVirtualFocus
 
 Both manage keyboard navigation, but they use different focus strategies:
 
@@ -79,18 +91,6 @@ Both manage keyboard navigation, but they use different focus strategies:
 | **Keyboard pattern** | Items are real focusable elements | Items are virtual — only one DOM node has focus |
 
 Choose `useRovingFocus` when items are real interactive elements (buttons, links). Choose `useVirtualFocus` when a single input drives a list of options that aren't individually focusable.
-
-## Architecture
-
-`useRovingFocus` builds on `useEventListener` for keydown handling. It is a standalone composable — not part of the registry/selection hierarchy — making it composable alongside `createSingle` or `createSelection` for widgets that separate focus from selection (e.g., listboxes, selects).
-
-```mermaid "Roving Focus Architecture"
-flowchart TD
-  useEventListener --> useRovingFocus
-  useRovingFocus --> Linear["Linear: toolbar, menu, tabs"]
-  useRovingFocus --> Grid["Grid: calendar, color picker, data table"]
-  useRovingFocus --> Composed["+ createSingle = listbox/select"]
-```
 
 ## Reactivity
 

--- a/apps/docs/src/pages/composables/system/use-timer.md
+++ b/apps/docs/src/pages/composables/system/use-timer.md
@@ -101,9 +101,11 @@ The key design point is one timer per toast, not a single shared timer. Each toa
 
 :::
 
-## Key Features
+## Recipes
 
-### One-Shot vs Repeating
+### Key Features
+
+#### One-Shot vs Repeating
 
 By default, the timer fires once and stops. Set `repeat: true` for an interval that restarts after each fire:
 
@@ -115,7 +117,7 @@ const delay = useTimer(() => save(), { duration: 3000 })
 const poll = useTimer(() => refresh(), { duration: 5000, repeat: true })
 ```
 
-### Pause and Resume
+#### Pause and Resume
 
 Pause preserves the remaining time. Resume continues from where it left off:
 
@@ -132,7 +134,7 @@ timer.resume()
 // fires after ~7 more seconds
 ```
 
-### Restart Behavior
+#### Restart Behavior
 
 Calling `start()` while already running restarts from full duration:
 
@@ -142,7 +144,7 @@ timer.start()  // starts 5s countdown
 timer.start()  // restarts — fires in 5s, not 3s
 ```
 
-### Automatic Cleanup
+#### Automatic Cleanup
 
 The timer clears on scope disposal — no manual cleanup needed:
 

--- a/apps/docs/src/pages/composables/transformers/to-element.md
+++ b/apps/docs/src/pages/composables/transformers/to-element.md
@@ -52,17 +52,7 @@ flowchart LR
   extract --> output
 ```
 
-## Reactivity
-
-`toElement` is a **pure transformer function**. It does not track reactivity or return reactive values.
-
-> [!TIP] Use inside computed for reactivity
-> Wrap in `computed()` if you need reactive element resolution:
-```ts
-const resolved = computed(() => toElement(targetRef))
-```
-
-## Supported Input Types
+### Supported Input Types
 
 | Input | Result |
 | - | - |
@@ -75,6 +65,16 @@ const resolved = computed(() => toElement(targetRef))
 
 > [!TIP] Structural typing
 > Uses `{ readonly value: T }` instead of Vue's nominal `Ref<T>` to avoid type mismatches across Vue versions.
+
+## Reactivity
+
+`toElement` is a **pure transformer function**. It does not track reactivity or return reactive values.
+
+> [!TIP] Use inside computed for reactivity
+> Wrap in `computed()` if you need reactive element resolution:
+```ts
+const resolved = computed(() => toElement(targetRef))
+```
 
 ## Examples
 


### PR DESCRIPTION
Enforce the canonical heading structure defined in `.claude/rules/docs.md` across every component and composable docs page, so they all share one consistent shape.

**What changed**
- Reordered drifted sections into canonical order (Options after Architecture, Adapters before Architecture, Examples before FAQ, etc.).
- Folded bespoke H2 headings under their canonical parents — keyboard/ARIA → Accessibility, limitations → FAQ, config → Options, internals → Architecture, behavior how-tos → Recipes.
- Notable splits: `Tabs` Features → Accessibility (keyboard nav) + Recipes; `Atom` Guide → Architecture (rendering model) + Recipes (how-tos); `Dialog` Known Limitations → FAQ.
- Synced `docs.md`'s documented composable structure to the enforced order.

**Canonical orders**
- Component: `Usage → Anatomy → Architecture → Examples → Recipes → Accessibility → FAQ`
- Composable: `Usage → Context/DI → Adapters → Architecture → Options → Reactivity → Examples → Recipes → Accessibility → FAQ`

44 pages updated. All content moved verbatim — only heading text/levels changed, no prose or examples altered (verified by content-preservation diff on every modified page). The two heading renames (Features→Recipes, Guide→Architecture) introduce no broken anchor links.