### PR TITLE
docs(rules): codify the shared runtime markdown pipeline

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -294,6 +294,21 @@ Real worked examples on master:
 | `` ```ts collapse `` `` | Collapsible code block |
 | `` ```ts no-filename `` `` | Hide filename in code block |
 
+## Runtime markdown
+
+Markdown that arrives at runtime (GitHub API bodies/descriptions, AI responses) renders through the single shared pipeline in `@/composables/useMarkdown`:
+
+- `useMarkdown(content)` — full documents (Shiki code blocks, callouts, tables). Consumers: `DocsAskMessage`, `DocsReleases`.
+- `renderInline(text)` — single lines inside `p`/`li` (e.g. roadmap milestone descriptions).
+
+Rules:
+
+- **Never instantiate `Marked` in a component** — extend `useMarkdown` instead. Duplicated configs drift (this is how `DocsReleases` and `DocsRoadmap` diverged before #485/#487).
+- **Never interpolate markdown-bearing API text with `{{ }}`** — raw `**`/`[]()` syntax leaks to the reader.
+- Link decoration comes from `processLinks` (`v0-link` class, `target=_blank`, `↗︎` suffix) so runtime content matches build-time markdown. Don't hand-roll link renderers or add `[&_a]` utility overrides.
+- **Trust boundary for `v-html`:** maintainer-authored content only (milestone descriptions, release bodies). Community-authored strings (issue titles, PR titles) must be HTML-escaped before rendering — marked passes raw inline HTML through.
+- Callout (`data-alert`) and mermaid placeholders render empty unless the consumer mounts them (see `DocsAskMessage`). If new runtime content can contain callouts, reuse that mounting pattern.
+
 ## API Reference
 
 Auto-generated at build time — no manual API tables. [intent:208]
@@ -481,3 +496,4 @@ Real worked examples:
 - [ ] Stable features expose playground-enabled fences/examples
 - [ ] No orphaned example files after edits; `pnpm repo:check` clean
 - [ ] Mermaid diagrams used for architecture/state/flow, not for content that belongs in tables
+- [ ] Runtime markdown rendered via `useMarkdown`/`renderInline` — no component-local `Marked` instances, no plain interpolation of API-sourced markdown

--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -212,6 +212,7 @@ import BasicExampleRaw from '@/examples/components/tabs/basic.vue?raw'
 | `useClipboard` | Copy to clipboard |
 | `useThemeToggle` | Dark/light mode toggle |
 | `useAsk` | AI Q&A chat with page context |
+| `useMarkdown` | Runtime markdown → HTML (GitHub API content, AI responses); also exports `renderInline` for single lines. Never instantiate `Marked` in a component — this is the only runtime markdown pipeline |
 
 ## Virtual Modules
 


### PR DESCRIPTION
## Description

Codifies the pattern consolidated in #485/#487 so it doesn't drift again. Root cause of both was discoverability: `useMarkdown` wasn't listed in `apps/docs/CLAUDE.md`'s App Composables table and no rule named it as the single runtime markdown pipeline.

## Changes

- `apps/docs/CLAUDE.md` — add `useMarkdown`/`renderInline` to the App Composables table with a 'never instantiate Marked in a component' note.
- `.claude/rules/docs.md` — new **Runtime markdown** section: the two entry points and their consumers, no component-local `Marked` instances, no plain interpolation of API-sourced markdown, link decoration via `processLinks`, the `v-html` trust boundary (maintainer-authored only; community-authored strings must be escaped), and the callout/mermaid placeholder-mounting caveat. Plus one checklist bullet.