### PR TITLE
fix(useTheme): validate adapter prefix against SAFE_IDENT

### DIFF
--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -26,6 +26,9 @@ export abstract class ThemeAdapter {
   dispose?: () => void
 
   constructor (prefix: string) {
+    if (!ThemeAdapter.SAFE_IDENT.test(prefix)) {
+      throw new Error(`Invalid theme prefix "${prefix}": must match /^[a-zA-Z0-9_-]+$/.`)
+    }
     this.prefix = prefix
   }
 

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { hexToRgb, isUndefined } from '#v0/utilities'
+import { hexToRgb, isUndefined, V0Error } from '#v0/utilities'
 
 // Types
 import type { ID } from '#v0/types'
@@ -27,7 +27,7 @@ export abstract class ThemeAdapter {
 
   constructor (prefix: string) {
     if (!ThemeAdapter.SAFE_IDENT.test(prefix)) {
-      throw new Error(`Invalid theme prefix "${prefix}": must match /^[a-zA-Z0-9_-]+$/.`)
+      throw new V0Error(`Invalid theme prefix "${prefix}": must match /^[a-zA-Z0-9_-]+$/.`, { code: 'V0_THEME_INVALID_PREFIX', prefix })
     }
     this.prefix = prefix
   }

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -53,6 +53,12 @@ describe('v0StyleSheetThemeAdapter', () => {
 
       expect(adapter.cspNonce).toBe('test-nonce')
     })
+
+    it('should throw on a malformed prefix', () => {
+      expect(() => new V0StyleSheetThemeAdapter({ prefix: 'bad}{prefix' })).toThrow('Invalid theme prefix')
+      expect(() => new V0StyleSheetThemeAdapter({ prefix: 'bad<script>' })).toThrow('Invalid theme prefix')
+      expect(() => new V0StyleSheetThemeAdapter({ prefix: '' })).toThrow('Invalid theme prefix')
+    })
   })
 
   // eslint-disable-next-line vitest/prefer-lowercase-title

--- a/packages/0/src/types/index.ts
+++ b/packages/0/src/types/index.ts
@@ -166,6 +166,7 @@ export type V0ErrorDetails =
   | { code: 'V0_PALETTE_INVALID_SEED', palette: 'material' | 'leonardo' | 'ant', seed: string }
   | { code: 'V0_PALETTE_UNKNOWN_VARIANT', palette: 'material', variant: string }
   | { code: 'V0_ADAPTER_INSTANCE_MISSING', adapter: string }
+  | { code: 'V0_THEME_INVALID_PREFIX', prefix: string }
 
 /**
  * Union of every error code thrown by v0


### PR DESCRIPTION
## Summary
- Theme adapter `prefix` was interpolated into CSS as `--${prefix}-${key}` without validation
- A crafted prefix like `bad}{...` could break out of the declaration block and inject arbitrary CSS rules
- Added SAFE_IDENT check in `ThemeAdapter` constructor — throws on any prefix that doesn't match `/^[a-zA-Z0-9_-]+$/`
- Added test covering invalid prefix shapes (`bad}{prefix`, `bad<script>`, empty string)

Closes #405