### PR TITLE
fix(hooks): use check-only lint in pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-push": "pnpm lint:fix && pnpm typecheck && pnpm test:run && pnpm repo:check"
+    "pre-push": "pnpm lint && pnpm typecheck && pnpm test:run && pnpm repo:check"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",


### PR DESCRIPTION
## Summary
- `pre-push` was running `pnpm lint:fix` which auto-fixes files as unstaged edits and then exits 0
- The already-committed (unfixed) code gets pushed, then CI's check-only `pnpm lint` fails on it
- Changed to `pnpm lint` (check-only) so any lint error blocks the push instead of silently fixing it in the working tree

Closes #402