### PR TITLE
fix(useRules): widen StandardSchemaV1 issue path typing to spec

### DIFF
--- a/.changeset/standard-schema-path-typing.md
+++ b/.changeset/standard-schema-path-typing.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(useRules): accept spec-compliant Standard Schema issue paths
+
+Widens the vendored `StandardSchemaV1` issue `path` typing to `ReadonlyArray<PropertyKey | PathSegment>` per the Standard Schema v1 spec, so schemas typed with `@standard-schema/spec` (Valibot, Zod, ArkType) are assignable to `rules` again.

--- a/packages/0/src/composables/useRules/adapters/standard.ts
+++ b/packages/0/src/composables/useRules/adapters/standard.ts
@@ -11,20 +11,20 @@ import type { FormValidationRule } from '#v0/composables/createForm'
  * @see https://standardschema.dev/
  */
 interface StandardSchemaIssue {
-  message: string
-  path?: ReadonlyArray<{ key: PropertyKey }>
+  readonly message: string
+  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }> | undefined
 }
 
 interface StandardSchemaResult {
-  value?: unknown
-  issues?: ReadonlyArray<StandardSchemaIssue>
+  readonly value?: unknown
+  readonly issues?: ReadonlyArray<StandardSchemaIssue> | undefined
 }
 
 export interface StandardSchemaV1 {
-  '~standard': {
-    version: 1
-    vendor: string
-    validate: (value: unknown) => StandardSchemaResult | Promise<StandardSchemaResult>
+  readonly '~standard': {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (value: unknown) => StandardSchemaResult | Promise<StandardSchemaResult>
   }
 }
 

--- a/packages/0/src/composables/useRules/index.test.ts
+++ b/packages/0/src/composables/useRules/index.test.ts
@@ -299,7 +299,7 @@ describe('useRules', () => {
 })
 
 /** Helper to create a mock Standard Schema object */
-function mockSchema (validate: (value: unknown) => { value?: unknown, issues?: ReadonlyArray<{ message: string }> }): StandardSchemaV1 {
+function mockSchema (validate: StandardSchemaV1['~standard']['validate']): StandardSchemaV1 {
   return {
     '~standard': {
       version: 1,
@@ -376,6 +376,15 @@ describe('standard Schema integration', () => {
       const rule = toRule(schema)
 
       expect(await rule('test')).toBe(true)
+    })
+
+    it('should accept issues with spec path segments', async () => {
+      const schema = mockSchema(() => ({
+        issues: [{ message: 'Must be a string', path: ['field', { key: 'nested' }] }],
+      }))
+      const rule = toRule(schema)
+
+      expect(await rule({})).toBe('Must be a string')
     })
 
     it('should return first issue when multiple issues exist', async () => {


### PR DESCRIPTION
The vendored `StandardSchemaV1` type in the useRules standard adapter typed issue `path` elements as `{ key: PropertyKey }` only, dropping the bare `PropertyKey` union member the Standard Schema v1 spec allows. Schemas typed with `@standard-schema/spec` (Valibot, Zod, ArkType) were therefore not assignable to `rules`.

This widens `path` to `ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>` and aligns `readonly` modifiers with the published spec. Pure type-surface change — runtime is untouched, and the adapter stays dependency-free. The test suite's mock schema is now typed against the full spec `validate` signature, so any future re-narrowing fails typecheck.

Closes #498
https://github.com/vuetifyjs/0/issues/498