### PR TITLE
fix(build): correct tsdown alias paths to packages/0/src

### DIFF
--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -4,8 +4,8 @@ import Vue from 'unplugin-vue/rolldown'
 
 import pkg from './package.json' with { type: 'json' }
 
-const at = fileURLToPath(new URL('./src', import.meta.url))
-const v0 = fileURLToPath(new URL('./src', import.meta.url))
+const at = fileURLToPath(new URL('src', import.meta.url))
+const v0 = fileURLToPath(new URL('src', import.meta.url))
 const __VERSION__ = JSON.stringify(pkg.version)
 
 export default defineConfig([{

--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -4,8 +4,8 @@ import Vue from 'unplugin-vue/rolldown'
 
 import pkg from './package.json' with { type: 'json' }
 
-const at = fileURLToPath(new URL('../src', import.meta.url))
-const v0 = fileURLToPath(new URL('../../0/src', import.meta.url))
+const at = fileURLToPath(new URL('./src', import.meta.url))
+const v0 = fileURLToPath(new URL('./src', import.meta.url))
 const __VERSION__ = JSON.stringify(pkg.version)
 
 export default defineConfig([{


### PR DESCRIPTION
## Summary
- `new URL('../src', import.meta.url)` from `packages/0/` resolves to `packages/src` (non-existent)
- `new URL('../../0/src', import.meta.url)` resolves to a path outside the monorepo root
- Both are corrected to `new URL('./src', import.meta.url)` which resolves to `packages/0/src`
- Build was green only because `@` is unused in source and `#v0` is resolved via `package.json#imports` before hitting the alias

Closes #403