### PR TITLE
docs(README): remove promotional sponsorship sections

### DIFF
--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -30,10 +30,6 @@ Headless Vue 3 UI primitives and composables for building modern applications an
 
 > **Note:** v0 is a release candidate — the v1 stable set is locked. Install with `npm i @vuetify/v0@rc`. Preview APIs may still see minor, documented changes before the stable release.
 
-## Primary Sponsor
-
-This spot is open. Vuetify0 accepts one Primary Sponsor at a time — $2,000/mo gets your logo on the Vuetify0 docs site (home page + desktop sidebar on every docs page) and this README. [Become the Primary Sponsor →](https://0.vuetifyjs.com/sponsor)
-
 ## Repository Structure
 
 This is a **pnpm monorepo** containing:
@@ -306,15 +302,6 @@ pnpm validate
 ## Contributing
 
 Vuetify0 is a release candidate — open for final validation, bug reports, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap#release-candidate) for what's planned and how to get involved.
-
-## Supporting Vuetify
-
-Vuetify0 is an MIT-licensed open source project. Its ongoing development is made possible by the support of sponsors and backers. If you'd like to join them, please consider:
-
-- [Sponsor on GitHub](https://github.com/sponsors/johnleider)
-- [Donate via Open Collective](https://opencollective.com/vuetify)
-
-For direct support plans and fixed-scope project builds, see [Vuetify Services](https://0.vuetifyjs.com/services).
 
 ## License
 


### PR DESCRIPTION
Removes the promotional sponsorship content from the v0 README:

- **Primary Sponsor** section (the open $2,000/mo ad-slot pitch)
- **Supporting Vuetify** section (GitHub Sponsors / Open Collective / Vuetify Services links)

Root `README.md` symlinks `packages/0/README.md`, so both are covered by the single edit. No other content changed.