### PR TITLE
fix(createTokens): guard resolve() against inherited prototype members

### DIFF
--- a/.changeset/tokens-resolve-proto-guard-400.md
+++ b/.changeset/tokens-resolve-proto-guard-400.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createTokens): `resolve()` no longer returns inherited prototype members — the alias-path walk used `segment in current`, which traverses the prototype chain, so resolving a path whose final segment named an `Object.prototype` member (`constructor`, `toString`, `hasOwnProperty`, `__proto__`, …) returned that builtin instead of `undefined` + the "Path not found" warning. `resolve()` now mirrors `flatten()`'s guard (`UNSAFE_KEYS` + `Object.prototype.hasOwnProperty.call`). Correctness/defense-in-depth — config and the resolve argument are developer-authored, so this is a consistency fix, not a security fix.

--- a/packages/0/src/composables/createTokens/index.test.ts
+++ b/packages/0/src/composables/createTokens/index.test.ts
@@ -2100,6 +2100,23 @@ describe('createTokens', () => {
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Path not found'))
       })
 
+      it('should not resolve inherited Object.prototype members as token paths', () => {
+        const tokens: TokenCollection = {
+          complex: { inner: { leaf: '#FFFFFF' } },
+        }
+
+        const context = createTokens(tokens, { flat: true })
+
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        expect(context.resolve('complex.inner.leaf')).toBe('#FFFFFF')
+        expect(context.resolve('complex.constructor')).toBeUndefined()
+        expect(context.resolve('complex.__proto__')).toBeUndefined()
+        expect(context.resolve('complex.hasOwnProperty')).toBeUndefined()
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Path not found'))
+      })
+
       it('should handle object with $value when continuing path', () => {
         const tokens: TokenCollection = {
           config: {

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -232,7 +232,7 @@ export function createTokens<
       if (isTokenAlias(current)) current = current.$value
 
       for (const segment of segments) {
-        if (!isObject(current) || !(segment in current)) {
+        if (!isObject(current) || UNSAFE_KEYS.has(segment) || !Object.prototype.hasOwnProperty.call(current, segment)) {
           current = undefined
           break
         }


### PR DESCRIPTION
`createTokens` `resolve()` walked alias path segments with `segment in current`, which traverses the prototype chain. When a prefix resolved to a plain-object token value, resolving a path whose final segment named an `Object.prototype` member (`constructor`, `toString`, `hasOwnProperty`, `__proto__`, …) returned that inherited builtin instead of `undefined` + the "Path not found" warning.

`resolve()` now mirrors the guard its twin `flatten()` already uses — `UNSAFE_KEYS` (for `__proto__`/`constructor`/`prototype`) plus `Object.prototype.hasOwnProperty.call` (for every other inherited member). `UNSAFE_KEYS` was already imported.

This is a **correctness / defense-in-depth** fix, not a security fix: token config and the `resolve()` argument are developer-authored, so there's no attacker surface — the bite is `resolve()` handing back a builtin function instead of `undefined`. Since `flatten` can never register an unsafe/inherited key, mirroring the guard carries zero false-negative risk.

Regression test added: with an object-valued token registered, a legit nested path still resolves while `resolve('complex.constructor')` / `.__proto__` / `.hasOwnProperty` return `undefined`. Verified locally: createTokens 250/250, and consumers useTheme/useLocale/useFeatures 259/259.

Closes #400