### PR TITLE
docs: add tour callouts to landing pages

### DIFF
--- a/apps/docs/src/pages/components/index.md
+++ b/apps/docs/src/pages/components/index.md
@@ -18,6 +18,8 @@ A collection of <DocsCount type="component" /> foundational components designed 
 
 <DocsPageFeatures :frontmatter />
 
+> [!TOUR] using-examples
+
 ## Primitives
 
 Foundation components for building higher-level abstractions.

--- a/apps/docs/src/pages/composables/index.md
+++ b/apps/docs/src/pages/composables/index.md
@@ -18,6 +18,8 @@ Type-safe composables for headless UI — <DocsCount type="composable" /> of the
 
 <DocsPageFeatures :frontmatter />
 
+> [!TOUR] using-examples
+
 ## Minimal Reactivity
 
 Vuetify0 composables use the absolute minimum reactivity required to fulfill their responsibilities. This deliberate constraint keeps bundle sizes small, maximizes performance, and gives you full control over what triggers updates.

--- a/apps/docs/src/pages/guide/index.md
+++ b/apps/docs/src/pages/guide/index.md
@@ -79,6 +79,8 @@ See v0 patterns in production.
 > [!TIP]
 > New to v0? Start with Track A. Already building? Jump to Track B as needed.
 
+> [!TOUR] using-the-docs
+
 ## Migrating to Headless
 
 If you have an existing styled component library and want to adopt v0's headless approach:

--- a/apps/docs/src/pages/introduction/getting-started.md
+++ b/apps/docs/src/pages/introduction/getting-started.md
@@ -484,6 +484,8 @@ Now that v0 is installed, choose your path:
 > [!TIP]
 > Use `Cmd+/` on any documentation page to ask AI questions about v0.
 
+> [!TOUR] using-search
+
 ## Support v0
 
 v0 is built and maintained in the open. If it's useful to you or your team, sponsoring funds the work and keeps it moving — and need a hand shipping? The [Services](/services) page covers direct support plans and fixed-scope project builds.


### PR DESCRIPTION
## Summary

Adds `[!TOUR]` callouts on landing pages that had no entry point to an existing, fully-built tour:

- `introduction/getting-started.md` — `using-search` (the tour's own `startRoute` is this page, but nothing linked to it)
- `components/index.md` — `using-examples`
- `composables/index.md` — `using-examples`
- `guide/index.md` — `using-the-docs`