### PR TITLE
chore(release): condense release notes into a skimmable title overview

### DIFF
--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -64,6 +64,30 @@ function notes (changelog, value) {
   return lines.slice(start + 1, end).join('\n').trim()
 }
 
+// Condense each changelog bullet's conventional-commit title into a flat, skimmable
+// list at the top of the release notes — changesets' per-entry prose buries the
+// one-line summaries readers skim for. Two authoring shapes both need trimming: a
+// title-only first line with the detail in a separate indented paragraph below
+// (BULLET's `.+$` already stops at line end), and a single line packing title +
+// detail together, separated by ' — ' (em dash).
+const BULLET = /^- (?:\[#(\d+)]\([^)]*\)\s*)?(?:\[`[0-9a-f]+`]\([^)]*\)\s*)?(?:Thanks .*?! - )?(.+)$/
+
+function overview (body) {
+  const titles = []
+  for (const line of body.split('\n')) {
+    const match = line.match(BULLET)
+    if (!match) continue
+    const [, pr, text] = match
+    // Changesets emits its own boilerplate bullet ("Updated dependencies [sha, …]:")
+    // for packages that only bumped because an internal dependency changed — no
+    // conventional-commit title to extract, and the sha list is pure noise here.
+    if (text.startsWith('Updated dependencies')) continue
+    const title = text.split(' — ')[0]
+    titles.push(pr ? `- ${title} (#${pr})` : `- ${title}`)
+  }
+  return titles.length > 0 ? `## Overview\n${titles.join('\n')}\n\n---\n\n` : ''
+}
+
 function exists (tag) {
   try {
     execFileSync('gh', ['release', 'view', tag], { stdio: 'ignore' })
@@ -120,6 +144,7 @@ function mint (tag, body, target, prerelease) {
 const substrate = version['@vuetify/v0'] ?? version['@vuetify/paper']
 if (substrate) {
   let body = notes('packages/0/CHANGELOG.md', substrate) || notes('packages/paper/CHANGELOG.md', substrate)
+  body = overview(body) + body
   if (version['@vuetify/v0'] && version['@vuetify/paper']) {
     body += `\n\n---\n\`@vuetify/paper@${version['@vuetify/paper']}\` shipped in lockstep.`
   }
@@ -131,7 +156,8 @@ if (substrate) {
 for (const { name, version: value } of published) {
   if (SUBSTRATE.has(name)) continue
   const dir = name.split('/').pop()
-  mint(`${name}@${value}`, notes(`packages/${dir}/CHANGELOG.md`, value), sha, value.includes('-'))
+  const body = notes(`packages/${dir}/CHANGELOG.md`, value)
+  mint(`${name}@${value}`, overview(body) + body, sha, value.includes('-'))
 }
 
 // Fail the step (after attempting every release) if any could not be minted, so a


### PR DESCRIPTION
Prepends a `## Overview` section to the GitHub release bodies minted by `scripts/github-release.js` — one line per change, just the conventional-commit title plus PR ref, with the full changesets entries unchanged below.

The changesets-generated notes are thorough but hard to skim: every entry opens with PR/sha/author boilerplate and often runs multi-paragraph. User feedback on `v1.0.0-beta.4` called this a regression vs. the old one-liner releases, where detail was a click away. The overview restores the skimmable list without losing any of the detail.

- Titles are cut at the first ` — ` when a changeset packs title + explanation into a single line (about half of the existing entries)
- Changesets' auto-generated `Updated dependencies [sha, …]` bullets are skipped — no title to extract; a dependency-only bump (e.g. paper in lockstep) renders no overview section at all
- Applied to both the aggregate substrate release and the per-design-system releases

Sample, generated from the real `v1.0.0-beta.4` changelog block:

```markdown
## Overview
- feat(locale): add `ti()` so components carry inline English aria labels without bundling a locale (WCAG 4.1.2) (#372)
- fix(Dialog, Snackbar): overlays can teleport into the topmost open modal so snackbars shown over a modal Dialog appear above it and stay interactive (#397)
- fix(build): ship type declarations for the `@vuetify/v0/browser` entry (#443)
- fix(Button): don't auto-set aria-label in renderless mode (#390)
…

---

### Minor Changes
(full entries unchanged)
```