### PR TITLE
fix(usePopover): coerce synthesized anchor-name custom-ident to a valid charset

### DIFF
--- a/.changeset/popover-anchor-ident.md
+++ b/.changeset/popover-anchor-ident.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(usePopover): coerce the synthesized `anchor-name` / `position-anchor` custom-ident to a valid charset
+
+A consumer-supplied `id` (or activator `target` / content `_id`) containing non-ident characters produced an invalid `--${id}` custom-property name. The browser rejects it on the client (`style.setProperty` drops the whole inline value), so anchor positioning silently broke. The interpolated identifier is now coerced to `[a-zA-Z0-9_-]`, mirroring the `SAFE_IDENT` guard `ThemeAdapter` already applies. The raw `id` is still used verbatim for the DOM element id and the `popovertarget` linkage — only the CSS custom-ident is coerced, so the native popover wiring is unchanged.

--- a/packages/0/src/components/Popover/PopoverActivator.vue
+++ b/packages/0/src/components/Popover/PopoverActivator.vue
@@ -54,7 +54,7 @@
 
   const style = toRef(() => {
     if (target) {
-      return { anchorName: `--${target}` }
+      return { anchorName: `--${String(target).replace(/[^a-zA-Z0-9_-]/g, '')}` }
     }
     return context.anchorStyles.value
   })

--- a/packages/0/src/components/Popover/PopoverContent.vue
+++ b/packages/0/src/components/Popover/PopoverContent.vue
@@ -77,7 +77,7 @@
         'margin': 'unset',
         'inset-area': positionArea ?? 'bottom',
         'position-area': positionArea ?? 'bottom',
-        'position-anchor': `--${_id}`,
+        'position-anchor': `--${String(_id).replace(/[^a-zA-Z0-9_-]/g, '')}`,
         'position-try-fallbacks': positionTry ?? 'most-width bottom',
       }
     }

--- a/packages/0/src/composables/usePopover/index.ts
+++ b/packages/0/src/composables/usePopover/index.ts
@@ -86,6 +86,7 @@ export function usePopover (options: PopoverOptions = {}): PopoverReturn {
   } = options
 
   const id = _id ?? useId()
+  const anchor = `--${String(id).replace(/[^a-zA-Z0-9_-]/g, '')}`
   const isOpen = options.isOpen ?? shallowRef(false)
 
   const delay = useDelay(direction => {
@@ -113,7 +114,7 @@ export function usePopover (options: PopoverOptions = {}): PopoverReturn {
   }
 
   const anchorStyles = toRef(() => ({
-    anchorName: `--${id}`,
+    anchorName: anchor,
   }))
 
   const contentAttrs = toRef((): { id: string, popover: '' } => ({
@@ -126,7 +127,7 @@ export function usePopover (options: PopoverOptions = {}): PopoverReturn {
     'margin': 'unset',
     'inset-area': positionArea,
     'position-area': positionArea,
-    'position-anchor': `--${id}`,
+    'position-anchor': anchor,
     'position-try-fallbacks': positionTry,
   }))
 


### PR DESCRIPTION
Closes #413.

## What

`usePopover` synthesizes a CSS custom-ident (`anchor-name` / `position-anchor`) by interpolating its `id` as `--${id}`. The `id` is consumer-overridable; a value with non-ident characters (a space, `;`, etc.) produced an invalid `--${id}`, which the browser rejects on the client (`style.setProperty` drops the whole inline-style value) → anchor positioning silently breaks.

This coerces the interpolated identifier to `[a-zA-Z0-9_-]` at all three synthesis sites:

- `composables/usePopover/index.ts` — derive `anchor` once from `id`, used by both `anchorStyles` and `contentStyles`
- `components/Popover/PopoverActivator.vue` — the custom `target` branch
- `components/Popover/PopoverContent.vue` — the custom `_id` branch

The raw `id` is still used verbatim for the DOM element id and the `popovertarget` linkage — only the CSS custom-ident is coerced, so the native popover wiring is unchanged.

## Scope

Identifier-validity **correctness**, not style-value sanitization. Per the maintainer ruling, v0 does not sanitize free-form CSS *values* (`positionArea` / `positionTry` are untouched) — that's Vue's responsibility. This is the identifier-validation sibling of #405, mirroring the `SAFE_IDENT` guard `ThemeAdapter` already applies (`.claude/rules/implementation.md` "Security primitives"). The guard is mirrored locally (no shared utility, no new export) — public surface unchanged.

Non-breaking: every `useId()` output already matches the charset, so the default path is identical; only out-of-charset overrides are coerced into a working ident.

## Verify

`vue-tsc --noEmit` on `packages/0` — clean (exit 0).
