### PR TITLE
docs(DiscoverySkip): announce final-step button as "Complete tour"

### DIFF
--- a/apps/docs/src/components/discovery/DiscoverySkip.vue
+++ b/apps/docs/src/components/discovery/DiscoverySkip.vue
@@ -34,7 +34,7 @@
 
 <template>
   <button
-    aria-label="Skip tour"
+    :aria-label="root.isLast.value ? 'Complete tour' : 'Skip tour'"
     type="button"
     @click="skip"
   >


### PR DESCRIPTION
## Problem

On the last step of a Skillz tour, the primary button reads **"Complete"** but announces to screen readers as **"Skip tour"** — the semantic opposite of the action it performs.

## Root cause

The tour footer (`DocsDiscoveryStep.vue`) reuses `Discovery.Skip` for two roles:

- mid-tour **Exit** (`v-if="!isLast"`)
- last-step **Complete** (`v-else`)

`DiscoverySkip.vue` hardcoded `aria-label="Skip tour"` for both. Its `skip()` already branches on `root.isLast` — on the final step it calls `skillz.complete()` and routes to the tour's `completeRoute`, so the *behavior* was always correct; only the label was wrong.

## Fix

Derive the label from the same `root.isLast` ref, mirroring the pattern `DiscoveryNext.vue` already uses for its `Go to next step` → `Complete tour` swap:

```diff
-    aria-label="Skip tour"
+    :aria-label="root.isLast.value ? 'Complete tour' : 'Skip tour'"
```

- Mid-tour **Exit** stays `Skip tour`.
- Last-step **Complete** becomes `Complete tour`.

No behavior change — `Discovery.Next` is hidden in interactive tours, so the last-step action must remain `Discovery.Skip`; only its announced label is corrected.

## Verification

Drove the `using-search` tour end-to-end in a browser:

- Step 1 Exit button → `aria-label="Skip tour"` (unchanged)
- Step 9 Complete button → `aria-label="Complete tour"` (was `Skip tour`)
- Completion still records `status: "completed"` and navigates to the tour detail page.