### PR TITLE
fix(createSelection): reject disabled items in multiple-mode apply

### DIFF
--- a/.changeset/disabled-apply-guard-398.md
+++ b/.changeset/disabled-apply-guard-398.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createSelection): reject disabled items in multiple-mode `apply()` — the v-model sync path (`apply()`) could select a disabled item even though `select`/`unselect`/`toggle` all reject them, violating the "disabled = all selection ops are no-ops" contract. `createModel.apply()`'s browse-fallback now routes through `select()` (which guards instance- and ticket-level `disabled`), and `createSelection.apply()`'s multiple branch gains an inline per-ticket guard before adding (kept inline rather than routed through `select()` so the single-mode `multiple: true` override still works). The ref-write value-sync path is untouched. Affects multiple-mode `createSelection`/`createGroup`/`createNested` via `useProxyModel`.

--- a/packages/0/src/composables/createModel/index.test.ts
+++ b/packages/0/src/composables/createModel/index.test.ts
@@ -510,6 +510,27 @@ describe('createModel', () => {
       expect(model.selectedIds.size).toBe(1)
       expect(model.selectedIds.has('item-1')).toBe(true)
     })
+
+    it('should not select a disabled ticket via browse resolution', () => {
+      const model = createModel()
+      model.register({ id: 'item-1', value: 'val-1', disabled: true })
+
+      model.apply(['val-1'])
+
+      expect(model.selectedIds.has('item-1')).toBe(false)
+      expect(model.selectedIds.size).toBe(0)
+    })
+
+    it('should still resolve a non-disabled value through the guard', () => {
+      const model = createModel()
+      model.register({ id: 'item-1', value: 'val-1' })
+      model.register({ id: 'item-2', value: 'val-2', disabled: true })
+
+      model.apply(['val-1'])
+
+      expect(model.selectedIds.has('item-1')).toBe(true)
+      expect(model.selectedIds.has('item-2')).toBe(false)
+    })
   })
 
   describe('size', () => {

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -431,7 +431,7 @@ export function createModel<
 
     const ids = registry.browse(toRaw(value))
     const id = ids?.values().next().value
-    if (!isUndefined(id)) selectedIds.add(id)
+    if (!isUndefined(id)) select(id)
   }
 
   function register (registration: Partial<Z> = {}): E {

--- a/packages/0/src/composables/createSelection/index.test.ts
+++ b/packages/0/src/composables/createSelection/index.test.ts
@@ -1064,6 +1064,19 @@ describe('createSelection', () => {
         expect(selection.selectedIds.has('b')).toBe(true)
         expect(selection.selectedIds.size).toBe(2)
       })
+
+      it('should not select a disabled item when applying in multiple mode', () => {
+        const selection = createSelection({ multiple: true })
+        selection.onboard([
+          { id: 'a', value: 'A' },
+          { id: 'b', value: 'B', disabled: true },
+        ])
+
+        selection.apply(['A', 'B'])
+
+        expect(selection.selectedIds.has('a')).toBe(true)
+        expect(selection.selectedIds.has('b')).toBe(false)
+      })
     })
 
     describe('custom ticket types', () => {

--- a/packages/0/src/composables/createSelection/index.ts
+++ b/packages/0/src/composables/createSelection/index.ts
@@ -257,7 +257,10 @@ export function createSelection<
         if (!targetIds.has(id)) unselect(id)
       }
       for (const id of targetIds) {
-        if (!currentIds.has(id)) model.selectedIds.add(id)
+        if (currentIds.has(id)) continue
+        const ticket = model.get(id)
+        if (ticket && toValue(ticket.disabled)) continue
+        model.selectedIds.add(id)
       }
     } else {
       const next = targetIds.values().next().value


### PR DESCRIPTION
In multiple-selection mode, `apply()` (the v-model sync path) could select a **disabled** item, even though `select()`, `unselect()`, and `toggle()` all correctly reject disabled items — violating the documented "disabled model/item makes all selection operations no-ops" contract.

Two unguarded add paths, fixed per the issue's prescription:

- `createModel.apply()` browse-fallback now routes through `select(id)` (which guards both instance-level and per-ticket `disabled`) instead of `selectedIds.add(id)`.
- `createSelection.apply()`'s **multiple** branch gains an inline per-ticket guard (`model.get(id)` → skip if `toValue(ticket.disabled)`) before the add — kept **inline** rather than routed through `model.select(id)`, because `select` clears based on the model's own `multiple` and would break the single-mode `apply([...], { multiple: true })` override.
- The ref-write value-sync loop is left unguarded so already-selected tickets keep syncing.

Affects multiple-mode `createSelection` / `createGroup` / `createNested` via `useProxyModel` (multi-`Select`, `Combobox`, `CheckboxGroup`, `Treeview`, …).

Regression tests added to both `createModel` and `createSelection` (none existed for disabled + apply). Verified locally: createModel + createSelection 136/136, and the selection family (`createSingle`/`createGroup`/`createNested`/`createStep`) + `useProxyModel` 379/379 — no downstream regression.

The issue's open question — whether instance-level `disabled` should gate v-model *sync* at all — is intentionally deferred; the per-ticket guard is correct either way.

Closes #398