### PR TITLE
test(usePermissions): cover UNSAFE_KEYS prototype-pollution guards

### DIFF
--- a/packages/0/src/composables/usePermissions/index.test.ts
+++ b/packages/0/src/composables/usePermissions/index.test.ts
@@ -336,6 +336,57 @@ describe('createPermissions', () => {
         expect(permissions.can('user', 'read', 'posts')).toBe(true)
       })
     })
+
+    // Guards the UNSAFE_KEYS skips at index.ts role/action/subject; without them a
+    // `__proto__` role walks record['__proto__'] -> Object.prototype and pollutes it.
+    // JSON.parse yields an own-enumerable `__proto__`; an object literal would not.
+    describe('prototype pollution protection', () => {
+      afterEach(() => {
+        delete (Object.prototype as any).read
+        delete (Object.prototype as any).polluted
+        delete (Object.prototype as any).x
+      })
+
+      it('should skip an unsafe role key without polluting Object.prototype', () => {
+        const malicious = JSON.parse('{"__proto__":[["read","polluted",true]],"admin":[["read","users"]]}')
+        const permissions = createPermissions({ permissions: malicious })
+
+        expect(({} as any).read).toBeUndefined()
+        expect(permissions.can('__proto__', 'read', 'polluted')).toBe(false)
+        // A legit role declared alongside the malicious key still registers.
+        expect(permissions.can('admin', 'read', 'users')).toBe(true)
+      })
+
+      it('should skip constructor and prototype role keys', () => {
+        const permissions = createPermissions({
+          permissions: JSON.parse('{"constructor":[["read","users"]],"prototype":[["read","users"]]}'),
+        })
+
+        expect(permissions.can('constructor', 'read', 'users')).toBe(false)
+        expect(permissions.can('prototype', 'read', 'users')).toBe(false)
+        expect(({} as any).polluted).toBeUndefined()
+      })
+
+      it('should skip an unsafe action key without polluting Object.prototype', () => {
+        const permissions = createPermissions({
+          permissions: JSON.parse('{"admin":[["__proto__","x",true],["read","users"]]}'),
+        })
+
+        expect(({} as any).x).toBeUndefined()
+        expect(permissions.can('admin', '__proto__', 'x')).toBe(false)
+        expect(permissions.can('admin', 'read', 'users')).toBe(true)
+      })
+
+      it('should skip an unsafe subject key without polluting Object.prototype', () => {
+        const permissions = createPermissions({
+          permissions: JSON.parse('{"admin":[["read","__proto__",true],["read","users"]]}'),
+        })
+
+        expect(permissions.can('admin', 'read', '__proto__')).toBe(false)
+        expect(permissions.can('admin', 'read', 'users')).toBe(true)
+        expect(({} as any).polluted).toBeUndefined()
+      })
+    })
   })
 
   describe('createPermissionsContext', () => {


### PR DESCRIPTION
`createPermissions` skips `__proto__` / `constructor` / `prototype` at the **role, action, and subject** levels (`usePermissions/index.ts`), but shipped with **zero regression tests** for it — the exact sibling `.claude/rules/implementation.md`'s security-primitive table flags as having historically *missed* the guard its twin `mergeDeep` already had.

## What
Adds a `prototype pollution protection` suite to `usePermissions/index.test.ts` covering each guarded level. Assertions:
- `Object.prototype` stays clean after a malicious config (a `__proto__` role walks `record['__proto__'] → Object.prototype` when unguarded).
- the malicious role/action/subject is **non-grantable** (`can()` returns `false`).
- a legit permission declared **alongside** the malicious key still registers (the guard doesn't over-skip / break iteration).

Payloads use `JSON.parse` to produce an *own-enumerable* `__proto__` key — an object literal wouldn't, matching the established idiom in the `mergeDeep` pollution tests.

## Verification
Test-only change; no source or public surface touched.
- 32/32 pass in `usePermissions/index.test.ts`.
- **Regression teeth confirmed:** temporarily removing the role- and action-level `UNSAFE_KEYS` guards makes the corresponding tests fail (global `Object.prototype` pollution), then pass again once restored.

Scope note: `mergeDeep`, `createTokens`, and the feature-flag adapters already carry pollution tests; this fills the one consumer that had guards but no coverage. No fuzzer added — the guarded surface is a fixed three-key blocklist, fully enumerable by explicit cases.