### PR TITLE
chore(maturity): add createTour, createTimePicker, createDatePicker draft primitives

### DIFF
--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -129,11 +129,13 @@
     },
     "createDatePicker": {
       "level": "draft",
-      "category": "forms"
+      "category": "forms",
+      "description": "Headless date state with calendar-grid geometry, single-date and range modes, preset ranges, min/max bounds, and disabled-date rules. Composable-first, without an `@internationalized/date` dependency."
     },
     "createTimePicker": {
       "level": "draft",
-      "category": "forms"
+      "category": "forms",
+      "description": "Segmented time value with hour, minute, and second fields, 12/24-hour modes, meridiem handling, step snapping, and min/max bounds."
     },
     "createDataGrid": {
       "level": "preview",
@@ -197,7 +199,8 @@
     },
     "createTour": {
       "level": "draft",
-      "category": "semantic"
+      "category": "semantic",
+      "description": "Headless state for guided product tours and feature discovery: step sequencing, target-element tracking, mask cutout geometry, and per-step focus management. Built on `createStep`, `usePopover`, and `useRovingFocus`."
     },
     "useBreakpoints": {
       "level": "stable",

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -127,6 +127,14 @@
       "category": "forms",
       "description": "Fixed-length one-time-password or verification-code value with pattern-gated entry and completion detection."
     },
+    "createDatePicker": {
+      "level": "draft",
+      "category": "forms"
+    },
+    "createTimePicker": {
+      "level": "draft",
+      "category": "forms"
+    },
     "createDataGrid": {
       "level": "preview",
       "since": "1.0.0-beta.0",
@@ -186,6 +194,10 @@
       "since": "0.1.0",
       "category": "semantic",
       "description": "Computes how many items fit in a container based on available width, for responsive truncation in pagination, breadcrumbs, and similar UIs."
+    },
+    "createTour": {
+      "level": "draft",
+      "category": "semantic"
     },
     "useBreakpoints": {
       "level": "stable",


### PR DESCRIPTION
Registers the three greenfield composable primitives split out of the v1.2 / v1.4 / v1.5 epics as `draft` entries in `maturity.json`, so they surface in the roadmap maturity matrix ahead of implementation.

- `createTour` — semantic (backs Tour, #515)
- `createTimePicker` — forms (backs TimePicker, #520)
- `createDatePicker` — forms (backs DatePicker/DateRangePicker, #522)

Draft entries carry `level` + `category` only; `since`/`description` are filled in when each ships (per the new-feature checklist). Categories and names are provisional — adjustable at implementation.

Refs #508, #510, #511, #515, #520, #522