### PR TITLE
docs(DocsRoadmap): render milestone descriptions as markdown

### DIFF
--- a/apps/docs/src/components/docs/DocsRoadmap.vue
+++ b/apps/docs/src/components/docs/DocsRoadmap.vue
@@ -6,6 +6,9 @@
   import DocsProgressBar from './DocsProgressBar.vue'
   import DocsSkeleton from './DocsSkeleton.vue'
 
+  // Composables
+  import { renderInline } from '@/composables/useMarkdown'
+
   import { MATURITY_LEVELS as levels } from '@/constants/maturity'
 
   // Stores
@@ -78,12 +81,12 @@
 
   function getSummary (description: string | null | undefined): string {
     if (!description) return ''
-    return description.split('\n')[0]
+    return renderInline(description.split('\n')[0])
   }
 
   function getDetails (description: string | null | undefined): string[] {
     if (!description) return []
-    return description.split('\n').slice(1).map(line => line.trim()).filter(Boolean).map(line => line.replace(/^[•\-\*]\s*/, '')) // Strip leading bullets
+    return description.split('\n').slice(1).map(line => line.trim()).filter(Boolean).map(line => line.replace(/^[•*-]\s+/, '')).map(line => renderInline(line))
   }
 
   function findMilestoneByQuery (query: string | undefined) {
@@ -239,9 +242,11 @@
                       </span>
                     </div>
 
-                    <p v-if="milestone.description" class="text-sm opacity-70 mt-1">
-                      {{ getSummary(milestone.description) }}
-                    </p>
+                    <p
+                      v-if="milestone.description"
+                      class="text-sm opacity-70 mt-1"
+                      v-html="getSummary(milestone.description)"
+                    />
 
                     <!-- Progress bar -->
                     <DocsProgressBar
@@ -274,9 +279,8 @@
                       v-for="(line, i) in getDetails(milestone.description)"
                       :key="i"
                       class="text-sm opacity-80"
-                    >
-                      {{ line }}
-                    </li>
+                      v-html="line"
+                    />
                   </ul>
                 </div>
 

--- a/apps/docs/src/composables/useMarkdown.ts
+++ b/apps/docs/src/composables/useMarkdown.ts
@@ -44,6 +44,14 @@ function getInlineMarked (): Marked {
   return syncInlineMarked ??= new Marked({ async: false, gfm: true })
 }
 
+/**
+ * Renders a single line of markdown as inline HTML with decorated links.
+ * No block elements — safe inside p, li, and other inline containers.
+ */
+export function renderInline (text: string): string {
+  return processLinks(getInlineMarked().parseInline(text) as string)
+}
+
 function getMarked (hl: Highlighter): Marked {
   // Return cached if highlighter is the same
   if (cachedMarked && cachedHighlighter === hl) return cachedMarked


### PR DESCRIPTION
## Description

Milestone descriptions fetched from the GitHub API were interpolated as plain text on the roadmap page, so bold, links, and inline code rendered as raw markdown syntax (`**Status: …**`, `[v1.0.0-rc.6](…)`). The bullet-strip regex also consumed the first asterisk of bold lines, producing lopsided `*Status: …**` output.

## Changes

- Add a `renderInline` helper to `useMarkdown` — reuses the existing sync inline `Marked` instance and `processLinks`, so links get the standard `v0-link` treatment (`target=_blank`, ↗︎ suffix) consistent with build-time markdown.
- Render milestone summary and detail lines through it via `v-html` in `DocsRoadmap`.
- Fix the bullet-strip regex to require whitespace after the marker so bold markers survive.

Note: `v-html` here matches the existing precedent in `DocsReleases` — content is maintainer-authored milestone text from vuetifyjs/0, same trust boundary as release bodies.