### PR TITLE
docs: reconcile PHILOSOPHY.md with current source

### DIFF
--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -13,16 +13,16 @@ v0 is a **headless meta-framework for building UI libraries** — a set of Vue 3
 ### What v0 is
 
 - A layer of Vue 3 composables (~73) and compound components (~40) that encode interaction patterns, selection state, registries, accessibility contracts, keyboard navigation, focus management, SSR safety, and adapter-backed plugin state.
-- The bottom of a four-layer stack: **v0 → Paper → Design Systems → Vuetify**. v0 handles logic; Paper handles styling primitives (`useColor`, `useTheme`, `useContrast`); design systems (Emerald, Helix, etc.) compose Paper into complete frameworks; Vuetify 4 is one such consumer. [intent:295, intent:296, intent:297, intent:298]
+- The bottom of a four-layer stack: **v0 → Paper → Design Systems → Vuetify**. v0 handles logic *and the headless token substrate* — theme state (`useTheme`), design tokens (`createTokens`), palettes-as-data (`src/palettes/`), and color/contrast math (`apca`); Paper consumes that substrate and handles styling *application* (`useColor`, `useContrast`); design systems (Emerald, Helix, etc.) compose Paper into complete frameworks; Vuetify 4 is one such consumer. [intent:295, intent:296, intent:297, intent:298]
 - Zero runtime dependencies on UI styling. No Tailwind, no UnoCSS, no Vuetify classes inside `packages/0/src/`. [intent:82, intent:278]
 - WAI-ARIA correct by default. Every interactive component ships `role`, `aria-*`, keyboard handlers, and `aria-disabled` semantics. [intent:174, intent:178]
 - Headless in the operational sense: consumers can replicate every visible behavior by writing CSS against the data attributes v0 exposes. [intent:281]
 
 ### What v0 is not
 
-- Not a component library. No theme, no skin, no CSS. Icons belong to Paper, not v0. [intent:299]
+- Not a component library. No skin, no CSS, no *applied* styling. (v0 ships headless theme *state* and token *data*, but never paints — see below.) Icons belong to Paper, not v0. [intent:299]
 - Not a framework wrapper. Composables are not thin wrappers around `vue-i18n`, `date-fns`, or `pino` — those ship as adapters. [intent:107, intent:145]
-- Not a styling primitive. Color math, contrast, theme tokens — those live one layer up in Paper. [intent:297]
+- Not a styling *application* layer. v0 owns the headless substrate — theme state, design tokens, palettes-as-data, and color/contrast math (`useTheme`, `createTokens`, `src/palettes/`, `apca`) — but never turns a token into a rendered pixel. Applying tokens to visible color is Paper's job. [intent:297]
 
 ### Audience
 
@@ -59,7 +59,7 @@ Non-negotiable. Each axiom carries a statement, a rationale, and a concrete anti
 
 ### 2.1 Headless contract is absolute
 
-**Statement.** No utility classes, no CSS framework references, no color values, no typography, no spacing in `packages/0/src/`. Styling is the consumer's responsibility. [intent:82, intent:278, intent:203]
+**Statement.** No utility classes, no CSS framework references, no typography, no spacing in `packages/0/src/`. Color *values* appear only as headless token data (`src/palettes/`, consumed via `createTokens`) — never applied to a rendered element. Styling is the consumer's responsibility. [intent:82, intent:278, intent:203]
 
 **Why.** v0 sits at the bottom of the stack. A single `class="px-4"` anywhere in source binds every downstream design system to UnoCSS defaults and breaks the promise that design systems can paint v0 with their own tokens. "Headless" that ships even one utility class is not headless.
 
@@ -81,7 +81,7 @@ Non-negotiable. Each axiom carries a statement, a rationale, and a concrete anti
 
 **Why.** `any` silently disables type-checking downstream. A single `as any` in a composable propagates into every consumer that spreads it. `unknown` forces the consumer to narrow, which is the correct contract.
 
-**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` anywhere in `packages/0/src/`.
+**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` in `packages/0/src/` — with one sanctioned exception: the slot-return type in `defineSlots<{ default: (props: SlotProps) => any }>()`, which Volar requires for correct slot inference (see §8.8). That `=> any` types the slot's *return*, never a value or argument, so it disables no downstream checking.
 
 **Anti-example (do not do this).**
 ```ts
@@ -135,15 +135,18 @@ import { createRegistry } from '../createRegistry'
 
 ---
 
-### 2.5 Composables never touch DOM events
+### 2.5 Composables never reach into the consumer's element tree
 
-**Statement.** Composables expose state and methods. Components bind those to DOM events. `blur`, `input`, `keydown`, `wheel`, `pointer*` — these appear only in `.vue` files. [intent:262, intent:263, intent:264]
+**Statement.** Composables expose state and methods; components bind those to DOM events. The dividing line is *how a composable obtains its target*, not which file the event word appears in. A composable must never create an element, query the DOM for one, or implicitly pick a rendered node — those are `.vue` concerns. `blur`, `input`, `change`, `wheel` on component-owned inputs appear only in `.vue` files. [intent:262, intent:263, intent:264]
 
-**Why.** Event binding couples a composable to the consumer's element tree. A composable that binds `keydown` directly picks the target for you; one that exposes `onKeydown(event)` lets the consumer decide. The second form composes; the first does not.
+**Why.** Event binding is a problem only when it couples a composable to a tree it does not own. A composable that `querySelector`s its target, or binds to an element it rendered, picks the tree for you; one that exposes `onKeydown(event)`, or binds via `useEventListener` to a target the consumer *injects*, does not. The first couples; the second composes.
 
-**Allowed.** The small set of browser-primitive composables whose entire purpose is to wrap a listener or a matched-media observer: `useEventListener`, `useHotkey`, `useClickOutside`, `useMediaQuery`. These are the boundary. Anything that sits on top of them is a component concern.
+**Allowed.** Two boundaries own listeners legitimately:
 
-**Anti-example (do not introduce).** A `createSlider` that internally binds `pointermove` to a passed `el` ref. The correct shape exposes `onPointerdown`, `onPointermove`, `onPointerup` and the `SliderThumb.vue` component wires them.
+- The browser-primitive composables whose entire purpose is to wrap a listener or matched-media observer: `useEventListener`, `useHotkey`, `useClickOutside`, `useMediaQuery`.
+- System composables that compose those primitives against an **explicitly injected** `MaybeRefOrGetter<EventTarget>` target, or a global (`document` / `window`) for session-scoped behavior. `useRovingFocus` and `useVirtualFocus` bind `keydown` to an injected container ref; `useDragDrop` adapters bind `pointer*` to `document`; `useStorage` listens for `storage` on `window`. The consumer supplies (or globally scopes) the target, so no tree is stolen — consistent with §5.2's `MaybeRefOrGetter<EventTarget>` input contract.
+
+**Anti-example (do not introduce).** A `createSlider` that calls `document.querySelector('.thumb')` (or renders and binds its own element) to attach `pointermove`. The correct shape exposes `onPointerdown`, `onPointermove`, `onPointerup` and the `SliderThumb.vue` component wires them — or, if it must own the listener, takes the thumb element as an injected `MaybeRefOrGetter<EventTarget>` rather than finding it.
 
 ---
 
@@ -305,7 +308,7 @@ return {
 }
 ```
 
-**3.1.2 Trinity tuple.** `[useX, provideX, defaultX] as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly two foundation factories: `createTrinity` and `createPlugin`. `createContext` returns the `[useX, provideX]` pair that `createTrinity` consumes and extends into the trinity. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
+**3.1.2 Trinity tuple.** `[useX, provideX, defaultX] as const` (registries) or `[createXContext, createXPlugin, useX] as const` (plugins). Returned from exactly two foundation factories: `createTrinity` and `createPluginContext`. (`createPlugin` itself returns a Vue plugin *object*, not the tuple; `createPluginContext` is the tuple-returning factory.) `createContext` returns the `[useX, provideX]` pair that `createTrinity` consumes and extends into the trinity. Every other "trinity-using" composable *consumes* these internally and returns a plain object. [intent:80, intent:119, intent:120]
 
 ```ts
 // packages/0/src/composables/createTrinity/index.ts:100-104
@@ -592,7 +595,7 @@ This is an acid test, not a vibe. If the only way to get state X to render diffe
 
 - **No DOM creation.** Composables do not `document.createElement`. They accept targets via `MaybeRefOrGetter<EventTarget>`. [intent:99]
 - **No visual state.** A composable never cares what color something is. `createRating` tracks a number; `RatingRoot.vue` tracks hover state internally — the composable is value-only. [intent:319, intent:320]
-- **No event binding.** Restated for emphasis: composables expose handlers, components wire them. [intent:262, intent:263]
+- **No event binding into an owned tree.** Composables expose handlers; components wire them. The exception is system composables that bind via `useEventListener` to an **injected** `MaybeRefOrGetter<EventTarget>` or a global — see §2.5. [intent:262, intent:263]
 
 ### 5.3 Components
 
@@ -603,7 +606,10 @@ This is an acid test, not a vibe. If the only way to get state X to render diffe
 
 ### 5.4 Hidden inputs
 
-Interactive inputs with a `name` prop render a `<ComponentHiddenInput>`: `inert`, `tabindex="-1"`, JSON-serialized for complex values, hidden via visually-hidden CSS. This is the native-form integration boundary; it is not styling. [intent:179, intent:187]
+Interactive inputs with a `name` prop render a `<ComponentHiddenInput>` for native-form integration. This is the boundary; it is not styling. Two tiers exist, by widget shape: [intent:179, intent:187]
+
+- **Focusable-mirror inputs** (`Checkbox`, `Radio`, `Switch`) — render a real `<input>` marked `inert` with `tabindex="-1"`, JSON-serialized for complex values, hidden via visually-hidden CSS. The mirror carries state the browser must see (checked, value) without stealing focus from the styled control.
+- **Value-only inputs** (`Rating`, `Slider`, `Progress`) — render a plain `<input type="hidden">`. There is nothing to focus or announce on the hidden node itself — the visible control owns interaction — so the `inert` / visually-hidden treatment is unnecessary; a native hidden input carries the value to form submission.
 
 ### 5.5 Locale-first strings
 
@@ -698,7 +704,7 @@ useProxyModel(context, model, { multiple })
 
 ### 6.7 `useProxyRegistry` — reactive view onto a registry
 
-**What.** Returns a shallow-reactive `{ keys, values, entries, size }` object that updates on every `register:ticket` / `unregister:ticket` / `update:ticket` / `clear:registry` / `reindex:registry` event. [intent:254]
+**What.** Returns a reactive `{ keys, values, entries, size }` object that updates on every `register:ticket` / `unregister:ticket` / `update:ticket` / `clear:registry` / `reindex:registry` event. [intent:254]
 
 **When to use.**
 - Templates need to iterate registry contents with `v-for`.
@@ -811,6 +817,8 @@ Components that defer the mount of **complex DOM** default to lazy. Expose only 
 
 **Scope.** "Complex DOM" means a sub-tree the user pays for only when an interaction opens it — Dialog content, Popover content, expanded Tabs panels, deferred Combobox lists. The point is keeping mount cost off the initial paint.
 
+**Current adopters.** `Combobox` and `Select` content implement the `useLazy` + `eager?` pattern today. `Dialog`, `Popover`, and `Tabs` panels are named here as the *target* for this convention but are always-mounted at present. Treat lazy + `eager?` as the standard for new deferred-content work; retrofitting the existing always-mounted components is a possible future enhancement, not a current guarantee.
+
 **Carve-outs.** Components whose entire identity is "manage the mount lifecycle" expose their own dedicated knobs and do not follow the `eager?` shorthand:
 
 - `Image` — `<Image.Img>` mounts on load-state transitions; the `Image.Placeholder` / `Image.Fallback` slots are the visible mount surface. There is no `eager` prop because the load lifecycle is the component.
@@ -824,7 +832,7 @@ Components use `onBeforeUnmount` for registry deregistration — not `onUnmounte
 
 ### 7.4 Presence state machine
 
-Mount-and-animate components follow the presence state machine: `UNMOUNTED → MOUNTED → PRESENT → LEAVING → UNMOUNTED`. `Presence` with `lazy: true` is the current replacement for the older `useLazy` pattern. [intent:313, intent:314]
+Mount-and-animate components follow the presence state machine. Default (eager): `UNMOUNTED → MOUNTED → PRESENT → LEAVING → UNMOUNTED`. With `lazy: true` the node is retained in the DOM after leave, so the terminal state is `MOUNTED`, not `UNMOUNTED` (`usePresence/index.ts:114` — `state = lazy ? 'mounted' : 'unmounted'`); a re-open resumes from `MOUNTED → PRESENT` and skips the initial mount. `Presence` / `usePresence` with `lazy: true` is the intended replacement for the older `useLazy` pattern; migration is in progress — `Combobox` and `Select` content still use `useLazy`. [intent:313, intent:314]
 
 ### 7.5 Conditional scopes with `useToggleScope`
 
@@ -955,7 +963,7 @@ Current exempt sites:
 
 ### 9.3 Namespace keys contain `:`
 
-Every key passed to `createContext(key)` or `createXContext({ namespace })` must contain a colon. `v0:` prefix for production keys, `test:` prefix for test-only keys. Missing colons trigger a `[v0:context]` warning. [intent:226, intent:227]
+Every key passed to `createContext(key)` or `createXContext({ namespace })` must contain a colon. Use the `v0:` prefix for keys — production and test alike (`v0:tabs`, `v0:test`, `v0:test-key`); source keeps a single `v0:` namespace rather than introducing a separate `test:` one. Missing colons trigger a `[v0:context]` warning. [intent:226, intent:227]
 
 **Static-key vs dynamic-key modes.** `createContext` operates in two modes:
 
@@ -1167,7 +1175,7 @@ Reason: §3.5, [intent:189, intent:206, intent:207].
 ```ts
 function createSlider (options) {
   const el = toElement(options.el)
-  document.addEventListener('pointermove', onPointermove)  // Wrong: composable bound a DOM listener
+  document.addEventListener('pointermove', onPointermove)  // Wrong: raw listener for a component-owned widget, no injected target, no scope cleanup (cf. the §2.5 carve-out for session-scoped system composables)
   // ...
 }
 ```
@@ -1285,7 +1293,7 @@ attrs: {
 ```ts
 const locale = useLocale()
 attrs: {
-  'aria-label': locale.t('$v0.dialog.close'),
+  'aria-label': locale.ti('Dialog.close') ?? 'Close',
 }
 ```
 


### PR DESCRIPTION
Audits `packages/0/PHILOSOPHY.md` against the current `packages/0/src` and fixes nine consistency drifts. Documentation only — no behavior change.

## Findings addressed

| § | Fix |
|---|-----|
| §1 / §2.1 | v0 owns the headless token substrate (`useTheme`, `createTokens`, `src/palettes/`, `apca`); Paper handles styling *application*. Reworded the identity claims that placed theme/color/tokens entirely in Paper while v0 ships them. |
| §2.2 | Carve out the sanctioned slot-return `=> any` — `defineSlots<{ default: (props) => any }>()` is Volar-required (§8.8) and used by 145 SFCs, so the "no `<any>` anywhere" absolute needed the exception. |
| §2.5 / §5.2 | Redraw the event-binding rule around *target provenance*, not file type. System composables (`useRovingFocus`, `useVirtualFocus`, `useDragDrop`, `useStorage`) legitimately own listeners via `useEventListener` against an **injected** or global target — consistent with §5.2's `MaybeRefOrGetter<EventTarget>` contract. |
| §3.1.2 | The trinity tuple is returned by `createPluginContext`, not `createPlugin` (which returns a Vue plugin object). |
| §5.4 | Document both hidden-input tiers: focusable-mirror (`Checkbox`/`Radio`/`Switch`, `inert`) vs value-only (`Rating`/`Slider`/`Progress`, `type="hidden"`). |
| §7.2 | Name current `useLazy` + `eager?` adopters (`Combobox`, `Select`) vs the always-mounted target components (`Dialog`, `Popover`, `Tabs`). |
| §7.4 | Document the `lazy: true` terminal state (`mounted`, not `unmounted`); soften the `useLazy`-replacement claim (`Combobox`/`Select` still use it). |
| §9.3 | Test namespace keys use the `v0:` prefix (`v0:test`), matching `testing.md` and source — not a separate `test:` namespace. |
| §6.7 | `useProxyRegistry` returns `reactive()`, not "shallow-reactive". |
| §10.13 | Fix the locale example to the real idiom: `locale.ti('Dialog.close') ?? 'Close'`. |

## Deliberately not changed
- §5.5 stays strict. `ComboboxEmpty` hardcodes a `No results` slot default (a real §5.5 gap) — the rule is correct, so the source is brought into compliance via a follow-up rather than weakening the doc: #528.
- §5.5 `ProgressRoot` `aria-valuetext` `${pct}%` is number formatting, not a translatable phrase — out of scope.