### PR TITLE
fix(useStack): avoid module-scoped fallback singleton in SSR

### DIFF
--- a/packages/0/src/composables/useStack/index.test.ts
+++ b/packages/0/src/composables/useStack/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createStack,
@@ -13,6 +13,14 @@ import { defineComponent, nextTick, ref, watch } from 'vue'
 
 // Types
 import type { StackContext } from '.'
+
+const mockInBrowser = vi.hoisted(() => ({ value: true }))
+
+vi.mock('#v0/constants/globals', () => ({
+  get IN_BROWSER () {
+    return mockInBrowser.value
+  },
+}))
 
 describe('createStack', () => {
   describe('useStack', () => {
@@ -559,6 +567,23 @@ describe('createStack', () => {
         stack.register({ el: () => el }).select()
         expect(stack.topElement.value).toBe(el)
       })
+    })
+  })
+
+  describe('SSR fallback isolation', () => {
+    beforeEach(() => {
+      mockInBrowser.value = false
+    })
+
+    afterEach(() => {
+      mockInBrowser.value = true
+    })
+
+    it('should return a fresh stack on each useStack call in SSR to prevent cross-request bleed', () => {
+      const stack1 = useStack()
+      const stack2 = useStack()
+
+      expect(stack1).not.toBe(stack2)
     })
   })
 })

--- a/packages/0/src/composables/useStack/index.test.ts
+++ b/packages/0/src/composables/useStack/index.test.ts
@@ -570,7 +570,7 @@ describe('createStack', () => {
     })
   })
 
-  describe('SSR fallback isolation', () => {
+  describe('ssr fallback isolation', () => {
     beforeEach(() => {
       mockInBrowser.value = false
     })

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -24,6 +24,9 @@
  */
 
 // Composables
+// Globals
+import { IN_BROWSER } from '#v0/constants/globals'
+
 import { useContext } from '#v0/composables/createContext'
 import { createPlugin } from '#v0/composables/createPlugin'
 import { createSelection } from '#v0/composables/createSelection'
@@ -405,10 +408,14 @@ export function createStackPlugin (_options: StackPluginOptions = {}) {
   })
 }
 
-// Lazy singleton fallback for when no provider exists
+// Lazy singleton fallback for when no provider exists (browser-only)
 let fallbackStack: StackContext | undefined
 
 function getStackFallback (): StackContext {
+  // In SSR a module-scoped singleton persists across requests causing z-index
+  // bleed and unbounded memory growth. Return a fresh per-call context instead.
+  if (!IN_BROWSER) return createStack()
+
   if (!fallbackStack) {
     fallbackStack = createStack()
   }

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -24,9 +24,6 @@
  */
 
 // Composables
-// Globals
-import { IN_BROWSER } from '#v0/constants/globals'
-
 import { useContext } from '#v0/composables/createContext'
 import { createPlugin } from '#v0/composables/createPlugin'
 import { createSelection } from '#v0/composables/createSelection'
@@ -34,6 +31,9 @@ import { createTrinity } from '#v0/composables/createTrinity'
 
 // Transformers
 import { toElement } from '#v0/composables/toElement'
+
+// Globals
+import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities
 import { instanceExists, useId } from '#v0/utilities'


### PR DESCRIPTION
## Summary
- `getStackFallback()` lazily initialized a module-scoped `fallbackStack` singleton
- In SSR (long-lived Node process) tickets registered into this global persist across requests — wrong z-index for unrelated users, unbounded memory growth
- In browser the singleton is fine (one app per tab); in SSR each call should get an isolated context so request A's overlays don't bleed into request B
- Fix: return a fresh `createStack()` when `IN_BROWSER` is false instead of the cached singleton
- Adds a test that verifies two consecutive `useStack()` calls in SSR return distinct contexts

Closes #407