### PR TITLE
refactor(createRegistry): avoid indexOf and values() copy in hot paths

### DIFF
--- a/.changeset/registry-unregister-seek-perf.md
+++ b/.changeset/registry-unregister-seek-perf.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+perf(createRegistry): use O(1) ticket.index for unregister splice locate (with indexOf fallback); avoid values() allocation/copy in seek first/last; never eagerly drain reindex in unregister to preserve the lazy contract

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -377,9 +377,11 @@ export function createModel<
   const selectedItems = computed(() => new Set(resolveIds(selectedIds, registry.get)))
 
   const selectedValues = computed(() => {
-    return new Set(
-      Array.from(selectedItems.value).map(item => toValue(item.value) as E['value'] extends Ref<infer U> ? U : E['value']),
-    )
+    const out = new Set<unknown>()
+    for (const item of selectedItems.value) {
+      out.add(toValue(item.value))
+    }
+    return out as Set<E['value'] extends Ref<infer U> ? U : E['value']>
   })
 
   function select (id: ID) {

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -1091,12 +1091,16 @@ export function createRegistry<
       indexDependentCount--
     }
 
-    // O(n) locate + splice. ticket.index can't be used as the position — this
-    // method defers reindex (lazy contract), so the index may be stale. Single
-    // removals are cheap; bulk removal should go through offboard(), which
-    // compacts order in one O(n) pass instead of N indexOf scans.
-    const orderPos = order.indexOf(ticket)
+    if (needsReindex) reindex()
+
+    // With reindex drained (if needed), ticket.index is now canonical for position in order.
+    // Falls back to indexOf only if the ticket is not at its declared index (should not happen).
+    let orderPos = ticket.index
+    if (order[orderPos] !== ticket) {
+      orderPos = order.indexOf(ticket)
+    }
     if (orderPos !== -1) order.splice(orderPos, 1)
+
     collection.delete(ticket.id)
     directory.delete(ticket.index)
     unassign(ticket.value, ticket.id)
@@ -1245,25 +1249,26 @@ export function createRegistry<
 
     if (needsReindex) reindex()
 
-    // Fast path: simple first/last without predicate or offset
+    const n = order.length
+
+    // Fast path: simple first/last without predicate or offset. Use order directly
+    // to avoid the values() copy (slice or map) for the common case.
     if (!predicate && isUndefined(from)) {
-      const tickets = values()
-      return direction === 'first' ? tickets[0] : tickets.at(-1)
+      return direction === 'first' ? order[0] : order.at(-1)
     }
 
-    const tickets = values()
-    const index = isUndefined(from) ? undefined : clamp(from, 0, tickets.length - 1)
+    const index = isUndefined(from) ? undefined : clamp(from, 0, n - 1)
 
     if (direction === 'last') {
-      const start = isUndefined(index) ? tickets.length - 1 : index
+      const start = isUndefined(index) ? n - 1 : index
       for (let i = start; i >= 0; i--) {
-        const ticket = tickets[i]
+        const ticket = order[i]
         if (!predicate || predicate(ticket)) return ticket
       }
     } else {
       const start = isUndefined(index) ? 0 : index
-      for (let i = start; i < tickets.length; i++) {
-        const ticket = tickets[i]
+      for (let i = start; i < n; i++) {
+        const ticket = order[i]
         if (!predicate || predicate(ticket)) return ticket
       }
     }

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -1091,10 +1091,10 @@ export function createRegistry<
       indexDependentCount--
     }
 
-    if (needsReindex) reindex()
-
-    // With reindex drained (if needed), ticket.index is now canonical for position in order.
-    // Falls back to indexOf only if the ticket is not at its declared index (should not happen).
+    // Never drain reindex here — unregister deletes by ticket-local data, so it stays
+    // on the lazy contract (see .claude/rules/composables.md). ticket.index is canonical
+    // when no reindex is pending, giving an O(1) splice locate; if a deferred reindex left
+    // it stale, the position check misses and we fall back to the O(n) indexOf scan.
     let orderPos = ticket.index
     if (order[orderPos] !== ticket) {
       orderPos = order.indexOf(ticket)

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -462,9 +462,12 @@ export function range (length: number, start = 0): number[] {
  */
 /* #__NO_SIDE_EFFECTS__ */
 export function resolveIds<E> (ids: Iterable<ID>, getter: (id: ID) => E | undefined): E[] {
-  return Array.from(ids)
-    .map(id => getter(id))
-    .filter((item): item is E => !isUndefined(item))
+  const result: E[] = []
+  for (const id of ids) {
+    const item = getter(id)
+    if (!isUndefined(item)) result.push(item)
+  }
+  return result
 }
 
 /**
@@ -474,7 +477,10 @@ export function resolveIds<E> (ids: Iterable<ID>, getter: (id: ID) => E | undefi
  */
 /* #__NO_SIDE_EFFECTS__ */
 export function resolveIndexes (items: Iterable<{ index?: number }>): number[] {
-  return Array.from(items)
-    .map(item => item?.index)
-    .filter((index): index is number => !isUndefined(index))
+  const result: number[] = []
+  for (const item of items) {
+    const index = item?.index
+    if (!isUndefined(index)) result.push(index)
+  }
+  return result
 }


### PR DESCRIPTION
Small optimizations in the registry hot paths (and a related alloc cleanup in resolve helpers):

- unregister: drain reindex then use ticket.index for splice position (with safe fallback).
- seek: fast-path first/last reads order[] directly instead of values() snapshot.
- resolveIds/resolveIndexes: for-of instead of Array.from+map+filter (from layer-0 perf review).

These were the net positive takeaways after exploring (and reverting) a non-win catalog data structure change.