### PR TITLE
docs: close out remaining minor staleness from the guide-pages audit

### DIFF
--- a/apps/docs/src/pages/guide/features/constants.md
+++ b/apps/docs/src/pages/guide/features/constants.md
@@ -103,7 +103,7 @@ The current package version string. Resolves to the build-time version in produc
 ```ts
 import { version } from '@vuetify/v0/constants'
 
-console.log(version)  // e.g. '0.4.2'
+console.log(version)  // e.g. '1.0.0-beta.4'
 ```
 
 ## HTML Elements

--- a/apps/docs/src/pages/guide/features/theming.md
+++ b/apps/docs/src/pages/guide/features/theming.md
@@ -212,6 +212,22 @@ export default defineConfig({
 
 Use `useStorage` to persist theme selection across page loads. The key is installing the storage plugin first, then reading the stored preference during theme plugin setup:
 
+> [!TIP] Built-in persistence
+> `createThemePlugin` ships `persist`/`restore` wiring out of the box — pass `persist: true` and skip the manual `useStorage` + `watch` code below:
+>
+> ```ts no-filename
+> app.use(createStoragePlugin())
+> app.use(
+>   createThemePlugin({
+>     default: 'light',
+>     themes: { light: { dark: false, colors: { /* ... */ } }, dark: { dark: true, colors: { /* ... */ } } },
+>     persist: true,
+>   }),
+> )
+> ```
+>
+> `createStoragePlugin()` still has to be installed first — the theme plugin reads/writes through it. Reach for the manual approach below when persistence needs custom logic the built-in path doesn't cover — a cookie for SSR, a backend call, or resolving `prefers-color-scheme` before the first paint.
+
 ```ts main.ts collapse
 import { createApp } from 'vue'
 import {

--- a/apps/docs/src/pages/guide/fundamentals/composables.md
+++ b/apps/docs/src/pages/guide/fundamentals/composables.md
@@ -121,6 +121,7 @@ Form state and validation:
 | [createInput](/composables/forms/create-input) | Shared form field primitive with ARIA IDs |
 | [createNumberField](/composables/forms/create-number-field) | Numeric input with formatting, parsing, and stepping |
 | [createNumeric](/composables/forms/create-numeric) | Bounded numeric math with step and clamp |
+| [createOtp](/composables/forms/create-otp) | Fixed-length OTP / verification-code value with pattern-gated entry |
 | [createRating](/composables/forms/create-rating) | Bounded rating with discrete items |
 | [createSlider](/composables/forms/create-slider) | Multi-thumb slider with step snapping |
 | [createValidation](/composables/forms/create-validation) | Per-field validation lifecycle |
@@ -160,6 +161,7 @@ Filtering, pagination, and virtualization for collections:
 
 | Composable | Purpose |
 | - | - |
+| [createDataGrid](/composables/data/create-data-grid) | Column layout, cell editing, and row spanning for data tables |
 | [createDataTable](/composables/data/create-data-table) | Data table with sort, filter, paginate, and select |
 | [createFilter](/composables/data/create-filter) | Array filtering |
 | [createKanban](/composables/data/create-kanban) | Two-level sortable board with cross-column transfer |

--- a/apps/docs/src/pages/guide/fundamentals/reactivity.md
+++ b/apps/docs/src/pages/guide/fundamentals/reactivity.md
@@ -358,12 +358,7 @@ Minimal reactivity isn't just a design choice—it has measurable impact.
 
 ### Benchmark: Bulk Registration
 
-Registering items in batch, comparing `reactive: false` vs `reactive: true`:
-
-| Items | Non-Reactive | Reactive | Slowdown |
-| -: | -: | -: | :-: |
-| 1,000 | <AppIcon icon="benchmark-blazing" class="text-error" :size="16" /> 0.78ms | <AppIcon icon="benchmark-fast" class="text-warning" :size="16" /> 1.92ms | 2.5x |
-| 5,000 | <AppIcon icon="benchmark-blazing" class="text-error" :size="16" /> 2.14ms | <AppIcon icon="benchmark-good" class="text-info" :size="16" /> 9.55ms | **4.5x** |
+Registering items in batch is measurably slower with `reactive: true` than with the default non-reactive registry — every write goes through Vue's change-tracking machinery instead of a plain `Map` mutation. The exact slowdown depends on dataset size, browser, and hardware, so rather than quoting fixed numbers here, run the comparison live:
 
 ```vue playground collapse
 <script setup>

--- a/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
+++ b/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
@@ -137,7 +137,7 @@ Utility functions are annotated with `/*#__NO_SIDE_EFFECTS__*/` so bundlers know
 ```ts
 /*#__NO_SIDE_EFFECTS__*/
 function isObject(value: unknown): value is object {
-  return value !== null && typeof value === 'object'
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 ```
 

--- a/apps/docs/src/pages/guide/integration/nuxt.md
+++ b/apps/docs/src/pages/guide/integration/nuxt.md
@@ -278,9 +278,6 @@ When you see hydration warnings in the console:
 
 ```ts nuxt.config.ts
 export default defineNuxtConfig({
-  vue: {
-    propsDestructure: true,
-  },
   vite: {
     define: {
       __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: true,


### PR DESCRIPTION
## Summary

Follow-up to #458. That PR fixed the broken/misleading issues found in an audit of 11 `apps/docs/src/pages/guide/**` pages; this closes out the smaller items that were deliberately deferred:

- `constants.md`: stale `version` example (`'0.4.2'` → `'1.0.0-beta.4'`)
- `tree-shaking.md`: illustrative `isObject` sample now matches the real implementation (excludes arrays)
- `reactivity.md`: removed a hardcoded benchmark table whose numbers didn't correspond to any real, current bench (the registry bench suite has no reactive-vs-non-reactive *registration* comparison at these dataset sizes) — the page's existing live "Run Benchmark" widget is the source of truth for this comparison now
- `nuxt.md`: removed an unrelated `propsDestructure` config option from a hydration-mismatch-debugging sample (also obsolete given this repo's `vue: >=3.5.0` peer range)
- `theming.md`: added a tip pointing to `createThemePlugin`'s built-in `persist`/`restore` option, which the page's manual `useStorage` example was duplicating without mentioning
- `composables.md`: added `createOtp` and `createDataGrid` to the Forms/Data composable tables (both real, shipped, previously omitted only because they postdated the page's prior last edit)

All verified against current `packages/0/src` source before writing.