### PR TITLE
feat(Popover): dev-mode warning when display utility overrides native popover hide

### DIFF
--- a/.changeset/popover-display-utility-dev-warning-448.md
+++ b/.changeset/popover-display-utility-dev-warning-448.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+feat(Popover): dev-mode warning when a display utility overrides native popover hide
+
+In `__DEV__` builds, `Popover.Content` now warns via `useLogger` when a display utility class (`flex`, `grid`, `inline-flex`, etc.) is placed directly on the content element. The check clones the element without its `[popover]` attribute so neither the UA closed-state rule nor the component's own `[popover]:not(:popover-open){display:none!important}` override applies, then reads `getComputedStyle().display` on the off-screen clone. A non-`block`/non-`none` result means author CSS would have made the element visible while closed; the warning names the detected value and points to the fix: wrap layout classes in a child element. The guard is tree-shaken in production and is SSR-safe via `IN_BROWSER`.

--- a/packages/0/src/components/Popover/PopoverContent.vue
+++ b/packages/0/src/components/Popover/PopoverContent.vue
@@ -46,8 +46,14 @@
   // Context
   import { usePopoverContext } from './PopoverRoot.vue'
 
+  // Composables
+  import { useLogger } from '#v0/composables/useLogger'
+
+  // Globals
+  import { IN_BROWSER } from '#v0/constants/globals'
+
   // Utilities
-  import { toRef, useTemplateRef } from 'vue'
+  import { onMounted, toRef, useTemplateRef } from 'vue'
 
   defineOptions({ name: 'PopoverContent' })
 
@@ -85,6 +91,35 @@
   })
 
   context.attach(() => ref.value?.element)
+
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+    const logger = useLogger('PopoverContent')
+
+    onMounted(() => {
+      if (!IN_BROWSER) return
+      const el = ref.value?.element
+      if (!el) return
+
+      // Clone the element without [popover] so neither the UA closed-state rule
+      // nor our [popover]:not(:popover-open){display:none!important} override
+      // applies. A non-block computed display on the clone signals that an author
+      // utility class (flex, grid, …) has been placed directly on the element.
+      const probe = el.cloneNode() as HTMLElement
+      probe.removeAttribute('popover')
+      probe.style.position = 'fixed'
+      probe.style.visibility = 'hidden'
+      probe.style.pointerEvents = 'none'
+      probe.style.top = '-9999px'
+      document.body.append(probe)
+      const display = window.getComputedStyle(probe).display
+      probe.remove()
+
+      if (display && display !== 'none' && display !== 'block') {
+        const msg = `[Popover.Content] A display utility class (detected: "${display}") is set directly on the content element. This conflicts with the native [popover] closed-state hide. Move layout classes (flex, grid, etc.) to a wrapper element inside the slot instead.`
+        logger.warn(msg)
+      }
+    })
+  }
 
   function onBeforeToggle (e: ToggleEvent) {
     emit('beforetoggle', e)

--- a/packages/0/src/components/Popover/index.test.ts
+++ b/packages/0/src/components/Popover/index.test.ts
@@ -471,6 +471,57 @@ describe('popover', () => {
       })
     })
 
+    describe('dev warning', () => {
+      it('should warn when a display utility overrides the native popover hide', async () => {
+        const originalDev = (globalThis as unknown as Record<string, unknown>).__DEV__
+        ;(globalThis as unknown as Record<string, unknown>).__DEV__ = true
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+          // Identify the off-screen probe by its injected visibility style
+          if (el instanceof HTMLElement && el.style.visibility === 'hidden') {
+            return { display: 'flex' } as CSSStyleDeclaration
+          }
+          return { display: '' } as CSSStyleDeclaration
+        })
+
+        mount(Popover.Root, {
+          slots: {
+            default: () => h(Popover.Content, { class: 'flex flex-col' }, () => 'Content'),
+          },
+        })
+
+        await nextTick()
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('display utility'))
+
+        vi.restoreAllMocks()
+        ;(globalThis as unknown as Record<string, unknown>).__DEV__ = originalDev
+      })
+
+      it('should not warn when no display utility is present', async () => {
+        const originalDev = (globalThis as unknown as Record<string, unknown>).__DEV__
+        ;(globalThis as unknown as Record<string, unknown>).__DEV__ = true
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        // getComputedStyle returns '' (happy-dom default) — no display detected
+        mount(Popover.Root, {
+          slots: {
+            default: () => h(Popover.Content, {}, () => 'Content'),
+          },
+        })
+
+        await nextTick()
+
+        expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('display utility'))
+
+        vi.restoreAllMocks()
+        ;(globalThis as unknown as Record<string, unknown>).__DEV__ = originalDev
+      })
+    })
+
     describe('renderless', () => {
       it('should expose popover attrs, style, and onBeforetoggle in slot props so renderless mode works', async () => {
         let contentProps: any

--- a/packages/0/src/components/Popover/index.test.ts
+++ b/packages/0/src/components/Popover/index.test.ts
@@ -478,7 +478,7 @@ describe('popover', () => {
 
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-        vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+        vi.spyOn(window, 'getComputedStyle').mockImplementation(el => {
           // Identify the off-screen probe by its injected visibility style
           if (el instanceof HTMLElement && el.style.visibility === 'hidden') {
             return { display: 'flex' } as CSSStyleDeclaration


### PR DESCRIPTION
## Summary

Closes #448.

When a layout utility class (`flex`, `grid`, `inline-flex`, etc.) is placed directly on `<Popover.Content>`, it can conflict with the UA `[popover]:not(:popover-open) { display: none }` rule that hides a closed popover. This was the root cause of #419; the CSS-layer fix landed in #419/398, but there was no developer feedback to prevent the pattern from reappearing.

### What this PR adds

**`PopoverContent.vue`** — `onMounted` guard (tree-shaken to nothing in production via `typeof __DEV__ !== 'undefined' && __DEV__`):

1. Clones the content element and removes its `[popover]` attribute, so neither the UA closed-state rule nor the component's own `[popover]:not(:popover-open){display:none!important}` override applies to the clone.
2. Appends the clone off-screen and reads `getComputedStyle(clone).display`.
3. If the computed value is anything other than `none` or `block` (i.e. the default div display), a `useLogger('PopoverContent').warn(...)` is emitted, naming the detected value and pointing to the fix: wrap layout classes in a child element.
4. Removes the clone immediately — zero DOM leak.

The guard is also SSR-safe via the `IN_BROWSER` early return.

### Tests

Two new cases in `index.test.ts` under `content > dev warning`:

- **warns** when `getComputedStyle` returns `'flex'` for the off-screen probe (simulated via `vi.spyOn`).
- **does not warn** when `getComputedStyle` returns the happy-dom default `''` (no utility class present).

### Before / After

```html
<!-- triggers warning in dev -->
<Popover.Content class="flex flex-col gap-4">…</Popover.Content>

<!-- correct: layout on the inner wrapper -->
<Popover.Content>
  <div class="flex flex-col gap-4">…</div>
</Popover.Content>
```