### PR TITLE
docs: default code size to medium

### DIFF
--- a/apps/docs/src/composables/useSettings.ts
+++ b/apps/docs/src/composables/useSettings.ts
@@ -65,7 +65,7 @@ export interface SettingsContext {
 
 const DEFAULTS: DocSettings = {
   lineWrap: false,
-  codeSize: 'small',
+  codeSize: 'medium',
   reduceMotion: 'system',
   packageManager: 'pnpm',
   showInlineApi: false,


### PR DESCRIPTION
Changes the docs default `codeSize` from `small` (0.8125rem) to `medium` (0.875rem) in `useSettings.ts`. Readers can still switch to small/large via the settings panel or the per-example size button.