### PR TITLE
chore(release): enter rc pre mode and promote the v1 stable set

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,13 +1,13 @@
 {
   "mode": "pre",
-  "tag": "beta",
+  "tag": "rc",
   "initialVersions": {
     "@vuetify-private/docs": "1.0.0-beta.2",
     "@vuetify-private/playground": "1.0.0-beta.2",
     "dev": "1.0.0-beta.2",
-    "@vuetify/v0": "1.0.0-beta.3",
-    "@paper/genesis": "1.0.0-beta.2",
-    "@vuetify/paper": "1.0.0-beta.3",
+    "@vuetify/v0": "1.0.0-beta.5",
+    "@paper/genesis": "1.0.0-beta.4",
+    "@vuetify/paper": "1.0.0-beta.5",
     "@vuetify-private/vapor-tests": "0.0.0"
   },
   "changesets": [

--- a/.changeset/stable-set-promotion.md
+++ b/.changeset/stable-set-promotion.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+chore(maturity): promote the v1 stable set to `stable` — the selection family (`createModel`, `createSelection`, `createSingle`, `createStep`, `createGroup`, `createNested`), `createRegistry`, and the plugin trio (`useTheme`, `useStorage`, `useBreakpoints`) are now API-locked for 1.0. They join the already-stable foundation (`createContext`, `createPlugin`, `createTrinity`) and observer (`useIntersectionObserver`, `useMutationObserver`, `useResizeObserver`) composables, bringing the stable surface to 16 composables plus the 17 stable utilities.

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -26,7 +26,7 @@
       "category": "forms"
     },
     "createRegistry": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "registration"
     },
@@ -41,33 +41,33 @@
       "category": "registration"
     },
     "createGroup": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "selection"
     },
     "createModel": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.5",
       "category": "selection",
       "notes": "Recently redesigned from selection system"
     },
     "createNested": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "selection"
     },
     "createSelection": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "selection"
     },
     "createSingle": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "selection"
     },
     "createStep": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "selection"
     },
@@ -157,7 +157,7 @@
       "category": "semantic"
     },
     "useBreakpoints": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "plugins"
     },
@@ -197,12 +197,12 @@
       "category": "plugins"
     },
     "useStorage": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "plugins"
     },
     "useTheme": {
-      "level": "preview",
+      "level": "stable",
       "since": "0.1.0",
       "category": "plugins"
     },
@@ -333,7 +333,7 @@
     },
     "useReducedMotion": {
       "level": "preview",
-      "since": null,
+      "since": "1.0.0-beta.2",
       "category": "plugins"
     },
     "useRtl": {

--- a/skills/vuetify0/SKILL.md
+++ b/skills/vuetify0/SKILL.md
@@ -88,7 +88,7 @@ Every public composable and utility, grouped by category. `(stable)` and `(draft
 **Registration:**
 
 - `createQueue` — A queue composable for managing time-based collections
-- `createRegistry` — A foundational composable for managing collections of items (tickets)
+- `createRegistry` — A foundational composable for managing collections of items (tickets) (stable)
 - `createTimeline` — Bounded undo/redo system with overflow management.
 - `createTokens` — Design token registry with alias resolution and W3C Design Tokens format support.
 
@@ -106,12 +106,12 @@ Every public composable and utility, grouped by category. `(stable)` and `(draft
 
 **Selection:**
 
-- `createGroup` — Multi-selection composable that extends createSelection with batch operations and tri-state support.
-- `createModel` — Recently redesigned from selection system
-- `createNested` — Hierarchical tree management composable extending createGroup
-- `createSelection` — Selection composable that extends createModel with multi-select, mandatory enforcement, auto-enrollment, and ticket self-methods.
-- `createSingle` — Single-selection composable that extends createSelection to enforce only one selected item.
-- `createStep` — Navigation composable that extends createSingle with first/last/next/prev/step methods.
+- `createGroup` — Multi-selection composable that extends createSelection with batch operations and tri-state support. (stable)
+- `createModel` — Recently redesigned from selection system (stable)
+- `createNested` — Hierarchical tree management composable extending createGroup (stable)
+- `createSelection` — Selection composable that extends createModel with multi-select, mandatory enforcement, auto-enrollment, and ticket self-methods. (stable)
+- `createSingle` — Single-selection composable that extends createSelection to enforce only one selected item. (stable)
+- `createStep` — Navigation composable that extends createSingle with first/last/next/prev/step methods. (stable)
 
 **Data:**
 
@@ -131,7 +131,7 @@ Every public composable and utility, grouped by category. `(stable)` and `(draft
 
 **Plugins:**
 
-- `useBreakpoints` — Responsive breakpoint detection composable with window resize handling.
+- `useBreakpoints` — Responsive breakpoint detection composable with window resize handling. (stable)
 - `useDate` — Date manipulation composable with adapter pattern for date operations.
 - `useFeatures` — Feature flag system with boolean and token-based features.
 - `useHydration` — SSR hydration state management composable.
@@ -143,8 +143,8 @@ Every public composable and utility, grouped by category. `(stable)` and `(draft
 - `useRtl` — RTL (right-to-left) direction composable with adapter pattern.
 - `useRules` — Validation rule composable with Standard Schema support.
 - `useStack` — Overlay z-index stacking composable
-- `useStorage` — Reactive storage composable with adapter pattern for localStorage, sessionStorage, or memory.
-- `useTheme` — Theme management composable with token resolution and CSS variable injection.
+- `useStorage` — Reactive storage composable with adapter pattern for localStorage, sessionStorage, or memory. (stable)
+- `useTheme` — Theme management composable with token resolution and CSS variable injection. (stable)
 - `useTooltip` — Region-scoped tooltip coordination plugin.
 
 **System:**
@@ -247,7 +247,7 @@ All components are headless and compound. Root owns state, children are named su
 
 **Planned (not yet exported — do not import):**
 
-- `Alert`, `DataGrid`, `DatePicker`, `DateRangePicker`, `Kanban`, `Otp`, `TimePicker`, `Tour`, `Virtualizer`
+- `Alert`, `DataGrid`, `DataTable`, `DatePicker`, `DateRangePicker`, `Kanban`, `Otp`, `TimePicker`, `Tour`, `Virtualizer`
 <!-- @generated:components:end -->
 
 **More compound examples:** see [references/component-examples.md](references/component-examples.md).


### PR DESCRIPTION
Release-candidate preparation for v1.0.0, following the final beta (`1.0.0-beta.5`).

## Prerelease tag: `beta` → `rc`

`changeset pre exit` + `changeset pre enter rc`, committed together. The consumed-changesets ledger carries over, so previously shipped beta content does not re-enter the rc changelog. Once this merges, the changesets action regenerates the Version Packages PR against `rc` — expected version for `@vuetify/v0` / `@vuetify/paper` is **`1.0.0-rc.6`** (the prerelease counter continues from `beta.5`; it is not per-tag). Publishes land under the `rc` npm dist-tag; `latest` is untouched until the first stable release.

## Maturity: promote the v1 stable set

`maturity.json` promotes 10 composables from `preview` to `stable` — the API commitment for 1.0:

- **Selection family**: `createModel`, `createSelection`, `createSingle`, `createStep`, `createGroup`, `createNested`
- **Registration**: `createRegistry`
- **Plugin trio**: `useTheme`, `useStorage`, `useBreakpoints`

They join the already-stable foundation (`createContext`, `createPlugin`, `createTrinity`) and observers (`useIntersectionObserver`, `useMutationObserver`, `useResizeObserver`): 16 stable composables + 17 stable utilities. `since` values are untouched (they track first-ship, not stability). Also backfills `useReducedMotion` `since: null` → `"1.0.0-beta.2"`, its actual first-published version.

A changeset is included so the promotion is the headline of the `1.0.0-rc.6` changelog entry.

## SKILL.md regeneration

`pnpm skill` output committed: the 10 new `(stable)` marks, plus one line of pre-existing drift it caught (`DataTable` was added to `maturity.json` as a draft component on Jun 25 but the generator hadn't been re-run — it now appears in the Planned list).