### PR TITLE
fix(useStack): use an ephemeral fallback stack under SSR

### DIFF
--- a/.changeset/usestack-ssr-fallback-407.md
+++ b/.changeset/usestack-ssr-fallback-407.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useStack): don't share the fallback stack across SSR requests — `useStack()` fell back to a module-scoped singleton when no provider existed, so in a long-lived Node SSR process overlay tickets persisted across requests (z-index bleed + unbounded memory growth). Under SSR (`!IN_BROWSER`), `getStackFallback()` now returns a fresh ephemeral `createStack()` per call instead of the shared global; the browser singleton is unchanged. For coordinated per-app SSR z-index, use `createStackPlugin` (as the docs already advise).

--- a/packages/0/src/composables/useStack/index.ssr.test.ts
+++ b/packages/0/src/composables/useStack/index.ssr.test.ts
@@ -1,0 +1,36 @@
+/**
+ * SSR-specific tests for useStack composable.
+ *
+ * These tests run with IN_BROWSER = false to validate server-side behavior.
+ * Separated from main tests because vi.mock is hoisted and applies file-wide.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('#v0/constants/globals', () => ({
+  IN_BROWSER: false,
+}))
+
+import { useStack } from './index'
+
+describe('useStack SSR', () => {
+  it('should not throw when called without a provider in SSR', () => {
+    expect(() => useStack()).not.toThrow()
+  })
+
+  it('should return a fresh ephemeral stack per call in SSR', () => {
+    const first = useStack()
+    const second = useStack()
+
+    expect(first).not.toBe(second)
+  })
+
+  it('should not share registered tickets across calls in SSR', () => {
+    const first = useStack()
+    first.register()
+
+    const second = useStack()
+
+    expect(first.size).toBe(1)
+    expect(second.size).toBe(0)
+  })
+})

--- a/packages/0/src/composables/useStack/index.test.ts
+++ b/packages/0/src/composables/useStack/index.test.ts
@@ -322,6 +322,13 @@ describe('createStack', () => {
     })
 
     describe('useStack', () => {
+      it('should reuse the same fallback instance across calls in the browser', () => {
+        const first = useStack()
+        const second = useStack()
+
+        expect(first).toBe(second)
+      })
+
       it('should return context from provider', () => {
         const plugin = createStackPlugin()
 

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -32,6 +32,9 @@ import { createTrinity } from '#v0/composables/createTrinity'
 // Transformers
 import { toElement } from '#v0/composables/toElement'
 
+// Globals
+import { IN_BROWSER } from '#v0/constants/globals'
+
 // Utilities
 import { instanceExists, useId } from '#v0/utilities'
 import { onScopeDispose, toRef, toValue } from 'vue'
@@ -409,6 +412,11 @@ export function createStackPlugin (_options: StackPluginOptions = {}) {
 let fallbackStack: StackContext | undefined
 
 function getStackFallback (): StackContext {
+  // SSR: never share a module-scoped stack across requests — a long-lived Node
+  // process would leak tickets and bleed z-index between requests. Each call gets
+  // an ephemeral stack; use createStackPlugin for coordinated per-app SSR z-index.
+  if (!IN_BROWSER) return createStack()
+
   if (!fallbackStack) {
     fallbackStack = createStack()
   }


### PR DESCRIPTION
`useStack()` falls back to a **module-scoped singleton** (`fallbackStack`) when no provider/context exists. In SSR (a long-lived Node process), overlay tickets registered into this global persist across requests and aren't cleaned up (`onScopeDispose` is unreliable server-side) — causing cross-request z-index bleed and unbounded memory growth. The JSDoc already steers SSR users to `createStackPlugin`, but the fallback silently leaked.

**Fix:** under SSR (`!IN_BROWSER`), `getStackFallback()` now returns a fresh ephemeral `createStack()` per call instead of the shared module singleton — each request's tickets are isolated and GC'd after the request. The browser path keeps the lazy singleton (single client, correct). No control-flow change to `useStack()` itself; `createStack`/`createStackContext`/`createStackPlugin` untouched.

These are z-index tickets, not user data — the impact is state bleed + memory growth, not data exfiltration.

Tests: new `index.ssr.test.ts` (mocks `IN_BROWSER: false`, mirroring `useDate`'s SSR test) asserts two no-provider `useStack()` calls return distinct instances and don't share registered tickets; the client suite confirms the browser singleton is preserved. Verified locally: useStack 40/40, lint clean.

Closes #407