### PR TITLE
docs: upgrade code of conduct to Contributor Covenant 2.1 with community spaces

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,45 +2,86 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Publishing others' private information, such as a physical or email address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Community spaces operated by the Vuetify team include:
+
+* The [Vuetify Discord server](https://community.vuetifyjs.com)
+* The [vuetifyjs GitHub organization](https://github.com/vuetifyjs) — issues, discussions, pull requests, and code review
+* Official Vuetify social media accounts
+* Official events, online or offline
+
+Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at hello@vuetifyjs.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior in any of these spaces may be reported to the community leaders responsible for enforcement at [hello@vuetifyjs.com](mailto:hello@vuetifyjs.com).
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident. Enforcement actions apply across all community spaces — behavior on Discord can result in consequences on GitHub, and vice versa.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/apps/docs/src/pages/introduction/code-of-conduct.md
+++ b/apps/docs/src/pages/introduction/code-of-conduct.md
@@ -2,9 +2,9 @@
 title: Code of Conduct - Community Guidelines
 meta:
   - name: description
-    content: The Vuetify0 Code of Conduct establishes standards for respectful participation in our open source community.
+    content: The Vuetify0 Code of Conduct establishes standards for respectful participation across our community spaces, including Discord and GitHub.
   - name: keywords
-    content: vuetify0, code of conduct, community, guidelines, contributor covenant
+    content: vuetify0, code of conduct, community, guidelines, contributor covenant, discord, github
 features:
   order: 4
   level: 1
@@ -15,40 +15,64 @@ related:
 
 # Code of Conduct
 
-We are committed to providing a welcoming and inspiring community for all. This Code of Conduct outlines our expectations for participant behavior and the consequences for unacceptable behavior.
+We are committed to providing a welcoming and inspiring community for all. This Code of Conduct outlines our expectations for participant behavior in every space we operate — and the consequences for unacceptable behavior.
 
 <DocsPageFeatures :frontmatter />
 
 ## Our Pledge
 
-We pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
 **Positive behaviors include:**
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
 
 **Unacceptable behaviors include:**
 
-- Sexualized language or imagery and unwelcome sexual attention
+- Sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting/derogatory comments, and personal attacks
 - Public or private harassment
 - Publishing others' private information without permission
 - Other conduct inappropriate in a professional setting
 
+## Where This Applies
+
+This Code of Conduct applies within all community spaces operated by the Vuetify team:
+
+- The [Vuetify Discord server](https://community.vuetifyjs.com) — support channels, showcase, and general chat
+- The [vuetifyjs GitHub organization](https://github.com/vuetifyjs) — issues, discussions, pull requests, and code review
+- Official Vuetify social media accounts
+- Official events, online or offline
+
+It also applies when you are officially representing the community in public spaces — for example, posting via an official social media account or acting as an appointed representative at an event.
+
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [hello@vuetifyjs.com](mailto:hello@vuetifyjs.com).
+Instances of abusive, harassing, or otherwise unacceptable behavior in any of these spaces may be reported by contacting the project team at [hello@vuetifyjs.com](mailto:hello@vuetifyjs.com). On Discord, you can also reach out directly to any member of the moderation team.
 
-The project team will review and investigate all complaints, responding in a way appropriate to the circumstances. The team is obligated to maintain confidentiality regarding the reporter.
+The project team will review and investigate all complaints, responding in a way appropriate to the circumstances. The team is obligated to maintain confidentiality regarding the reporter. Enforcement actions apply across all community spaces — behavior on Discord can result in consequences on GitHub, and vice versa.
+
+Consequences follow the Contributor Covenant enforcement ladder:
+
+| Action | When | Consequence |
+|--------|------|-------------|
+| **Correction** | Unprofessional or unwelcome behavior | Private written warning |
+| **Warning** | A violation through a single incident or series of actions | Warning with a no-interaction period |
+| **Temporary Ban** | Serious or sustained violation | Time-limited ban from all community spaces |
+| **Permanent Ban** | Pattern of violations, harassment, or aggression | Permanent ban from all community spaces |
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
 
 View the full [CODE_OF_CONDUCT.md](https://github.com/vuetifyjs/0/blob/master/CODE_OF_CONDUCT.md) on GitHub.
+
+> [!DISCORD]


### PR DESCRIPTION
The code of conduct never named the spaces it actually governs — no mention of Discord, the GitHub org, or any other channel the team operates. The docs page had also dropped the Scope section entirely in its adaptation of the root file.

- Upgrade both `CODE_OF_CONDUCT.md` and the docs page from Contributor Covenant 1.4 to 2.1
- Add an explicit community-spaces list to Scope: Discord, the vuetifyjs GitHub organization (issues, discussions, PRs, code review), official social accounts, and official events
- Note in Enforcement that actions apply across spaces (Discord ↔ GitHub) and include the 2.1 enforcement ladder (docs page renders it as a table)
- End the docs page with the same Discord callout used by the other introduction pages