### PR TITLE
fix(useTheme): apply cspNonce on the SSR head path

### DIFF
--- a/.changeset/theme-csp-nonce-406.md
+++ b/.changeset/theme-csp-nonce-406.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useTheme): apply `cspNonce` on the SSR head path — `V0StyleSheetThemeAdapter` accepted a `cspNonce` option but never applied it: the SSR `head.push` `<style>` was emitted without the nonce, so strict-CSP (`style-src 'nonce-…'`) apps had their server-rendered theme styles blocked (FOUC until client hydration). The nonce is now threaded into the SSR style entry, and `V0UnheadThemeAdapter` accepts and forwards `cspNonce` too (initial push, reactive patch, and `update()`). The nonce is added only when set, so non-CSP usage is unchanged. The client `adoptedStyleSheets` path correctly needs no nonce.

--- a/packages/0/src/composables/useTheme/adapters/unhead.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.test.ts
@@ -66,6 +66,28 @@ describe('v0UnheadThemeAdapter', () => {
       mockInBrowser.value = true
     })
 
+    it('should include cspNonce in the pushed style entry', () => {
+      mockInBrowser.value = false
+      const head = createMockHead()
+      const app = createMockApp(head)
+      const context = createMockContext()
+      const adapter = new V0UnheadThemeAdapter({ cspNonce: 'test-nonce' })
+
+      const scope = effectScope()
+      scope.run(() => adapter.setup(app, context))
+
+      expect(head.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          style: expect.arrayContaining([
+            expect.objectContaining({ nonce: 'test-nonce' }),
+          ]),
+        }),
+      )
+
+      scope.stop()
+      mockInBrowser.value = true
+    })
+
     it('should fall back to provides.head when usehead is missing', () => {
       mockInBrowser.value = false
       const head = createMockHead()

--- a/packages/0/src/composables/useTheme/adapters/unhead.ts
+++ b/packages/0/src/composables/useTheme/adapters/unhead.ts
@@ -20,7 +20,7 @@ import type { App } from 'vue'
 // Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
 interface ThemeHeadInput {
   htmlAttrs?: { 'data-theme': string }
-  style?: Array<{ innerHTML: string, id: string }>
+  style?: Array<{ innerHTML: string, id: string, nonce?: string }>
 }
 
 interface HeadEntry {
@@ -33,6 +33,7 @@ interface Head {
 }
 
 export interface V0UnheadThemeOptions {
+  cspNonce?: string
   stylesheetId?: string
   prefix?: string
 }
@@ -46,9 +47,11 @@ export interface V0UnheadThemeOptions {
  */
 export class V0UnheadThemeAdapter extends ThemeAdapter {
   private entry?: HeadEntry
+  private cspNonce?: string
 
   constructor (options: V0UnheadThemeOptions = {}) {
     super(options.prefix ?? 'v0')
+    this.cspNonce = options.cspNonce
     this.stylesheetId = options.stylesheetId ?? this.stylesheetId
   }
 
@@ -68,6 +71,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
         style: [{
           innerHTML: this.generate(context.colors.value, context.isDark.value),
           id: this.stylesheetId,
+          ...(this.cspNonce ? { nonce: this.cspNonce } : {}),
         }],
       })
     }
@@ -103,6 +107,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
             style: [{
               innerHTML: this.generate(colors, isDark),
               id: this.stylesheetId,
+              ...(this.cspNonce ? { nonce: this.cspNonce } : {}),
             }],
           })
         },
@@ -127,6 +132,7 @@ export class V0UnheadThemeAdapter extends ThemeAdapter {
       style: [{
         innerHTML: this.generate(colors, isDark),
         id: this.stylesheetId,
+        ...(this.cspNonce ? { nonce: this.cspNonce } : {}),
       }],
     })
   }

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -82,6 +82,29 @@ describe('v0StyleSheetThemeAdapter', () => {
       scope.stop()
     })
 
+    it('should include cspNonce in the pushed style entry', () => {
+      mockInBrowser.value = false
+      const headMock = { push: vi.fn() }
+      const app = createMockApp(headMock)
+      const context = createMockContext()
+      const adapter = new V0StyleSheetThemeAdapter({ cspNonce: 'test-nonce' })
+
+      const scope = effectScope()
+      scope.run(() => {
+        adapter.setup(app, context)
+      })
+
+      expect(headMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          style: expect.arrayContaining([
+            expect.objectContaining({ nonce: 'test-nonce' }),
+          ]),
+        }),
+      )
+
+      scope.stop()
+    })
+
     it('should use head provider when usehead not available', () => {
       mockInBrowser.value = false
       const headMock = { push: vi.fn() }

--- a/packages/0/src/composables/useTheme/adapters/v0.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.ts
@@ -16,7 +16,7 @@ import type { App } from 'vue'
 // Structural @unhead seam — duck-typed so v0 takes no dependency on @unhead types.
 interface ThemeHeadInput {
   htmlAttrs: { 'data-theme': string }
-  style: Array<{ innerHTML: string, id: string }>
+  style: Array<{ innerHTML: string, id: string, nonce?: string }>
 }
 
 interface HeadEntry {
@@ -102,6 +102,7 @@ export class V0StyleSheetThemeAdapter extends ThemeAdapter {
           style: [{
             innerHTML: this.generate(context.colors.value, context.isDark.value),
             id: this.stylesheetId,
+            ...(this.cspNonce ? { nonce: this.cspNonce } : {}),
           }],
         })
 


### PR DESCRIPTION
`V0StyleSheetThemeAdapter` accepts a `cspNonce` option and stores `this.cspNonce`, but never applied it: the SSR `head.push({ style: [...] })` omitted the nonce, and `V0UnheadThemeAdapter` didn't accept a nonce at all. With `style-src 'nonce-…'`, the server-rendered theme `<style>` is blocked → FOUC until client hydration swaps to `adoptedStyleSheets`. Accepted-but-unused config is also a wart (false assurance).

**Fix:**
- `v0.ts` — thread `cspNonce` into the SSR `head.push` style entry. Added **conditionally** (`...(this.cspNonce ? { nonce } : {})`) so the entry is byte-identical when no nonce is configured.
- `unhead.ts` — add `cspNonce` to `V0UnheadThemeOptions` + a private field, and forward it into the style entry in all three places it builds one (initial `push`, the reactive `patch`, and `update()`).
- Both adapters' module-private `ThemeHeadInput` style type gains an optional `nonce?: string`.
- The client `adoptedStyleSheets` path is untouched — it correctly needs no nonce.

Tests: each adapter now asserts the pushed `<style>` entry carries `nonce` when configured; the existing no-nonce SSR push assertion stays green. Verified locally: useTheme 104/104, lint clean.

> Note: touches `useTheme/adapters/v0.ts`, which also changes in #424 (sheet dispose) — adjacent but distinct regions (SSR branch vs dispose closures); resolve at merge if both land.

Closes #406