### PR TITLE
docs: registry/storage accuracy notes + surface-freeze checklist step

### DIFF
--- a/.claude/rules/new-feature-checklist.md
+++ b/.claude/rules/new-feature-checklist.md
@@ -26,6 +26,7 @@ When a new component or composable is created, **all** items below must be compl
 | 6 | `apps/docs/src/pages/components/index.md` | Add table entry in the correct category section |
 | 7 | `packages/0/README.md` | Add to "What's Included" table [intent:247] |
 | 8 | `README.md` (root) | Keep in sync with package README [intent:247] |
+| 9 | `packages/0/src/surface.test.ts` | Add the new component's exported names to the `COMPONENTS` freeze array (sorted) — the public-surface freeze test fails until they match |
 
 ## Composables
 
@@ -39,6 +40,7 @@ When a new component or composable is created, **all** items below must be compl
 | 6 | `apps/docs/src/pages/composables/index.md` | Add table entry in the correct category section |
 | 7 | `packages/0/README.md` | Add to "What's Included" table |
 | 8 | `README.md` (root) | Keep in sync with package README |
+| 9 | `packages/0/src/surface.test.ts` | Add the new composable's exported names to the `COMPOSABLES` freeze array (sorted) — the public-surface freeze test fails until they match |
 
 ## Auto-generated (no manual action)
 
@@ -179,6 +181,7 @@ Prefer extending an existing pattern over creating a new one.
 ## Checklist
 
 - [ ] Directory and barrel entry created with alphabetical ordering
+- [ ] New public exports added to the `packages/0/src/surface.test.ts` freeze array (sorted)
 - [ ] `maturity.json` entry added with `level` (start at `draft`) and `category`; `since` once promoted past `draft` (`null` until first release ships, then the version)
 - [ ] Docs page created with required frontmatter fields
 - [ ] At least a basic example exists at `apps/docs/src/examples/{type}/{kebab-name}/basic.vue` (folder kebab-cased: `use-popover`, `alert-dialog` — never `usePopover`, `AlertDialog`)

--- a/apps/docs/src/pages/composables/registration/create-registry.md
+++ b/apps/docs/src/pages/composables/registration/create-registry.md
@@ -207,6 +207,10 @@ Pass `{ reactive: true }` to make `keys()`, `values()`, `entries()`, `size`, and
 
 Wrap them in `batch(fn)`. It defers cache invalidation and event emission until the callback finishes, so a sequence of `register` / `move` / `unregister` calls settles once instead of per-mutation.
 
+??? Does unregistering many tickets one at a time scale?
+
+Each `unregister` does an O(n) scan to locate and splice the ticket, so tearing down N tickets individually — a parent unmounting hundreds of registered children, for example — is O(n²). Batch removals through `offboard(ids)` or `clear()`, which compact in a single pass, and keep the mounted (and therefore registered) count bounded with [createVirtual](/composables/data/create-virtual) for large lists.
+
 :::
 
 <DocsApi />

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -62,7 +62,7 @@ export interface RegistryTicket<V = unknown> {
   /**
    * The index of the ticket in the registry.
    *
-   * @remarks Automatically managed by the registry. Assigned at registration and updated during reindexing; a supplied index is ignored — use `move()` to position a ticket. It's not recommended to manually set this.
+   * @remarks Automatically managed by the registry. Assigned at registration and updated during reindexing; a supplied index is ignored — use `move()` to position a ticket. It's not recommended to manually set this. A ticket read via `values()`/`entries()` immediately after `unregister()`/`offboard()` may carry a stale index until the next position-reading call (`register`/`upsert`/`browse`/`lookup`/`move`/`reorder`/`seek`) drains the deferred reindex.
    */
   index: number
   /** The value associated with the ticket. If not provided, it defaults to the index. */

--- a/packages/0/src/composables/useStorage/index.ts
+++ b/packages/0/src/composables/useStorage/index.ts
@@ -52,9 +52,9 @@ export interface StorageContext {
   get: <T>(key: string, defaultValue?: T) => Ref<T>
   /** Set a value for a storage key */
   set: <T>(key: string, value: T) => void
-  /** Remove a key from storage */
+  /** Remove a key accessed through this storage instance. Keys persisted by a previous session but never read here are not removed. */
   remove: (key: string) => void
-  /** Clear all keys from storage */
+  /** Clear keys accessed through this storage instance. Keys persisted by a previous session but never read here are not removed. */
   clear: () => void
 }
 


### PR DESCRIPTION
## What

Documentation-accuracy fixes, each confirmed against source — no behavior changes (`docs`).

- **createRegistry** (`RegistryTicket.index` JSDoc) — notes the lazy-reindex contract: a ticket read via `values()`/`entries()` immediately after `unregister()`/`offboard()` may carry a stale `index` until the next position-reading call (`register`/`upsert`/`browse`/`lookup`/`move`/`reorder`/`seek`) drains the deferred reindex.
- **useStorage** (`StorageContext.remove`/`clear` JSDoc) — tightened to reflect actual scope: they act on keys accessed through this storage instance; keys persisted by a previous session but never read here are not removed. Drops the "all keys from storage" overstatement.
- **createRegistry docs** — new FAQ entry: per-item teardown is O(n²) (each `unregister` is an O(n) locate+splice), so batch removals via `offboard`/`clear` and bound the mounted/registered count with createVirtual for large lists.
- **new-feature-checklist** — adds the manual step to update `packages/0/src/surface.test.ts` (the public-surface freeze test) when a new public export is added — both tables + the bottom checklist.

## Verification

`pnpm typecheck:0` + `pnpm build:docs` — both green.

> The checklist step references `packages/0/src/surface.test.ts`, which is added in #409. Merge #409 first (or together) so the referenced file exists on master.
