### PR TITLE
fix(useTheme): validate theme adapter prefix against SAFE_IDENT

### DIFF
--- a/.changeset/theme-prefix-safe-ident-405.md
+++ b/.changeset/theme-prefix-safe-ident-405.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useTheme): validate the theme adapter `prefix` against `SAFE_IDENT` — `ThemeAdapter.generate()` sanitized theme names, color keys, and values, but interpolated the adapter `prefix` into the generated CSS (`--${prefix}-…`, `var(--${prefix}-on-background)`) unvalidated, so a malformed prefix (e.g. containing `}`) could break out of the declaration block and inject arbitrary CSS rules. The constructor now rejects any prefix that doesn't match `SAFE_IDENT` (`/^[a-zA-Z0-9_-]+$/`) with a `V0Error` (`V0_THEME_INVALID_PREFIX`), mirroring the guard already applied to adjacent inputs and the `V0_PALETTE_INVALID_SEED` precedent. Both `V0StyleSheetThemeAdapter` and the unhead adapter inherit it. Non-breaking — valid prefixes already match.

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { hexToRgb, isUndefined } from '#v0/utilities'
+import { hexToRgb, isUndefined, V0Error } from '#v0/utilities'
 
 // Types
 import type { ID } from '#v0/types'
@@ -26,6 +26,13 @@ export abstract class ThemeAdapter {
   dispose?: () => void
 
   constructor (prefix: string) {
+    if (!ThemeAdapter.SAFE_IDENT.test(prefix)) {
+      throw new V0Error(`Invalid theme prefix: "${prefix}". Expected an identifier matching ${ThemeAdapter.SAFE_IDENT}.`, {
+        code: 'V0_THEME_INVALID_PREFIX',
+        prefix,
+      })
+    }
+
     this.prefix = prefix
   }
 

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { V0StyleSheetThemeAdapter } from './v0'
 
 // Utilities
+import { isV0Error } from '#v0/utilities'
 import { computed, effectScope, nextTick, ref } from 'vue'
 
 // Types
@@ -52,6 +53,41 @@ describe('v0StyleSheetThemeAdapter', () => {
       })
 
       expect(adapter.cspNonce).toBe('test-nonce')
+    })
+
+    it('should accept valid prefixes', () => {
+      const dashed = new V0StyleSheetThemeAdapter({ prefix: 'my-prefix' })
+      const underscored = new V0StyleSheetThemeAdapter({ prefix: 'theme_1' })
+
+      expect(dashed.prefix).toBe('my-prefix')
+      expect(underscored.prefix).toBe('theme_1')
+    })
+
+    it('should default the prefix when none is provided', () => {
+      const adapter = new V0StyleSheetThemeAdapter()
+
+      expect(adapter.prefix).toBe('v0')
+    })
+
+    it('should throw a V0Error with code V0_THEME_INVALID_PREFIX for malformed prefixes', () => {
+      const prefixes = ['x}body{display:none', 'a b', 'url(']
+
+      for (const prefix of prefixes) {
+        function construct () {
+          return new V0StyleSheetThemeAdapter({ prefix })
+        }
+
+        expect(construct).toThrow()
+
+        let error: unknown
+        try {
+          construct()
+        } catch (error_) {
+          error = error_
+        }
+
+        expect(isV0Error(error, 'V0_THEME_INVALID_PREFIX')).toBe(true)
+      }
     })
   })
 

--- a/packages/0/src/types/index.ts
+++ b/packages/0/src/types/index.ts
@@ -166,6 +166,7 @@ export type V0ErrorDetails =
   | { code: 'V0_PALETTE_INVALID_SEED', palette: 'material' | 'leonardo' | 'ant', seed: string }
   | { code: 'V0_PALETTE_UNKNOWN_VARIANT', palette: 'material', variant: string }
   | { code: 'V0_ADAPTER_INSTANCE_MISSING', adapter: string }
+  | { code: 'V0_THEME_INVALID_PREFIX', prefix: string }
 
 /**
  * Union of every error code thrown by v0

--- a/packages/0/src/utilities/errors.ts
+++ b/packages/0/src/utilities/errors.ts
@@ -77,6 +77,7 @@ export class V0Error extends Error {
   readonly seed?: string
   readonly variant?: string
   readonly adapter?: string
+  readonly prefix?: string
 
   constructor (message: string, details: V0ErrorDetails & { cause?: unknown }) {
     const { cause, ...rest } = details


### PR DESCRIPTION
`ThemeAdapter.generate()` sanitizes theme names (`SAFE_IDENT`), color keys (`SAFE_IDENT`), and values (`!UNSAFE_CSS`), but interpolated the adapter `prefix` into the generated CSS **unvalidated** (`--${prefix}-${key}`, `var(--${prefix}-on-background)`). A malformed prefix containing `}` can break out of the declaration block and inject arbitrary CSS rules (UI redress, attribute-selector exfiltration) — the prefix is interpolated into a string injected via `adoptedStyleSheets` / `<style>`, so a breakout genuinely injects.

**Severity:** low in core v0 — `prefix` is developer-supplied config with a default. It becomes a real vector only if a downstream design system pipes user/tenant-controlled input into the theme prefix. The repo's own `implementation.md` "Security primitives" table already prescribes this exact guard for CSS interpolation; the prefix was the one input in `generate()` that skipped it.

**Fix:** the `ThemeAdapter` constructor now validates `prefix` against `SAFE_IDENT` (`/^[a-zA-Z0-9_-]+$/`) and throws a `V0Error` (`code: 'V0_THEME_INVALID_PREFIX'`) on failure — mirroring the `V0_PALETTE_INVALID_SEED` precedent. Both `V0StyleSheetThemeAdapter` and the unhead adapter extend `ThemeAdapter`, so both inherit the guard. Non-breaking: valid prefixes (the default `'v0'`, `'custom'`, etc.) already match.

**Design note:** chose **throw** (fail-closed, consistent with v0's `V0Error` precedent for invalid developer-supplied string config) over silent fallback-to-default. Trade-off: under the tenant-controlled-prefix threat model, throwing turns an injection attempt into a thrown error at theme setup — surfacing the misuse loudly. If you'd prefer fallback-to-`'v0'`-with-warn instead, easy to switch.

New `V0ErrorCode` arm `V0_THEME_INVALID_PREFIX` (+ `prefix` field on `V0Error`); typechecks clean. Tests: valid prefixes accepted, default applied, malformed prefixes throw with the right code. Verified locally: useTheme 105/105, `pnpm --filter @vuetify/v0 typecheck` clean.

Closes #405