### PR TITLE
docs: add exact Beta and RC dates to Road to v1 timeline

### DIFF
--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -34,8 +34,8 @@ Alpha opened on April 7, 2026 for feedback; beta hardened the APIs. The release 
 
 <DocsTimeline :milestones="[
   { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Opened for feedback, bug reports, and contributions. APIs mostly stable, may evolve.' },
-  { id: 'beta', label: 'Beta', date: 'June 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
-  { id: 'rc', label: 'RC', date: 'July 2026', description: 'Release candidate for final testing and documentation. No new features.', active: true },
+  { id: 'beta', label: 'Beta', date: 'June 2, 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
+  { id: 'rc', label: 'RC', date: 'July 2, 2026', description: 'Release candidate for final testing and documentation. No new features.', active: true },
   { id: 'v1', label: 'v1.0', date: 'Q3 2026', description: 'Milestone-driven. Ships when the milestones are met.' },
 ]" />
 


### PR DESCRIPTION
## Summary
- `Road to v1` timeline on `/roadmap` had month-only placeholders for Beta (`June 2026`) and RC (`July 2026`), unlike Alpha's exact date (`April 7, 2026`).
- Beta shipped as `v1.0.0-beta.0` on June 2, 2026; RC shipped as `v1.0.0-rc.6` on July 2, 2026 (per git tags + CHANGELOG). Both are now updated to exact dates for parity with Alpha.

## Test plan
- N/A — docs-only string change