### PR TITLE
docs: fix createSortable reorder description and createTrinity link styling

### DIFF
--- a/apps/docs/src/pages/composables/data/create-sortable.md
+++ b/apps/docs/src/pages/composables/data/create-sortable.md
@@ -75,7 +75,7 @@ The composable adds four things on top of `createModel`:
 |---|---|---|
 | `move` override | sortable | Wraps `registry.move` to emit `move:ticket` with `{ ticket, from, to }` |
 | `swap(a, b)` | sortable | Two batched `move` calls; emits two `move:ticket` events |
-| `reorder(ids)` | sortable | Strict permutation set; throws on length mismatch, unknown id, or duplicate id |
+| `reorder(ids)` | sortable | Strict permutation set; logs a warning and no-ops on length mismatch, unknown id, or duplicate id |
 | Typed `on` / `off` | sortable | Overloads narrow `move:ticket` callback payload to `SortableMovePayload<E>` |
 
 > [!TIP]

--- a/apps/docs/src/pages/composables/foundation/create-trinity.md
+++ b/apps/docs/src/pages/composables/foundation/create-trinity.md
@@ -84,7 +84,7 @@ flowchart LR
 
 ### Plugin Trinity
 
-When building a Vue plugin, use [`createPluginContext`](/composables/foundation/create-plugin) instead of wiring `createContext + createTrinity` manually. It generates the same trinity tuple from a factory function with far less boilerplate:
+When building a Vue plugin, use [createPluginContext](/composables/foundation/create-plugin) instead of wiring `createContext + createTrinity` manually. It generates the same trinity tuple from a factory function with far less boilerplate:
 
 ```ts no-filename
 // Manual (createTrinity) — needed for non-plugin state


### PR DESCRIPTION
Two small, unrelated documentation corrections surfaced while homogenizing FAQ sections (#395), split out into their own PR:

- **createSortable** — the Architecture table said `reorder()` *throws* on an invalid permutation, contradicting the Reactivity table and the source, which logs a warning via `useLogger()` and silently no-ops. Wording aligned to the actual behavior.
- **createTrinity** — unwrapped backticked link text on the `createPluginContext` link, per the docs rule against backticks in link text (the link styling already signals a code identifier).