### PR TITLE
chore(ci): run docs/playground build checks on package changes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,8 +109,10 @@ jobs:
           filters: |
             docs:
               - 'apps/docs/**'
+              - 'packages/**'
             playground:
               - 'apps/playground/**'
+              - 'packages/**'
 
   docs-check:
     needs: changes


### PR DESCRIPTION
A PR that touches only `packages/**` (e.g. renaming/removing an export, changing a prop type) can break docs examples or playground usage and still pass every PR gate — the breakage surfaces only post-merge as a failed deploy. The `dorny/paths-filter` step gated `docs-check` / `playground-check` solely on `apps/docs/**` / `apps/playground/**`, so package-only PRs skipped both.

Adds `- 'packages/**'` to both filter lists, reusing the existing `docs-check` / `playground-check` jobs (which run `build:docs` / `build:play`). The build cost is only paid when packages or the respective app actually change.

⚠️ Verification: this is a CI-workflow change — it can't be exercised locally. The YAML parses and the paths-filter structure matches the existing entries; the authoritative check is this PR's own CI run (and the fact that this very PR touches `.github/**` only, so the new package filter won't fire here — a follow-up package PR will exercise it).

Closes #401