### PR TITLE
chore(genesis): add repository field for npm provenance

### DIFF
--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0-beta.3",
   "description": "Genesis Design System — minimal docs primitives extracted from the v0 docs site",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuetifyjs/0.git",
+    "directory": "packages/genesis"
+  },
   "types": "./dist/index.d.mts",
   "type": "module",
   "files": [


### PR DESCRIPTION
\`@paper/genesis\` failed to publish in the last release while \`@vuetify/v0\` and \`@vuetify/paper\` succeeded:

\`\`\`
E422 ... Error verifying sigstore provenance bundle: package.json: "repository.url" is "", expected to match "https://github.com/vuetifyjs/0"
\`\`\`

**Root cause:** genesis's \`package.json\` had no \`repository\` field. npm OIDC trusted publishing validates sigstore provenance against it, so the empty value is rejected. v0/paper carry the field and published fine.

This adds the matching field with \`directory: packages/genesis\`.

**No changeset** — genesis \`1.0.0-beta.3\` is already bumped but unpublished, so this republishes that exact version. On merge, the release workflow's "publish any unpublished packages" step picks up genesis beta.3 with valid provenance (v0/paper beta.4 already published → skipped).