### PR TITLE
docs(AppNav): scroll active leaf into view on navigation, not category header

### DIFF
--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -109,8 +109,17 @@
     // Don't scroll during initial state restoration or in flat mode
     if (!navNested.scrollEnabled.value || navConfig.flatMode.value) return
 
+    // When a route change expanded this category, scroll to the destination leaf —
+    // the link whose href exactly matches the current path — not the category header.
+    // Match by exact attribute, not [aria-current="page"]: ancestor links also carry
+    // aria-current (isActive uses startsWith), so a loose match would land on the
+    // category's own link. Fall back to the section itself for a manual expand of an
+    // unrelated category, where no descendant link matches the route.
     // block: 'nearest' resolves the .nav-scroll container itself and is a no-op when already visible
-    itemRef.value?.scrollIntoView({
+    const links = itemRef.value ? [...itemRef.value.querySelectorAll<HTMLElement>('a[href]')] : []
+    const target = links.find(link => link.getAttribute('href') === route.path) ?? itemRef.value
+
+    target?.scrollIntoView({
       block: 'nearest',
       behavior: settings.prefersReducedMotion.value ? 'instant' : 'smooth',
     })


### PR DESCRIPTION
## Problem

Navigating to a deep docs page (e.g. from search or Ask AI) scrolled the nav drawer to the **category header** ("Composables") instead of the destination page (useTimer), leaving the active item far below the fold.

## Cause

When a route change expands a category, the `<Transition>`'s `@after-enter` handler `onAfterExpand` ran `scrollIntoView` on the category `<li>`. Firing *after* the ~200ms expand transition, it overrode `AppNav`'s correct active-leaf scroll — landing the viewport on the category header.

## Fix

`onAfterExpand` now scrolls to the link whose `href` exactly matches `route.path`. It matches by exact attribute rather than `[aria-current=page]` because ancestor links also carry `aria-current` (`isActive` uses `startsWith`), so a loose selector would land on the category's own link. Falls back to the section element for a manual expand of an unrelated category.

Verified in-browser via the search → click-result repro: the active leaf lands fully in view.