### PR TITLE
docs: cache highlighted example code to remove show-code flash

### DIFF
--- a/apps/docs/src/components/docs/DocsExample.vue
+++ b/apps/docs/src/components/docs/DocsExample.vue
@@ -7,12 +7,14 @@
 
   // Composables
   import { getMultiFileBinUrl } from '@/composables/bin'
+  import { useCodeHighlighter } from '@/composables/useCodeHighlighter'
   import { useExamples } from '@/composables/useExamples'
+  import { useIdleCallback } from '@/composables/useIdleCallback'
   import { usePlayground } from '@/composables/usePlayground'
 
   // Utilities
   import { toKebab } from '@/utilities/strings'
-  import { computed, ref, shallowRef, toRef, useId, useSlots, useTemplateRef, watch } from 'vue'
+  import { computed, onMounted, ref, shallowRef, toRef, useId, useSlots, useTemplateRef, watch } from 'vue'
 
   // Types
   import type DocsExampleCodePaneType from './DocsExampleCodePane.vue'
@@ -184,6 +186,23 @@
   )
 
   const language = toRef(() => file?.split('.').pop() || 'vue')
+
+  const { highlight: highlightCode } = useCodeHighlighter()
+
+  // Highlight code into the shared cache before the pane opens, so the first
+  // "show code" renders highlighted output instead of flashing raw text
+  function warm () {
+    const files = displayFiles.value
+    if (files?.length) {
+      for (const f of files) highlightCode({ code: f.code, language: f.language || f.name.split('.').pop() || 'text' })
+    } else if (resolvedCode.value) {
+      highlightCode({ code: resolvedCode.value, language: language.value })
+    }
+  }
+
+  onMounted(() => {
+    useIdleCallback(warm)
+  })
 
   async function openAllInPlayground () {
     if (!displayFiles.value?.length) return

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -8,12 +8,14 @@
   // Composables
   import { getMultiFileBinUrl } from '@/composables/bin'
   import { useExamples } from '@/composables/useExamples'
+  import { prehighlight } from '@/composables/useHighlightCode'
+  import { useIdleCallback } from '@/composables/useIdleCallback'
   import { usePlayground } from '@/composables/usePlayground'
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
 
   // Utilities
-  import { computed, toRef } from 'vue'
+  import { computed, onMounted, toRef } from 'vue'
 
   // Types
   import type { GnDocsExampleFile } from '@paper/genesis'
@@ -72,6 +74,21 @@
   const settings = useSettings()
   const lineWrap = useSyncedRef(settings.lineWrap)
   const size = settings.codeSize
+
+  // Highlight code into the shared cache before the pane opens, so the first
+  // "Show code" renders highlighted output instead of flashing raw text
+  function warm () {
+    const files = resolvedFiles.value
+    if (files?.length) {
+      for (const f of files) prehighlight(f.code, f.language || f.name.split('.').pop() || 'text')
+    } else if (resolvedCode.value) {
+      prehighlight(resolvedCode.value, language.value)
+    }
+  }
+
+  onMounted(() => {
+    useIdleCallback(warm)
+  })
 
   async function onPlayground (list: GnDocsExampleFile[]) {
     const files = list.map(f => ({ name: f.name, code: f.code }))

--- a/apps/docs/src/composables/useCodeHighlighter.ts
+++ b/apps/docs/src/composables/useCodeHighlighter.ts
@@ -1,6 +1,9 @@
 // Transformers
 import { createApiTransformer } from '@build/shiki-api-transformer'
 
+// Framework
+import { isUndefined } from '@vuetify/v0'
+
 // Composables
 import { useHighlighter } from './useHighlighter'
 
@@ -41,6 +44,24 @@ function normalizeLanguage (lang?: string): { shikiLang: string, displayLang: st
   return LANGUAGE_MAP[lower] ?? { shikiLang: lower, displayLang: lower }
 }
 
+const MAX_CACHE = 256
+
+// Highlighted HTML keyed by language + code (default transformers only) so
+// remounted code panes resolve synchronously instead of flashing raw code.
+const cache = new Map<string, string>()
+
+function cacheKey (lang: string, code: string): string {
+  return `${lang}\n${code}`
+}
+
+function remember (key: string, html: string) {
+  if (cache.size >= MAX_CACHE) {
+    const oldest = cache.keys().next().value
+    if (!isUndefined(oldest)) cache.delete(oldest)
+  }
+  cache.set(key, html)
+}
+
 /**
  * Creates a transformer that adds language-* class to the code element.
  */
@@ -63,8 +84,24 @@ export function useCodeHighlighter () {
   const { highlighter, getHighlighter } = useHighlighter()
 
   async function highlight (options: CodeHighlightOptions): Promise<CodeHighlightResult> {
-    const hl = highlighter.value ?? await getHighlighter()
     const { shikiLang, displayLang } = normalizeLanguage(options.language)
+
+    // Custom transformers change the output, so only default calls are cacheable
+    const cacheable = !options.transformers?.length
+    const key = cacheKey(shikiLang, options.code)
+
+    if (cacheable) {
+      const hit = cache.get(key)
+      if (!isUndefined(hit)) {
+        return {
+          html: hit,
+          code: options.code,
+          language: displayLang,
+        }
+      }
+    }
+
+    const hl = highlighter.value ?? await getHighlighter()
 
     const html = hl.codeToHtml(options.code, {
       lang: shikiLang,
@@ -76,6 +113,8 @@ export function useCodeHighlighter () {
         ...(options.transformers ?? []),
       ],
     })
+
+    if (cacheable) remember(key, html)
 
     return {
       html,

--- a/apps/docs/src/composables/useHighlightCode.ts
+++ b/apps/docs/src/composables/useHighlightCode.ts
@@ -1,6 +1,9 @@
 // Transformers
 import { createApiTransformer } from '@build/shiki-api-transformer'
 
+// Framework
+import { isUndefined } from '@vuetify/v0'
+
 // Composables
 import { useIdleCallback } from './useIdleCallback'
 
@@ -32,12 +35,46 @@ async function loadHighlighter () {
   return useHighlighter()
 }
 
+const MAX_CACHE = 256
+
+// Highlighted HTML keyed by language + code so remounted panes (v-if toggles,
+// tab switches) render highlighted output synchronously instead of flashing
+// the raw fallback while Shiki re-runs.
+const cache = new Map<string, string>()
+
+function cacheKey (lang: string, code: string): string {
+  return `${lang}\n${code}`
+}
+
+function remember (key: string, html: string) {
+  if (cache.size >= MAX_CACHE) {
+    const oldest = cache.keys().next().value
+    if (!isUndefined(oldest)) cache.delete(oldest)
+  }
+  cache.set(key, html)
+}
+
+/** Highlights code into the shared cache ahead of render (e.g., at idle before a pane opens). */
+export async function prehighlight (code: string, lang = 'vue'): Promise<void> {
+  if (!code || cache.has(cacheKey(lang, code))) return
+
+  const { highlighter, getHighlighter } = await loadHighlighter()
+  const hl = highlighter.value ?? await getHighlighter()
+
+  remember(cacheKey(lang, code), hl.codeToHtml(code, {
+    lang,
+    themes: SHIKI_THEMES,
+    defaultColor: false,
+    transformers: [createApiTransformer()],
+  }))
+}
+
 export function useHighlightCode (
   code: MaybeRefOrGetter<string | undefined>,
   options: UseHighlightCodeOptions = {},
 ) {
   const { lang = 'vue', immediate = true, idle = false, idleTimeout = 2000, debounce = 50 } = options
-  const highlightedCode = shallowRef('')
+  const highlightedCode = shallowRef(cache.get(cacheKey(lang, toValue(code) ?? '')) ?? '')
   const isLoading = shallowRef(false)
   const showLoader = shallowRef(false)
 
@@ -53,6 +90,13 @@ export function useHighlightCode (
     const value = source ?? toValue(code)
     if (!value) return
 
+    // Cache hit renders synchronously — no fallback flash on remount
+    const hit = cache.get(cacheKey(lang, value))
+    if (!isUndefined(hit)) {
+      highlightedCode.value = hit
+      return
+    }
+
     isLoading.value = true
 
     // Delay showing loading indicator to avoid flicker for fast operations
@@ -60,15 +104,8 @@ export function useHighlightCode (
       showLoader.value = true
     }, 100)
 
-    const { highlighter, getHighlighter } = await loadHighlighter()
-    const hl = highlighter.value ?? await getHighlighter()
-
-    highlightedCode.value = hl.codeToHtml(value, {
-      lang,
-      themes: SHIKI_THEMES,
-      defaultColor: false,
-      transformers: [createApiTransformer()],
-    })
+    await prehighlight(value, lang)
+    highlightedCode.value = cache.get(cacheKey(lang, value)) ?? ''
 
     if (loadingTimer) clearTimeout(loadingTimer)
     isLoading.value = false


### PR DESCRIPTION
## Description

Clicking **Show code** on a docs example flashed ~100ms of raw, unhighlighted text before the Shiki output swapped in — on every toggle, not just the first.

Two causes:

- Shiki initializes lazily on the first code-pane mount, so the first open per page paid the full engine + grammar init (~100ms) while the plain-text fallback `<pre>` was painted.
- Each pane discards its highlighted HTML on unmount and re-runs the async highlight on remount, so even re-opens painted the fallback for a frame or two.

## Fix

- `useHighlightCode` / `useCodeHighlighter`: module-level cache of highlighted HTML keyed by language + code (capped at 256 entries; skipped when custom transformers are passed). Cache hits resolve synchronously, so a remounted pane renders highlighted output in its first frame — the fallback never mounts.
- `DocsGenesisExample` / `DocsExample`: pre-highlight their example files during idle time after page load, so the highlighter is initialized and the cache is warm before the first click.

Verified in-browser with a MutationObserver on the pane: before, the fallback `<pre>` was painted for ~100ms (first open) / ~12ms (re-open); after, it never mounts — first open, re-open, tab switches, and mixed-language (`.ts`/`.vue`) multi-file examples all render tokenized output immediately. API hover popovers share the `useCodeHighlighter` cache and are unaffected (custom-transformer calls bypass it).