### PR TITLE
fix(exports): add type declarations to browser subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "preview:docs": "pnpm --filter=docs preview",
     "repo:knip": "knip",
     "repo:sherif": "sherif",
-    "repo:exports": "publint ./packages/0 && attw --pack ./packages/0 --profile esm-only --exclude-entrypoints browser",
+    "repo:exports": "publint ./packages/0 && attw --pack ./packages/0 --profile esm-only",
     "repo:check": "pnpm repo:knip && pnpm repo:sherif",
     "validate": "pnpm lint && pnpm typecheck && pnpm test:run",
     "changeset": "changeset",

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -344,8 +344,8 @@
     },
     "./package.json": "./package.json",
     "./browser": {
-      "development": "./src/index.ts",
       "types": "./dist/index.d.mts",
+      "development": "./src/index.ts",
       "default": "./dist/browser/index.js"
     }
   }

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -83,7 +83,10 @@
       "./types": "./dist/types/index.mjs",
       "./utilities": "./dist/utilities/index.mjs",
       "./package.json": "./package.json",
-      "./browser": "./dist/browser/index.js"
+      "./browser": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/browser/index.js"
+      }
     }
   },
   "peerDependencies": {
@@ -342,6 +345,7 @@
     "./package.json": "./package.json",
     "./browser": {
       "development": "./src/index.ts",
+      "types": "./dist/index.d.mts",
       "default": "./dist/browser/index.js"
     }
   }

--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -51,7 +51,7 @@ export default defineConfig([{
     customExports (pkg, ctx) {
       pkg['./browser'] = ctx.isPublish
         ? { types: './dist/index.d.mts', default: './dist/browser/index.js' }
-        : { ...pkg['.'], types: './dist/index.d.mts', default: './dist/browser/index.js' }
+        : { types: './dist/index.d.mts', development: './src/index.ts', default: './dist/browser/index.js' }
       return pkg
     },
   },

--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -49,7 +49,9 @@ export default defineConfig([{
   exports: {
     devExports: 'development',
     customExports (pkg, ctx) {
-      pkg['./browser'] = ctx.isPublish ? './dist/browser/index.js' : { ...pkg['.'], default: './dist/browser/index.js' }
+      pkg['./browser'] = ctx.isPublish
+        ? { types: './dist/index.d.mts', default: './dist/browser/index.js' }
+        : { ...pkg['.'], types: './dist/index.d.mts', default: './dist/browser/index.js' }
       return pkg
     },
   },


### PR DESCRIPTION
## Summary
- `@vuetify/v0/browser` had no `types` condition — `are-the-types-wrong` flagged it as `UntypedResolution`
- Added `"types": "./dist/index.d.mts"` to both the dev `exports["./browser"]` and `publishConfig.exports["./browser"]`
- Updated `tsdown.config.mts` `customExports` to emit the same condition on publish
- Removed the `--exclude-entrypoints browser` baseline from `repo:exports` script now that types resolve correctly

Closes #408