### PR TITLE
chore(ci): align PR validation Node with .nvmrc and enforce engines

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: pnpm/action-setup@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: lts/*
+        node-version-file: .nvmrc
         cache: pnpm
     - run: pnpm install
       shell: bash

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "vue-tsc": "catalog:"
   },
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=26"
+  },
   "web-types": "dist/json/web-types.json"
 }


### PR DESCRIPTION
PR validation ran on a different (lower) Node major than the release build and the declared minimum, with nothing enforcing alignment:

- `.github/actions/setup/action.yml` used `node-version: lts/*` (Node 24 as of mid-2026) — and this composite action is used throughout `pr-checks.yml`.
- `release.yml` uses `node-version-file: .nvmrc` (`.nvmrc` = `26.0.0`); `README.md` declares Node >= 26; no `engines` field enforced it.

Risk: a Node-26-only API passes locally / ships via release but fails PR CI on 24 (or the inverse).

**Fix:**
- setup action → `node-version-file: .nvmrc`, so PR CI resolves Node from the same file as the release build (`cache: pnpm` preserved).
- add `engines.node: ">=26"` to `package.json` to machine-enforce the README/.nvmrc minimum.

Scoped to PR validation per the issue — `metrics-regen.yml` (separate `setup-node` usage) left untouched. The `--frozen-lockfile` note in the issue is a non-issue (pnpm auto-enables it when `CI` is set), so not changed.

⚠️ CI-workflow change — exercised on this PR's own run, not locally. YAML parses and `package.json` is valid JSON.

Closes #404