### PR TITLE
docs: silence vite.dev link-check false positive, update redirecting MDN links

### DIFF
--- a/apps/docs/src/pages/components/disclosure/popover.md
+++ b/apps/docs/src/pages/components/disclosure/popover.md
@@ -58,7 +58,7 @@ The Popover component leverages the CSS Anchor Positioning API to create popover
 
 ### Positioning
 
-Use `position-area` on `Popover.Content` to control where the popover appears relative to its anchor. Accepts any [CSS `position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/position-area) value (default: `'bottom'`):
+Use `position-area` on `Popover.Content` to control where the popover appears relative to its anchor. Accepts any [CSS `position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-area) value (default: `'bottom'`):
 
 ```vue
 <template>
@@ -89,7 +89,7 @@ Use `position-try` to specify fallback positions when the preferred position doe
 
 ??? How do I control where the popover appears relative to its anchor?
 
-Set `position-area` on `Popover.Content` to any [CSS `position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/position-area) value such as `top` or `end`. It defaults to `bottom`.
+Set `position-area` on `Popover.Content` to any [CSS `position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-area) value such as `top` or `end`. It defaults to `bottom`.
 
 ??? What happens in browsers that don't support CSS Anchor Positioning?
 

--- a/apps/docs/src/pages/guide/fundamentals/styling.md
+++ b/apps/docs/src/pages/guide/fundamentals/styling.md
@@ -86,7 +86,7 @@ Tabs styled with CSS modules targeting `[data-selected]` in scoped styles.
 
 ### Plain CSS
 
-Standard [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) work in any stylesheet:
+Standard [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Attribute_selectors) work in any stylesheet:
 
 ```css
 /* Single state */

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,6 +2,6 @@
 # /dist/documents: breadcrumbs examples use intentional demo hrefs.
 # /dist/https:: lychee misparses Vue component markup (<DocsCard href>) in the
 # copied page-source markdown, resolving the URL as a relative path.
-exclude = ["/dist/documents", "/dist/https:", "^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://([^/]*\\.)?vuejs\\.org", "^https?://(www\\.)?npmjs\\.com"]
+exclude = ["/dist/documents", "/dist/https:", "^https?://(www\\.)?github\\.com", "^https?://discord\\.gg", "^https?://community\\.vuetifyjs\\.com", "invalid.jpg", "^https://mcp\\.vuetifyjs\\.com/mcp", "^https?://([^/]*\\.)?vuejs\\.org", "^https?://(www\\.)?npmjs\\.com", "^https?://(www\\.)?vite\\.dev"]
 
 root_dir = "./apps/docs/dist"


### PR DESCRIPTION
The weekly Lychee link check (`link-check.yml`) failed on transient network errors reaching `https://vite.dev/` — a live, valid host — which regenerates the "Link checker report" issue each run. This mirrors the flaky-host failures already excluded for `vuejs.org` and `npmjs.com`.

## Changes

- **`lychee.toml`** — add `^https?://(www\.)?vite\.dev` to the `exclude` array, matching the existing `vuejs.org` / `npmjs.com` precedent. This is the load-bearing fix: `vite.dev` was the only ERROR in the report (one real `Connection failed`, five cached copies); every other report entry was a redirect that already resolves 200 and is accepted by `--accept '...200..=299...'`.
- **`popover.md`, `styling.md`** — update two MDN links that now 301 to their canonical paths (`Reference/Properties/position-area`, `Reference/Selectors/Attribute_selectors`) to trim redirect noise. Both already resolved 200 after redirect, so this is hygiene only.

Verified all three target URLs resolve 200 directly (no redirect) via `curl`.

Closes #499
https://github.com/vuetifyjs/0/issues/499