### PR TITLE
docs: highlight API type signatures with Shiki

### DIFF
--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -18,8 +18,8 @@
       [data-theme]:not([data-theme="light"]):not([data-theme="odyssey"]):not([data-theme="tailwind-light"]):not([data-theme="material-3-light"]):not([data-theme="ant-design-light"]):not([data-theme="radix-light"]) .shiki {
         background-color: var(--shiki-dark-bg, #0d1117);
       }
-      .shiki span { color: var(--shiki-light) }
-      [data-theme]:not([data-theme="light"]):not([data-theme="odyssey"]):not([data-theme="tailwind-light"]):not([data-theme="material-3-light"]):not([data-theme="ant-design-light"]):not([data-theme="radix-light"]) .shiki span {
+      .shiki span, .shiki-inline span { color: var(--shiki-light) }
+      [data-theme]:not([data-theme="light"]):not([data-theme="odyssey"]):not([data-theme="tailwind-light"]):not([data-theme="material-3-light"]):not([data-theme="ant-design-light"]):not([data-theme="radix-light"]) :is(.shiki, .shiki-inline) span {
         color: var(--shiki-dark);
       }
       /* Logo light/dark visibility before Vue hydrates */

--- a/apps/docs/src/components/docs/DocsApiCard.vue
+++ b/apps/docs/src/components/docs/DocsApiCard.vue
@@ -49,13 +49,15 @@
     watchEffect(async () => {
       const code = signature.value
       if (!code) return
-      chips.signature = (await highlighter.inline({ code, language: 'typescript' })).html
+      const result = await highlighter.inline({ code, language: 'typescript' })
+      if (signature.value === code) chips.signature = result.html
     })
 
     watchEffect(async () => {
       const code = preset.value
       if (!code) return
-      chips.preset = (await highlighter.inline({ code, language: 'typescript' })).html
+      const result = await highlighter.inline({ code, language: 'typescript' })
+      if (preset.value === code) chips.preset = result.html
     })
   }
 </script>

--- a/apps/docs/src/components/docs/DocsApiCard.vue
+++ b/apps/docs/src/components/docs/DocsApiCard.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
+  // Framework
+  import { IN_BROWSER } from '@vuetify/v0'
+
   // Composables
   import { useApiHelpers } from '@/composables/useApiHelpers'
+  import { useCodeHighlighter } from '@/composables/useCodeHighlighter'
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { shallowReactive, toRef, watchEffect } from 'vue'
 
   // Types
   import type { ApiEvent, ApiFunction, ApiMethod, ApiOption, ApiProp, ApiProperty, ApiSlot } from '@build/generate-api'
@@ -20,6 +24,7 @@
 
   const api = useApiHelpers()
   const settings = useSettings()
+  const highlighter = useCodeHighlighter()
 
   const lineWrap = useSyncedRef(settings.lineWrap)
 
@@ -29,6 +34,30 @@
     if (!('example' in props.item) || !props.item.example) return null
     return /^<(?:template|script)/.test(props.item.example.trim()) ? 'vue' : 'ts'
   })
+
+  const signature = toRef(() => {
+    if ('signature' in props.item) return props.item.signature
+    if (['option', 'prop', 'event', 'slot'].includes(props.kind)) return props.item.type
+    return api.formatSignature(props.item as ApiProperty | ApiMethod)
+  })
+
+  const preset = toRef(() => 'default' in props.item ? props.item.default : '')
+
+  const chips = shallowReactive({ signature: '', preset: '' })
+
+  if (IN_BROWSER) {
+    watchEffect(async () => {
+      const code = signature.value
+      if (!code) return
+      chips.signature = (await highlighter.inline({ code, language: 'typescript' })).html
+    })
+
+    watchEffect(async () => {
+      const code = preset.value
+      if (!code) return
+      chips.preset = (await highlighter.inline({ code, language: 'typescript' })).html
+    })
+  }
 </script>
 
 <template>
@@ -57,9 +86,10 @@
 
       <code
         v-if="item.type || ('signature' in item && item.signature)"
-        class="text-xs mt-1 inline-block font-mono bg-surface-variant px-1.5 py-0.5 rounded"
+        class="shiki-inline text-xs mt-1 inline-block font-mono bg-surface-variant px-1.5 py-0.5 rounded"
       >
-        {{ 'signature' in item ? item.signature : ['option', 'prop', 'event', 'slot'].includes(kind) ? item.type : api.formatSignature(item as ApiProperty | ApiMethod) }}
+        <span v-if="chips.signature" v-html="chips.signature" />
+        <template v-else>{{ signature }}</template>
       </code>
 
       <p
@@ -74,7 +104,10 @@
         v-if="(kind === 'option' || kind === 'prop') && 'default' in item && item.default"
         class="text-xs text-on-surface-variant mt-2 !mb-0"
       >
-        Default: <code class="text-xs bg-surface-variant px-1.5 py-0.5 rounded">{{ item.default }}</code>
+        Default: <code class="shiki-inline text-xs bg-surface-variant px-1.5 py-0.5 rounded">
+          <span v-if="chips.preset" v-html="chips.preset" />
+          <template v-else>{{ item.default }}</template>
+        </code>
       </p>
     </div>
 

--- a/apps/docs/src/components/docs/DocsApiHover.vue
+++ b/apps/docs/src/components/docs/DocsApiHover.vue
@@ -20,11 +20,12 @@
   import DocsApiHoverSection from './DocsApiHoverSection.vue'
 
   // Composables
+  import { useCodeHighlighter } from '@/composables/useCodeHighlighter'
   import { usePopoverPosition } from '@/composables/usePopoverPosition'
 
   // Utilities
   import { toKebab } from '@/utilities/strings'
-  import { computed, onScopeDispose, ref, shallowRef, toRef } from 'vue'
+  import { computed, onScopeDispose, ref, shallowRef, toRef, watchEffect } from 'vue'
   import { useRouter } from 'vue-router'
 
   // Types
@@ -251,6 +252,19 @@
     activeApiType.value === 'vue' ? activeApi.value as VueApiEntry : null,
   )
 
+  const highlighter = useCodeHighlighter()
+  const signature = shallowRef('')
+
+  if (IN_BROWSER) {
+    watchEffect(async () => {
+      const code = vueApi.value?.signature
+      signature.value = ''
+      if (!code) return
+      const result = await highlighter.inline({ code, language: 'typescript' })
+      if (vueApi.value?.signature === code) signature.value = result.html
+    })
+  }
+
   const displayProps = toRef(() => componentApi.value?.props || [])
   const displayEvents = toRef(() => componentApi.value?.events || [])
   const displaySlots = toRef(() => componentApi.value?.slots || [])
@@ -326,7 +340,10 @@
             </DocsApiHoverSection>
 
             <DocsApiHoverSection title="Signature">
-              <code>{{ vueApi.signature }}</code>
+              <code class="shiki-inline">
+                <span v-if="signature" v-html="signature" />
+                <template v-else>{{ vueApi.signature }}</template>
+              </code>
             </DocsApiHoverSection>
           </div>
         </template>

--- a/apps/docs/src/components/docs/DocsApiHoverList.vue
+++ b/apps/docs/src/components/docs/DocsApiHoverList.vue
@@ -3,6 +3,16 @@
    * Renders a list of API items (props, events, slots, functions, etc.)
    * Used inside DocsApiHoverSection for v0 API content.
    */
+
+  // Framework
+  import { IN_BROWSER } from '@vuetify/v0'
+
+  // Composables
+  import { useCodeHighlighter } from '@/composables/useCodeHighlighter'
+
+  // Utilities
+  import { shallowReactive, watchEffect } from 'vue'
+
   export interface ApiItem {
     name: string
     type?: string
@@ -11,12 +21,30 @@
     description?: string
   }
 
-  defineProps<{
+  const props = defineProps<{
     /** List of API items to display */
     items: ApiItem[]
     /** Show signature instead of type (for functions) */
     showSignature?: boolean
   }>()
+
+  const highlighter = useCodeHighlighter()
+
+  const chips = shallowReactive<Record<string, string>>({})
+
+  if (IN_BROWSER) {
+    watchEffect(() => {
+      for (const item of props.items) {
+        for (const code of [item.type, item.signature, item.default]) {
+          if (!code || code in chips) continue
+          chips[code] = ''
+          highlighter.inline({ code, language: 'typescript' }).then(result => {
+            chips[code] = result.html
+          })
+        }
+      }
+    })
+  }
 </script>
 
 <template>
@@ -24,11 +52,23 @@
     <li v-for="item in items" :key="item.name">
       <div class="api-item-header">
         <span class="api-item-name">{{ item.name }}</span>
-        <code v-if="item.default" class="api-item-default">{{ item.default }}</code>
+
+        <code v-if="item.default" class="api-item-default shiki-inline">
+          <span v-if="chips[item.default]" v-html="chips[item.default]" />
+          <template v-else>{{ item.default }}</template>
+        </code>
       </div>
 
-      <code v-if="item.type && !showSignature" class="api-item-type">{{ item.type }}</code>
-      <code v-if="item.signature && showSignature" class="api-item-signature">{{ item.signature }}</code>
+      <code v-if="item.type && !showSignature" class="api-item-type shiki-inline">
+        <span v-if="chips[item.type]" v-html="chips[item.type]" />
+        <template v-else>{{ item.type }}</template>
+      </code>
+
+      <code v-if="item.signature && showSignature" class="api-item-signature shiki-inline">
+        <span v-if="chips[item.signature]" v-html="chips[item.signature]" />
+        <template v-else>{{ item.signature }}</template>
+      </code>
+
       <p v-if="item.description" class="api-item-description">{{ item.description }}</p>
     </li>
   </ul>
@@ -69,7 +109,6 @@
   font-family: var(--v0-font-mono);
   font-size: 10px;
   color: var(--v0-on-surface);
-  opacity: 0.5;
   background: var(--v0-surface-variant);
   border-radius: 3px;
 }
@@ -82,7 +121,6 @@
   font-size: 10px;
   line-height: 1.5;
   color: var(--v0-on-surface);
-  opacity: 0.7;
   background: var(--v0-surface-tint);
   border-radius: 4px;
 }

--- a/apps/docs/src/components/docs/DocsApiHoverSection.vue
+++ b/apps/docs/src/components/docs/DocsApiHoverSection.vue
@@ -63,7 +63,6 @@
   font-family: var(--v0-font-mono);
   font-size: 11px;
   color: var(--v0-on-surface);
-  opacity: 0.7;
   background: var(--v0-surface-variant);
   border-radius: 4px;
   overflow-x: auto;

--- a/apps/docs/src/composables/useCodeHighlighter.ts
+++ b/apps/docs/src/composables/useCodeHighlighter.ts
@@ -84,10 +84,29 @@ export function useCodeHighlighter () {
     }
   }
 
+  async function inline (options: CodeHighlightOptions): Promise<CodeHighlightResult> {
+    const hl = highlighter.value ?? await getHighlighter()
+    const { shikiLang, displayLang } = normalizeLanguage(options.language)
+
+    const html = hl.codeToHtml(options.code, {
+      lang: shikiLang,
+      themes: SHIKI_THEMES,
+      defaultColor: false,
+      structure: 'inline',
+    })
+
+    return {
+      html,
+      code: options.code,
+      language: displayLang,
+    }
+  }
+
   return {
     highlight,
     highlighter,
     getHighlighter,
+    inline,
     normalizeLanguage,
   }
 }


### PR DESCRIPTION
Type signatures and default values in the API reference cards rendered as flat muted-gray chips — the `text-primary` on the type line was dropped in 8a212d818 and nothing replaced it, leaving the text hard to read.

This runs the type/signature and `Default:` strings through Shiki (`structure: 'inline'`) so they get real token colors, matching the highlighted example blocks:

- `useCodeHighlighter`: new `inline()` variant that emits bare token spans (no `pre`/`code` wrapper)
- `DocsApiCard`: highlights the signature and default chips client-side, with the plain string as SSG/fallback render
- `index.html`: extends the critical-CSS light/dark token rules to cover the new `.shiki-inline` class

Theme switching uses the exact same `data-theme` mechanism as existing code blocks, so custom palettes behave identically. Verified in the running docs app across light/dark and the standalone + inline API views.