### PR TITLE
chore(playground): surface preview load failures with a recoverable banner

### DIFF
--- a/apps/playground/src/components.d.ts
+++ b/apps/playground/src/components.d.ts
@@ -33,6 +33,7 @@ declare module 'vue' {
     PlaygroundMarkdownHeader: typeof import('./components/playground/markdown/PlaygroundMarkdownHeader.vue')['default']
     PlaygroundMenuBar: typeof import('./components/playground/app/PlaygroundMenuBar.vue')['default']
     PlaygroundOpenDialog: typeof import('./components/playground/app/PlaygroundOpenDialog.vue')['default']
+    PlaygroundPreviewError: typeof import('./components/playground/editor/PlaygroundPreviewError.vue')['default']
     PlaygroundSettings: typeof import('./components/playground/settings/PlaygroundSettings.vue')['default']
     PlaygroundSettingsExport: typeof import('./components/playground/settings/PlaygroundSettingsExport.vue')['default']
     PlaygroundSettingsPresets: typeof import('./components/playground/settings/PlaygroundSettingsPresets.vue')['default']

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorPreview.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorPreview.vue
@@ -5,11 +5,19 @@
   // Components
   import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
 
+  // Composables
+  import { usePreviewHealth } from '@/composables/usePreviewHealth'
+
   // Utilities
-  import { defineAsyncComponent } from 'vue'
+  import { defineAsyncComponent, useTemplateRef } from 'vue'
 
   const playground = usePlayground()
   const theme = useTheme()
+
+  const host = useTemplateRef<HTMLElement>('host')
+  const { status, failed, dismissed, reloadKey, retry, dismiss } = usePreviewHealth(
+    () => host.value?.querySelector('iframe'),
+  )
 
   const Sandbox = defineAsyncComponent(() =>
     import('@vue/repl').then(m => m.Sandbox),
@@ -17,9 +25,10 @@
 </script>
 
 <template>
-  <div class="relative flex-1 min-w-0 min-h-0">
+  <div ref="host" class="relative flex-1 min-w-0 min-h-0">
     <Sandbox
       v-if="playground.isReady.value"
+      :key="reloadKey"
       :auto-store-init="false"
       :clear-console="false"
       show
@@ -30,6 +39,13 @@
     <div v-else class="absolute inset-0 flex items-center justify-center">
       <AppSkeleton height="h-16" :lines="1" :widths="['w-16']" />
     </div>
+
+    <PlaygroundPreviewError
+      v-if="status === 'failed' && !dismissed"
+      :failed
+      @dismiss="dismiss"
+      @retry="retry"
+    />
   </div>
 </template>
 

--- a/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
@@ -2,10 +2,8 @@
   // Framework
   import { Atom } from '@vuetify/v0'
 
-  export interface FailedDep {
-    url: string
-    name: string
-  }
+  // Types
+  import type { FailedDep } from '@/composables/usePreviewHealth'
 
   const { failed = [] } = defineProps<{
     failed?: FailedDep[]

--- a/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-  // Framework
-  import { Atom } from '@vuetify/v0'
-
   // Types
   import type { FailedDep } from '@/composables/usePreviewHealth'
 
@@ -50,14 +47,14 @@
       </div>
 
       <div class="flex justify-end">
-        <Atom
-          as="button"
+        <button
           class="inline-flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-on-primary hover:opacity-90"
+          type="button"
           @click="$emit('retry')"
         >
           <AppIcon icon="reset" :size="16" />
           Retry
-        </Atom>
+        </button>
       </div>
     </div>
   </div>

--- a/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundPreviewError.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+  // Framework
+  import { Atom } from '@vuetify/v0'
+
+  export interface FailedDep {
+    url: string
+    name: string
+  }
+
+  const { failed = [] } = defineProps<{
+    failed?: FailedDep[]
+  }>()
+
+  defineEmits<{
+    retry: []
+    dismiss: []
+  }>()
+
+  function host (url: string) {
+    try {
+      return new URL(url).host
+    } catch {
+      return url
+    }
+  }
+</script>
+
+<template>
+  <div class="absolute inset-0 z-10 flex items-center justify-center p-6 bg-background/80 backdrop-blur-4">
+    <div
+      class="w-full max-w-sm flex flex-col gap-3 rounded-lg border border-divider bg-surface p-5 shadow-lg"
+      role="alert"
+    >
+      <div class="flex items-start gap-3">
+        <AppIcon class="mt-0.5 text-warning" icon="alert" :size="20" />
+
+        <div class="min-w-0 flex-1">
+          <p class="text-sm font-medium text-on-surface">Preview didn't load</p>
+
+          <p v-if="failed.length > 0" class="mt-1 text-sm text-on-surface-variant">
+            Couldn't load<template v-for="(dep, i) in failed" :key="dep.url"> <code class="text-on-surface">{{ dep.name }}</code> from {{ host(dep.url) }}<span v-if="i < failed.length - 1">,</span></template>. A network or CDN issue is preventing the preview from running.
+          </p>
+
+          <p v-else class="mt-1 text-sm text-on-surface-variant">
+            A network issue may be blocking the scripts the preview needs.
+          </p>
+
+          <p class="mt-2 text-xs text-on-surface-variant/70">Open your browser console for details.</p>
+        </div>
+
+        <AppCloseButton size="sm" @click="$emit('dismiss')" />
+      </div>
+
+      <div class="flex justify-end">
+        <Atom
+          as="button"
+          class="inline-flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-sm font-medium text-on-primary hover:opacity-90"
+          @click="$emit('retry')"
+        >
+          <AppIcon icon="reset" :size="16" />
+          Retry
+        </Atom>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/playground/src/composables/usePreviewHealth.ts
+++ b/apps/playground/src/composables/usePreviewHealth.ts
@@ -7,7 +7,6 @@ import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
 // Utilities
 import { shallowRef, watch } from 'vue'
 
-const SHIMS = 'https://cdn.jsdelivr.net/npm/es-module-shims@1.5.18/dist/es-module-shims.wasm.js'
 const POLL = 500
 const SPECIFIC = 2500
 const GENERIC = 6000
@@ -34,17 +33,21 @@ export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undef
   }
 
   function collect () {
+    const doc = iframe()?.contentDocument
     const out = new Map<string, string>()
-    const script = iframe()?.contentDocument?.querySelector('script[type="importmap"]')
-    if (script?.textContent) {
+    const map = doc?.querySelector('script[type="importmap"]')
+    if (map?.textContent) {
       try {
-        const map = JSON.parse(script.textContent) as { imports?: Record<string, string> }
-        for (const [name, url] of Object.entries(map.imports ?? {})) {
+        const parsed = JSON.parse(map.textContent) as { imports?: Record<string, string> }
+        for (const [name, url] of Object.entries(parsed.imports ?? {})) {
           if (/^https?:\/\//.test(url)) out.set(url, name)
         }
       } catch { /* malformed importmap — still probe the shims loader below */ }
     }
-    out.set(SHIMS, 'es-module-shims')
+    // Derive the es-module-shims loader from the sandbox's own <script> rather than
+    // hardcoding @vue/repl's bundled version, which drifts when repl is upgraded.
+    const shims = doc?.querySelector<HTMLScriptElement>('script[src*="es-module-shims"]')
+    if (shims?.src) out.set(shims.src, 'es-module-shims')
     return out
   }
 
@@ -52,7 +55,7 @@ export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undef
     const out: FailedDep[] = []
     await Promise.all([...collect()].map(async ([url, name]) => {
       try {
-        const res = await fetch(url, { method: 'HEAD', mode: 'cors' })
+        const res = await fetch(url, { method: 'HEAD' })
         if (!res.ok && res.status !== 405) out.push({ url, name })
       } catch {
         out.push({ url, name })
@@ -62,12 +65,18 @@ export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undef
   }
 
   async function tick () {
+    // Confirmed mount → healthy. Reset the countdown on EVERY mount: useTimer
+    // (repeat) can't be stopped from inside its own handler, and @vue/repl empties
+    // #app on every recompile, so without this reset `elapsed` would creep up across
+    // ordinary edits and eventually false-trigger the banner over a working preview.
     if (mounted()) {
       status.value = 'ok'
       failed.value = []
-      watchdog.stop()
+      elapsed = 0
+      probed = false
       return
     }
+
     // A genuine compile error is already shown by the REPL's own overlay.
     if (playground.store.errors.length > 0) return
 

--- a/apps/playground/src/composables/usePreviewHealth.ts
+++ b/apps/playground/src/composables/usePreviewHealth.ts
@@ -1,0 +1,122 @@
+// Framework
+import { IN_BROWSER, useTimer } from '@vuetify/v0'
+
+// Components
+import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
+
+// Utilities
+import { shallowRef, watch } from 'vue'
+
+const SHIMS = 'https://cdn.jsdelivr.net/npm/es-module-shims@1.5.18/dist/es-module-shims.wasm.js'
+const POLL = 500
+const SPECIFIC = 2500
+const GENERIC = 6000
+
+export interface FailedDep {
+  url: string
+  name: string
+}
+
+export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undefined) {
+  const playground = usePlayground()
+
+  const status = shallowRef<'ok' | 'failed'>('ok')
+  const failed = shallowRef<FailedDep[]>([])
+  const dismissed = shallowRef(false)
+  const reloadKey = shallowRef(0)
+
+  let elapsed = 0
+  let probed = false
+
+  function mounted () {
+    const app = iframe()?.contentDocument?.querySelector('#app')
+    return !!app && app.childElementCount > 0
+  }
+
+  function collect () {
+    const out = new Map<string, string>()
+    const script = iframe()?.contentDocument?.querySelector('script[type="importmap"]')
+    if (script?.textContent) {
+      try {
+        const map = JSON.parse(script.textContent) as { imports?: Record<string, string> }
+        for (const [name, url] of Object.entries(map.imports ?? {})) {
+          if (/^https?:\/\//.test(url)) out.set(url, name)
+        }
+      } catch { /* malformed importmap — still probe the shims loader below */ }
+    }
+    out.set(SHIMS, 'es-module-shims')
+    return out
+  }
+
+  async function probe () {
+    const out: FailedDep[] = []
+    await Promise.all([...collect()].map(async ([url, name]) => {
+      try {
+        const res = await fetch(url, { method: 'HEAD', mode: 'cors' })
+        if (!res.ok && res.status !== 405) out.push({ url, name })
+      } catch {
+        out.push({ url, name })
+      }
+    }))
+    return out
+  }
+
+  async function tick () {
+    if (mounted()) {
+      status.value = 'ok'
+      failed.value = []
+      watchdog.stop()
+      return
+    }
+    // A genuine compile error is already shown by the REPL's own overlay.
+    if (playground.store.errors.length > 0) return
+
+    elapsed += POLL
+
+    if (!probed && elapsed >= SPECIFIC) {
+      probed = true
+      const bad = await probe()
+      if (bad.length > 0 && !mounted()) {
+        failed.value = bad
+        status.value = 'failed'
+        return
+      }
+    }
+
+    if (elapsed >= GENERIC && !mounted()) {
+      status.value = 'failed' // failed stays [] → generic message
+    }
+  }
+
+  const watchdog = useTimer(tick, { duration: POLL, repeat: true })
+
+  function start () {
+    watchdog.stop()
+    elapsed = 0
+    probed = false
+    status.value = 'ok'
+    failed.value = []
+    dismissed.value = false
+    if (!IN_BROWSER) return
+    watchdog.start()
+  }
+
+  function retry () {
+    reloadKey.value++
+    start()
+  }
+
+  function dismiss () {
+    dismissed.value = true
+  }
+
+  watch(
+    () => [playground.isReady.value, playground.filesVersion.value],
+    () => {
+      if (playground.isReady.value) start()
+    },
+    { immediate: true },
+  )
+
+  return { status, failed, dismissed, reloadKey, retry, dismiss }
+}

--- a/apps/playground/src/plugins/icons.ts
+++ b/apps/playground/src/plugins/icons.ts
@@ -1,5 +1,6 @@
 // Icons
 import {
+  mdiAlertCircleOutline,
   mdiBookOpenBlankVariant,
   mdiBookOutline,
   mdiCheck,
@@ -43,6 +44,7 @@ import type { App } from 'vue'
 export const [useIconContext, provideIconContext, context] = createTokensContext({
   namespace: 'v0:icons',
   tokens: {
+    'alert': mdiAlertCircleOutline,
     'left': mdiChevronLeft,
     'book-open': mdiBookOpenBlankVariant,
     'book-closed': mdiBookOutline,


### PR DESCRIPTION
When an external CDN script the REPL preview depends on fails to load (e.g. a jsdelivr 404/outage on `@vuetify/v0` or the Vue runtime), the preview pane went silently blank — compilation succeeded, so no error surfaced and it just looked like an empty app.

This adds detection + a visible, recoverable banner:

- `usePreviewHealth` composable — a v0 `useTimer` watchdog polls the preview iframe's `#app`; on a stall it probes the iframe's actually-injected import-map URLs (and the sandbox's es-module-shims `<script>`) to name the failing dependency, with a generic fallback if none is pinpointed. Resets on every confirmed mount (self-heals), stays silent during compile errors, and is SSR-safe.
- `PlaygroundPreviewError` — an overlay banner naming the culprit (or a generic message), with Retry and a console hint.
- Wiring in `PlaygroundEditorPreview` (`reloadKey` remounts `<Sandbox>` for Retry) plus an `alert` icon.

App-only (`apps/playground`); no package or build changes.