### PR TITLE
fix(ci): trigger docs/playground builds when packages change

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,8 +109,10 @@ jobs:
           filters: |
             docs:
               - 'apps/docs/**'
+              - 'packages/**'
             playground:
               - 'apps/playground/**'
+              - 'packages/**'
 
   docs-check:
     needs: changes


### PR DESCRIPTION
## Summary

- Adds `- 'packages/**'` to both the `docs` and `playground` filter lists in the `dorny/paths-filter` step of the `changes` job in `pr-checks.yml`

**Before:** PRs that only touch `packages/*` produce `docs: false` and `playground: false` from the path filter, so neither the docs build nor the playground build runs in CI. Library changes that break app builds go undetected until after merge.

**After:** Any change under `packages/**` also triggers both app builds, ensuring library PRs are validated end-to-end.

Closes #401