### PR TITLE
chore: run check-only lint in pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-push": "pnpm lint:fix && pnpm typecheck && pnpm test:run && pnpm repo:check"
+    "pre-push": "pnpm lint && pnpm typecheck && pnpm test:run && pnpm repo:check"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",


### PR DESCRIPTION
The `pre-push` git hook ran `pnpm lint:fix`. `eslint --fix` exits 0 after auto-fixing, so the push proceeded while the fixes landed as **unstaged** working-tree edits — the already-committed unfixed code was pushed, and CI's check-only `pnpm lint` then failed on a commit that "passed" locally (plus a surprise dirty tree).

Changes the `simple-git-hooks` `pre-push` command's first step from `pnpm lint:fix` to check-only `pnpm lint`, so local pre-push mirrors CI exactly — a lint error blocks the push loudly instead of silently rewriting the tree. (`typecheck` / `test:run` / `repo:check` unchanged.) Per the issue, preferred over moving a blanket fix to `pre-commit`; scope with lint-staged if a pre-commit fix is wanted later.

The committed `.git/hooks/pre-push` re-syncs from this config on the next `pnpm install` (`prepare` → `simple-git-hooks`).

Closes #402