### PR TITLE
fix(useStack): make ticket blocking/scrim reactive

### DIFF
--- a/.changeset/usestack-reactive-blocking.md
+++ b/.changeset/usestack-reactive-blocking.md
@@ -1,0 +1,9 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useStack): make ticket blocking/scrim reactive
+
+`register()` now accepts `MaybeRefOrGetter` for `blocking`/`scrim` and exposes them as `Readonly<Ref<boolean>>` on the ticket, so a reactive `blocking` (e.g. a Dialog backing VDialog's reactive `persistent`) propagates instead of freezing at registration. `Dialog`/`AlertDialog`/`Portal` now pass them as getters.
+
+Type change: `StackTicket.blocking`/`scrim` are now `Readonly<Ref<boolean>>` (were `boolean`) — read `.value`. Reads are internal to v0; `register()` still accepts plain booleans.

--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -97,7 +97,7 @@
   const stack = useStack()
   const ticket = stack.register({
     onDismiss: () => context.close(),
-    blocking,
+    blocking: () => blocking,
     el: () => contentRef.value?.element,
   })
 

--- a/packages/0/src/components/AlertDialog/index.test.ts
+++ b/packages/0/src/components/AlertDialog/index.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
+// Components
+import { Scrim } from '#v0/components/Scrim'
+
 // Composables
 import { createStackPlugin, useStack } from '#v0/composables/useStack'
 
@@ -1191,6 +1194,47 @@ describe('alertDialog', () => {
     wrapper.unmount()
     await nextTick()
     expect(capturedStack!.topElement.value).toBeNull()
+  })
+
+  it('reactively honors a blocking alert dialog when its scrim is clicked', async () => {
+    const open = ref(true)
+    const blocking = ref(true)
+    const wrapper = mountWithStack(
+      defineComponent({
+        setup () {
+          return () => [
+            h(AlertDialog.Root, {
+              'modelValue': open.value,
+              'onUpdate:modelValue': (v: boolean) => {
+                open.value = v
+              },
+            }, {
+              default: () => h(AlertDialog.Content as any, { blocking: blocking.value }, () => h('p', 'Body')),
+            }),
+            h(Scrim, { teleport: false, class: 'test-scrim' }),
+          ]
+        },
+      }),
+      { attachTo: document.body },
+    )
+
+    await nextTick()
+
+    // While blocking, a scrim click must not dismiss the alert dialog.
+    const scrim = wrapper.find('.test-scrim')
+    expect(scrim.exists()).toBe(true)
+    await scrim.trigger('click')
+    await nextTick()
+    expect(open.value).toBe(true)
+
+    // Flipping blocking off must propagate reactively: the same scrim now dismisses.
+    blocking.value = false
+    await nextTick()
+    await wrapper.find('.test-scrim').trigger('click')
+    await nextTick()
+    expect(open.value).toBe(false)
+
+    wrapper.unmount()
   })
 })
 

--- a/packages/0/src/components/Dialog/DialogContent.vue
+++ b/packages/0/src/components/Dialog/DialogContent.vue
@@ -95,7 +95,7 @@
   const stack = useStack()
   const ticket = stack.register({
     onDismiss: () => context.close(),
-    blocking,
+    blocking: () => blocking,
     el: () => contentRef.value?.element,
   })
 

--- a/packages/0/src/components/Dialog/index.test.ts
+++ b/packages/0/src/components/Dialog/index.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
+// Components
+import { Scrim } from '#v0/components/Scrim'
+
 // Composables
 import { createStackPlugin, useStack } from '#v0/composables/useStack'
 
@@ -1165,5 +1168,46 @@ describe('dialog', () => {
     wrapper.unmount()
     await nextTick()
     expect(capturedStack!.topElement.value).toBeNull()
+  })
+
+  it('reactively honors a blocking dialog when its scrim is clicked', async () => {
+    const open = ref(true)
+    const blocking = ref(true)
+    const wrapper = mountWithStack(
+      defineComponent({
+        setup () {
+          return () => [
+            h(Dialog.Root, {
+              'modelValue': open.value,
+              'onUpdate:modelValue': (v: boolean) => {
+                open.value = v
+              },
+            }, {
+              default: () => h(Dialog.Content as any, { blocking: blocking.value }, () => h('p', 'Body')),
+            }),
+            h(Scrim, { teleport: false, class: 'test-scrim' }),
+          ]
+        },
+      }),
+      { attachTo: document.body },
+    )
+
+    await nextTick()
+
+    // While blocking, a scrim click must not dismiss the dialog.
+    const scrim = wrapper.find('.test-scrim')
+    expect(scrim.exists()).toBe(true)
+    await scrim.trigger('click')
+    await nextTick()
+    expect(open.value).toBe(true)
+
+    // Flipping blocking off must propagate reactively: the same scrim now dismisses.
+    blocking.value = false
+    await nextTick()
+    await wrapper.find('.test-scrim').trigger('click')
+    await nextTick()
+    expect(open.value).toBe(false)
+
+    wrapper.unmount()
   })
 })

--- a/packages/0/src/components/Portal/Portal.vue
+++ b/packages/0/src/components/Portal/Portal.vue
@@ -65,8 +65,8 @@
   // inline portal is excluded from the stack (z-index pins to base, inline
   // portals collide, no dismiss/scrim coordination).
   const ticket = stack.register({
-    blocking,
-    scrim,
+    blocking: () => blocking,
+    scrim: () => scrim,
     onDismiss: () => emit('close'),
   })
   ticket.select()

--- a/packages/0/src/components/Scrim/Scrim.vue
+++ b/packages/0/src/components/Scrim/Scrim.vue
@@ -81,10 +81,10 @@
   const attrs = useAttrs()
   const stack = useStack()
 
-  const tickets = computed(() => Array.from(stack.selectedItems.value).filter(ticket => ticket.scrim !== false))
+  const tickets = computed(() => Array.from(stack.selectedItems.value).filter(ticket => ticket.scrim.value !== false))
 
   function onDismiss (ticket: StackTicket) {
-    if (!ticket.blocking) {
+    if (!ticket.blocking.value) {
       ticket.dismiss()
     }
   }
@@ -94,7 +94,7 @@
     return {
       ticket,
       zIndex,
-      isBlocking: ticket.blocking,
+      isBlocking: ticket.blocking.value,
       dismiss: () => onDismiss(ticket),
       attrs: {
         style: { zIndex },

--- a/packages/0/src/components/Scrim/index.test.ts
+++ b/packages/0/src/components/Scrim/index.test.ts
@@ -23,12 +23,14 @@ function createMockTicket (overrides: {
   id?: string
   zIndex?: number
   blocking?: boolean
+  scrim?: boolean
 } = {}): StackTicket {
   const dismiss = vi.fn()
   return {
     id: overrides.id ?? 'ticket-1',
     zIndex: computed(() => overrides.zIndex ?? 2000),
-    blocking: overrides.blocking ?? false,
+    blocking: computed(() => overrides.blocking ?? false),
+    scrim: computed(() => overrides.scrim ?? true),
     dismiss,
     // Minimal ticket properties for testing
     index: 0,

--- a/packages/0/src/composables/useStack/index.test.ts
+++ b/packages/0/src/composables/useStack/index.test.ts
@@ -33,7 +33,7 @@ describe('createStack', () => {
 
         expect(ticket).toBeDefined()
         expect(ticket.id).toBeDefined()
-        expect(ticket.blocking).toBe(false)
+        expect(ticket.blocking.value).toBe(false)
       })
 
       it('should register tickets with options', () => {
@@ -42,7 +42,7 @@ describe('createStack', () => {
 
         const ticket = stack.register({ onDismiss, blocking: true })
 
-        expect(ticket.blocking).toBe(true)
+        expect(ticket.blocking.value).toBe(true)
         expect(ticket.onDismiss).toBe(onDismiss)
       })
 

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -59,7 +59,7 @@ export interface StackTicketInput extends SelectionTicketInput {
    * @remarks When true, clicking the scrim will not dismiss this overlay.
    * Use for critical dialogs requiring explicit user action.
    */
-  blocking?: boolean
+  blocking?: MaybeRefOrGetter<boolean>
   /**
    * Whether this overlay should be backed by a scrim/backdrop
    *
@@ -68,7 +68,7 @@ export interface StackTicketInput extends SelectionTicketInput {
    * but `Scrim` skips rendering a backdrop for it. Use for non-modal overlays
    * (snackbars, toasts, tooltips) that need layering without dimming.
    */
-  scrim?: boolean
+  scrim?: MaybeRefOrGetter<boolean>
   /**
    * The overlay's DOM element.
    *
@@ -95,11 +95,11 @@ export type StackTicket<Z extends StackTicketInput = StackTicketInput> = Selecti
   /**
    * Whether this overlay blocks scrim dismissal
    */
-  blocking: boolean
+  blocking: Readonly<Ref<boolean>>
   /**
    * Whether this overlay is backed by a scrim/backdrop
    */
-  scrim: boolean
+  scrim: Readonly<Ref<boolean>>
   /** The overlay's DOM element, if provided at registration. */
   el?: MaybeRefOrGetter<Element | null | undefined>
   /**
@@ -258,7 +258,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
   function selectedScrims () {
     return Array.from(selection.selectedIds)
       .map(id => selection.get(id) as StackTicket | undefined)
-      .filter((ticket): ticket is StackTicket => !!ticket && ticket.scrim !== false)
+      .filter((ticket): ticket is StackTicket => !!ticket && ticket.scrim.value !== false)
   }
 
   const isActive = toRef(() => selectedScrims().length > 0)
@@ -270,7 +270,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
     return ticket ? ticket.zIndex.value - 1 : 0
   })
 
-  const isBlocking = toRef(() => top.value?.blocking ?? false)
+  const isBlocking = toRef(() => toValue(top.value?.blocking) ?? false)
 
   const topElement = toRef(() => {
     const scrims = selectedScrims()
@@ -287,8 +287,8 @@ export function createStack (_options: StackOptions = {}): StackContext {
 
   function register (input: Partial<StackTicketInput> = {} as Partial<StackTicketInput>): StackTicket {
     const id = input.id ?? useId()
-    const blocking = input.blocking ?? false
-    const scrim = input.scrim ?? true
+    const blocking = toRef(() => toValue(input.blocking) ?? false)
+    const scrim = toRef(() => toValue(input.scrim) ?? true)
     const onDismiss = input.onDismiss
 
     const zIndex = toRef(() => {
@@ -304,19 +304,19 @@ export function createStack (_options: StackOptions = {}): StackContext {
     })
 
     function dismiss () {
-      if (blocking) return
+      if (blocking.value) return
       onDismiss?.()
       selection.unselect(id)
     }
 
     const ticket = selection.register({
+      ...input,
       blocking,
       scrim,
       onDismiss,
       zIndex,
       globalTop,
       dismiss,
-      ...input,
       id,
     } as Partial<StackTicketInput>)
 


### PR DESCRIPTION
Closes #414.

## What

`useStack`'s `register` captured `blocking`/`scrim` non-reactively (read once at registration), so a `Dialog`/`AlertDialog` could not have a **reactive** `blocking` — the value froze at mount. Since v0 `Dialog` is meant to back Vuetify 4 `VDialog` (whose `persistent` is reactive), this was a latent correctness gap.

This makes them reactive refs end-to-end:

- `register` accepts `MaybeRefOrGetter<boolean>` for `blocking`/`scrim` and normalizes each to a `toRef(() => toValue(...) ?? default)`.
- The ticket now exposes `blocking`/`scrim` as `Readonly<Ref<boolean>>`; all internal reads use `.value` (`Scrim.vue` ×3, `selectedScrims`, `isBlocking`, the `dismiss` guard).
- `Dialog`/`AlertDialog`/`Portal` pass them as getters (`blocking: () => blocking`) so a reactive prop propagates instead of being snapshotted.
- Fixed a latent spread-ordering bug in `register`: `...input` was spread **after** the normalized fields and would re-clobber them with the raw input — moved it first.

## Breaking type change (approved, pre-1.0)

`StackTicket.blocking`/`scrim`: `boolean` → `Readonly<Ref<boolean>>` (read `.value`). `register()` input still accepts plain booleans. The only readers of these fields are internal to v0 (`Scrim.vue`, `useStack`); a repo-wide sweep found no external consumer reads them (the docs `use-stack` example reads its own local model, not the ticket).

## Verify

- `vue-tsc --noEmit` on `packages/0` — clean (exit 0).
- 197 tests pass across the affected suites: `useStack` (36), `Scrim` (28), `Dialog` (57), `AlertDialog` (58), `Portal` (18). 0 warnings.

(Local test run inside the worktree used a throwaway single-project vitest config to dodge an unrelated worktree `node_modules`/`unplugin-vue` resolution issue; CI runs the full suite in a clean environment.)
