### PR TITLE
docs: add core terminology glossary page

### DIFF
--- a/apps/docs/src/pages/guide/essentials/glossary.md
+++ b/apps/docs/src/pages/guide/essentials/glossary.md
@@ -1,0 +1,137 @@
+---
+title: Glossary - Core v0 Terminology
+meta:
+  - name: description
+    content: "Definitions of the vocabulary that recurs throughout v0: ticket, registry, trinity, context, namespace, model, selection, plugin, and adapter, with why each exists."
+  - name: keywords
+    content: "vuetify0, glossary, terminology, ticket, registry, trinity, context, namespace, model, selection, plugin, adapter, headless"
+features:
+  order: 0.6
+  level: 1
+related:
+  - /guide/fundamentals/core
+  - /guide/fundamentals/building-frameworks
+  - /composables/registration/create-registry
+  - /composables/foundation/create-context
+---
+
+# Glossary
+
+Short definitions of the vocabulary that recurs throughout v0's docs and source — ticket, registry, trinity, context, and the rest. Each entry says what the term means, why it exists, and where to read more.
+
+<DocsPageFeatures :frontmatter />
+
+> [!TIP]
+> The terms build on each other. If you want the full picture of how they connect, read [Core](/guide/fundamentals/core) — this page is the quick-lookup reference.
+
+## Core architecture
+
+### Headless
+
+A component or composable that ships behavior, state, and accessibility but **no styling** — you write every line of CSS yourself.
+
+Why it exists: v0 sits at the bottom of the stack (v0 → Paper → design systems → Vuetify). A single utility class in source would bind every downstream design system to it. The acid test is "strip every stylesheet and the component still functions and announces its state to a screen reader."
+
+See [Styling](/guide/fundamentals/styling) and [Components](/guide/fundamentals/components).
+
+### Compound component
+
+A component split into a stateful Root plus named sub-components — `Tabs.Root`, `Tabs.List`, `Tabs.Item` — that coordinate through a shared context rather than through props.
+
+Why it exists: the Root owns the state once; children read it from the context, so siblings never prop-drill state between each other. Each piece stays independently styleable while the behavior stays centralized.
+
+See [Components](/guide/fundamentals/components).
+
+### Trinity
+
+The signature return shape of v0's context and plugin factories: a readonly three-element tuple. Context factories return `[useX, provideX, defaultX]`; plugin factories return `[createXContext, createXPlugin, useX]`.
+
+Why it exists: three elements cover every consumption mode — inject in a child (`useX`), provide from a parent (`provideX`), and use standalone or in a test without mounting Vue (`defaultX`). One predictable shape across the whole library keeps data flow debuggable.
+
+See [Core](/guide/fundamentals/core) and [createTrinity](/composables/foundation/create-trinity).
+
+### Context
+
+A type-safe wrapper around Vue's provide/inject, created with `createContext(key)`. It returns a `[useX, provideX]` pair and **throws** when a consumer injects a context no ancestor provided.
+
+Why it exists: raw `inject()` silently returns `undefined` when the provider is missing, turning a setup mistake into a downstream null-reference bug. `createContext` fails loudly at the injection site and gives full type inference. v0 never calls raw provide/inject outside its two foundation factories.
+
+See [createContext](/composables/foundation/create-context) and [Core](/guide/fundamentals/core).
+
+### Namespace
+
+The string key that scopes a context, such as `v0:tabs`. Production keys are prefixed `v0:` and must contain a colon.
+
+Why it exists: the colon namespaces the key so independent contexts never collide, and a missing colon triggers a `[v0:context]` warning. Dynamic-key mode appends a `suffix` (`key:suffix`) so one factory can service many disjoint subtrees — nested panels, or tabs within tabs.
+
+See [Core](/guide/fundamentals/core).
+
+## Plugins and adapters
+
+### Plugin
+
+An app-level singleton installed with `app.use(...)`. Built with `createPlugin` or `createPluginContext`, a plugin wires an install hook, optional adapters, and optional persist/restore lifecycle hooks.
+
+Why it exists: some state is genuinely global — theme, locale, breakpoints, feature flags. A plugin provides it once at the app root so any component can inject it, instead of threading it through every tree. Plugins are order-independent and degrade gracefully when a dependency is missing.
+
+See [createPlugin](/composables/foundation/create-plugin) and [Plugins](/guide/fundamentals/plugins).
+
+### Adapter
+
+A swappable backend behind a composable. The composable defines an interface; an adapter implements it against a concrete library — console, pino, or consola for the logger; localStorage or sessionStorage for storage; a date library for dates.
+
+Why it exists: v0 is not a thin wrapper around any one library. Adapters let a consumer keep v0's API while choosing — or writing — the implementation underneath, and they are the boundary where untrusted input is sanitized before it reaches the DOM.
+
+See [useLogger](/composables/plugins/use-logger) and [Plugins](/guide/fundamentals/plugins).
+
+## Registries and tickets
+
+### Registry
+
+The indexed store that holds registered items as tickets, created with `createRegistry`. It is the foundation every selection, form, and token composable extends.
+
+Why it exists: parent-child coordination — which tab exists, in what order, with what value — needs one reactive source of truth keyed by id with stable ordering. Building it once means selection, validation, and data composables all share the same `register` / `get` / `move` surface.
+
+See [createRegistry](/composables/registration/create-registry) and [Core](/guide/fundamentals/core).
+
+### Ticket
+
+The plain object you get back when you register an item with a registry. Every ticket carries `{ id, index, value, valueIsIndex, unregister }`, and richer registries add reactive properties and bound methods — `isSelected` (a ref), `select()`, `toggle()`.
+
+Why it exists: the ticket is the handle a sub-component holds onto its own slot in the parent's registry. Reactive fields update automatically as state changes; the bound methods let a child act on itself without knowing the registry's internals. Ticket types extend their parent and never override the base shape.
+
+See [Building Frameworks](/guide/fundamentals/building-frameworks) and [Core](/guide/fundamentals/core).
+
+### Register, onboard, and unregister
+
+The registry lifecycle verbs. `register(ticket)` adds one item and returns its ticket; `onboard(tickets)` bulk-registers many; `unregister(id)` removes one and `offboard(ids)` removes many, returning the removed data.
+
+Why it exists: collection composables own their items through this surface instead of accepting an `items` array option — the registry stays the single source of truth. Sub-components `register` during setup so sibling order is correct before paint, and `unregister` in `onBeforeUnmount` while the context is still reachable.
+
+See [createRegistry](/composables/registration/create-registry).
+
+### Enroll
+
+Distinct from register, enrollment is **auto-selection on registration**. `createModel` enrolls by default (`enroll: true`), so a newly registered ticket is selected immediately; `createSelection` turns it off and applies its own multiple-aware logic.
+
+Why it exists: adding an item to the store and marking it active are different actions that are easy to conflate. Naming the auto-select behavior separately keeps "in the registry" and "currently selected" as independent states.
+
+See [createModel](/composables/selection/create-model).
+
+## Models and selection
+
+### Model
+
+The value layer, created with `createModel`. It extends a registry with a reactive Set of selected ids plus the `multiple` and `enroll` options, and is the shared base for both selection and slider state.
+
+Why it exists: "what value(s) are held" is a concern separate from "what selection rules apply." Factoring the value store into createModel lets createSelection (rules) and createSlider (per-thumb math) reuse the same value plumbing.
+
+See [createModel](/composables/selection/create-model) and [Core](/guide/fundamentals/core).
+
+### Selection
+
+The selection-logic layer on top of a model, created with `createSelection`: it adds mandatory enforcement, disabled guards, and multi-select. Its specializations are `createSingle` (one at a time), `createGroup` (tri-state batches), `createStep` (next/prev navigation), and `createNested` (trees).
+
+Why it exists: most interactive widgets — tabs, radios, checkboxes, wizards, treeviews — are selection problems. Layering the rules above the value store lets you pick the specialization that matches the widget and inherit the rest.
+
+See [createSelection](/composables/selection/create-selection) and [Core](/guide/fundamentals/core).

--- a/apps/docs/src/pages/guide/fundamentals/building-frameworks.md
+++ b/apps/docs/src/pages/guide/fundamentals/building-frameworks.md
@@ -22,7 +22,7 @@ When building a component framework, you're often reimplementing the same patter
 <DocsPageFeatures :frontmatter />
 
 > [!NOTE] Prerequisites
-> This guide builds on concepts from [Core](/guide/fundamentals/core), [Components](/guide/fundamentals/components), and [Composables](/guide/fundamentals/composables). Read those first if you're new to v0.
+> This guide builds on concepts from [Core](/guide/fundamentals/core), [Components](/guide/fundamentals/components), and [Composables](/guide/fundamentals/composables). Read those first if you're new to v0, or check the [Glossary](/guide/essentials/glossary) for a quick term lookup.
 
 ## Getting Started
 

--- a/apps/docs/src/pages/guide/fundamentals/core.md
+++ b/apps/docs/src/pages/guide/fundamentals/core.md
@@ -17,7 +17,7 @@ related:
 
 # Core
 
-v0's core architecture provides type-safe dependency injection and composable patterns. This page explains **how v0 works**. For creating plugins, see [Plugins Guide](/guide/fundamentals/plugins).
+v0's core architecture provides type-safe dependency injection and composable patterns. This page explains **how v0 works**. For creating plugins, see [Plugins Guide](/guide/fundamentals/plugins); for one-line definitions of the terms used here, see the [Glossary](/guide/essentials/glossary).
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/typed-router.d.ts
+++ b/apps/docs/src/typed-router.d.ts
@@ -856,6 +856,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/guide/essentials/glossary': RouteRecordInfo<
+      '/guide/essentials/glossary',
+      '/guide/essentials/glossary',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/guide/essentials/using-the-docs': RouteRecordInfo<
       '/guide/essentials/using-the-docs',
       '/guide/essentials/using-the-docs',
@@ -1847,6 +1854,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/guide/index.md': {
       routes:
         | '/guide/'
+      views:
+        | never
+    }
+    'src/pages/guide/essentials/glossary.md': {
+      routes:
+        | '/guide/essentials/glossary'
       views:
         | never
     }


### PR DESCRIPTION
## What

Adds a glossary of core v0 terminology — the page that gives readers the vocabulary the rest of the docs assume (ticket, registry, trinity, context, model, selection, plugin, adapter, namespace, …). Serves the audience-tiered docs philosophy and gives every page a place to deep-link unfamiliar terms.

- New: `apps/docs/src/pages/guide/essentials/glossary.md` — 14 terms, grouped; each entry = one-line definition + "why it exists" + cross-link to the relevant deep page. `level: 1`.
- Cross-linked from `core.md` and `building-frameworks.md` (one pointer each).
- Nav/search auto-generated (`generate-nav.ts`); `typed-router.d.ts` regenerated for the new route.

Each definition is grounded in PHILOSOPHY (§3.1.2 trinity, §6.5 context throw-on-missing, §6.8/§6.10 enroll vs register, §9.3 namespace, §6.2 ticket). "session" was intentionally excluded — it's a Helix design-system primitive, not a v0 concept. `docs` — no changeset.

## Verification

`build:docs` green; page present in `nav.json` + `search-index.json`; all H3 anchors emit.
