### PR TITLE
chore(release): group release-notes overview by commit type with emoji headers

### DIFF
--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -64,16 +64,45 @@ function notes (changelog, value) {
   return lines.slice(start + 1, end).join('\n').trim()
 }
 
-// Condense each changelog bullet's conventional-commit title into a flat, skimmable
-// list at the top of the release notes — changesets' per-entry prose buries the
-// one-line summaries readers skim for. Two authoring shapes both need trimming: a
-// title-only first line with the detail in a separate indented paragraph below
-// (BULLET's `.+$` already stops at line end), and a single line packing title +
-// detail together, separated by ' — ' (em dash).
+// Condense each changelog bullet's conventional-commit title into a skimmable,
+// grouped overview at the top of the release notes — changesets' per-entry prose
+// buries the one-line summaries readers skim for, and its flat list mixes features,
+// fixes, and perf work together. The overview reorganizes them the way the old
+// `conventional-changelog-vuetify` preset did: a section per commit type (its exact
+// emoji headers and group order — see SECTIONS below), the redundant `type(scope): `
+// prefix folded into a bold scope, and real Markdown PR links so the notes render on
+// our own releases page — not just on GitHub, which is the only place bare `#123`
+// text autolinks.
+//
+// BULLET peels off the changesets-added preamble (PR link, commit link, "Thanks
+// X!"), leaving `text` = the conventional-commit title the author wrote, optionally
+// with a ` — <detail>` trailer on the same line. TITLE then splits that title into
+// type / scope / description; a title with no recognizable `type:` prefix keeps its
+// full text and falls through to the Other bucket.
+const REPO = 'vuetifyjs/0'
 const BULLET = /^- (?:\[#(\d+)]\([^)]*\)\s*)?(?:\[`[0-9a-f]+`]\([^)]*\)\s*)?(?:Thanks .*?! - )?(.+)$/
+const TITLE = /^(\w+)(?:\(([^)]*)\))?!?:\s*(.+)$/
+
+// Commit type → overview section, mirroring `conventional-changelog-vuetify`'s
+// writer map and group order. Literal emoji (not `:shortcode:`) so the section
+// headers render on the docs releases page too — its markedEmoji map doesn't carry
+// every shortcode (e.g. arrows_counterclockwise). Array order is the render order.
+// The preset's Labs section is vuetify-core-specific (keyed off packages/vuetify/src
+// /labs) and omitted here. Unlike the preset — which discards non-breaking docs/
+// chore/style — any type absent here or a title with no type prefix lands in Other
+// Commits, because in the changesets flow every entry exists only because an author
+// wrote a changeset, so nothing should silently vanish.
+const SECTIONS = [
+  ['feat', '🚀 Features'],
+  ['fix', '🔧 Bug Fixes'],
+  ['perf', '🔥 Performance Improvements'],
+  ['refactor', '🔬 Code Refactoring'],
+  ['revert', '🔁 Reverts'],
+]
+const OTHER = 'Other Commits'
 
 function overview (body) {
-  const titles = []
+  const buckets = new Map()
   for (const line of body.split('\n')) {
     const match = line.match(BULLET)
     if (!match) continue
@@ -82,10 +111,37 @@ function overview (body) {
     // for packages that only bumped because an internal dependency changed — no
     // conventional-commit title to extract, and the sha list is pure noise here.
     if (text.startsWith('Updated dependencies')) continue
-    const title = text.split(' — ')[0]
-    titles.push(pr ? `- ${title} (#${pr})` : `- ${title}`)
+
+    const title = text.split(' — ')[0].trim()
+    const parts = title.match(TITLE)
+    const type = parts ? parts[1] : ''
+    const scope = parts ? parts[2] : ''
+    const desc = parts ? parts[3] : title
+
+    // Bold the scope and drop the type word (it's the section header now); a
+    // scopeless title keeps its bare description.
+    const summary = scope ? `**${scope}:** ${desc}` : desc
+    // Skip our appended PR link when the author already ended the title with a
+    // linked issue/PR reference (e.g. a "…stay interactive ([#279](…))" trailer) —
+    // otherwise the row renders two adjacent parenthesized links.
+    const linked = /\(\[#\d+]\([^)]*\)\)\s*$/.test(desc)
+    const link = pr && !linked ? ` ([#${pr}](https://github.com/${REPO}/pull/${pr}))` : ''
+    const label = SECTIONS.find(([t]) => t === type)?.[1] ?? OTHER
+
+    if (!buckets.has(label)) buckets.set(label, [])
+    buckets.get(label).push(`- ${summary}${link}`)
   }
-  return titles.length > 0 ? `## Overview\n${titles.join('\n')}\n\n---\n\n` : ''
+
+  if (buckets.size === 0) return ''
+
+  const order = [...SECTIONS.map(([, label]) => label), OTHER]
+  const sections = []
+  for (const label of order) {
+    const lines = buckets.get(label)
+    if (lines) sections.push(`### ${label}\n${lines.join('\n')}`)
+  }
+
+  return `## Overview\n\n${sections.join('\n\n')}\n\n---\n\n`
 }
 
 function exists (tag) {


### PR DESCRIPTION
## Summary

Reworks the `overview()` section synthesized in `scripts/github-release.js` (the step that mints GitHub Releases after `changeset publish`) from a flat title list into type-grouped sections with emoji headers, restoring the readability of the old `conventional-changelog-vuetify` output while keeping changesets as the single source of truth.

No new dependency, no changeset (this is CI-only release tooling — it ships in no npm package, so a version bump would be wrong).

## What changed

- **Grouped, emoji headers** — buckets each changelog bullet by its `type(scope):` prefix into sections mirroring the `conventional-changelog-vuetify` writer map and order:
  - 🚀 Features · 🔧 Bug Fixes · 🔥 Performance Improvements · 🔬 Code Refactoring · 🔁 Reverts · Other Commits
  - The preset's Labs section is vuetify-core-specific and omitted. Unlike the preset (which discards non-breaking `docs`/`chore`/`style`), those route to **Other Commits** — in the changesets flow every entry exists only because an author wrote a changeset, so nothing should silently vanish.
- **Bold scope** — the redundant `type(scope): ` prefix is folded into a bold scope; the type word is now the section header (`fix(useTheme): apply cspNonce…` → **useTheme:** apply cspNonce…).
- **Real PR links** — emits `([#NNN](url))` instead of bare `#NNN` text. Bare references only autolink on GitHub; our own `/releases` page renders the body through `marked`, which left them inert. Literal emoji (not `:shortcode:`) since the `DocsReleases` `markedEmoji` map lacks some shortcodes (e.g. `arrows_counterclockwise`).
- **No duplicate links** — suppresses the appended PR link when the author's title already ends in a linked issue/PR reference, avoiding two adjacent parenthesized links.

## Example — `1.0.0-beta.4` regenerated

**Before** (flat, inert `#NNN`):
```
## Overview
- feat(locale): add `ti()`… (#372)
- fix(Dialog, Snackbar): overlays can teleport… (#397)
- perf(Overflow): cache item visibility… (#417)
  …16 mixed lines…
```

**After:**
```
## Overview

### 🚀 Features
- **locale:** add `ti()` so components carry inline English aria labels… ([#372](https://github.com/vuetifyjs/0/pull/372))

### 🔧 Bug Fixes
- **Dialog, Snackbar:** overlays can teleport into the topmost open modal… ([#279](https://github.com/vuetifyjs/0/issues/279))
- **useTheme:** apply `cspNonce` on the SSR head path ([#441](https://github.com/vuetifyjs/0/pull/441))
  …12 more…

### 🔥 Performance Improvements
- **Overflow:** cache item visibility in a hidden-index set… ([#417](https://github.com/vuetifyjs/0/pull/417))
```

## Caveat

Categorization inherits commit-type discipline: a changeset title without a real `type(scope):` prefix lands in **Other Commits**. Same advisory-enforcement surface changesets already have.