### PR TITLE
docs: add open-source sustainability section to why-v0

### DIFF
--- a/apps/docs/src/pages/introduction/why-vuetify0.md
+++ b/apps/docs/src/pages/introduction/why-vuetify0.md
@@ -230,6 +230,12 @@ While v0 is new, its patterns are not. Registration, selection, theming, forms �
 
 Active Discord. Weekly releases. Responsive maintainers. The kind of support that comes from 10 years of earning trust — not a weekend project that might go quiet.
 
+### Open Source, Forever
+
+**MIT licensed — and nothing to gate.**
+
+v0 is MIT licensed — every component, composable, and utility. No pro tier, no paywalled features, no plans for either. There's nothing to gate, because the project isn't funded by gating it: development is carried by the wider Vuetify ecosystem — sponsorships, optional services, and a decade of continuous open-source work. The foundation you build on today stays free, and stays maintained.
+
 ### Vuetify Convergence
 
 Vuetify0 is already being merged into Vuetify's next major release. The first PR has landed. Investing in v0 now means your foundation aligns with where the entire Vuetify ecosystem is actively heading.


### PR DESCRIPTION
Adds an **Open Source, Forever** subsection to the why-vuetify0 page, within *A Decade of Battle-Testing*.

It reinforces that v0 is MIT licensed — every component, composable, and utility — with no pro tier or paywalled features, and explains *why* that's durable: the project isn't funded by gating the code. Development is carried by the wider Vuetify ecosystem (sponsorships, optional services, a decade of continuous OSS work), so adopters know the foundation stays free and maintained.

Leads with the structural point ("nothing to gate") rather than a bare promise; names no specific sponsor.