### PR TITLE
docs: fix outdated composable examples and stale data across guide pages

### DIFF
--- a/apps/docs/src/pages/guide/features/palettes.md
+++ b/apps/docs/src/pages/guide/features/palettes.md
@@ -212,4 +212,13 @@ app.use(
 
 ## Custom Adapters
 
-The `PaletteGenerator` type is exported from `@vuetify/v0` for building custom adapters that conform to the same `{ palette, themes }` return shape.
+The `PaletteGenerator` type is exported from `@vuetify/v0/palettes` for building custom adapters that conform to the same `{ palette, themes }` return shape.
+
+```ts
+import type { PaletteGenerator } from '@vuetify/v0/palettes'
+
+const myGenerator: PaletteGenerator<{ variant?: 'vibrant' | 'muted' }> = (seed, options) => {
+  // ... derive palette + themes from seed
+  return { palette, themes }
+}
+```

--- a/apps/docs/src/pages/guide/features/types.md
+++ b/apps/docs/src/pages/guide/features/types.md
@@ -20,7 +20,8 @@ Shared TypeScript types used across the library and available for your own code.
 <DocsPageFeatures :frontmatter />
 
 ```ts
-import type { ID, Activation, DeepPartial, Extensible, MaybeArray } from '@vuetify/v0'
+import type { ID } from '@vuetify/v0'
+import type { Activation, DeepPartial, Extensible, MaybeArray } from '@vuetify/v0/types'
 ```
 
 ## ID
@@ -123,4 +124,38 @@ Object with string keys and unknown values for generic record handling. Requires
 
 ```ts
 type UnknownObject = Record<string, unknown>
+```
+
+## V0ErrorDetails
+
+Discriminated union of structured details attached to every v0-thrown error. Each arm pairs a stable `code` with the domain context for that code — consumed by the `V0Error` constructor and narrowed by `isV0Error(err, code)` (both from `@vuetify/v0`, see [Utilities](/guide/features/utilities#errors)).
+
+```ts
+type V0ErrorDetails =
+  | { code: 'V0_CONTEXT_MISSING', key: string | symbol }
+  | { code: 'V0_PLUGIN_MISSING', plugin: string }
+  | { code: 'V0_PALETTE_INVALID_SEED', palette: 'material' | 'leonardo' | 'ant', seed: string }
+  | { code: 'V0_PALETTE_UNKNOWN_VARIANT', palette: 'material', variant: string }
+  | { code: 'V0_ADAPTER_INSTANCE_MISSING', adapter: string }
+  | { code: 'V0_THEME_INVALID_PREFIX', prefix: string }
+```
+
+## V0ErrorCode
+
+Union of every error code thrown by v0. Convenience alias for the discriminant field of `V0ErrorDetails`.
+
+```ts
+type V0ErrorCode = V0ErrorDetails['code']
+```
+
+```ts
+import { isV0Error, V0Error } from '@vuetify/v0'
+
+try {
+  throw new V0Error('Context not found.', { code: 'V0_CONTEXT_MISSING', key: 'v0:theme' })
+} catch (err) {
+  if (isV0Error(err, 'V0_CONTEXT_MISSING')) {
+    console.log(err.key) // typed as string | symbol, not string | symbol | undefined
+  }
+}
 ```

--- a/apps/docs/src/pages/guide/features/utilities.md
+++ b/apps/docs/src/pages/guide/features/utilities.md
@@ -133,11 +133,15 @@ const virtual = createVirtual(items, {
 ```
 
 ```vue playground VirtualList.vue
+<script setup lang="ts">
+  const { element, items: virtualItems, offset, size } = virtual
+</script>
+
 <template>
-  <div ref="virtual.element" style="height: 400px; overflow: auto;">
-    <div :style="{ height: `${virtual.size}px`, paddingTop: `${virtual.offset}px` }">
+  <div ref="element" style="height: 400px; overflow: auto;">
+    <div :style="{ height: `${size}px`, paddingTop: `${offset}px` }">
       <div
-        v-for="item in virtual.items"
+        v-for="item in virtualItems"
         :key="item.index"
         style="height: 40px"
       >
@@ -273,6 +277,26 @@ foreground('#ffd600')  // '#000000' (black reads better on yellow)
 > [!TIP]
 > `foreground` is ideal for computing on-color text in design tokens. It uses APCA to select the higher-contrast option.
 
+## Errors
+
+Structured error class and type guard for errors thrown by v0 internals.
+
+### V0Error / isV0Error
+
+```ts
+import { isV0Error, V0Error } from '@vuetify/v0'
+
+try {
+  useContext('v0:missing')
+} catch (err) {
+  if (isV0Error(err, 'V0_CONTEXT_MISSING')) {
+    console.log(err.code, err.key) // 'V0_CONTEXT_MISSING', 'v0:missing'
+  }
+}
+```
+
+`V0Error` carries a stable `code` discriminant (see [V0ErrorCode](/guide/features/types#v0errorcode)) instead of a message-only `Error`, so callers can branch on failure kind without parsing strings. `isV0Error(err, code?)` narrows `unknown` to `V0Error`, and — when `code` is passed — further narrows to the matching error-detail shape, so per-code fields like `key` or `plugin` become required instead of optional.
+
 ## Best Practices
 
 ### Combine Utilities
@@ -312,8 +336,8 @@ const virtual = createVirtual(filtered, {
 For large datasets that need all three utilities working together:
 
 ```ts collapse
-import { shallowRef, computed } from 'vue'
-import { createFilter, createPagination, createVirtual } from '@vuetify/v0'
+import { computed, shallowRef } from 'vue'
+import { createFilter, createPagination, createVirtual, Pagination } from '@vuetify/v0'
 
 // Source data
 const items = shallowRef(Array.from({ length: 10000 }, (_, i) => ({
@@ -326,8 +350,10 @@ const query = shallowRef('')
 const filter = createFilter({ keys: ['name'] })
 const { items: filtered } = filter.apply(query, items)
 
-// 2. Paginate the filtered results
+// 2. Paginate the filtered results — `page` is shared with Pagination.Root below
+const page = shallowRef(1)
 const pagination = createPagination({
+  page,
   size: () => filtered.value.length,
   itemsPerPage: 100,
 })
@@ -341,21 +367,33 @@ const pageItems = computed(() => {
 
 // 4. Virtual scroll the current page
 const virtual = createVirtual(pageItems, { itemHeight: 40 })
+const { element, items: virtualItems, offset, size } = virtual
 ```
 
 ```vue
 <template>
   <input v-model="query" placeholder="Search..." />
 
-  <div ref="virtual.element" style="height: 400px; overflow: auto;">
-    <div :style="{ height: `${virtual.size}px`, paddingTop: `${virtual.offset}px` }">
-      <div v-for="item in virtual.items" :key="item.raw.id" style="height: 40px">
+  <div ref="element" style="height: 400px; overflow: auto;">
+    <div :style="{ height: `${size}px`, paddingTop: `${offset}px` }">
+      <div v-for="item in virtualItems" :key="item.raw.id" style="height: 40px">
         {{ item.raw.name }}
       </div>
     </div>
   </div>
 
-  <Pagination :pagination="pagination" />
+  <Pagination.Root v-model="page" :size="filtered.length" :items-per-page="100" v-slot="{ items: pageNumbers }" class="flex items-center gap-1">
+    <Pagination.Prev>‹</Pagination.Prev>
+
+    <template v-for="entry in pageNumbers" :key="entry.value">
+      <Pagination.Ellipsis v-if="entry.type === 'ellipsis'" />
+      <Pagination.Item v-else :value="entry.value as number">
+        {{ entry.value }}
+      </Pagination.Item>
+    </template>
+
+    <Pagination.Next>›</Pagination.Next>
+  </Pagination.Root>
 </template>
 ```
 
@@ -399,8 +437,10 @@ if (!isNullOrUndefined(x)) {
 | `isPrimitive(x)` | `string \| number \| boolean` |
 | `isSymbol(x)` | `symbol` |
 | `isNaN(x)` | `number` (only the NaN value)[^isnan-vs-global] |
+| `isThenable(x)` | `{ then: Function }`[^isthenable-duck-typed] |
 
 [^isnan-vs-global]: `isNaN` here uses `Number.isNaN()` internally — it does not coerce strings like the global `isNaN()`. `isNaN("foo")` returns `false`, not `true`.
+[^isthenable-duck-typed]: Duck-typed — matches native `Promise` instances and any other object exposing a callable `.then`, not just `instanceof Promise`. Use it to guard async-vs-sync return values; use `instanceof Promise` directly when only native promises should pass.
 
 > [!TIP]
 > Prefer these over raw comparisons.

--- a/apps/docs/src/pages/guide/fundamentals/benchmarks.md
+++ b/apps/docs/src/pages/guide/fundamentals/benchmarks.md
@@ -42,6 +42,8 @@ Headless UI libraries must be fast—they're foundational infrastructure. v0 ben
 | `createFilter` | Search/filter on large datasets must remain responsive |
 | `createVirtual` | Virtual scrolling is performance-critical by definition |
 | `createDataTable` | Composed orchestrator—measures sorting, filtering, and pagination together |
+| `createDataGrid` | Composed on top of createDataTable—measures column layout, cell editing, row ordering, and row spanning overhead |
+| `createSortable` | Ordered-list primitive—move, swap, and reorder operations must scale to large lists |
 | `useDate` | Date operations are frequent in UIs |
 | `useProxyRegistry` | Reactive proxy for templates—shows reactivity overhead vs raw registry |
 
@@ -115,14 +117,17 @@ Each benchmark is assigned a tier based on its throughput and detected complexit
 
 ### Complexity Detection
 
-Tiers adjust based on detected algorithmic complexity:
+Tiers adjust based on detected algorithmic complexity. Detection checks the benchmark name against patterns **in order** and uses the first match—so the check order matters as much as the patterns themselves:
 
-| Pattern in Benchmark Name | Complexity |
-| - | - |
-| "single" or "one item/query/key" | O(1) |
-| Number + items/objects/entries/elements | O(n) — default for most benchmarks |
-| "nested" or "recursive" | O(n²) |
-| No pattern matched | O(n) — conservative fallback |
+| Order | Pattern in Benchmark Name | Complexity |
+| - | - | - |
+| 1 | "nested", "recursive", or "all ... all" | O(n²) |
+| 2 | Number + items/objects/entries/elements | O(n) |
+| 3 | "all items" or "all keys" | O(n) |
+| 4 | "single" or "one item/query/key" | O(1) |
+| 5 | No pattern matched | O(n) — conservative fallback |
+
+"Nested"/"recursive" checks run first so a benchmark like "recursive lookup (single item)" is classified O(n²), not O(1)—the more expensive complexity wins on ambiguous names.
 
 ### Reading Results
 

--- a/apps/docs/src/pages/guide/fundamentals/components.md
+++ b/apps/docs/src/pages/guide/fundamentals/components.md
@@ -36,6 +36,7 @@ v0 components are Vue wrappers around composables. Composables hold logic, compo
 | - | - | - |
 | **Primitives** | Base building blocks | [Atom](/components/primitives/atom) |
 | **Providers** | Pure state management, no DOM | [Selection](/components/providers/selection), [Single](/components/providers/single), [Group](/components/providers/group), [Step](/components/providers/step) |
+| **Actions** | Interactive controls that trigger behavior | [Button](/components/actions/button), [Toggle](/components/actions/toggle) |
 | **Forms** | Form controls with accessibility | [Checkbox](/components/forms/checkbox) |
 | **Semantic** | Meaningful HTML defaults | [Avatar](/components/semantic/avatar), [Pagination](/components/semantic/pagination) |
 | **Disclosure** | Show/hide patterns | [Dialog](/components/disclosure/dialog), [ExpansionPanel](/components/disclosure/expansion-panel), [Popover](/components/disclosure/popover) |

--- a/apps/docs/src/pages/guide/fundamentals/composables.md
+++ b/apps/docs/src/pages/guide/fundamentals/composables.md
@@ -119,6 +119,7 @@ Form state and validation:
 | [createCombobox](/composables/forms/create-combobox) | Autocomplete with filtering and virtual focus |
 | [createForm](/composables/forms/create-form) | Form validation coordinator |
 | [createInput](/composables/forms/create-input) | Shared form field primitive with ARIA IDs |
+| [createNumberField](/composables/forms/create-number-field) | Numeric input with formatting, parsing, and stepping |
 | [createNumeric](/composables/forms/create-numeric) | Bounded numeric math with step and clamp |
 | [createRating](/composables/forms/create-rating) | Bounded rating with discrete items |
 | [createSlider](/composables/forms/create-slider) | Multi-thumb slider with step snapping |
@@ -161,7 +162,9 @@ Filtering, pagination, and virtualization for collections:
 | - | - |
 | [createDataTable](/composables/data/create-data-table) | Data table with sort, filter, paginate, and select |
 | [createFilter](/composables/data/create-filter) | Array filtering |
+| [createKanban](/composables/data/create-kanban) | Two-level sortable board with cross-column transfer |
 | [createPagination](/composables/data/create-pagination) | Page navigation |
+| [createSortable](/composables/data/create-sortable) | Reorderable list with swap and move events |
 | [createVirtual](/composables/data/create-virtual) | Virtual scrolling |
 
 ## Usage Patterns
@@ -298,7 +301,7 @@ const [useTheme, provideTheme, theme] = createThemeContext()
 
 // 'theme' is the shared default instance
 // Access it anywhere without injection
-theme.current.value // Works outside components, in tests, etc.
+theme.selectedId.value // Works outside components, in tests, etc.
 ```
 
 **Module singleton** — Export a factory result:
@@ -307,10 +310,13 @@ theme.current.value // Works outside components, in tests, etc.
 export const globalSelection = createSelection({ multiple: true })
 ```
 
-**Plugin installation** — App-wide via dependency injection:
+**Context injection** — App-wide via dependency injection:
 
 ```ts main.ts
-app.use(createSelectionPlugin({ multiple: true }))
+import { createSelectionContext } from '@vuetify/v0'
+
+export const [useSelection, provideSelection] = createSelectionContext({ multiple: true })
+provideSelection() // Call once at the app root; descendants call useSelection()
 ```
 
 ```mermaid "Sharing Patterns"
@@ -323,14 +329,14 @@ flowchart TD
         A[Component A] --> S[globalSelection]
         B[Component B] --> S
     end
-    subgraph Plugin DI
+    subgraph Context DI
         C[Component C] --> P[useSelection]
         D[Component D] --> P
         P --> I[Injected instance]
     end
 ```
 
-Trinity's third element is the idiomatic v0 approach—see [The Trinity Pattern](/guide/fundamentals/core#the-trinity-pattern) for details. Module singletons work outside Vue. Plugins integrate with devtools.
+Trinity's third element is the idiomatic v0 approach—see [The Trinity Pattern](/guide/fundamentals/core#the-trinity-pattern) for details. Module singletons work outside Vue. Context injection scopes sharing to the providing component's subtree.
 
 ??? What's the lifecycle of a composable when components unmount?
 

--- a/apps/docs/src/pages/guide/fundamentals/plugins.md
+++ b/apps/docs/src/pages/guide/fundamentals/plugins.md
@@ -77,6 +77,8 @@ app.use(
 | `createDatePlugin` | Date utilities with adapter pattern | [useDate](/composables/plugins/use-date) |
 | `createNotificationsPlugin` | Notification lifecycle and toast queue | [useNotifications](/composables/plugins/use-notifications) |
 | `createStackPlugin` | Overlay z-index stacking | [useStack](/composables/plugins/use-stack) |
+| `createReducedMotionPlugin` | Respect or override `prefers-reduced-motion` | [useReducedMotion](/composables/plugins/use-reduced-motion) |
+| `createTooltipPlugin` | Region-scoped tooltip delay coordination | [useTooltip](/composables/plugins/use-tooltip) |
 
 > [!TIP]
 > All plugins are optional. Only install what you need—v0 works without any plugins installed.

--- a/apps/docs/src/pages/guide/fundamentals/reactivity.md
+++ b/apps/docs/src/pages/guide/fundamentals/reactivity.md
@@ -97,8 +97,8 @@ Selection composables are fully reactive out of the box:
 | - | - |
 | [createSelection](/composables/selection/create-selection) | `selectedIds`, ticket `isSelected` |
 | [createSingle](/composables/selection/create-single) | `selectedId`, ticket `isSelected` |
-| [createGroup](/composables/selection/create-group) | `selectedIds`, `indeterminate` |
-| [createStep](/composables/selection/create-step) | `selectedId`, `canPrev`, `canNext` |
+| [createGroup](/composables/selection/create-group) | `selectedIds`, `isMixed` |
+| [createStep](/composables/selection/create-step) | `selectedId`, ticket `isSelected` |
 
 ```ts
 import { createSingle } from '@vuetify/v0'

--- a/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
+++ b/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
@@ -46,7 +46,7 @@ import { IN_BROWSER } from '@vuetify/v0/constants'
 import type { ID } from '@vuetify/v0/types'
 ```
 
-Subpath imports narrow the module scope, giving bundlers less work to analyze. The size difference is minimal (~0.4 KB) but subpaths can improve build speed on large projects.
+Subpath imports narrow the module scope, giving bundlers less work to analyze. The size difference is negligible (well under 0.1 KB gzip in current builds) but subpaths can improve build speed on large projects.
 
 ### Adapter Subpaths
 
@@ -73,17 +73,17 @@ All sizes measured with Vue externalized (v0 code only), minified with esbuild.
 
 | Import | Raw | Gzip |
 | - | - | - |
-| Constants (`IN_BROWSER`, `SUPPORTS_TOUCH`) | <span class="whitespace-nowrap">0.2 KB</span> | <span class="whitespace-nowrap">0.1 KB</span> |
-| Utilities (`isObject`, `mergeDeep`, `clamp`) | <span class="whitespace-nowrap">1.0 KB</span> | <span class="whitespace-nowrap">0.5 KB</span> |
-| Single composable (`createSelection`) | <span class="whitespace-nowrap">10.7 KB</span> | <span class="whitespace-nowrap">4.2 KB</span> |
-| Single composable + component (`SelectionRoot`, `SelectionItem`) | <span class="whitespace-nowrap">13.6 KB</span> | <span class="whitespace-nowrap">5.2 KB</span> |
-| Deep chain (`createStep` → `createSingle` → `createSelection` → `createRegistry`) | <span class="whitespace-nowrap">11.9 KB</span> | <span class="whitespace-nowrap">4.6 KB</span> |
-| 6 composables (`createSelection`, `createSingle`, `createGroup`, `createStep`, `createRegistry`, `useStorage`) | <span class="whitespace-nowrap">16.5 KB</span> | <span class="whitespace-nowrap">6.2 KB</span> |
-| 4 component families (Selection, Dialog, Checkbox, Tabs) | <span class="whitespace-nowrap">29.6 KB</span> | <span class="whitespace-nowrap">10.1 KB</span> |
-| Everything (`import *`) | <span class="whitespace-nowrap">147.4 KB</span> | <span class="whitespace-nowrap">42.4 KB</span> |
+| Constants (`IN_BROWSER`, `SUPPORTS_TOUCH`) | <span class="whitespace-nowrap">0.4 KB</span> | <span class="whitespace-nowrap">0.3 KB</span> |
+| Utilities (`isObject`, `mergeDeep`, `clamp`) | <span class="whitespace-nowrap">0.7 KB</span> | <span class="whitespace-nowrap">0.4 KB</span> |
+| Single composable (`createSelection`) | <span class="whitespace-nowrap">12.1 KB</span> | <span class="whitespace-nowrap">4.9 KB</span> |
+| Single composable + component (`SelectionRoot`, `SelectionItem`) | <span class="whitespace-nowrap">17.3 KB</span> | <span class="whitespace-nowrap">6.8 KB</span> |
+| Deep chain (`createStep` → `createSingle` → `createSelection` → `createRegistry`) | <span class="whitespace-nowrap">14.4 KB</span> | <span class="whitespace-nowrap">5.8 KB</span> |
+| 6 composables (`createSelection`, `createSingle`, `createGroup`, `createStep`, `createRegistry`, `useStorage`) | <span class="whitespace-nowrap">19.0 KB</span> | <span class="whitespace-nowrap">7.4 KB</span> |
+| 4 component families (Selection, Dialog, Checkbox, Tabs) | <span class="whitespace-nowrap">43.5 KB</span> | <span class="whitespace-nowrap">14.4 KB</span> |
+| Everything (`import *`) | <span class="whitespace-nowrap">297.8 KB</span> | <span class="whitespace-nowrap">81.2 KB</span> |
 
 > [!TIP]
-> A single composable is **7%** of the full library. Most apps use a fraction of v0.
+> A single composable is **4%** of the full library. Most apps use a fraction of v0.
 
 ### Composable Sharing
 
@@ -91,17 +91,17 @@ Composables share internal code. Adding more composables doesn't multiply cost l
 
 | Composables | v0 Cost (gzip) | Per-Composable |
 |-------------|----------------|----------------|
-| 1           | 4.2 KB         | 4.2 KB         |
-| 6           | 6.2 KB         | 1.0 KB         |
+| 1           | 4.9 KB         | 4.9 KB         |
+| 6           | 7.4 KB         | 1.2 KB         |
 
 ### Root vs Subpath
 
 | Scenario          | Root   | Subpath | Difference |
 |-------------------|--------|---------|------------|
-| Single composable | 4.4 KB | 4.2 KB  | 0.2 KB     |
-| 6 composables     | 6.4 KB | 6.2 KB  | 0.2 KB     |
+| Single composable | 4.9 KB | 4.9 KB  | 0.0 KB     |
+| 6 composables     | 7.4 KB | 7.4 KB  | 0.0 KB     |
 
-The difference is negligible. Use whichever import style you prefer.
+The difference is negligible — current builds produce byte-identical output regardless of entry point. Use whichever import style you prefer.
 
 ### Dead Code Elimination
 
@@ -187,7 +187,7 @@ No. v0 tree-shakes out of the box with Vite, Rollup, and webpack 5. No plugins, 
 
 ??? Should I use root imports or subpath imports?
 
-Either works. Root imports (`from '@vuetify/v0'`) are simpler and recommended for most apps. Subpath imports save ~0.2 KB gzip and can marginally improve build speed. Use subpaths when authoring a library that depends on v0.
+Either works. Root imports (`from '@vuetify/v0'`) are simpler and recommended for most apps. Subpath imports produce virtually identical bundle size in current builds but can marginally improve build speed on large projects. Use subpaths when authoring a library that depends on v0.
 
 ??? Does `sideEffects: false` matter?
 
@@ -195,7 +195,7 @@ v0 functions are already annotated as side-effect-free. Adding `sideEffects: fal
 
 ??? What's the base cost of using v0?
 
-A single composable adds ~4.2 KB gzip. Constants and utilities are even lighter (0.1–0.5 KB gzip). The full library is 42.4 KB gzip, but no app should import everything.
+A single composable adds ~4.9 KB gzip. Constants and utilities are even lighter (0.3–0.4 KB gzip). The full library is 81.2 KB gzip, but no app should import everything.
 
 ??? Why is my bundle larger than expected?
 

--- a/apps/docs/src/pages/guide/index.md
+++ b/apps/docs/src/pages/guide/index.md
@@ -136,9 +136,9 @@ If you have an existing styled component library and want to adopt v0's headless
 <script setup lang="ts">
   import { createSingle } from '@vuetify/v0'
 
-  const tabs = createSingle({ mandatory: true })
+  const tabs = createSingle({ mandatory: 'force' })
 
-  // Bulk register tabs - first is auto-selected due to mandatory
+  // Bulk register tabs - first is auto-selected because mandatory: 'force'
   const items = tabs.onboard([
     { id: 'home', value: 'Home' },
     { id: 'profile', value: 'Profile' },
@@ -163,8 +163,8 @@ If you have an existing styled component library and want to adopt v0's headless
 
 ### What You Get
 
-- **`mandatory`** auto-selects first registered item
-- **Navigation** methods built-in: `next()`, `prev()`, `first()`, `last()`
+- **`mandatory: 'force'`** auto-selects first registered item
+- **`createStep`** extends `createSingle` with `next()`, `prev()`, `first()`, `last()` navigation for wizards and carousels
 - **Computed properties**: `selectedId`, `selectedIndex`, `selectedValue`
 - **Ticket methods**: each item has `isSelected`, `select()`, `toggle()`
 - **Disabled support** via `{ disabled: true }` on any ticket

--- a/apps/docs/src/pages/guide/integration/nuxt.md
+++ b/apps/docs/src/pages/guide/integration/nuxt.md
@@ -90,7 +90,27 @@ The hydration plugin:
 
 ### Theme SSR Integration
 
-The theme plugin automatically integrates with Nuxt's `@unhead/vue` to inject styles during SSR. No additional configuration required.
+The default theme adapter (`V0StyleSheetThemeAdapter`) injects CSS via `document.adoptedStyleSheets`, a client-only API — it renders nothing during SSR. Under Nuxt this ships a themeless server response that repaints once the client hydrates, causing a flash of unstyled content.
+
+For SSR, opt into `V0UnheadThemeAdapter`. It renders the `<style>` tag and `data-theme` attribute into the initial HTML via [Unhead](https://unhead.unjs.io/) — the head manager Nuxt already ships — so the correct theme is present before hydration:
+
+```ts plugins/v0.ts
+import { createThemePlugin } from '@vuetify/v0'
+import { V0UnheadThemeAdapter } from '@vuetify/v0/theme/adapters/unhead'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(
+    createThemePlugin({
+      adapter: new V0UnheadThemeAdapter(),
+      default: 'light',
+      themes: {
+        light: { dark: false, colors: { primary: '#3b82f6' } },
+        dark: { dark: true, colors: { primary: '#60a5fa' } },
+      },
+    }),
+  )
+})
+```
 
 ## Theme Persistence
 
@@ -165,7 +185,7 @@ To sync theme changes back to the cookie:
 | Feature | SSR Support | Notes |
 | - | - | - |
 | Components | Full | All compound components work in SSR |
-| `useTheme` | Full | Auto-injects styles via Nuxt head manager |
+| `useTheme` | Partial | Client-only by default; pass `adapter: new V0UnheadThemeAdapter()` for SSR'd styles |
 | `useHydration` | Full | Designed for SSR/client state sync |
 | `useBreakpoints` | Full | Pass `ssr` option for server-side viewport matching |
 | `useStorage` | Partial | Uses memory adapter on server |


### PR DESCRIPTION
## Summary

Audit of 11 `apps/docs/src/pages/guide/**` pages flagged as stale (per the docs health/freshness tracking) turned up factual bugs, not just prose staleness. This fixes them:

- **Broken examples/claims**: `createSingle` example misattributed `createStep`'s navigation methods and used `mandatory: true` while claiming auto-select behavior (only `mandatory: 'force'` auto-selects); `theme.current` → `theme.selectedId`; a nonexistent `createSelectionPlugin` replaced with the real `createSelectionContext` pattern; fabricated `canPrev`/`canNext` on `createStep`; false claim that Nuxt SSR theme integration is automatic (now documents the `V0UnheadThemeAdapter` opt-in); wrong import paths for `PaletteGenerator` and several `#v0/types`; a `createVirtual` example missing `:ref`/`.value` bindings; a fabricated `Pagination` prop replaced with real compound markup.
- **Stale/missing data**: bundle-size table in the tree-shaking guide re-measured from scratch (some import scenarios had grown ~2x since last measured; root vs. subpath imports are now byte-identical, so the documented size advantage no longer holds); missing `useReducedMotion`/`useTooltip` plugin entries; incorrect benchmark complexity-detection precedence; missing `actions` component category; missing `createNumberField`/`createSortable`/`createKanban` composable entries; missing `V0ErrorCode`/`V0ErrorDetails` type docs and `V0Error`/`isV0Error`/`isThenable` utility docs.

All fixes verified against current `packages/0/src` and `packages/paper/src` source before writing.