### PR TITLE
docs: refresh stale browser-support compatibility data

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -249,29 +249,29 @@ Don't use a footnote for:
 - Information that applies to the whole table or page — that's still a TIP/NOTE block.
 - Short qualifiers (1–4 words) that read fine inline — e.g. `(zero-padded)`, `(0-indexed)`, `(includes NaN)`.
 
-**Naming:** short kebab identifiers tied to the row content, not numbered. `[^safari-anchor]`, not `[^1]` — survives reorder, scans better in source, makes the link descriptive when the footnote text is far from the anchor.
+**Naming:** short kebab identifiers tied to the row content, not numbered. `[^safari-temporal]`, not `[^1]` — survives reorder, scans better in source, makes the link descriptive when the footnote text is far from the anchor.
 
 ```markdown
 <!-- Right -->
 | Feature | Safari | Fallback |
 |---------|--------|----------|
-| [CSS Anchor Positioning](https://...) | —[^safari-anchor] | Properties ignored |
+| [Temporal](https://...) | —[^safari-temporal] | `@js-temporal/polyfill` |
 
-[^safari-anchor]: Not yet implemented in Safari; track at [WebKit Bug 286106](https://bugs.webkit.org/show_bug.cgi?id=286106).
+[^safari-temporal]: Not yet in stable Safari (available in Safari Technology Preview).
 
 <!-- Wrong — caveat wedged into cell, breaks row alignment -->
-| [CSS Anchor Positioning](https://...) | — (Not yet supported in Safari; tracking at WebKit) | Properties ignored |
+| [Temporal](https://...) | — (Not yet in stable Safari; available in Technology Preview) | `@js-temporal/polyfill` |
 
 <!-- Wrong — TIP block restating one row's caveat -->
-| [CSS Anchor Positioning](https://...) | — | Properties ignored |
+| [Temporal](https://...) | — | `@js-temporal/polyfill` |
 
 > [!TIP]
-> CSS Anchor Positioning is not yet supported in Safari; track at WebKit Bug 286106.
+> Temporal is not yet available in stable Safari; it ships in Safari Technology Preview.
 ```
 
 Real worked examples on master:
 
-- `apps/docs/src/pages/introduction/browser-support.md` — `[^safari-anchor]` on the Cutting-Edge Features table.
+- `apps/docs/src/pages/introduction/browser-support.md` — `[^safari-temporal]` on the Cutting-Edge Features table.
 - `apps/docs/src/pages/composables/index.md` — `[^plugin-install]` on the Plugin consumers row.
 - `apps/docs/src/pages/composables/plugins/use-date.md` — `[^temporal]` on the adapter's polyfill requirement.
 - `apps/docs/src/pages/guide/features/accessibility.md` — `[^pagination-nav]` and `[^popover-native]` on the ARIA attributes table.

--- a/apps/docs/src/pages/components/disclosure/popover.md
+++ b/apps/docs/src/pages/components/disclosure/popover.md
@@ -24,10 +24,10 @@ A headless component for creating popovers and tooltips using modern CSS anchor 
 
 <DocsBrowserSupport
   feature="CSS Anchor Positioning"
-  :versions="{ chrome: '125+', edge: '125+', firefox: '147+ (beta)' }"
+  :versions="{ chrome: '125+', edge: '125+', firefox: '147+', safari: '26+' }"
   anchor="css-anchor-positioning"
 >
-  The component works in all browsers, but automatic anchor positioning requires CSS Anchor Positioning support. In unsupported browsers, you'll need to position the popover manually or use [Floating UI](https://floating-ui.com).
+  The component works in all browsers, but automatic anchor positioning requires CSS Anchor Positioning support. In older browsers without it, you'll need to position the popover manually or use [Floating UI](https://floating-ui.com).
 </DocsBrowserSupport>
 
 ## Usage
@@ -93,7 +93,7 @@ Set `position-area` on `Popover.Content` to any [CSS `position-area`](https://de
 
 ??? What happens in browsers that don't support CSS Anchor Positioning?
 
-The component still renders and toggles open and closed, but automatic anchor positioning won't apply. In Safari and older browsers, position `Popover.Content` manually or use [Floating UI](https://floating-ui.com).
+The component still renders and toggles open and closed, but automatic anchor positioning won't apply. In older browsers (before Chrome/Edge 125, Firefox 147, or Safari 26), position `Popover.Content` manually or use [Floating UI](https://floating-ui.com).
 
 ??? How do I keep the popover on-screen when the preferred position doesn't fit?
 

--- a/apps/docs/src/pages/introduction/browser-support.md
+++ b/apps/docs/src/pages/introduction/browser-support.md
@@ -45,12 +45,11 @@ These features require the latest browser versions and may not work in all brows
 
 | Feature | <AppBrowserIcon browser="chrome" /> | <AppBrowserIcon browser="firefox" /> | <AppBrowserIcon browser="safari" /> | <AppBrowserIcon browser="edge" /> | Fallback |
 |---------|---:|---:|---:|---:|----------|
-| [CSS Anchor Positioning](https://caniuse.com/css-anchor-positioning) | 125+ | 147+ | —[^safari-anchor] | 125+ | Properties ignored |
+| [CSS Anchor Positioning](https://caniuse.com/css-anchor-positioning) | 125+ | 147+ | 26+ | 125+ | Properties ignored |
 | [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) | 114+ | 125+ | 17+ | 114+ | Optional chaining |
-| [Scrollend Event](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) | 112+ | 109+ | 18+ | 112+ | Falls back to scroll |
+| [Scrollend Event](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event) | 114+ | 109+ | 26.2+ | 114+ | Falls back to scroll |
 | [Temporal](https://caniuse.com/temporal) | 144+ | 139+ | —[^safari-temporal] | 144+ | `@js-temporal/polyfill` |
 
-[^safari-anchor]: Safari support for CSS Anchor Positioning is not yet available; track at [WebKit Bug 286106](https://bugs.webkit.org/show_bug.cgi?id=286106). Firefox 147+ requires the beta channel.
 [^safari-temporal]: Temporal is not yet in stable Safari (available in Safari Technology Preview). `useDate`'s `V0DateAdapter` automatically uses the [@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) peer when native Temporal is absent. The API reached TC39 Stage 4 (ES2026) in 2026.
 
 ### Well-Supported Features
@@ -126,14 +125,14 @@ The documentation site uses these modern CSS and browser features:
 
 ### CSS Anchor Positioning
 
-The `Popover` component uses CSS Anchor Positioning for automatic placement relative to trigger elements. This is a new CSS feature with limited support:
+The `Popover` component uses CSS Anchor Positioning for automatic placement relative to trigger elements. Support landed in all major engines between mid-2024 and early 2026, so only recent versions have it:
 
 - <AppBrowserIcon browser="chrome" /> **Chrome 125+**: Full support
 - <AppBrowserIcon browser="edge" /> **Edge 125+**: Full support
-- <AppBrowserIcon browser="firefox" /> **Firefox 147+**: Beta support only
-- <AppBrowserIcon browser="safari" /> **Safari**: Not yet supported
+- <AppBrowserIcon browser="firefox" /> **Firefox 147+**: Full support
+- <AppBrowserIcon browser="safari" /> **Safari 26+**: Full support
 
-When anchor positioning is unavailable, the CSS properties are simply ignored. Consider using a JavaScript positioning library like [Floating UI](https://floating-ui.com) for broader browser support.
+When anchor positioning is unavailable, the CSS properties are simply ignored. Consider using a JavaScript positioning library like [Floating UI](https://floating-ui.com) if you need to support older browser versions.
 
 ### Popover API
 


### PR DESCRIPTION
## Summary

Audit of the [browser support page](https://0.vuetifyjs.com/introduction/browser-support) prompted by its WebKit bug reference. All claims were re-verified against current vendor announcements and MDN/caniuse; three were stale:

- **CSS Anchor Positioning** — shipped in [Safari 26.0](https://webkit.org/blog/17333/webkit-features-in-safari-26-0/) (Sept 2025) and enabled by default in stable Firefox 147 (Jan 2026). Updated the Cutting-Edge table (`—` → `26+`, beta note dropped) and the Known Limitations section. Removed the `[^safari-anchor]` footnote — besides being outdated, its link ([WebKit Bug 286106](https://bugs.webkit.org/show_bug.cgi?id=286106)) points at an unrelated webkitpy test cleanup, not an anchor-positioning tracker.
- **Scrollend Event** — Chrome/Edge support is 114+ (not 112+) and Safari shipped it in [26.2](https://webkit.org/blog/17640/webkit-features-for-safari-26-2/) (not 18+); MDN marks it Baseline newly available since Dec 2025.
- **Popover page** — `<DocsBrowserSupport>` omitted Safari entirely (rendering a misleading "Safari —" warning) and still said "147+ (beta)" for Firefox; the FAQ singled out Safari as unsupported. Both updated.

Verified unchanged: Temporal (Chrome 144+/Firefox 139+, still Safari Technology Preview only), Popover API, Native Dialog (dialog.md versions match MDN), and the Well-Supported table.

Also swapped the footnote worked example in `.claude/rules/docs.md` to the still-live `[^safari-temporal]`, since it cited the deleted footnote as its on-master reference.