### PR TITLE
docs(contributing): link PHILOSOPHY.md and per-scope rules

### DIFF
--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -44,7 +44,7 @@ For new features:
 
 - Check if it's already been requested in [issues](https://github.com/vuetifyjs/0/issues)
 - Explain the use case and why it would benefit others
-- Consider if it fits the headless/composable philosophy of Vuetify0
+- Consider if it fits the [headless/composable philosophy](https://github.com/vuetifyjs/0/blob/master/packages/0/PHILOSOPHY.md) of Vuetify0
 
 ## Local Development
 
@@ -181,6 +181,8 @@ test(useForm): add validation edge cases
 - Reference issues when applicable: `fix(useForm): validation error (#123)`
 
 ## Code Style
+
+The sections below are a summary. The design contract behind them — axioms, return-shape conventions, reactivity rules — lives in [PHILOSOPHY.md](https://github.com/vuetifyjs/0/blob/master/packages/0/PHILOSOPHY.md), with detailed per-scope playbooks in [.claude/rules](https://github.com/vuetifyjs/0/tree/master/.claude/rules).
 
 ### General
 


### PR DESCRIPTION
Follow-up to #478. The contributing page asked feature requests to "consider if it fits the headless/composable philosophy" without linking the document where that philosophy is written down — `packages/0/PHILOSOPHY.md` was referenced by exactly one docs page and otherwise undiscoverable.

- Links the Feature Requests bullet to PHILOSOPHY.md so proposals can be checked against the actual design axioms before review.
- Adds one line under Code Style pointing at PHILOSOPHY.md (the design contract) and `.claude/rules` (the per-scope playbooks) — the style bullets on this page are a summary of those, not a second source of truth.