### PR TITLE
docs(Overflow): keep responsive-toolbar popover closed on load

### DIFF
--- a/apps/docs/src/examples/components/overflow/OverflowToolbar.vue
+++ b/apps/docs/src/examples/components/overflow/OverflowToolbar.vue
@@ -42,17 +42,19 @@
           +{{ count }} more
         </Popover.Activator>
 
-        <Popover.Content class="flex flex-col gap-0.5 rounded-lg border border-divider bg-surface p-1 shadow-lg min-w-40">
-          <Button.Root
-            v-for="action in resolve(hidden)"
-            :key="action.id"
-            as="button"
-            class="whitespace-nowrap rounded-md px-3 py-1.5 text-left text-sm text-on-surface hover:bg-surface-variant"
-            type="button"
-            @click="run(action); toggle()"
-          >
-            {{ action.label }}
-          </Button.Root>
+        <Popover.Content class="rounded-lg border border-divider bg-surface p-1 shadow-lg min-w-40">
+          <div class="flex flex-col gap-0.5">
+            <Button.Root
+              v-for="action in resolve(hidden)"
+              :key="action.id"
+              as="button"
+              class="whitespace-nowrap rounded-md px-3 py-1.5 text-left text-sm text-on-surface hover:bg-surface-variant"
+              type="button"
+              @click="run(action); toggle()"
+            >
+              {{ action.label }}
+            </Button.Root>
+          </div>
         </Popover.Content>
       </Popover.Root>
     </Overflow.Indicator>


### PR DESCRIPTION
The Overflow **Responsive toolbar** example (`overflow/OverflowToolbar.vue`) rendered its `+N more` popover **open on load** — the hidden-actions menu was visible without ever clicking the activator (reproduces ≤ ~500px wide).

**Triage:** the example set `flex flex-col gap-0.5` directly on `Popover.Content`. Applying a `display` utility to a native-popover element overrides the UA's closed-state auto-hide (`[popover]:not(:popover-open) { display: none }`), so the panel shows regardless of open state. The canonical `popover/basic.vue` example puts **no** display utility on `Popover.Content` and starts correctly closed. So this is an **example-usage** issue (the documented native-popover footgun), not a `Popover` component bug — the component correctly drives the native popover API.

**Fix:** move the layout/display classes (`flex flex-col gap-0.5`) onto an inner wrapper `<div>`; `Popover.Content` keeps only non-display styling (`rounded-lg border bg-surface p-1 shadow-lg min-w-40`).

**Verified** against the built docs (`build:docs` + `preview:docs`) with Playwright at 480px: the toolbar overflows to `+6 more` and the popover menu stays **closed** until the activator is clicked (screenshot confirmed).

> Possible follow-up (out of scope): a component-level guard/warning when consumers set `display` on `Popover.Content`, since this is an easy footgun to hit.

Closes #419