### PR TITLE
fix(ci): align setup action node version to .nvmrc

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: pnpm/action-setup@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: lts/*
+        node-version-file: .nvmrc
         cache: pnpm
     - run: pnpm install
       shell: bash


### PR DESCRIPTION
## Summary
- PR validation was running `lts/*` (Node 24) while release builds used `node-version-file: .nvmrc` (Node 26)
- Aligns the shared setup action to read from `.nvmrc` so all CI jobs use the same Node major

Closes #404