### PR TITLE
docs(readme): update status note from beta to release candidate

### DIFF
--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -28,7 +28,7 @@
 
 Headless Vue 3 UI primitives and composables for building modern applications and design systems. `@vuetify/v0` is the foundation of the Vuetify ecosystem, offering lightweight, unstyled building blocks with full TypeScript support and accessibility features built-in.
 
-> **Note:** v0 is in beta — the API is stabilizing toward 1.0. Some APIs may still change before the stable release.
+> **Note:** v0 is a release candidate — the v1 stable set is locked. Install with `npm i @vuetify/v0@rc`. Preview APIs may still see minor, documented changes before the stable release.
 
 ## Primary Sponsor
 


### PR DESCRIPTION
Follow-up to #471 — the intro **Note** blockquote (line 31) still claimed beta; #471 only updated the Contributing blurb. Now states the RC status, the locked stable set, and the `npm i @vuetify/v0@rc` install line (bare installs currently resolve `latest` = 1.0.0-beta.3). Root README covered via symlink. No other beta references remain in the file.