### PR TITLE
chore(build): emit type declarations for the browser entry

### DIFF
--- a/.changeset/browser-entry-types-408.md
+++ b/.changeset/browser-entry-types-408.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(build): ship type declarations for the `@vuetify/v0/browser` entry — `./browser` mapped to `./dist/browser/index.js` with no `.d.ts`, so `are-the-types-wrong` flagged it `UntypedResolution` and TypeScript consumers importing `@vuetify/v0/browser` got no types. The browser bundle now emits `dist/browser/index.d.ts` (it bundles the same `src/index.ts` as the main entry, so its types are identical), and the `repo:exports` attw check no longer needs to exclude the browser entrypoint.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "preview:docs": "pnpm --filter=docs preview",
     "repo:knip": "knip",
     "repo:sherif": "sherif",
-    "repo:exports": "publint ./packages/0 && attw --pack ./packages/0 --profile esm-only --exclude-entrypoints browser",
+    "repo:exports": "publint ./packages/0 && attw --pack ./packages/0 --profile esm-only",
     "repo:check": "pnpm repo:knip && pnpm repo:sherif",
     "validate": "pnpm lint && pnpm typecheck && pnpm test:run",
     "changeset": "changeset",

--- a/packages/0/tsdown.config.mts
+++ b/packages/0/tsdown.config.mts
@@ -13,7 +13,9 @@ export default defineConfig([{
     Vue({ isProduction: true }),
   ],
   platform: 'browser',
-  dts: false,
+  dts: {
+    vue: true,
+  },
   define: {
     __DEV__: 'false',
     __VITE_LOGGER_ENABLED__: 'false',


### PR DESCRIPTION
`are-the-types-wrong` flagged `@vuetify/v0/browser` as `UntypedResolution`: `./browser` maps to `./dist/browser/index.js`, but `dist/browser/` shipped only `index.js` — no `.d.ts`, so TypeScript consumers importing `@vuetify/v0/browser` got no types. The `repo:exports` check baselined this by excluding the browser entrypoint from attw.

This is the issue's **option 1** (make the entry typed). Rather than touch the publish-shape `customExports` wiring, the browser tsdown config now emits dts (`dts: { vue: true }`, matching the main config). The browser bundle is the same `./src/index.ts` as the main entry, so its public API/types are identical; `dist/browser/index.d.ts` lands as a sibling of `index.js` and resolves typed under any export shape. The attw exclusion (`--exclude-entrypoints browser`) is dropped.

**Verified locally:** `pnpm build:0` emits `dist/browser/index.d.ts`; `pnpm repo:exports` (publint + attw, **no exclusion**) passes — `@vuetify/v0/browser` now reports 🟢 (ESM) instead of UntypedResolution, matching every other entrypoint.

> **Decision for review** (the issue framed this as "decision needed"): this implements **option 1**. If you'd rather keep the browser entry untyped (option 2 — it's primarily for `<script>`-tag use, not TS imports) and retain the documented attw exclusion, close this in favour of that. The only cost of option 1 is a duplicated ~940 KB `.d.ts` in `dist/browser/` (same content as `dist/index.d.mts`).

Closes #408