### PR TITLE
fix(useTheme): thread cspNonce into SSR head.push style entry

### DIFF
--- a/packages/0/src/composables/useTheme/adapters/unhead.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.ts
@@ -20,7 +20,7 @@ import type { App } from 'vue'
 // Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
 interface ThemeHeadInput {
   htmlAttrs?: { 'data-theme': string }
-  style?: Array<{ innerHTML: string, id: string }>
+  style?: Array<{ innerHTML: string, id: string, nonce?: string }>
 }
 
 interface HeadEntry {
@@ -33,6 +33,7 @@ interface Head {
 }
 
 export interface V0UnheadThemeOptions {
+  cspNonce?: string
   stylesheetId?: string
   prefix?: string
 }
@@ -46,9 +47,11 @@ export interface V0UnheadThemeOptions {
  */
 export class V0UnheadThemeAdapter extends ThemeAdapter {
   private entry?: HeadEntry
+  cspNonce?: string
 
   constructor (options: V0UnheadThemeOptions = {}) {
     super(options.prefix ?? 'v0')
+    this.cspNonce = options.cspNonce
     this.stylesheetId = options.stylesheetId ?? this.stylesheetId
   }
 
@@ -68,6 +71,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
         style: [{
           innerHTML: this.generate(context.colors.value, context.isDark.value),
           id: this.stylesheetId,
+          ...(this.cspNonce != null && { nonce: this.cspNonce }),
         }],
       })
     }
@@ -103,6 +107,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
             style: [{
               innerHTML: this.generate(colors, isDark),
               id: this.stylesheetId,
+              ...(this.cspNonce != null && { nonce: this.cspNonce }),
             }],
           })
         },
@@ -127,6 +132,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
       style: [{
         innerHTML: this.generate(colors, isDark),
         id: this.stylesheetId,
+        ...(this.cspNonce != null && { nonce: this.cspNonce }),
       }],
     })
   }

--- a/packages/0/src/composables/useTheme/adapters/unhead.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.ts
@@ -46,8 +46,8 @@ export interface V0UnheadThemeOptions {
  * Requires @unhead/vue to be installed in the app.
  */
 export class V0UnheadThemeAdapter extends ThemeAdapter {
-  private entry?: HeadEntry
   cspNonce?: string
+  private entry?: HeadEntry
 
   constructor (options: V0UnheadThemeOptions = {}) {
     super(options.prefix ?? 'v0')

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -57,6 +57,27 @@ describe('v0StyleSheetThemeAdapter', () => {
 
   // eslint-disable-next-line vitest/prefer-lowercase-title
   describe('SSR (non-browser) environment', () => {
+    it('should thread cspNonce into the style entry on SSR head push', () => {
+      mockInBrowser.value = false
+      const headMock = { push: vi.fn() }
+      const app = createMockApp(headMock)
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter({ cspNonce: 'abc123' })
+
+      const scope = effectScope()
+      scope.run(() => {
+        adapter.setup(app, context)
+      })
+
+      expect(headMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          style: [expect.objectContaining({ nonce: 'abc123' })],
+        }),
+      )
+
+      scope.stop()
+    })
+
     it('should push styles to head when usehead is available', () => {
       mockInBrowser.value = false
       const headMock = { push: vi.fn() }

--- a/packages/0/src/composables/useTheme/adapters/v0.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.ts
@@ -16,7 +16,7 @@ import type { App } from 'vue'
 // Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
 interface ThemeHeadInput {
   htmlAttrs: { 'data-theme': string }
-  style: Array<{ innerHTML: string, id: string }>
+  style: Array<{ innerHTML: string, id: string, nonce?: string }>
 }
 
 interface HeadEntry {
@@ -109,6 +109,7 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
           style: [{
             innerHTML: this.generate(context.colors.value, context.isDark.value),
             id: this.stylesheetId,
+            ...(this.cspNonce != null && { nonce: this.cspNonce }),
           }],
         })
 


### PR DESCRIPTION
## Summary
- `V0StyleSheetThemeAdapter` accepted `cspNonce` but never used it on the SSR `head.push()` path — strict-CSP apps got a FOUC from blocked style elements
- `V0UnheadThemeAdapter` didn't accept `cspNonce` at all
- Adds `nonce` to the duck-typed `ThemeHeadInput` style element type
- Threads `this.cspNonce` into every `head.push()` and `entry.patch()` call in both adapters (only when nonce is set, no `nonce: undefined` in the output)
- Adds test verifying the nonce appears in the `head.push` call

Closes #406