### PR TITLE
docs: navigate to tour startRoute before starting callout tours

### DIFF
--- a/apps/docs/src/components/docs/DocsCallout.vue
+++ b/apps/docs/src/components/docs/DocsCallout.vue
@@ -97,12 +97,16 @@
     return decodeURIComponent(escape(atob(encoded)))
   }
 
-  function onClick () {
+  async function onClick () {
     if (props.type === 'askai' && props.question) {
       ask.ask(decodeQuestion(props.question))
     } else if (props.type === 'discord') {
       window.open('https://discord.gg/vK6T89eNP7', '_blank', 'noopener,noreferrer')
     } else if (props.type === 'tour' && props.tourId) {
+      if (!tour.value) return
+
+      await router.push(tour.value.startRoute)
+
       skillz.start(props.tourId, {
         context: {
           ask,


### PR DESCRIPTION
Tour callouts (#480) started the tour in place, so clicking one on a page other than the tour's start page left the tour running where its step targets don't exist — e.g. the using-examples callout on /components never redirected to /guide/essentials/using-the-docs.

DocsCallout now awaits `router.push(tour.startRoute)` before `skillz.start()`, matching the two existing start paths (skillz detail page and the resume banner). Verified in-browser: cross-page callouts redirect and start on the correct page, and same-page callouts (using-search on /introduction/getting-started) are unaffected.