### PR TITLE
test(vapor): add isolated Vue Vapor parity harness for v0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,19 @@ jobs:
       - name: Run sherif check
         run: pnpm repo:sherif
 
+  # Vapor parity tests run on a beta Vue (tests/vapor, vue@3.6.0-beta), pinned
+  # separately from the rest of the repo. Non-blocking: a Vapor regression
+  # surfaces as a visible signal without redding the build on a beta hiccup.
+  vapor:
+    needs: prepare
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Run Vapor-mode tests
+        run: pnpm test:vapor
+
   build:
     runs-on: ubuntu-latest
     needs: [prepare]

--- a/apps/docs/src/pages/guide/integration/vapor.md
+++ b/apps/docs/src/pages/guide/integration/vapor.md
@@ -34,13 +34,17 @@ This is a standing design rule, not an afterthought: every new v0 abstraction is
 
 ## What is verified today
 
-v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`) that mounts real Vapor components against a pinned Vue 3.6 beta and asserts:
+v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`) that mounts real Vapor components against a pinned Vue 3.6 beta[^beta-pin] and asserts:
 
 | Area | What it proves |
 | - | - |
-| Instance detection | `getCurrentInstance()` returns `null` in a Vapor component, but v0 still detects the active instance internally, so composables that rely on component context keep working. |
-| Composables | A registry-backed composable (`createSelection`) registers items, updates reactive state, and drives Vapor DOM updates from inside a Vapor `setup`. |
-| Component interop | A classic v0 component renders inside a Vapor app through `vaporInteropPlugin`, including slot content forwarded from a Vapor parent. |
+| Instance detection | `getCurrentInstance()` is `null` in a Vapor component, yet v0 still resolves the active instance[^instance-shim] — so composables that depend on component context keep working. |
+| Composables | `createSelection` registers items, updates reactive state, and drives Vapor DOM updates from inside a Vapor `setup`. |
+| Component interop | A classic (vdom) v0 component renders inside a Vapor app through `vaporInteropPlugin`, including slot content forwarded from a Vapor parent[^interop-slots]. |
+
+[^beta-pin]: Pinned to `vue@3.6.0-beta.15` — the newest 3.6 beta old enough to clear the workspace's install-age policy. The Vapor surface the suite touches (the `vapor` SFC attribute, `createVaporApp`, `vaporInteropPlugin`) has been stable across the beta line; bump the pin as 3.6 nears release.
+[^instance-shim]: Vapor exposes the active instance on Vue 3.6's `currentInstance` export; `getCurrentInstance()` returns `null` inside a Vapor component by design ([vuejs/core discussion #13629](https://github.com/orgs/vuejs/discussions/13629)). v0 reads `currentInstance` when present and falls back to `getCurrentInstance()` on Vue 3.5 — see `utilities/instance.ts`.
+[^interop-slots]: Interop is directional. A vdom component rendering inside a Vapor parent (the tested path) works; passing Vapor slots *into* a vdom component needs `renderSlot` rather than `slots.default()`, per [Vue's Vapor notes](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1). Keep a region in one rendering mode where you can.
 
 ## Using composables under Vapor
 
@@ -93,7 +97,7 @@ createApp(App)
 
 - **Vue 3.6 is beta.** The runtime, the `vapor` SFC attribute, and `vaporInteropPlugin` are stabilizing; APIs can still shift before release.
 - **Coverage is representative, not exhaustive.** The suite proves the instance-context substrate, a registry composable, and component interop. It does not yet mount every component under Vapor.
-- **Interop has rough edges.** Per Vue's own guidance, deeply interleaving Vapor and vdom regions (especially passing Vapor slots into vdom components) can hit edge cases. Keep a given region in one mode where you can.
+- **Interop has rough edges.** Vapor↔vdom interop still has edge cases, so keep a given region in one rendering mode where you can.
 
 ## Verifying it yourself
 

--- a/apps/docs/src/pages/guide/integration/vapor.md
+++ b/apps/docs/src/pages/guide/integration/vapor.md
@@ -1,0 +1,106 @@
+---
+title: Vapor - Vue Vapor Mode Compatibility
+features:
+  order: 2
+  level: 3
+meta:
+  - name: description
+    content: How Vuetify0 works under Vue Vapor mode, the compiler-optimized runtime without a virtual DOM. Covers composables, component interop, what is verified, and current caveats.
+  - name: keywords
+    content: vuetify0, vue vapor, vapor mode, vue 3.6, virtual dom, fine-grained reactivity, vaporInteropPlugin
+related:
+  - /guide/fundamentals/reactivity
+  - /guide/fundamentals/building-frameworks
+  - /composables/foundation/create-context
+---
+
+# Vapor
+
+[Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1) is Vue's compiler-optimized runtime that ships without the virtual DOM, compiling templates to direct DOM operations. v0 is built to keep working under Vapor.
+
+<DocsPageFeatures :frontmatter />
+
+> [!IMPORTANT]
+> Vapor mode ships in **Vue 3.6**, which is still in beta. This page describes a **forward-compatibility target**, not a stable guarantee. v0 itself is published against Vue `>=3.5`; the Vapor support below is verified on a pinned Vue 3.6 beta and exercised by a dedicated test suite, but treat it as experimental until Vue 3.6 is stable.
+
+## Why v0 is a good fit for Vapor
+
+Vapor leans harder on fine-grained reactivity and removes the virtual DOM. v0's design already points that way:
+
+- **Composables are logic, not markup.** Selection state, registries, validation, and the rest are plain reactive primitives (`shallowRef`, `toRef`, `computed`). They have no dependency on the virtual DOM, so they run unchanged inside a Vapor component's `setup`.
+- **Components keep templates conventional.** v0's compound components are authored as ordinary SFCs — no `h()` tricks, no hand-rolled `render()`, no vnode metaprogramming — which is exactly what compiles cleanly under Vapor or renders through interop.
+
+This is a standing design rule, not an afterthought: every new v0 abstraction is checked against "does this depend on the virtual DOM?" before it lands.
+
+## What is verified today
+
+v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`) that mounts real Vapor components against a pinned Vue 3.6 beta and asserts:
+
+| Area | What it proves |
+| - | - |
+| Instance detection | `getCurrentInstance()` returns `null` in a Vapor component, but v0 still detects the active instance internally, so composables that rely on component context keep working. |
+| Composables | A registry-backed composable (`createSelection`) registers items, updates reactive state, and drives Vapor DOM updates from inside a Vapor `setup`. |
+| Component interop | A classic v0 component renders inside a Vapor app through `vaporInteropPlugin`, including slot content forwarded from a Vapor parent. |
+
+## Using composables under Vapor
+
+Composables need no special handling — call them inside a `<script setup vapor>` component the same way you would in a classic one:
+
+```vue
+<script setup vapor lang="ts">
+  import { createSelection } from '@vuetify/v0'
+
+  const selection = createSelection()
+  const a = selection.register({ value: 'a' })
+  const b = selection.register({ value: 'b' })
+</script>
+
+<template>
+  <button :data-selected="a.isSelected.value" @click="a.toggle()">A</button>
+  <button :data-selected="b.isSelected.value" @click="b.toggle()">B</button>
+</template>
+```
+
+### The `getCurrentInstance()` caveat
+
+Vapor intentionally makes `getCurrentInstance()` return `null` inside a component. Libraries that call it directly to detect component context can break — v0 does not. Internally v0 reads Vue 3.6's `currentInstance` export when it is available and falls back to `getCurrentInstance()` on older Vue, so instance-aware helpers like `useId()` continue to resolve correctly under Vapor. If you write your own instance-aware logic, prefer the same pattern over a bare `getCurrentInstance()` call.
+
+## Using components under Vapor
+
+v0's components are classic (vdom) SFCs. To render them from a Vapor-root app, install `vaporInteropPlugin` so the two runtimes can nest:
+
+```ts main.ts
+import { createVaporApp, vaporInteropPlugin } from 'vue'
+import App from './App.vue' // <script setup vapor>
+
+createVaporApp(App)
+  .use(vaporInteropPlugin)
+  .mount('#app')
+```
+
+The same plugin enables the reverse — dropping a Vapor component into an existing vdom app for incremental adoption:
+
+```ts main.ts
+import { createApp, vaporInteropPlugin } from 'vue'
+import App from './App.vue'
+
+createApp(App)
+  .use(vaporInteropPlugin)
+  .mount('#app')
+```
+
+## Current limitations
+
+- **Vue 3.6 is beta.** The runtime, the `vapor` SFC attribute, and `vaporInteropPlugin` are stabilizing; APIs can still shift before release.
+- **Coverage is representative, not exhaustive.** The suite proves the instance-context substrate, a registry composable, and component interop. It does not yet mount every component under Vapor.
+- **Interop has rough edges.** Per Vue's own guidance, deeply interleaving Vapor and vdom regions (especially passing Vapor slots into vdom components) can hit edge cases. Keep a given region in one mode where you can.
+
+## Verifying it yourself
+
+The Vapor suite is intentionally kept out of the default test run (it depends on a beta Vue). Run it directly:
+
+```bash
+pnpm test:vapor
+```
+
+See `tests/vapor/README.md` in the repository for the toolchain setup and the beta-specific configuration notes.

--- a/apps/docs/src/typed-router.d.ts
+++ b/apps/docs/src/typed-router.d.ts
@@ -989,6 +989,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/guide/integration/vapor': RouteRecordInfo<
+      '/guide/integration/vapor',
+      '/guide/integration/vapor',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/guide/tooling/ai-tools': RouteRecordInfo<
       '/guide/tooling/ai-tools',
       '/guide/tooling/ai-tools',
@@ -1961,6 +1968,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/guide/integration/nuxt.md': {
       routes:
         | '/guide/integration/nuxt'
+      views:
+        | never
+    }
+    'src/pages/guide/integration/vapor.md': {
+      routes:
+        | '/guide/integration/vapor'
       views:
         | never
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -124,6 +124,18 @@ export default vuetify({
   },
 },
 {
+  // The vapor test package intentionally pins Vue 3.6 beta + the Vapor runtime.
+  // They can't be cataloged: a second catalog entry for `vue` would duplicate
+  // the default catalog's 3.5.x and trip pnpm/yaml-no-duplicate-catalog-item.
+  // Allow these specifiers to stay un-cataloged in this one package only.
+  files: ['tests/vapor/package.json'],
+  rules: {
+    'pnpm/json-enforce-catalog': ['error', {
+      ignores: ['vue', '@vue/runtime-vapor', '@vitejs/plugin-vue'],
+    }],
+  },
+},
+{
   ignores: ['**/export-templates/package.json'],
 },
 {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "test:vapor": "pnpm --filter=@vuetify-private/vapor-tests test",
     "test:bench": "vitest --reporter=verbose bench --run",
     "test:bench:json": "vitest bench --run --outputJson apps/docs/public/benchmarks.json",
     "bench": "vitest --reporter=default bench",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,16 @@ catalogs:
     vue-tsc:
       specifier: 3.2.7
       version: 3.2.7
+  vapor:
+    '@vitejs/plugin-vue':
+      specifier: ^6.0.7
+      version: 6.0.7
+    '@vue/runtime-vapor':
+      specifier: 3.6.0-beta.15
+      version: 3.6.0-beta.15
+    vue:
+      specifier: 3.6.0-beta.15
+      version: 3.6.0-beta.15
 
 patchedDependencies:
   '@vue/repl@4.7.1':
@@ -668,10 +678,10 @@ importers:
         version: link:../../packages/0
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^6.0.7
+        specifier: catalog:vapor
         version: 6.0.7(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))
       '@vue/runtime-vapor':
-        specifier: 3.6.0-beta.15
+        specifier: catalog:vapor
         version: 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
       happy-dom:
         specifier: 'catalog:'
@@ -683,7 +693,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@28.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       vue:
-        specifier: 3.6.0-beta.15
+        specifier: catalog:vapor
         version: 3.6.0-beta.15(typescript@6.0.3)
 
 packages:
@@ -7069,7 +7079,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -7082,10 +7092,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -7114,7 +7124,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -7160,14 +7170,14 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7175,14 +7185,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -7207,7 +7217,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7229,14 +7239,14 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -7478,7 +7488,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -7718,7 +7728,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/runtime@7.29.2': {}
@@ -7726,17 +7736,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -9859,7 +9869,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
 
   ast-kit@3.0.0-beta.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,16 +237,6 @@ catalogs:
     vue-tsc:
       specifier: 3.2.7
       version: 3.2.7
-  vapor:
-    '@vitejs/plugin-vue':
-      specifier: ^6.0.7
-      version: 6.0.7
-    '@vue/runtime-vapor':
-      specifier: 3.6.0-beta.15
-      version: 3.6.0-beta.15
-    vue:
-      specifier: 3.6.0-beta.15
-      version: 3.6.0-beta.15
 
 patchedDependencies:
   '@vue/repl@4.7.1':
@@ -678,10 +668,10 @@ importers:
         version: link:../../packages/0
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: catalog:vapor
+        specifier: ^6.0.7
         version: 6.0.7(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))
       '@vue/runtime-vapor':
-        specifier: catalog:vapor
+        specifier: 3.6.0-beta.15
         version: 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
       happy-dom:
         specifier: 'catalog:'
@@ -693,7 +683,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@28.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       vue:
-        specifier: catalog:vapor
+        specifier: 3.6.0-beta.15
         version: 3.6.0-beta.15(typescript@6.0.3)
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,7 +397,7 @@ importers:
         version: 2.1.13(vue@3.5.33(typescript@6.0.3))
       '@vue/test-utils':
         specifier: 'catalog:'
-        version: 2.4.10(@vue/compiler-dom@3.5.33)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.10(@vue/compiler-dom@3.6.0-beta.15)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
       markdown-it:
         specifier: 'catalog:'
         version: 14.1.1
@@ -661,6 +661,31 @@ importers:
         specifier: 'catalog:'
         version: 7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(vue@3.5.33(typescript@6.0.3))(yaml@2.9.0)
 
+  tests/vapor:
+    dependencies:
+      '@vuetify/v0':
+        specifier: workspace:*
+        version: link:../../packages/0
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))
+      '@vue/runtime-vapor':
+        specifier: 3.6.0-beta.15
+        version: 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.9.0
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@28.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vue:
+        specifier: 3.6.0-beta.15
+        version: 3.6.0-beta.15(typescript@6.0.3)
+
 packages:
 
   '@acemir/cssom@0.9.31':
@@ -804,12 +829,20 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@8.0.0-rc.3':
     resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@8.0.0-rc.3':
@@ -830,6 +863,11 @@ packages:
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1223,6 +1261,10 @@ packages:
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.3':
@@ -2540,6 +2582,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -3129,6 +3174,13 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vitejs/plugin-vue@6.0.7':
+    resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
     peerDependencies:
@@ -3200,14 +3252,29 @@ packages:
   '@vue/compiler-core@3.5.33':
     resolution: {integrity: sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==}
 
+  '@vue/compiler-core@3.6.0-beta.15':
+    resolution: {integrity: sha512-TtzIgaBexYK1CAtZZBPQunaXtXx2sf3TS/F1LT9m+tnqtvuAi9SBt3Sa+aWb8/0cnon0H5UQrOenQZgiTQdCYw==}
+
   '@vue/compiler-dom@3.5.33':
     resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
+
+  '@vue/compiler-dom@3.6.0-beta.15':
+    resolution: {integrity: sha512-RG1pNFEvFTdUS6GjnkXnCD8wkTm6lmSCg0uimExYioYY6jBteU7uZGmW1UvweZ1FzgXTTOIzj0PGaXi2qDYeVQ==}
 
   '@vue/compiler-sfc@3.5.33':
     resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
 
+  '@vue/compiler-sfc@3.6.0-beta.15':
+    resolution: {integrity: sha512-QEcaQnw1PLmIqEZHUd2WrxSHj8hwPBI6GWZ2QGdsczhInral/PHoTtdDdnh6OgF/nmczS03+SpZ3LvAdtnF0Ag==}
+
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
+
+  '@vue/compiler-ssr@3.6.0-beta.15':
+    resolution: {integrity: sha512-0/CLPSiIrbXjuBZzBxd9NvC4GTLHFWFseSEb4rhlY3qx7hyP6qdE0BHYnuobz/0ce+YdrSoL6M6rAqolZuC2fg==}
+
+  '@vue/compiler-vapor@3.6.0-beta.15':
+    resolution: {integrity: sha512-iu5iZ04/d+QO5CnoYXJDEjS/rp2kkUOqGwC8wUAKFJSv2+9/APA0hMCr8xHBnGPr4QurvBu2xto3vwYSaPhIzg==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -3236,22 +3303,44 @@ packages:
   '@vue/reactivity@3.5.33':
     resolution: {integrity: sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==}
 
+  '@vue/reactivity@3.6.0-beta.15':
+    resolution: {integrity: sha512-TX2Im+/SD9l+diT7ZqWjLLdoSnVp1k5+GIegg6MOWaFLiTkOZ+ZbbFr+ANTyn9cLu5RryALLipCCz9ug4d10/g==}
+
   '@vue/repl@4.7.1':
     resolution: {integrity: sha512-8w5Z3cyqBJ5ufzXO2eut2stzb7aX/ZnSva2d3ee8eEINEB7FG2JYwc14eAHHHGGuoXOGN5v4cyb5ti/YZGcwlg==}
 
   '@vue/runtime-core@3.5.33':
     resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
 
+  '@vue/runtime-core@3.6.0-beta.15':
+    resolution: {integrity: sha512-0lGFf6tN7L9b5it3PApFwL+fUDCmg2Gk/Q2HxKP7wukWqYlRYN/5XtzLHamRJjiXVAjzi24SDpD/uCC2gE/geA==}
+
   '@vue/runtime-dom@3.5.33':
     resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
+
+  '@vue/runtime-dom@3.6.0-beta.15':
+    resolution: {integrity: sha512-glceCzw46XQSRSfKRD9iRfGCuWVkWWRC4Sx8bWNM2RHM1Oki9Sa4mmTLeXu7S2Rwjhfx2aIcghQ4XhoENL8xfg==}
+
+  '@vue/runtime-vapor@3.6.0-beta.15':
+    resolution: {integrity: sha512-nS/yKrXsKPiFed3zzfihMVoA0xqmN+UDvd1ezLCmFj0tDw6TNo3NnPH0/M5NrX40L4i7h8dMpIkwA63ExpoeAA==}
+    peerDependencies:
+      '@vue/runtime-dom': 3.6.0-beta.15
 
   '@vue/server-renderer@3.5.33':
     resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
     peerDependencies:
       vue: 3.5.33
 
+  '@vue/server-renderer@3.6.0-beta.15':
+    resolution: {integrity: sha512-jj5E0KsP7dPS+tJ3AAF/XRm4qtSrOGWhIYqXoe31DHJDswbRAS68p/hhkzaozezlnQld8w2xHntd0I4YbXb1KA==}
+    peerDependencies:
+      vue: 3.6.0-beta.15
+
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
+
+  '@vue/shared@3.6.0-beta.15':
+    resolution: {integrity: sha512-wyjMjw2AmP6h9qNpVZAO77rgxd6+jcMu+2Wmg9729mmR+V5HPweBSKWggioSNR6NBazMMGY4ekb5U9DUp1KRFg==}
 
   '@vue/test-utils@2.4.10':
     resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
@@ -6714,6 +6803,14 @@ packages:
       typescript:
         optional: true
 
+  vue@3.6.0-beta.15:
+    resolution: {integrity: sha512-KMz/cLpxspxVOX0MyRGRd+ppW9qpajuxaE1/xLcs1uRsYYD7Sc0G/56TpVX9uDjVdcgFwWIBfG9Ukj92XUP1TQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -7116,9 +7213,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-string-parser@8.0.0-rc.3': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
@@ -7140,6 +7241,10 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/parser@8.0.0-rc.3':
     dependencies:
@@ -7640,6 +7745,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.0-rc.3':
     dependencies:
@@ -8725,6 +8835,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(rollup@2.80.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9384,6 +9496,12 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vue: 3.6.0-beta.15(typescript@6.0.3)
+
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -9480,10 +9598,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.6.0-beta.15':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.6.0-beta.15
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.33':
     dependencies:
       '@vue/compiler-core': 3.5.33
       '@vue/shared': 3.5.33
+
+  '@vue/compiler-dom@3.6.0-beta.15':
+    dependencies:
+      '@vue/compiler-core': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
 
   '@vue/compiler-sfc@3.5.33':
     dependencies:
@@ -9497,10 +9628,36 @@ snapshots:
       postcss: 8.5.14
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.6.0-beta.15':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.6.0-beta.15
+      '@vue/compiler-dom': 3.6.0-beta.15
+      '@vue/compiler-ssr': 3.6.0-beta.15
+      '@vue/compiler-vapor': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.14
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.33':
     dependencies:
       '@vue/compiler-dom': 3.5.33
       '@vue/shared': 3.5.33
+
+  '@vue/compiler-ssr@3.6.0-beta.15':
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+
+  '@vue/compiler-vapor@3.6.0-beta.15':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-dom': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -9549,12 +9706,21 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.33
 
+  '@vue/reactivity@3.6.0-beta.15':
+    dependencies:
+      '@vue/shared': 3.6.0-beta.15
+
   '@vue/repl@4.7.1(patch_hash=22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe)': {}
 
   '@vue/runtime-core@3.5.33':
     dependencies:
       '@vue/reactivity': 3.5.33
       '@vue/shared': 3.5.33
+
+  '@vue/runtime-core@3.6.0-beta.15':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
 
   '@vue/runtime-dom@3.5.33':
     dependencies:
@@ -9563,17 +9729,47 @@ snapshots:
       '@vue/shared': 3.5.33
       csstype: 3.2.3
 
+  '@vue/runtime-dom@3.6.0-beta.15':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.15
+      '@vue/runtime-core': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+      csstype: 3.2.3
+
+  '@vue/runtime-vapor@3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.15
+      '@vue/runtime-dom': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+
   '@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.33
       '@vue/shared': 3.5.33
       vue: 3.5.33(typescript@6.0.3)
 
+  '@vue/server-renderer@3.6.0-beta.15(vue@3.6.0-beta.15(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-beta.15
+      vue: 3.6.0-beta.15(typescript@6.0.3)
+
   '@vue/shared@3.5.33': {}
+
+  '@vue/shared@3.6.0-beta.15': {}
 
   '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.33)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-dom': 3.5.33
+      js-beautify: 1.15.4
+      vue: 3.5.33(typescript@6.0.3)
+      vue-component-type-helpers: 3.2.8
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.6.0-beta.15)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-beta.15
       js-beautify: 1.15.4
       vue: 3.5.33(typescript@6.0.3)
       vue-component-type-helpers: 3.2.8
@@ -13335,6 +13531,17 @@ snapshots:
       '@vue/runtime-dom': 3.5.33
       '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
       '@vue/shared': 3.5.33
+    optionalDependencies:
+      typescript: 6.0.3
+
+  vue@3.6.0-beta.15(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-beta.15
+      '@vue/compiler-sfc': 3.6.0-beta.15
+      '@vue/runtime-dom': 3.6.0-beta.15
+      '@vue/runtime-vapor': 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
+      '@vue/server-renderer': 3.6.0-beta.15(vue@3.6.0-beta.15(typescript@6.0.3))
+      '@vue/shared': 3.6.0-beta.15
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
   - apps/*
   - dev
+  - tests/*
 
 autoInstallPeers: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -117,11 +117,3 @@ patchedDependencies:
 peerDependencyRules:
   allowedVersions:
     vite: '8'
-catalogs:
-  # Vue 3.6 beta + Vapor toolchain, isolated to tests/vapor (the rest of the
-  # workspace stays on the default catalog's vue 3.5.x). Referenced as
-  # `catalog:vapor`.
-  vapor:
-    '@vitejs/plugin-vue': ^6.0.7
-    '@vue/runtime-vapor': 3.6.0-beta.15
-    vue: 3.6.0-beta.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -117,3 +117,11 @@ patchedDependencies:
 peerDependencyRules:
   allowedVersions:
     vite: '8'
+catalogs:
+  # Vue 3.6 beta + Vapor toolchain, isolated to tests/vapor (the rest of the
+  # workspace stays on the default catalog's vue 3.5.x). Referenced as
+  # `catalog:vapor`.
+  vapor:
+    '@vitejs/plugin-vue': ^6.0.7
+    '@vue/runtime-vapor': 3.6.0-beta.15
+    vue: 3.6.0-beta.15

--- a/tests/vapor/README.md
+++ b/tests/vapor/README.md
@@ -1,0 +1,58 @@
+# @vuetify-private/vapor-tests
+
+Isolated [Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1)
+parity tests for `@vuetify/v0`. This package verifies — with **real Vapor
+renders**, not mocks — that v0's composables and components work under Vue's
+vdom-less runtime.
+
+## Why this is a separate package
+
+Vapor ships in **Vue 3.6** (still beta). The rest of the monorepo is pinned to
+`vue@3.5.33` via the catalog, and we don't want a beta Vue in the default test
+run. So this package:
+
+- Declares its **own** `vue@3.6.0-beta.15` + `@vue/runtime-vapor@3.6.0-beta.15`
+  devDependencies. pnpm installs them alongside the 3.5 copy; `packages/0`
+  is untouched.
+- Lives under `tests/*`, which the root `vitest.config.ts`
+  (`projects: ['packages/*', 'apps/docs']`) does **not** match — so
+  `pnpm test` / CI never run it.
+
+Run it explicitly:
+
+```bash
+pnpm test:vapor        # from repo root
+pnpm --filter @vuetify-private/vapor-tests test
+```
+
+## What it covers
+
+| File | Proves |
+|------|--------|
+| `test/smoke.test.ts` | The beta toolchain compiles + mounts a `<script setup vapor>` SFC and reacts. If this fails, the harness is broken, not v0. |
+| `test/instance.vapor.test.ts` | `utilities/instance.ts` works under a real Vapor render: `getCurrentInstance()` is genuinely `null`, yet the `currentInstance` shim still detects the instance and `useId()` resolves. `instance.test.ts` can only mock this. |
+| `test/composables.vapor.test.ts` | `createSelection` (registry + reactive tickets + computed Set) runs in a Vapor setup and drives Vapor DOM updates. |
+| `test/interop.vapor.test.ts` | A classic (vdom) v0 component renders inside a Vapor root via `vaporInteropPlugin`, including slot content forwarded from the Vapor parent. |
+
+## Why the vitest config is unusual
+
+Two beta-specific traps, both handled in `vitest.config.ts`:
+
+1. **Vue's `node` export condition resolves to a Vapor-less build.** `vue`'s
+   `.` export maps `node` → `index.mjs` → the full CJS build, which does **not**
+   re-export the Vapor runtime — so `import { defineVaporComponent } from 'vue'`
+   (emitted by the compiler) comes back `undefined`. We alias every Vue runtime
+   package (`vue`, `@vue/runtime-*`, `@vue/reactivity`, `@vue/shared`) straight
+   to its `*.esm-bundler.js` build, which re-exports the Vapor symbols and the
+   `@internal` cross-package helpers (e.g. `initFeatureFlags`) that the CJS
+   builds strip.
+2. **Those esm-bundler builds reference compile-time globals.** `__DEV__` and
+   the `__VUE_*__` feature flags are replaced via `define`, and the packages are
+   `inline`d so Vite (not Node) transforms them.
+
+## Beta pin
+
+`3.6.0-beta.15` is deliberate: it is the newest 3.6 beta older than the
+workspace's `minimumReleaseAge` (14 days), so it installs without a policy
+exclusion. Bump it as 3.6 stabilizes; the Vapor API (`vapor` attribute,
+`createVaporApp`, `vaporInteropPlugin`) has been stable across the beta line.

--- a/tests/vapor/README.md
+++ b/tests/vapor/README.md
@@ -32,6 +32,7 @@ pnpm --filter @vuetify-private/vapor-tests test
 | `test/smoke.test.ts` | The beta toolchain compiles + mounts a `<script setup vapor>` SFC and reacts. If this fails, the harness is broken, not v0. |
 | `test/instance.vapor.test.ts` | `utilities/instance.ts` works under a real Vapor render: `getCurrentInstance()` is genuinely `null`, yet the `currentInstance` shim still detects the instance and `useId()` resolves. `instance.test.ts` can only mock this. |
 | `test/composables.vapor.test.ts` | `createSelection` (registry + reactive tickets + computed Set) runs in a Vapor setup and drives Vapor DOM updates. |
+| `test/context.vapor.test.ts` | `createContext` carries a value from a Vapor ancestor to a Vapor descendant — the provide/inject substrate beneath every v0 compound component. |
 | `test/interop.vapor.test.ts` | A classic (vdom) v0 component renders inside a Vapor root via `vaporInteropPlugin`, including slot content forwarded from the Vapor parent. |
 
 ## Why the vitest config is unusual

--- a/tests/vapor/env.d.ts
+++ b/tests/vapor/env.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  // Types
+  import type { Component } from 'vue'
+  const component: Component
+  export default component
+}

--- a/tests/vapor/package.json
+++ b/tests/vapor/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@vuetify-private/vapor-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Isolated Vue 3.6 Vapor-mode parity tests for @vuetify/v0. Runs on a beta Vue, deliberately kept out of the default test run.",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@vuetify/v0": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/runtime-vapor": "3.6.0-beta.15",
+    "happy-dom": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vue": "3.6.0-beta.15"
+  }
+}

--- a/tests/vapor/package.json
+++ b/tests/vapor/package.json
@@ -12,11 +12,11 @@
     "@vuetify/v0": "workspace:*"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
-    "@vue/runtime-vapor": "3.6.0-beta.15",
+    "@vitejs/plugin-vue": "catalog:vapor",
+    "@vue/runtime-vapor": "catalog:vapor",
     "happy-dom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vue": "3.6.0-beta.15"
+    "vue": "catalog:vapor"
   }
 }

--- a/tests/vapor/package.json
+++ b/tests/vapor/package.json
@@ -12,11 +12,11 @@
     "@vuetify/v0": "workspace:*"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "catalog:vapor",
-    "@vue/runtime-vapor": "catalog:vapor",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/runtime-vapor": "3.6.0-beta.15",
     "happy-dom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vue": "catalog:vapor"
+    "vue": "3.6.0-beta.15"
   }
 }

--- a/tests/vapor/src/ContextConsumer.vue
+++ b/tests/vapor/src/ContextConsumer.vue
@@ -1,0 +1,9 @@
+<script setup vapor lang="ts">
+  import { useGreeting } from './context'
+
+  const greeting = useGreeting()
+</script>
+
+<template>
+  <span data-greeting>{{ greeting.text }}</span>
+</template>

--- a/tests/vapor/src/ContextProvider.vue
+++ b/tests/vapor/src/ContextProvider.vue
@@ -1,0 +1,12 @@
+<script setup vapor lang="ts">
+  // Context
+  import ContextConsumer from './ContextConsumer.vue'
+
+  import { provideGreeting } from './context'
+
+  provideGreeting({ text: 'hello-vapor' })
+</script>
+
+<template>
+  <ContextConsumer />
+</template>

--- a/tests/vapor/src/Counter.vue
+++ b/tests/vapor/src/Counter.vue
@@ -1,0 +1,14 @@
+<script setup vapor lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  const count = shallowRef(0)
+
+  function increment () {
+    count.value++
+  }
+</script>
+
+<template>
+  <button type="button" @click="increment">Count: {{ count }}</button>
+</template>

--- a/tests/vapor/src/InstanceProbe.vue
+++ b/tests/vapor/src/InstanceProbe.vue
@@ -1,11 +1,11 @@
 <script setup vapor lang="ts">
   // Utilities
-  import { instanceExists, instanceName, useId } from '#v0/utilities'
+  import { instanceExists, instanceName, isNull, useId } from '#v0/utilities'
   import { getCurrentInstance } from 'vue'
 
   // Under real Vapor, getCurrentInstance() returns null by design
   // (vuejs/core v3.6.0-beta.1 release notes).
-  const rawNull = getCurrentInstance() === null
+  const rawNull = isNull(getCurrentInstance())
 
   // ...but v0's shim (utilities/instance.ts) reads the `currentInstance`
   // export directly, so it must still detect the active component. This is the

--- a/tests/vapor/src/InstanceProbe.vue
+++ b/tests/vapor/src/InstanceProbe.vue
@@ -1,0 +1,35 @@
+<script setup vapor lang="ts">
+  // Utilities
+  import { instanceExists, instanceName, useId } from '#v0/utilities'
+  import { getCurrentInstance } from 'vue'
+
+  // Under real Vapor, getCurrentInstance() returns null by design
+  // (vuejs/core v3.6.0-beta.1 release notes).
+  const rawNull = getCurrentInstance() === null
+
+  // ...but v0's shim (utilities/instance.ts) reads the `currentInstance`
+  // export directly, so it must still detect the active component. This is the
+  // exact branch instance.test.ts can only simulate with a mock.
+  const shimDetects = instanceExists()
+  const shimName = instanceName() ?? '<none>'
+
+  // useId() routes through instanceExists() → Vue's own useId() in component
+  // context. Capture whether that survives Vapor (genuine unknown).
+  let id = ''
+  let idError = ''
+  try {
+    id = useId()
+  } catch (error) {
+    idError = (error as Error).message
+  }
+</script>
+
+<template>
+  <div
+    :data-id="id"
+    :data-id-error="idError"
+    :data-raw-null="String(rawNull)"
+    :data-shim-detects="String(shimDetects)"
+    :data-shim-name="shimName"
+  />
+</template>

--- a/tests/vapor/src/InteropAtom.vue
+++ b/tests/vapor/src/InteropAtom.vue
@@ -1,0 +1,12 @@
+<script setup vapor lang="ts">
+  // Atom is a classic (vdom) v0 SFC; mounting it from a Vapor root exercises vdom-in-Vapor interop (requires vaporInteropPlugin).
+
+  // Framework
+  import { Atom } from '@vuetify/v0/components'
+</script>
+
+<template>
+  <Atom as="section" data-interop="host">
+    <span data-child>child</span>
+  </Atom>
+</template>

--- a/tests/vapor/src/SelectionProbe.vue
+++ b/tests/vapor/src/SelectionProbe.vue
@@ -1,0 +1,22 @@
+<script setup vapor lang="ts">
+  import { createSelection } from '#v0/composables'
+
+  // A representative registry-backed composable: exercises ticket registration,
+  // reactive ticket state (isSelected), and a computed Set derivation — all
+  // under Vapor's fine-grained reactivity.
+  const selection = createSelection()
+  const alpha = selection.register({ value: 'alpha' })
+  selection.register({ value: 'beta' })
+
+  function toggle () {
+    alpha.toggle()
+  }
+</script>
+
+<template>
+  <div>
+    <button data-toggle type="button" @click="toggle">toggle</button>
+    <span data-alpha-selected>{{ String(alpha.isSelected.value) }}</span>
+    <span data-selected-count>{{ selection.selectedValues.value.size }}</span>
+  </div>
+</template>

--- a/tests/vapor/src/context.ts
+++ b/tests/vapor/src/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from '#v0/composables'
+
+export interface Greeting {
+  text: string
+}
+
+// createContext is the DI substrate under every v0 compound component. The
+// namespace carries a `:` per the context-key convention.
+export const [useGreeting, provideGreeting] = createContext<Greeting>('v0:vapor-greeting')

--- a/tests/vapor/test/composables.vapor.test.ts
+++ b/tests/vapor/test/composables.vapor.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mountVapor } from './mount'
+
+// Utilities
+import { nextTick } from 'vue'
+
+// Types
+import type { VaporMount } from './mount'
+
+import SelectionProbe from '../src/SelectionProbe.vue'
+
+// Proves a registry-backed v0 composable (createSelection) runs correctly when
+// instantiated inside a Vapor component setup, and that its reactive state
+// drives Vapor DOM updates.
+describe('v0 createSelection under real Vapor', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('should register tickets and start unselected', () => {
+    wrapper = mountVapor(SelectionProbe)
+
+    expect(wrapper.host.querySelector('[data-alpha-selected]')!.textContent).toBe('false')
+    expect(wrapper.host.querySelector('[data-selected-count]')!.textContent).toBe('0')
+  })
+
+  it('should reactively update Vapor DOM when a ticket is toggled', async () => {
+    wrapper = mountVapor(SelectionProbe)
+
+    wrapper.host.querySelector<HTMLButtonElement>('[data-toggle]')!.click()
+    await nextTick()
+
+    expect(wrapper.host.querySelector('[data-alpha-selected]')!.textContent).toBe('true')
+    expect(wrapper.host.querySelector('[data-selected-count]')!.textContent).toBe('1')
+  })
+})

--- a/tests/vapor/test/context.vapor.test.ts
+++ b/tests/vapor/test/context.vapor.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mountVapor } from './mount'
+
+// Types
+import type { VaporMount } from './mount'
+
+import ContextProvider from '../src/ContextProvider.vue'
+
+// createContext is the provide/inject substrate beneath every v0 compound
+// component. This proves it carries a value from a Vapor ancestor to a Vapor
+// descendant — i.e. the compound-component pattern holds in a pure Vapor tree.
+describe('v0 createContext under real Vapor', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('should inject a value provided by a Vapor ancestor', () => {
+    wrapper = mountVapor(ContextProvider)
+
+    expect(wrapper.host.querySelector('[data-greeting]')?.textContent).toBe('hello-vapor')
+  })
+})

--- a/tests/vapor/test/instance.vapor.test.ts
+++ b/tests/vapor/test/instance.vapor.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mountVapor } from './mount'
+
+// Types
+import type { VaporMount } from './mount'
+
+import InstanceProbe from '../src/InstanceProbe.vue'
+
+// The payoff test. instance.test.ts proves the shim's branch logic with a
+// mocked `currentInstance`; this proves it against a REAL Vapor render where
+// getCurrentInstance() genuinely returns null but the component is live.
+describe('v0 instance shim under real Vapor', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  function probe () {
+    wrapper = mountVapor(InstanceProbe)
+    return wrapper.host.firstElementChild as HTMLElement
+  }
+
+  it('should confirm we are genuinely in Vapor mode (getCurrentInstance is null)', () => {
+    expect(probe().dataset.rawNull).toBe('true')
+  })
+
+  it('should detect the active instance via the currentInstance shim', () => {
+    // This is the assertion the mock can only fake: under a live Vapor
+    // component, instanceExists() must return true.
+    expect(probe().dataset.shimDetects).toBe('true')
+  })
+
+  it('should resolve a usable id through useId() without throwing', () => {
+    const el = probe()
+    expect(el.dataset.idError).toBe('')
+    expect(el.dataset.id).toBeTruthy()
+  })
+})

--- a/tests/vapor/test/interop.vapor.test.ts
+++ b/tests/vapor/test/interop.vapor.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mountVapor } from './mount'
+
+// Types
+import type { VaporMount } from './mount'
+
+import InteropAtom from '../src/InteropAtom.vue'
+
+// v0 components are authored as classic (vdom) SFCs. This proves one renders
+// inside a Vapor root through vaporInteropPlugin — the path a real app on a
+// Vapor root would hit when consuming v0's component layer.
+describe('v0 classic component under a Vapor root (interop)', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('should render the polymorphic Atom element', () => {
+    wrapper = mountVapor(InteropAtom, { interop: true })
+
+    const section = wrapper.host.querySelector('section[data-interop="host"]')
+    expect(section).not.toBeNull()
+  })
+
+  it('should render slotted content forwarded from the Vapor parent', () => {
+    wrapper = mountVapor(InteropAtom, { interop: true })
+
+    expect(wrapper.host.querySelector('[data-child]')?.textContent).toBe('child')
+  })
+})

--- a/tests/vapor/test/mount.ts
+++ b/tests/vapor/test/mount.ts
@@ -1,0 +1,43 @@
+// Utilities
+import { createVaporApp, vaporInteropPlugin } from '@vue/runtime-vapor'
+
+// Types
+import type { Component } from 'vue'
+
+export interface VaporMount {
+  host: HTMLElement
+  app: ReturnType<typeof createVaporApp>
+  html: () => string
+  unmount: () => void
+}
+
+export interface MountOptions {
+  props?: Record<string, unknown>
+  // Install vaporInteropPlugin so classic (vdom) v0 components can render
+  // inside this Vapor app — required for any test that mounts a v0 SFC.
+  interop?: boolean
+}
+
+// @vue/test-utils has no Vapor support yet (vuejs/core#13687), so mount
+// manually: create a host, boot a vapor app, expose the rendered DOM, and
+// tear down. Pattern adapted from the runtime-vapor test utils.
+export function mountVapor (component: Component, options: MountOptions = {}): VaporMount {
+  const host = document.createElement('div')
+  document.body.append(host)
+
+  const app = createVaporApp(component as Parameters<typeof createVaporApp>[0], options.props)
+  if (options.interop) {
+    app.use(vaporInteropPlugin)
+  }
+  app.mount(host)
+
+  return {
+    host,
+    app,
+    html: () => host.innerHTML,
+    unmount () {
+      app.unmount()
+      host.remove()
+    },
+  }
+}

--- a/tests/vapor/test/smoke.test.ts
+++ b/tests/vapor/test/smoke.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mountVapor } from './mount'
+
+// Utilities
+import { nextTick } from 'vue'
+
+// Types
+import type { VaporMount } from './mount'
+
+import Counter from '../src/Counter.vue'
+
+// Smoke test: proves the beta toolchain (vue@3.6 + @vue/runtime-vapor +
+// @vitejs/plugin-vue) can compile a <script setup vapor> SFC, mount it, and
+// observe reactive DOM updates. Nothing v0-specific here — if this fails, the
+// harness is broken, not v0.
+describe('vapor toolchain smoke', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('should compile and mount a vapor SFC', () => {
+    wrapper = mountVapor(Counter)
+
+    const button = wrapper.host.querySelector('button')
+    expect(button).not.toBeNull()
+    expect(button!.textContent).toContain('Count: 0')
+  })
+
+  it('should update the DOM on reactive change', async () => {
+    wrapper = mountVapor(Counter)
+
+    const button = wrapper.host.querySelector('button')!
+    button.click()
+    await nextTick()
+
+    expect(button.textContent).toContain('Count: 1')
+  })
+})

--- a/tests/vapor/vitest.config.ts
+++ b/tests/vapor/vitest.config.ts
@@ -1,0 +1,82 @@
+import { fileURLToPath } from 'node:url'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vitest/config'
+
+// Resolve @vuetify/v0 (and its internal #v0 alias) to source, not built dist,
+// so the Vapor graph compiles the real v0 TypeScript against Vue 3.6.
+const v0Src = fileURLToPath(new URL('../../packages/0/src', import.meta.url))
+const paperSrc = fileURLToPath(new URL('../../packages/paper/src', import.meta.url))
+
+export default defineConfig({
+  // Vapor is opted into per-SFC via the `vapor` attribute on <script setup>;
+  // @vitejs/plugin-vue routes vapor descriptors to the vapor compiler with no
+  // plugin-level option required.
+  plugins: [vue()],
+  resolve: {
+    conditions: ['import', 'module', 'development', 'browser', 'default'],
+    // Array form so `vue` can be matched EXACTLY via regex. Vue's `.` export
+    // resolves the `node` condition to index.mjs → the full CJS build, which
+    // does NOT re-export the Vapor runtime — so the compiled SFC's
+    // `import { defineVaporComponent } from 'vue'` comes back undefined.
+    // Redirect the bare `vue` specifier straight to the esm-bundler build,
+    // which does `export * from "@vue/runtime-vapor"`. The `^vue$` regex
+    // leaves subpaths like `vue/server-renderer` untouched.
+    // The @vue/* esm-bundler builds re-export each other's @internal symbols
+    // (e.g. runtime-vapor imports `initFeatureFlags` from runtime-dom, which
+    // gets it via `export * from "@vue/runtime-core"`). The CJS builds strip
+    // those internals, so a single CJS resolution anywhere in the chain breaks
+    // linking. Pin every Vue runtime package to its esm-bundler build.
+    alias: [
+      { find: /^vue$/, replacement: 'vue/dist/vue.runtime.esm-bundler.js' },
+      { find: /^@vue\/runtime-vapor$/, replacement: '@vue/runtime-vapor/dist/runtime-vapor.esm-bundler.js' },
+      { find: /^@vue\/runtime-dom$/, replacement: '@vue/runtime-dom/dist/runtime-dom.esm-bundler.js' },
+      { find: /^@vue\/runtime-core$/, replacement: '@vue/runtime-core/dist/runtime-core.esm-bundler.js' },
+      { find: /^@vue\/reactivity$/, replacement: '@vue/reactivity/dist/reactivity.esm-bundler.js' },
+      { find: /^@vue\/shared$/, replacement: '@vue/shared/dist/shared.esm-bundler.js' },
+      { find: '@vuetify/v0', replacement: v0Src },
+      { find: '@vuetify/paper', replacement: paperSrc },
+      { find: '#v0', replacement: v0Src },
+      { find: '#paper', replacement: paperSrc },
+    ],
+    // CRITICAL: v0 source physically lives next to a Vue 3.5 copy. Without
+    // deduping, `import * as Vue from 'vue'` inside v0 would walk up to that
+    // 3.5 install and the Vapor-only branch in utilities/instance.ts would
+    // never fire. Force every Vue runtime package to the single 3.6 copy.
+    dedupe: [
+      'vue',
+      '@vue/runtime-core',
+      '@vue/runtime-dom',
+      '@vue/runtime-vapor',
+      '@vue/reactivity',
+      '@vue/shared',
+    ],
+  },
+  // v0 source references __DEV__/__VERSION__/__VITE_LOGGER_ENABLED__ (mirror
+  // packages/0); the inlined Vue esm-bundler builds reference __DEV__ and the
+  // __VUE_*__ feature flags. All must be replaced at transform time or the
+  // externalized/transformed runtime throws on undefined globals.
+  define: {
+    __DEV__: 'process.env.NODE_ENV !== \'production\'',
+    __VITE_LOGGER_ENABLED__: 'process.env.VITE_LOGGER_ENABLED',
+    __VERSION__: '"0.0.0-vapor"',
+    __VUE_OPTIONS_API__: 'true',
+    __VUE_PROD_DEVTOOLS__: 'false',
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: ['test/**/*.test.ts'],
+    testTimeout: 20_000,
+    server: {
+      deps: {
+        // Vapor symbols (defineVaporComponent, createVaporApp, …) are only
+        // re-exported from Vue's ESM-bundler build. Externalized in Node,
+        // `vue` resolves to the CJS entry which lacks them. Inlining forces
+        // Vite to transform the runtime via the `import` condition.
+        inline: [/^vue$/, /vue\/dist\//, /@vue\//],
+      },
+    },
+  },
+})


### PR DESCRIPTION
Verifies `@vuetify/v0` works under **Vue Vapor mode** with real renders (not mocks), on an isolated `vue@3.6.0-beta.15` + `@vue/runtime-vapor` toolchain kept separate from the repo's `vue@3.5.33` pin.

## What's here
- `tests/vapor` — a private workspace package, excluded from the default `pnpm test` / CI run. Run it with `pnpm test:vapor`.
- Tests proving, under a genuine Vapor render:
  - **instance shim** (`utilities/instance.ts`) — `getCurrentInstance()` is null, yet the `currentInstance` shim still detects the instance and `useId()` resolves. This is the exact branch `instance.test.ts` can only simulate with a mock.
  - **`createSelection`** — registry + reactive ticket state drives Vapor DOM updates.
  - **classic-component interop** — a vdom v0 `Atom` renders under a Vapor root via `vaporInteropPlugin`, including forwarded slot content.
- Non-blocking `vapor` job in `pr-checks.yml` (beta-pinned, `continue-on-error`).

## Why isolated
Vapor ships in Vue 3.6 (still beta); the rest of the repo stays on 3.5. The beta Vue is confined to `tests/vapor` via the lockfile, so `packages/0` and the default test run are untouched. `tests/vapor/README.md` documents the two beta config traps (Vue's `node` export condition resolving to a Vapor-less build; `@vue/*` esm-bundler linking).