### PR TITLE
docs: generate OG images for skillz tour pages

### DIFF
--- a/apps/docs/build/generate-og-images.ts
+++ b/apps/docs/build/generate-og-images.ts
@@ -8,6 +8,7 @@ import { Worker } from 'node:worker_threads'
 
 import { getApiNamesGrouped } from './api-names'
 import { parseFrontmatter } from './frontmatter'
+import { getSkillzTours } from './skillz-tours'
 
 // Types
 import type { Frontmatter } from './frontmatter'
@@ -224,6 +225,20 @@ export async function generateOgImages (): Promise<void> {
     const category = 'API Reference'
     files.push({
       path: `/api/${info.slug}`,
+      title,
+      description,
+      category,
+      hash: hash(`${TEMPLATE_VERSION}|${title}|${description}|${category}`),
+    })
+  }
+
+  const tours = await getSkillzTours()
+  for (const tour of tours) {
+    const title = tour.name
+    const description = tour.description
+    const category = 'Skillz'
+    files.push({
+      path: `/skillz/${tour.id}`,
       title,
       description,
       category,

--- a/apps/docs/build/skillz-tours.ts
+++ b/apps/docs/build/skillz-tours.ts
@@ -50,3 +50,31 @@ export async function getSkillzSlugs (): Promise<string[]> {
 
   return slugs
 }
+
+export interface SkillzTourInfo {
+  id: string
+  name: string
+  description: string
+}
+
+/**
+ * Get id/name/description for every skillz tour, for OG image generation
+ */
+export async function getSkillzTours (): Promise<SkillzTourInfo[]> {
+  const tourFiles = await findTourFiles(TOURS_DIR)
+  const tours: SkillzTourInfo[] = []
+
+  for (const file of tourFiles) {
+    try {
+      const content = await readFile(file, 'utf8')
+      const tour = JSON.parse(content)
+      if (tour.id && tour.name) {
+        tours.push({ id: tour.id, name: tour.name, description: tour.description ?? '' })
+      }
+    } catch {
+      // Skip invalid files
+    }
+  }
+
+  return tours
+}

--- a/apps/docs/src/pages/skillz.[id].vue
+++ b/apps/docs/src/pages/skillz.[id].vue
@@ -58,13 +58,16 @@
       .toSorted((a, b) => a.order - b.order)[0] ?? null
   })
 
+  const ogImage = toRef(() => tour.value ? `https://0.vuetifyjs.com/og/skillz/${tour.value.id}.png` : undefined)
+
   useHead({
     title: () => tour.value ? `${tour.value.name} - Skillz` : 'Skill Not Found - Skillz',
-    meta: [
-      { key: 'description', name: 'description', content: () => tour.value?.description ?? 'The requested skill could not be found.' },
-      { key: 'og:title', property: 'og:title', content: () => tour.value ? `${tour.value.name} - Vuetify0 Skillz` : 'Skill Not Found' },
-      { key: 'og:description', property: 'og:description', content: () => tour.value?.description ?? 'The requested skill could not be found.' },
-    ],
+    meta: toRef(() => [
+      { key: 'description', name: 'description', content: tour.value?.description ?? 'The requested skill could not be found.' },
+      { key: 'og:title', property: 'og:title', content: tour.value ? `${tour.value.name} - Vuetify0 Skillz` : 'Skill Not Found' },
+      { key: 'og:description', property: 'og:description', content: tour.value?.description ?? 'The requested skill could not be found.' },
+      ...(ogImage.value ? [{ key: 'og:image', property: 'og:image', content: ogImage.value }] : []),
+    ]),
   })
 
   async function onClick (stepId?: string) {


### PR DESCRIPTION
## Summary
- Skillz tour pages (`/skillz/:id`) never got a per-page OG image — they use the `fullscreen` layout, which bypasses `AppMainDocs.vue`'s automatic per-route `og:image` injection, and `generate-og-images.ts` never enumerated skillz routes in the first place (only `.md` pages and API routes).
- Added `getSkillzTours()` to `skillz-tours.ts` to read `id`/`name`/`description` from each tour's `index.json`.
- Wired it into `generateOgImages()` so a PNG is rendered for every `/skillz/{id}` route (category badge: "Skillz").
- `skillz.[id].vue` now sets `og:image` pointing at `https://0.vuetifyjs.com/og/skillz/{id}.png` when a tour is found (falls back to the site-wide default image on the not-found state).

## Test plan
- [x] `pnpm typecheck` (vue-tsc on apps/docs) — clean
- [x] `pnpm exec eslint` on changed files — clean
- [x] Full `pnpm build` of `apps/docs` — generated 4 new PNGs under `dist/og/skillz/*.png`, confirmed `<meta property="og:image">` in the rendered HTML points to the new files
- [x] Visually inspected a generated image — renders correctly with title/description/Skillz badge
- [x] Pre-push hooks (lint, typecheck, full test suite, repo:check) all green