### PR TITLE
docs(roadmap): redesign graduation criteria as a maturity track

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -133,6 +133,7 @@ declare module 'vue' {
     DocsFreshnessTable: typeof import('./components/docs/DocsFreshnessTable.vue')['default']
     DocsGenesisExample: typeof import('./components/docs/DocsGenesisExample.vue')['default']
     DocsGenesisShikiBlock: typeof import('./components/docs/DocsGenesisShikiBlock.vue')['default']
+    DocsGraduation: typeof import('./components/docs/DocsGraduation.vue')['default']
     DocsHeaderAnchor: typeof import('./components/docs/DocsHeaderAnchor.vue')['default']
     DocsHighlight: typeof import('./components/docs/DocsHighlight.vue')['default']
     DocsKbd: typeof import('./components/docs/DocsKbd.vue')['default']

--- a/apps/docs/src/components/docs/DocsGraduation.vue
+++ b/apps/docs/src/components/docs/DocsGraduation.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+  // Framework
+  import maturityData from '#v0/maturity.json'
+  import { MATURITY_LEVELS as levels } from '@/constants/maturity'
+
+  // Types
+  import type { Level, MaturityData } from '@/constants/maturity'
+
+  interface Gate {
+    promoter: string
+    requirements: string[]
+  }
+
+  interface Rung {
+    level: Level
+    meaning: string
+    /** Requirements to reach this rung from the one above it. Absent on the entry rung. */
+    gate?: Gate
+  }
+
+  const data = maturityData as MaturityData
+
+  function tally (): Record<Level, number> {
+    const result: Record<Level, number> = { draft: 0, preview: 0, stable: 0, mature: 0, deprecated: 0 }
+    for (const bucket of [data.composables, data.components, data.utilities]) {
+      for (const entry of Object.values(bucket)) result[entry.level]++
+    }
+    return result
+  }
+
+  const counts = tally()
+
+  const rungs: Rung[] = [
+    {
+      level: 'draft',
+      meaning: 'Planned, not yet implemented. There is nothing to import.',
+    },
+    {
+      level: 'preview',
+      meaning: 'Implemented, tested, and documented. The API may still move in minor releases — every change lands in the release notes.',
+      gate: {
+        promoter: 'Author promotes in the landing PR',
+        requirements: [
+          'Implementation landed',
+          'Unit tests cover happy path and edge cases',
+          'Docs page with a working example',
+        ],
+      },
+    },
+    {
+      level: 'stable',
+      meaning: 'Production-ready. Breaking changes require a major version.',
+      gate: {
+        promoter: 'Maintainer decision',
+        requirements: [
+          'API unchanged for 2+ minor releases',
+          'Edge cases and failure modes tested',
+          'SSR-safe, or explicitly browser-only',
+          'Accessibility reviewed',
+          'Benchmarked when performance-critical',
+        ],
+      },
+    },
+    {
+      level: 'mature',
+      meaning: 'API frozen. Downstream frameworks — Vuetify itself — depend on it.',
+      gate: {
+        promoter: 'Maintainer decision',
+        requirements: [
+          'Proven in production downstream',
+          'Adapter ecosystem where applicable',
+          'API frozen — breaking changes need a major',
+        ],
+      },
+    },
+  ]
+
+  function plural (count: number): string {
+    return count === 1 ? 'feature' : 'features'
+  }
+</script>
+
+<template>
+  <div class="mb-8">
+    <ol class="list-none m-0 p-0">
+      <li v-for="(rung, index) in rungs" :key="rung.level">
+        <!-- Rung node -->
+        <div class="flex items-center gap-3">
+          <span
+            aria-hidden="true"
+            class="inline-flex items-center justify-center size-7 rounded-full border-2 shrink-0"
+            :style="{
+              borderColor: levels[rung.level].color,
+              color: levels[rung.level].color,
+              backgroundColor: levels[rung.level].color + '15',
+            }"
+          >
+            <AppIcon :icon="levels[rung.level].icon" :size="14" />
+          </span>
+
+          <span
+            class="text-sm font-semibold uppercase tracking-wide"
+            :style="{ color: levels[rung.level].color }"
+          >
+            {{ levels[rung.level].label }}
+          </span>
+
+          <span class="font-mono text-xs text-on-surface-variant">
+            {{ counts[rung.level] }} {{ plural(counts[rung.level]) }}
+          </span>
+        </div>
+
+        <!-- Rail segment: this rung's meaning, then the gate to the next rung -->
+        <div class="relative ml-3.5 pl-6 pt-1" :class="index < rungs.length - 1 ? 'pb-5' : 'pb-0'">
+          <span
+            v-if="index < rungs.length - 1"
+            aria-hidden="true"
+            class="absolute left-0 top-0 bottom-0 w-0.5 -translate-x-1/2"
+            :style="{
+              background: `linear-gradient(to bottom, ${levels[rung.level].color}, ${levels[rungs[index + 1]!.level].color})`,
+            }"
+          />
+
+          <p class="text-sm text-on-surface-variant m-0 mt-1 leading-relaxed">
+            {{ rung.meaning }}
+          </p>
+
+          <div
+            v-if="rungs[index + 1]?.gate"
+            class="mt-3 rounded-lg bg-glass-surface px-4 py-3"
+          >
+            <div class="flex items-center gap-2 flex-wrap">
+              <span
+                class="text-[10px] font-semibold uppercase tracking-widest"
+                :style="{ color: levels[rungs[index + 1]!.level].color }"
+              >
+                Gate to {{ levels[rungs[index + 1]!.level].label }}
+              </span>
+
+              <span class="flex-1" />
+
+              <span class="text-[10px] uppercase tracking-wide text-on-surface-variant/70">
+                {{ rungs[index + 1]!.gate!.promoter }}
+              </span>
+            </div>
+
+            <ul class="list-none m-0 mt-2 p-0 grid gap-x-6 gap-y-1.5 md:grid-cols-2">
+              <li
+                v-for="requirement in rungs[index + 1]!.gate!.requirements"
+                :key="requirement"
+                class="flex items-start gap-2 text-sm text-on-surface-variant"
+              >
+                <AppIcon
+                  aria-hidden="true"
+                  class="mt-0.5 shrink-0"
+                  icon="check"
+                  :size="14"
+                  :style="{ color: levels[rungs[index + 1]!.level].color }"
+                />
+
+                <span>{{ requirement }}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </li>
+    </ol>
+
+    <!-- Deprecated sits off the track: any rung can exit here -->
+    <div
+      class="mt-6 rounded-lg border border-dashed px-4 py-3"
+      :style="{ borderColor: levels.deprecated.color + '80' }"
+    >
+      <div class="flex items-center gap-2 flex-wrap">
+        <AppIcon
+          aria-hidden="true"
+          :icon="levels.deprecated.icon"
+          :size="14"
+          :style="{ color: levels.deprecated.color }"
+        />
+
+        <span
+          class="text-sm font-semibold uppercase tracking-wide"
+          :style="{ color: levels.deprecated.color }"
+        >
+          {{ levels.deprecated.label }}
+        </span>
+
+        <span class="font-mono text-xs text-on-surface-variant">
+          {{ counts.deprecated }} {{ plural(counts.deprecated) }}
+        </span>
+
+        <span class="flex-1" />
+
+        <span class="text-[10px] uppercase tracking-widest text-on-surface-variant/70">
+          Exit — from any level
+        </span>
+      </div>
+
+      <p class="text-sm text-on-surface-variant m-0 mt-2 leading-relaxed">
+        A feature leaves the track when a better pattern supersedes it. Deprecation always ships
+        with a migration guide and a removal timeline — nothing disappears in a minor release.
+      </p>
+    </div>
+  </div>
+</template>

--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -211,29 +211,6 @@
     return counts
   })
 
-  // Graduation criteria
-  const criteria = [
-    {
-      from: 'draft' as Level,
-      to: 'preview' as Level,
-      requirements: 'Has unit tests, has documentation page, at least one working example.',
-    },
-    {
-      from: 'preview' as Level,
-      to: 'stable' as Level,
-      requirements: 'Edge-case test coverage, SSR safe or explicitly browser-only, accessibility reviewed, API unchanged for 2+ releases, benchmarked if performance-critical.',
-    },
-    {
-      from: 'stable' as Level,
-      to: 'mature' as Level,
-      requirements: 'Used in production downstream (e.g. Vuetify 5), adapter ecosystem (if applicable), API frozen — breaking changes require major version.',
-    },
-    {
-      from: null,
-      to: 'deprecated' as Level,
-      requirements: 'Superseded by a better pattern, migration guide provided, removal timeline set.',
-    },
-  ]
 </script>
 
 <template>
@@ -590,59 +567,6 @@
       </table>
 
       <AppDotGrid :coverage="65" />
-    </div>
-
-    <!-- Graduation criteria -->
-    <h2 class="text-xl font-bold m-0 mb-4 text-on-surface">Graduation Criteria</h2>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-      <div
-        v-for="(item, index) in criteria"
-        :key="index"
-        class="border border-divider rounded-xl p-4"
-      >
-        <div class="flex items-center gap-2 mb-2">
-          <template v-if="item.from">
-            <AppIcon
-              :icon="levels[item.from].icon"
-              :size="14"
-              :style="{ color: levels[item.from].color }"
-            />
-
-            <span
-              class="text-sm font-semibold"
-              :style="{ color: levels[item.from].color }"
-            >
-              {{ levels[item.from].label }}
-            </span>
-          </template>
-
-          <span v-else class="text-sm font-semibold text-on-surface-variant">Any</span>
-
-          <AppIcon
-            class="text-on-surface-variant"
-            icon="chevron-right"
-            :size="14"
-          />
-
-          <AppIcon
-            :icon="levels[item.to].icon"
-            :size="14"
-            :style="{ color: levels[item.to].color }"
-          />
-
-          <span
-            class="text-sm font-semibold"
-            :style="{ color: levels[item.to].color }"
-          >
-            {{ levels[item.to].label }}
-          </span>
-        </div>
-
-        <p class="text-sm text-on-surface-variant m-0 leading-relaxed">
-          {{ item.requirements }}
-        </p>
-      </div>
     </div>
   </div>
 </template>

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -99,6 +99,12 @@ Whether you want to explore in the browser, scaffold a project, or integrate wit
 
 <DocsMaturity />
 
+### Graduation Criteria
+
+Every feature climbs the same track. Its level tells you what you can rely on today; the gate between levels is exactly what it takes to move up.
+
+<DocsGraduation />
+
 ## FAQ
 
 ::: faq
@@ -128,7 +134,7 @@ Yes. All composables and components are SSR-safe. Nuxt integration is documented
 
 ??? What's the difference between stable, preview, and draft?
 
-**Stable** means battle-tested with no planned breaking changes. **Preview** means feature-complete and documented, but the API may evolve in minor releases. **Draft** means experimental and subject to major changes. See the maturity matrix above for a full breakdown.
+**Stable** means battle-tested with no planned breaking changes. **Preview** means feature-complete and documented, but the API may evolve in minor releases. **Draft** means experimental and subject to major changes. See the [graduation criteria](#graduation-criteria) above for the full ladder and what it takes to move between levels.
 
 ??? How do I report a bug?
 


### PR DESCRIPTION
Reimagines the Graduation Criteria section on the roadmap page. The old 2x2 card grid flattened a real sequence into unordered cards with run-on requirement sentences, and its heading was rendered inside DocsMaturity without an id, so the section never appeared in the page TOC.

## What changed

- New \`DocsGraduation\` component: a vertical maturity track. Each level is a rung (existing level icon/color system) connected by rail segments that blend from one level's color into the next. The gate between rungs is a scannable checklist of promotion requirements, annotated with who promotes (author in the landing PR vs. maintainer decision).
- Live per-level counts computed from \`maturity.json\`, so the criteria double as a snapshot of where the library stands (10 draft / 102 preview / 33 stable).
- Deprecated is pulled off the track into a detached dashed card labeled "exit — from any level," matching its real semantics: it's not a fifth rung.
- Each rung states what the level means for a consumer (e.g. preview: API may move in minors, every change in release notes; stable: breaking changes require a major).
- Heading moved into \`roadmap.md\` as \`### Graduation Criteria\` — it now lands in the TOC with a linkable \`#graduation-criteria\` anchor, and the maturity FAQ links to it.
- \`DocsMaturity\` sheds the old criteria block and now renders the matrix only.

Verified: typecheck, knip/sherif, full \`build:docs\` SSG build, and visual pass in light/dark at desktop and mobile widths.