### PR TITLE
docs: fix nav footer height jump when devmode avocado is shown

### DIFF
--- a/apps/docs/src/components/app/AppNavFooter.vue
+++ b/apps/docs/src/components/app/AppNavFooter.vue
@@ -21,7 +21,7 @@
     <router-link
       v-if="devmode?.isSelected.value"
       :aria-label="freshnessLabel"
-      class="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-surface-tint transition-colors"
+      class="inline-flex items-center justify-center w-7 h-7 rounded-lg hover:bg-surface-tint transition-colors"
       :title="freshnessLabel"
       to="/health"
     >


### PR DESCRIPTION
The devmode freshness avocado link in the nav footer used a 36px (w-9 h-9) hit target, taller than the 28px version chip that otherwise sets the row height — toggling devmode on grew the footer from 45px to 53px.

Resize the link to w-7 h-7 (28px) to match the chip. The 22px icon keeps a 3px inset and the target still clears the 24px WCAG minimum. Footer now stays 45px with devmode on or off (verified in-browser both states).