### PR TITLE
docs: reflect release-candidate status across banner, roadmap, and README

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -13,10 +13,10 @@
   const notifications = useNotifications()
 
   // Seed banner notification (repla
-  if (!notifications.has('alpha-banner')) {
+  if (!notifications.has('rc-banner')) {
     notifications.register({
-      id: 'alpha-banner',
-      subject: 'Vuetify0 is now in beta!',
+      id: 'rc-banner',
+      subject: 'Vuetify0 is now a release candidate!',
       severity: 'warning',
       data: { type: 'banner' },
     })
@@ -54,7 +54,7 @@
     <AppIcon icon="vuetify-0" :size="14" />
 
     <div>
-      {{ banner?.subject }} <span class="hidden md:inline">See the <RouterLink class="underline underline-offset-2" to="/roadmap#beta">roadmap</RouterLink> for details.</span>
+      {{ banner?.subject }} <span class="hidden md:inline">See the <RouterLink class="underline underline-offset-2" to="/roadmap#release-candidate">roadmap</RouterLink> for details.</span>
     </div>
 
     <button

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -2,9 +2,9 @@
 title: Roadmap - Vuetify0 Development Timeline
 meta:
   - name: description
-    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 is in beta following its April 7, 2026 alpha.
+    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 is a release candidate on the road to v1.0.
   - name: keywords
-    content: vuetify0, roadmap, beta, alpha, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
+    content: vuetify0, roadmap, release candidate, rc, beta, alpha, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
 features:
   level: 1
 related:
@@ -26,28 +26,28 @@ Track the development of @vuetify/v0. Milestones are organized by time horizon:
 
 > [!IMPORTANT] Want to help shape the future of this project? [Become a Founder Supporter](mailto:john@vuetifyjs.com?subject=Founder%20Supporter%20Inquiry) and gain a guiding voice in what we build next.
 
-## Beta
+## Release Candidate
 
-**Now in beta.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
+**Now a release candidate.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
 
-Alpha opened on April 7, 2026 for feedback, bug reports, and contributions. With beta, the focus shifts to stability and locking in the APIs for v1.
+Alpha opened on April 7, 2026 for feedback; beta hardened the APIs. The release candidate locks the v1 stable set — what remains is final validation, documentation, and bug fixes before v1.0.
 
 ### Road to v1
 
 <DocsTimeline :milestones="[
   { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Opened for feedback, bug reports, and contributions. APIs mostly stable, may evolve.' },
-  { id: 'beta', label: 'Beta', date: 'June 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.', active: true },
-  { id: 'rc', label: 'RC', date: 'July 2026', description: 'Release candidate for final testing and documentation. No new features.', disabled: true },
+  { id: 'beta', label: 'Beta', date: 'June 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
+  { id: 'rc', label: 'RC', date: 'July 2026', description: 'Release candidate for final testing and documentation. No new features.', active: true },
   { id: 'v1', label: 'v1.0', date: 'Q3 2026', description: 'Milestone-driven. Ships when the milestones are met.' },
 ]" />
 
-### What beta means
+### What RC means
 
-This isn't a proof of concept. v0 is feature-complete enough to build with and evaluate seriously.
+This isn't a proof of concept. v0 is feature-complete for v1 and ready to build with.
 
-- **APIs are freezing.** The foundation is solid and the surface is settling as we lock things in for v1.
+- **The stable set is locked.** 16 composables and 17 utilities are now marked stable — breaking changes require a major version. See the [maturity matrix](#maturity-matrix) below for the full breakdown.
 - **v0 is being built directly into Vuetify.** The composables and patterns here are the same ones powering Vuetify's next generation. This isn't a side project — it's the core.
-- **Your feedback still matters.** Alpha was when design decisions were wide open; beta is the last window to flag anything before APIs lock for v1. If something feels wrong, this is the time to say so.
+- **This is the final validation window.** No new features land before v1.0 — every regression, gap, or rough edge you report gets priority. If something feels wrong, say so now.
 
 ### Try v0
 
@@ -112,11 +112,11 @@ v0 is the foundation layer being built directly into Vuetify's next generation. 
 
 ??? Can I use v0 in production?
 
-Yes, with the understanding that APIs are still settling during beta. The core is solid and is already being used to build Vuetify itself. If you're comfortable with occasional minor adjustments as things stabilize, v0 is ready to build with.
+Yes. The v1 stable set is locked, and the release candidate is the build we intend to ship as v1.0. The core is solid and is already being used to build Vuetify itself. Preview APIs may still see minor, documented adjustments.
 
-??? Will APIs break during beta?
+??? Will APIs break before v1?
 
-APIs are mostly stable and freezing for v1. Breaking changes are still possible but will be documented in release notes. Alpha gathered the feedback; beta is where APIs lock down.
+The stable set is locked — breaking changes to it now require a major version. Preview features may still evolve in minor releases, with every change documented in release notes. Alpha gathered the feedback; beta locked things down; RC is the final validation pass.
 
 ??? What styling framework should I use with v0?
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -305,7 +305,7 @@ pnpm validate
 
 ## Contributing
 
-Vuetify0 is in beta — open for feedback, bug reports, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap#beta) for what's planned and how to get involved.
+Vuetify0 is a release candidate — open for final validation, bug reports, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap#release-candidate) for what's planned and how to get involved.
 
 ## Supporting Vuetify
 


### PR DESCRIPTION
Follow-up to #470 — updates release-state copy now that v0 is moving from beta to release candidate.

## Changes

- **AppBanner** — "Vuetify0 is now in beta!" → "Vuetify0 is now a release candidate!"; notification id `alpha-banner` → `rc-banner`; roadmap link retargeted to the renamed `#release-candidate` anchor.
- **roadmap.md** — `## Beta` → `## Release Candidate` (meta description + keywords updated); the Road-to-v1 timeline advances the active step from Beta to RC; "What beta means" → "What RC means" (stable set locked: 16 composables + 17 utilities, final validation window, no new features before v1.0); FAQ entries reframed from "settling during beta" to "stable set locked, preview may still evolve".
- **packages/0/README.md** (root README via symlink) — Contributing blurb: beta → release candidate, anchor updated. No other `/roadmap#beta` references exist in the repo.

## Merge timing

Merge **after** #470 and after the `1.0.0-rc.6` publish completes, so the site announces the RC once it is actually installable. Note the "16 composables" stable count in "What RC means" assumes #470's maturity promotion has landed.