### PR TITLE
fix(useTheme): remove adopted stylesheet on V0 adapter dispose

### DIFF
--- a/.changeset/theme-adapter-sheet-leak-399.md
+++ b/.changeset/theme-adapter-sheet-leak-399.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useTheme): remove the adopted stylesheet on V0 adapter dispose — the browser adapter (`V0StyleSheetThemeAdapter`) appended a `CSSStyleSheet` to `document.adoptedStyleSheets` in `upsert()` but `dispose()` only stopped the Vue watchers, leaking orphaned sheets on repeated mount/unmount (HMR, test suites, micro-frontend teardown). Dispose now filters the sheet out of `adoptedStyleSheets` and clears the ref across all three dispose paths, mirroring the sibling unhead adapter. Follow-up to the leak-safe adapter lifecycle work.

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -490,5 +490,71 @@ describe('v0StyleSheetThemeAdapter', () => {
 
       expect(updateSpy.mock.calls.length).toBe(callCount)
     })
+
+    it('should remove the adopted stylesheet on dispose', () => {
+      const app = createMockApp()
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter()
+
+      const scope = effectScope()
+      scope.run(() => {
+        adapter.setup(app, context, null)
+      })
+
+      expect(document.adoptedStyleSheets).toHaveLength(1)
+      expect(adapter.sheet).toBeDefined()
+
+      adapter.dispose?.()
+
+      expect(document.adoptedStyleSheets).toHaveLength(0)
+      expect(adapter.sheet).toBeUndefined()
+
+      scope.stop()
+    })
+
+    it('should remove the adopted stylesheet on dispose with a target element', () => {
+      const app = createMockApp()
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter()
+      const targetEl = document.createElement('div')
+      document.body.append(targetEl)
+
+      const scope = effectScope()
+      scope.run(() => {
+        adapter.setup(app, context, targetEl)
+      })
+
+      expect(document.adoptedStyleSheets).toHaveLength(1)
+      expect(adapter.sheet).toBeDefined()
+
+      adapter.dispose?.()
+
+      expect(document.adoptedStyleSheets).toHaveLength(0)
+      expect(adapter.sheet).toBeUndefined()
+
+      targetEl.remove()
+      scope.stop()
+    })
+
+    it('should remove the adopted stylesheet on dispose when target resolves to no element', () => {
+      const app = createMockApp()
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter()
+
+      const scope = effectScope()
+      scope.run(() => {
+        adapter.setup(app, context, '#nonexistent-target')
+      })
+
+      expect(document.adoptedStyleSheets).toHaveLength(1)
+      expect(adapter.sheet).toBeDefined()
+
+      adapter.dispose?.()
+
+      expect(document.adoptedStyleSheets).toHaveLength(0)
+      expect(adapter.sheet).toBeUndefined()
+
+      scope.stop()
+    })
   })
 })

--- a/packages/0/src/composables/useTheme/adapters/v0.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.ts
@@ -61,7 +61,10 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
       })
 
       if (isNull(target)) {
-        this.dispose = stopWatch
+        this.dispose = () => {
+          stopWatch()
+          this.detach()
+        }
         return
       }
 
@@ -72,7 +75,10 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
             : (app._container as HTMLElement | undefined) || document.querySelector('#app') as HTMLElement | null || document.body)
 
       if (!targetEl) {
-        this.dispose = stopWatch
+        this.dispose = () => {
+          stopWatch()
+          this.detach()
+        }
         return
       }
 
@@ -89,6 +95,7 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
       this.dispose = () => {
         stopWatch()
         stopTheme()
+        this.detach()
       }
     } else {
       const head = (app._context?.provides?.usehead ?? app._context?.provides?.head) as Head | undefined
@@ -127,5 +134,12 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
       document.adoptedStyleSheets = [...document.adoptedStyleSheets, this.sheet]
     }
     this.sheet.replaceSync(styles)
+  }
+
+  private detach (): void {
+    if (!IN_BROWSER) return
+
+    document.adoptedStyleSheets = document.adoptedStyleSheets.filter(s => s !== this.sheet)
+    this.sheet = undefined
   }
 }


### PR DESCRIPTION
The `useTheme` browser adapter (`V0StyleSheetThemeAdapter`) appends a `CSSStyleSheet` to `document.adoptedStyleSheets` in `upsert()`, but `dispose()` only stopped the Vue watchers — the sheet was never removed. Repeated mount/unmount (HMR, test suites, micro-frontend teardown) accumulated orphaned stylesheets.

Adds an `IN_BROWSER`-gated `detach()` that filters the sheet out of `adoptedStyleSheets` and clears `this.sheet`, called from all three `dispose` paths. This mirrors the sibling `unhead` adapter, which already disposes the resource it owns. Follow-up to #342, which added `dispose → app.onUnmount` for watchers but didn't cover the adopted stylesheet.

Two regression tests assert the sheet is removed from `document.adoptedStyleSheets` (and `sheet` cleared) after `dispose()`, covering both the null-target and with-target dispose paths.

Closes #399