### PR TITLE
chore(build): point tsdown aliases at real src dirs

### DIFF
--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -4,8 +4,8 @@ import Vue from 'unplugin-vue/rolldown'
 
 import pkg from './package.json' with { type: 'json' }
 
-const at = fileURLToPath(new URL('../src', import.meta.url))
-const v0 = fileURLToPath(new URL('../../0/src', import.meta.url))
+const at = fileURLToPath(new URL('src', import.meta.url))
+const v0 = fileURLToPath(new URL('src', import.meta.url))
 const __VERSION__ = JSON.stringify(pkg.version)
 
 export default defineConfig([{

--- a/packages/paper/tsdown.config.mts
+++ b/packages/paper/tsdown.config.mts
@@ -5,8 +5,8 @@ import Vue from 'unplugin-vue/rolldown'
 
 import pkg from './package.json' with { type: 'json' }
 
-const v0 = fileURLToPath(new URL('../../0/src', import.meta.url))
-const paper = fileURLToPath(new URL('../src', import.meta.url))
+const v0 = fileURLToPath(new URL('../0/src', import.meta.url))
+const paper = fileURLToPath(new URL('src', import.meta.url))
 const __VERSION__ = JSON.stringify(pkg.version)
 
 export default defineConfig([{


### PR DESCRIPTION
The bundler-alias path consts in `packages/0/tsdown.config.mts` and `packages/paper/tsdown.config.mts` resolved to **non-existent** directories:
- `packages/0`: `at = ../src` → `packages/src` ✗, `v0 = ../../0/src` → `0/src` ✗
- `packages/paper`: `v0 = ../../0/src` → `0/src` ✗, `paper = ../src` → `packages/src` ✗

The build was green only because the keys never matched real imports (`@` is unused; `#v0`/`#paper` resolve via package.json `imports` / tsconfig paths). It's a latent footgun — a future `@/…` import would resolve to a nonexistent dir and fail confusingly.

**Fix:** correct the path consts to the real `src` dirs (matching `packages/0/vitest.config.ts` and `packages/genesis/tsdown.config.mts`):
- `packages/0`: both `at` and `v0` → `new URL('src', …)` (= `packages/0/src`)
- `packages/paper`: `v0` → `new URL('../0/src', …)` (= `packages/0/src`), `paper` → `new URL('src', …)` (= `packages/paper/src`)

I **kept the aliases (corrected)** rather than deleting them (the issue's other option): paper genuinely consumes `#v0`, and a correctly-pointed alias is zero-risk, whereas deletion risks removing something load-bearing. A maintainer can delete them later if confirmed fully unused.

Bug-family: both `packages/0` and `packages/paper` fixed in one pass. Verified locally: `pnpm build:0` and `pnpm build:paper` both complete green.

Closes #403