### PR TITLE
chore(refactor): use Object.hasOwn over hasOwnProperty.call

### DIFF
--- a/packages/0/src/composables/createQueue/index.ts
+++ b/packages/0/src/composables/createQueue/index.ts
@@ -341,7 +341,7 @@ export function createQueue (_options: QueueOptions = {}): QueueContext {
 
   function register (registration: Partial<QueueTicketInput> = {} as Partial<QueueTicketInput>): QueueTicket {
     const id = registration.id ?? useId()
-    const hasExplicitTimeout = Object.prototype.hasOwnProperty.call(registration, 'timeout')
+    const hasExplicitTimeout = Object.hasOwn(registration, 'timeout')
     const timeout = hasExplicitTimeout ? registration.timeout : _timeout
 
     const ticket = {

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -836,7 +836,7 @@ export function createRegistry<
 
     if (!existing) return register({ ...patch, id } as Partial<Z & RegistryTicket>)
 
-    const hasValue = Object.prototype.hasOwnProperty.call(patch, 'value')
+    const hasValue = Object.hasOwn(patch, 'value')
     let value = existing.value
     let valueIsIndex = existing.valueIsIndex
 

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -404,7 +404,7 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
 
     const meta: Record<string, unknown> = {}
     for (const k in currentTokens) {
-      if (!Object.prototype.hasOwnProperty.call(currentTokens, k)) continue
+      if (!Object.hasOwn(currentTokens, k)) continue
       if (k.startsWith('$')) meta[k] = (currentTokens as Record<string, unknown>)[k]
     }
 
@@ -416,7 +416,7 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
       // Skip inherited keys and prototype-pollution sinks so a polluted
       // Object.prototype (or a caller-supplied `constructor`/`prototype` token)
       // can't leak in as a registered token id. Mirrors mergeDeep.
-      if (!Object.prototype.hasOwnProperty.call(currentTokens, key)) continue
+      if (!Object.hasOwn(currentTokens, key)) continue
       if (UNSAFE_KEYS.has(key)) continue
       if (key.startsWith('$')) continue
 
@@ -434,7 +434,7 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
         const inner = value.$value
         if (isObject(inner) && !flat) {
           for (const innerKey in inner) {
-            if (!Object.prototype.hasOwnProperty.call(inner, innerKey)) continue
+            if (!Object.hasOwn(inner, innerKey)) continue
             if (UNSAFE_KEYS.has(innerKey)) continue
             if (innerKey.startsWith('$')) continue
 

--- a/packages/0/src/composables/toReactive/index.ts
+++ b/packages/0/src/composables/toReactive/index.ts
@@ -73,7 +73,7 @@ function createMapProxy<Z extends object> (refObject: Ref<Z>): UnwrapNestedRefs<
   const proxy = new Proxy(new Map(), {
     get (_, p) {
       if (p === 'size') return (refObject.value as Map<unknown, unknown>).size
-      if (Object.prototype.hasOwnProperty.call(mapHandlers, p)) return mapHandlers[p as keyof typeof mapHandlers]
+      if (Object.hasOwn(mapHandlers, p)) return mapHandlers[p as keyof typeof mapHandlers]
 
       const map = refObject.value as Map<unknown, unknown>
       const value = Reflect.get(map, p)
@@ -123,7 +123,7 @@ function createSetProxy<Z extends object> (refObject: Ref<Z>): UnwrapNestedRefs<
   const proxy = new Proxy(new Set(), {
     get (_, p) {
       if (p === 'size') return (refObject.value as Set<unknown>).size
-      if (Object.prototype.hasOwnProperty.call(setHandlers, p)) return setHandlers[p as keyof typeof setHandlers]
+      if (Object.hasOwn(setHandlers, p)) return setHandlers[p as keyof typeof setHandlers]
 
       const set = refObject.value as Set<unknown>
       const value = Reflect.get(set, p)

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -350,7 +350,7 @@ export function mergeDeep<T extends object> (target: T, ...sources: DeepPartial<
 
   // Copy all properties from target
   for (const key in target) {
-    if (Object.prototype.hasOwnProperty.call(target, key)) {
+    if (Object.hasOwn(target, key)) {
       out[key] = target[key]
     }
   }
@@ -361,7 +361,7 @@ export function mergeDeep<T extends object> (target: T, ...sources: DeepPartial<
     for (const key in source) {
       // Skip prototype pollution vectors and non-own properties
       if (UNSAFE_KEYS.has(key)) continue
-      if (!Object.prototype.hasOwnProperty.call(source, key)) continue
+      if (!Object.hasOwn(source, key)) continue
 
       const sourceValue = (source as Record<string, unknown>)[key]
       if (isUndefined(sourceValue)) continue


### PR DESCRIPTION
Replaces all 9 `Object.prototype.hasOwnProperty.call(obj, key)` call sites with the built-in `Object.hasOwn(obj, key)` (ES2022) across:

- `composables/createQueue/index.ts`
- `composables/toReactive/index.ts` (×2)
- `composables/createRegistry/index.ts`
- `composables/createTokens/index.ts` (×3)
- `utilities/helpers.ts` — `mergeDeep` (×2)

Behavior is **identical** — `Object.hasOwn` is the standardized equivalent of the `.call` form, including for symbol keys (the `toReactive` proxy traps) and the prototype-pollution guard sites (next to `UNSAFE_KEYS` in `createTokens`/`mergeDeep`). Shorter and clearer, dropping the prototype-method `.call` dance. Node ≥26 and modern browser targets support it natively — no new utility added.

No changeset: behavior-identical internal refactor, not consumer-facing.

**Verified:** full `packages/0` suite green (153 files, 6224 passed / 3 skipped), `pnpm --filter @vuetify/v0 typecheck` clean, lint clean.

> Note: PR #427 (fix for #400) adds one more `Object.prototype.hasOwnProperty.call` in `createTokens.resolve()`. Whichever of these two merges second should convert that one site too (it'll be the only remaining `.call` in source).