### PR TITLE
docs: link API hover popover to both docs page and API reference

### DIFF
--- a/apps/docs/src/components/docs/DocsApiHover.vue
+++ b/apps/docs/src/components/docs/DocsApiHover.vue
@@ -279,6 +279,18 @@
   const displayProperties = toRef(() => composableApi.value?.properties || [])
   const displayMethods = toRef(() => composableApi.value?.methods || [])
 
+  // The key used to look up the feature in apiData.related — namespace for
+  // components ("Popover.Root" -> "Popover"), full name for composables.
+  const apiName = toRef(() => {
+    if (!activeApi.value || activeApiType.value === 'vue') return null
+    if (activeApiType.value === 'component') {
+      const name = (activeApi.value as ComponentApi).name
+      const dotIndex = name.indexOf('.')
+      return dotIndex === -1 ? name : name.slice(0, dotIndex)
+    }
+    return (activeApi.value as ComposableApi).name
+  })
+
   const apiLink = computed(() => {
     if (!activeApi.value) return null
 
@@ -302,6 +314,14 @@
 
     // Composable
     return `/api/${toKebab((activeApi.value as ComposableApi).name)}`
+  })
+
+  // Link to the feature's regular docs page. apiData.related keys each v0 symbol
+  // to its own docs route (first entry), so v0 features get both an API and a
+  // docs link. Vue APIs have no v0 docs page.
+  const docsLink = toRef(() => {
+    if (!apiName.value) return null
+    return apiData.related[apiName.value]?.[0] ?? null
   })
 
   // Whether the link is external (Vue docs) or internal (v0 API page)
@@ -411,11 +431,11 @@
           </div>
         </template>
 
-        <!-- Footer link -->
-        <template v-if="apiLink">
+        <!-- Footer links -->
+        <div v-if="apiLink" class="popover-footer">
           <a
             v-if="isExternalLink"
-            class="popover-footer"
+            class="popover-footer-link"
             :href="apiLink"
             rel="noopener noreferrer"
             target="_blank"
@@ -424,15 +444,25 @@
             View Vue docs↗
           </a>
 
-          <router-link
-            v-else
-            class="popover-footer"
-            :to="apiLink"
-            @click.stop="hidePopover"
-          >
-            View API
-          </router-link>
-        </template>
+          <template v-else>
+            <router-link
+              v-if="docsLink"
+              class="popover-footer-link"
+              :to="docsLink"
+              @click.stop="hidePopover"
+            >
+              View Docs
+            </router-link>
+
+            <router-link
+              class="popover-footer-link"
+              :to="apiLink"
+              @click.stop="hidePopover"
+            >
+              View API
+            </router-link>
+          </template>
+        </div>
       </div>
     </Transition>
   </Teleport>
@@ -535,11 +565,15 @@
 }
 
 .popover-footer {
-  display: block;
+  display: flex;
   flex-shrink: 0;
   margin: 0 -12px -12px;
-  padding: 12px;
   border-top: 1px solid var(--v0-divider);
+}
+
+.popover-footer-link {
+  flex: 1;
+  padding: 12px;
   font-size: 12px;
   color: var(--v0-primary);
   text-align: center;
@@ -547,7 +581,11 @@
   cursor: pointer;
 }
 
-.popover-footer:hover {
+.popover-footer-link + .popover-footer-link {
+  border-left: 1px solid var(--v0-divider);
+}
+
+.popover-footer-link:hover {
   text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
## Summary

The API hover popover previously surfaced only a single footer link: `/api/<slug>` for v0 symbols, or the external Vue docs URL for Vue symbols. Per the docs rule (intent:284 — `ApiPopover on hover shows two links: "View API" and "View Docs"`), v0 features should link to **both** their regular docs page and their API reference.

This wires up the second link using a correlation that already exists — `virtual:api`'s `related` map, whose first entry for each symbol is its own docs-page route. The popover already imported `virtual:api`; it just wasn't consuming `related`. No new build step.

## Behavior

| Symbol kind | Footer links |
|---|---|
| Composable (`createSelection`) | **View Docs** → `/composables/selection/create-selection` · **View API** → `/api/create-selection` |
| Component (`Popover.Root`) | **View Docs** → `/components/disclosure/popover` · **View API** → `/api/popover#popover-root` |
| Vue (`defineProps`) | **View Vue docs↗** (single external link, unchanged) |

If a v0 symbol has no docs page (`related` miss), only **View API** shows.

## Changes

Single file, `apps/docs/src/components/docs/DocsApiHover.vue`:
- New `apiName` (related-map key: namespace for components, name for composables) and `docsLink` (`apiData.related[apiName]?.[0]`) computed values.
- Footer restructured into a flex row of `.popover-footer-link` columns with a divider; Vue path keeps its single external link.

## Verification

Drove the dev server with Playwright and confirmed all three cases live (composable, component-with-anchor, Vue) render the correct links.