### PR TITLE
docs(rules): sync .claude/rules with PHILOSOPHY changes from #451

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -209,7 +209,7 @@ const slotProps = toRef((): ComponentRootSlotProps => ({
 
 ## ARIA Pattern (WAI-ARIA compliant)
 
-Every interactive component ships a correct `role`, `aria-*` state attributes, keyboard handlers, and locale-driven strings via `useLocale()` / `locale.t(key)`. `aria-disabled` is always concrete `boolean` (not `true | undefined`). Tests assert `toBeDefined()` on the locale strings, not exact values. [intent:174, intent:175, intent:176, intent:177]
+Every interactive component ships a correct `role`, `aria-*` state attributes, keyboard handlers, and locale-driven strings via `useLocale()` (canonical: `locale.ti(key) ?? '<English default>'`). `aria-disabled` is always concrete `boolean` (not `true | undefined`). Tests assert `toBeDefined()` on the locale strings, not exact values. [intent:174, intent:175, intent:176, intent:177]
 
 The full ARIA vocabulary, WCAG success-criterion mapping, and worked precedents live under [WCAG Accessibility — how we apply the patterns](#wcag-accessibility--how-we-apply-the-patterns) below. Don't restate the table here.
 
@@ -339,7 +339,7 @@ A wrapper that supplies shared defaults or context to a compound family's Roots 
 
 ## Template Pattern (100% enforced)
 
-- Root element is always `<Atom :as :renderless>`. [intent:186, intent:336]
+- DOM-rendering Roots use `<Atom :as :renderless>`; pure context-provider Roots (`Group`, `Selection`, `Single`, `Step`, `Tabs`, `Treeview`) render only `<slot v-bind="slotProps" />` with no `Atom`. [intent:186, intent:336] (PHILOSOPHY §5.3)
 - Slot props via `<slot v-bind="slotProps" />`.
 - Hidden inputs conditionally rendered: `<ComponentHiddenInput v-if="name" />`. [intent:187]
 - `v-if` for structural conditionals; `v-show` only when the element must stay mounted to preserve state. [intent:188]
@@ -668,7 +668,7 @@ When uncertain, don't hook up. Adding a plugin later is a non-breaking change; r
 - [ ] Three-pronged disabled (`aria-disabled`, `data-disabled`, tabindex)
 - [ ] Hidden input conditionally rendered with `v-if="name"`
 - [ ] Barrel: no `export *` from `.vue`, named exports plus compound object
-- [ ] Template root is `<Atom :as :renderless>` and uses `<slot v-bind="slotProps" />`
+- [ ] Template root is `<Atom :as :renderless>` (DOM-rendering Roots) or a bare `<slot v-bind="slotProps" />` (pure context-provider Roots — §5.3)
 - [ ] `v-if` for structural conditionals; `v-show` only when the element must stay mounted (registry-driven visibility, load-state preservation, virtualization)
 - [ ] `onBeforeUnmount` for deregistration, not `onUnmounted`
 - [ ] Zero utility classes; all `:style` bindings structural
@@ -680,5 +680,5 @@ When uncertain, don't hook up. Adding a plugin later is a non-breaking change; r
 - [ ] Global plugins hooked up only when the component genuinely depends on app-level state
 - [ ] Multi-source `attrs` forwarding uses `mergeProps`, not spread
 - [ ] Props destructured directly (never `withDefaults`)
-- [ ] Local mirrors of props named `_option`, not `optionProp`
+- [ ] `_`-prefix on the raw prop when a resolved value is bound (never on the template-bound value); never `nameProp`/`optionProp` (§3.3)
 - [ ] No comments that restate the next line

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -206,7 +206,7 @@ See PHILOSOPHY §2.9 for the three-way split (throw / warn / return) and the ful
 Child spreads parent and adds or overrides: [intent:142]
 
 ```ts
-// packages/0/src/composables/createSelection/index.ts:296
+// packages/0/src/composables/createSelection/index.ts:299
 const model = createModel(options)
 return { ...model, multiple, register, onboard, unselect, toggle, apply, mandate, seek }
 ```

--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -28,7 +28,7 @@ All cross-cutting naming rules live in PHILOSOPHY §3.3. Restated invariants for
 - **`index`** not `idx`.
 - **`on<Action>`** not `handle<Action>`.
 - **Single-word** over multi-word when both are unambiguous.
-- **`_option`** for local mirrors of a prop or option; never `optionProp`.
+- **`_`-prefix marks a raw input, never the bound value** — the raw `defineProps` binding when a resolved value supersedes it (`{ name: _name }` → `const name = toRef(() => _name ?? …)`), or the rest-options param (`_options`). The value the template binds / logic reads keeps the short name. Never `nameProp`, never `optionProp`. See §3.3.
 - **`create` / `use` / `to`** prefix rule — see §3.3.
 - **`FooTicketInput` → `FooTicket`** pair for registry types.
 
@@ -121,7 +121,7 @@ interface RegistryTicket {
 
 ## Spread Pattern for Extension (PHILOSOPHY §2.6)
 
-100% enforced across all 27 registry-based composables. Parent is spread first, new properties added after. Never redefine.
+100% enforced across the registry-based composables. Parent is spread first, new properties added after. Never redefine.
 
 ```ts
 // packages/0/src/composables/createSelection/index.ts — see the spread `return { ...model, … }` near the end of createSelection()


### PR DESCRIPTION
`packages/0/PHILOSOPHY.md` is the source of truth and the `.claude/rules/*.md` files cite back to it, but #451 only touched PHILOSOPHY. This realigns the stale restatements the rules layer still carried:

- **§3.3 prop-mirror** — the `_`-prefix marks the raw input, not the template-bound value (`implementation.md`, plus the `components.md` checklist item).
- **§5.3** — Root is `<Atom>` only for DOM-rendering Roots; pure context-provider Roots (`Group`/`Selection`/`Single`/`Step`/`Tabs`/`Treeview`) render a bare slot (`components.md` template pattern + checklist).
- **§2.6** — drop the brittle "27 registry-based composables" count.
- **§5.5** — locale strings via `ti() ?? '<default>'`, not `t()` (`components.md`).
- fix a stale `createSelection` line citation (`:296` → `:299`, `composables.md`).

Docs-only; no source changes.