### PR TITLE
docs: fix missing spacing between API index tables

### DIFF
--- a/apps/docs/src/components/docs/DocsApiIndex.vue
+++ b/apps/docs/src/components/docs/DocsApiIndex.vue
@@ -82,54 +82,58 @@
 <template>
   <div>
     <template v-if="componentGroups.length > 0">
-      <h2>Components</h2>
+      <h2 class="text-3xl leading-9 mt-8 mb-3">Components</h2>
 
       <p>Detailed API reference for each component including props, events, and slots.</p>
 
       <template v-for="[category, entries] in componentGroups" :key="`c-${category}`">
-        <h3 class="capitalize">{{ category }}</h3>
+        <h3 class="capitalize text-2xl leading-8 mt-6 mb-2">{{ category }}</h3>
 
-        <table>
-          <thead>
-            <tr>
-              <th>Component</th>
-              <th>Description</th>
-            </tr>
-          </thead>
+        <div class="overflow-x-auto mb-4">
+          <table>
+            <thead>
+              <tr>
+                <th>Component</th>
+                <th>Description</th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr v-for="entry in entries" :key="entry.name">
-              <td><router-link :to="entry.href">{{ entry.name }}</router-link></td>
-              <td>{{ entry.description }}</td>
-            </tr>
-          </tbody>
-        </table>
+            <tbody>
+              <tr v-for="entry in entries" :key="entry.name">
+                <td><router-link :to="entry.href">{{ entry.name }}</router-link></td>
+                <td>{{ entry.description }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </template>
     </template>
 
     <template v-if="composableGroups.length > 0">
-      <h2>Composables</h2>
+      <h2 class="text-3xl leading-9 mt-8 mb-3">Composables</h2>
 
       <p>Detailed API reference for each composable including options, properties, and methods.</p>
 
       <template v-for="[category, entries] in composableGroups" :key="`e-${category}`">
-        <h3 class="capitalize">{{ category }}</h3>
+        <h3 class="capitalize text-2xl leading-8 mt-6 mb-2">{{ category }}</h3>
 
-        <table>
-          <thead>
-            <tr>
-              <th>Composable</th>
-              <th>Description</th>
-            </tr>
-          </thead>
+        <div class="overflow-x-auto mb-4">
+          <table>
+            <thead>
+              <tr>
+                <th>Composable</th>
+                <th>Description</th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr v-for="entry in entries" :key="entry.name">
-              <td><router-link :to="entry.href">{{ entry.name }}</router-link></td>
-              <td>{{ entry.description }}</td>
-            </tr>
-          </tbody>
-        </table>
+            <tbody>
+              <tr v-for="entry in entries" :key="entry.name">
+                <td><router-link :to="entry.href">{{ entry.name }}</router-link></td>
+                <td>{{ entry.description }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </template>
     </template>
   </div>


### PR DESCRIPTION
## Description

On [/api](https://0.vuetifyjs.com/api), the category tables rendered flush against each other with no vertical spacing, and the section headings (Components, Actions, Disclosure, …) rendered as plain 16px body text.

Cause: the `.markdown-body` heading/table rules in `App.vue` use the direct-child combinator (`> h2`, `> h3`), and markdown tables get their `overflow-x-auto mb-4` wrapper from the markdown pipeline (`build/markdown.ts`). `DocsApiIndex` renders raw `<h2>`/`<h3>`/`<table>` inside its own wrapper div, so none of those rules reached it.

Fix (template-only, `DocsApiIndex.vue`):
- Wrap each table in the same `overflow-x-auto mb-4` container the markdown pipeline emits (also restores mobile horizontal-scroll parity).
- Restore the heading scale/margins with utility classes matching the `.markdown-body > h2/h3` values.

Verified in the dev server: headings now render at proper scale and the tables have clear separation, matching markdown-authored pages.