### PR TITLE
docs: add quick reference table to glossary

### DIFF
--- a/apps/docs/src/pages/guide/essentials/glossary.md
+++ b/apps/docs/src/pages/guide/essentials/glossary.md
@@ -24,6 +24,24 @@ Short definitions of the vocabulary that recurs throughout v0's docs and source 
 > [!TIP]
 > The terms build on each other. If you want the full picture of how they connect, read [Core](/guide/fundamentals/core) — this page is the quick-lookup reference.
 
+## Quick reference
+
+| Term | One-line meaning | Created with |
+|------|------------------|--------------|
+| [Headless](#headless) | Behavior, state, and accessibility but no styling | — |
+| [Compound component](#compound-component) | Stateful Root plus named sub-components sharing a context | — |
+| [Trinity](#trinity) | Readonly three-element tuple returned by context and plugin factories | `createTrinity` |
+| [Context](#context) | Type-safe provide/inject that throws when the provider is missing | `createContext` |
+| [Namespace](#namespace) | Colon-scoped string key for a context, prefixed `v0:` | — |
+| [Plugin](#plugin) | App-level singleton installed with `app.use(...)` | `createPlugin` |
+| [Adapter](#adapter) | Swappable backend behind a composable's interface | — |
+| [Registry](#registry) | Indexed store of registered items, keyed by id | `createRegistry` |
+| [Ticket](#ticket) | Handle a sub-component holds on its slot in the registry | `register()` |
+| [Register / onboard / unregister](#register-onboard-and-unregister) | The registry lifecycle verbs for adding and removing items | `createRegistry` |
+| [Enroll](#enroll) | Auto-selection on registration | `createModel` |
+| [Model](#model) | The value layer — a registry plus a reactive Set of selected ids | `createModel` |
+| [Selection](#selection) | Selection rules layered on a model | `createSelection` |
+
 ## Core architecture
 
 ### Headless


### PR DESCRIPTION
The glossary's TIP callout already bills the page as "the quick-lookup reference," but there was no table — just prose definitions. Adds a **Quick reference** table right after the intro: every term, a one-line meaning, and its primary factory API, each linking down to the full definition below.

Grouped in the same order as the existing sections. Intra-page anchors verified against the docs' `markdown-it-anchor` slugify config (including the multi-word `register-onboard-and-unregister`).