### PR TITLE
docs: fix missing space after Requires: in skillz card

### DIFF
--- a/apps/docs/src/components/skillz/SkillPrerequisites.vue
+++ b/apps/docs/src/components/skillz/SkillPrerequisites.vue
@@ -10,7 +10,7 @@
 <template>
   <div v-if="prerequisites.length > 0" class="skill-prerequisites" :class="`skill-prerequisites--${variant}`">
     <span class="skill-prerequisites__label">
-      {{ variant === 'box' ? 'Prerequisites:' : 'Requires:' }}
+      {{ variant === 'box' ? 'Prerequisites:' : 'Requires: ' }}
     </span>
 
     <template v-if="variant === 'box'">


### PR DESCRIPTION
Fixes a missing space after the colon in the "Requires:" label on inline skill prerequisite cards, caused by Vue's whitespace condensing removing the newline-only text node between the label span and the v-else list span.