### PR TITLE
chore(playground): fix unclickable config files in file tree

### DIFF
--- a/apps/playground/src/components/playground/app/PlaygroundApp.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundApp.vue
@@ -32,6 +32,7 @@
     toggleAddon: (id: string) => Promise<void>
     filesVersion: ShallowRef<number>
     openPlayground: (content: string) => Promise<void>
+    showConfig: ShallowRef<boolean>
   }
 
   export const [usePlayground, providePlayground] = createContext<PlaygroundContext>('v0:playground')
@@ -66,6 +67,10 @@
   // while panels and splitters resolve to their persisted sizes.
   const settled = shallowRef(false)
 
+  // Shared with the tabs strip so config files are enrolled as tabbable
+  // before a click can race the mandatory Tabs.Root selection.
+  const showConfig = shallowRef(false)
+
   providePlayground({
     store,
     isReady,
@@ -86,6 +91,7 @@
     toggleAddon,
     filesVersion,
     openPlayground,
+    showConfig,
   })
 
   // Restore panel state on runtime breakpoint changes

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
@@ -3,7 +3,7 @@
   import { createNested, isString, useBreakpoints } from '@vuetify/v0'
 
   // Data
-  import { REPL_BUILTIN_FILES } from '@/data/playground-defaults'
+  import { CONFIG_FILE_IDS, REPL_BUILTIN_FILES } from '@/data/playground-defaults'
 
   // Utilities
   import { computed, nextTick, shallowRef, toRef, useTemplateRef, watch } from 'vue'
@@ -51,7 +51,7 @@
     return children
   }
 
-  const showConfig = shallowRef(false)
+  const showConfig = playground.showConfig
   const targetFolder = shallowRef('src')
 
   function rebuildFileTree () {
@@ -98,7 +98,7 @@
     { id: 'import-map.json', value: 'import-map.json' },
   ]
 
-  const CONFIG_IDS = new Set(CONFIG_FILES.map(f => f.id))
+  const CONFIG_IDS = CONFIG_FILE_IDS
 
   function toggleConfig () {
     showConfig.value = !showConfig.value

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorTabs.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorTabs.vue
@@ -3,7 +3,7 @@
   import { Tabs } from '@vuetify/v0'
 
   // Data
-  import { INFRASTRUCTURE_FILES } from '@/data/playground-defaults'
+  import { CONFIG_FILE_IDS, INFRASTRUCTURE_FILES } from '@/data/playground-defaults'
 
   // Utilities
   import { computed, shallowRef, watch } from 'vue'
@@ -14,6 +14,7 @@
   const playground = usePlayground()
 
   function isTabbable (f: { filename: string, hidden?: boolean }) {
+    if (CONFIG_FILE_IDS.has(f.filename)) return playground.showConfig.value
     if (INFRASTRUCTURE_FILES.has(f.filename)) return false
     if (f.hidden) return false
     return true

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -6,6 +6,9 @@ export const INFRASTRUCTURE_FILES = new Set(['import-map.json', 'tsconfig.json',
 /** Subset of infrastructure files shown in the "project" folder of the file tree */
 export const REPL_BUILTIN_FILES = ['import-map.json', 'tsconfig.json'] as const
 
+/** Infrastructure files revealed by the file tree's "Toggle config files" button */
+export const CONFIG_FILE_IDS = new Set(['src/main.ts', 'src/uno.config.ts', 'import-map.json'])
+
 // ── Template files (matching Vuetify Play's v0 template) ────────────────
 
 export interface MainOptions {


### PR DESCRIPTION
## Summary
- Clicking a config file (`main.ts`, `uno.config.ts`, `import-map.json`) revealed via the file tree's cog toggle silently reverted to the previous active file instead of switching
- Root cause: the tabs strip's `Tabs.Root` is a mandatory single-selection whose valid values come only from currently-enrolled tabs; `isTabbable()` unconditionally excluded these files, so `useProxyModel`'s sync watcher rejected the new value and wrote the previous one back, undoing the click
- Fix: promote `showConfig` to the shared playground context so the tabs strip enrolls config files as tabbable as soon as the cog is toggled, before any click can race the selection