### PR TITLE
docs: use canonical discord.gg/vuetify invite

### DIFF
--- a/.github/workflows/close-invalid-issues.yml
+++ b/.github/workflows/close-invalid-issues.yml
@@ -35,7 +35,7 @@ jobs:
             [issue creator](https://issues.vuetifyjs.com/?repo=vuetify0).
             Issues opened without it are closed automatically.
             For general questions, please join
-            [the Discord chat room](https://community.vuetifyjs.com). Thank you.
+            [the Discord chat room](https://discord.gg/vuetify). Thank you.
         run: |
           gh issue comment "$NUMBER" --repo "$REPO" --body "$COMMENT"
           gh issue edit "$NUMBER" --repo "$REPO" --add-label invalid

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ Community leaders have the right and responsibility to remove, edit, or reject c
 
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Community spaces operated by the Vuetify team include:
 
-* The [Vuetify Discord server](https://community.vuetifyjs.com)
+* The [Vuetify Discord server](https://discord.gg/vuetify)
 * The [vuetifyjs GitHub organization](https://github.com/vuetifyjs) — issues, discussions, pull requests, and code review
 * Official Vuetify social media accounts
 * Official events, online or offline

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -114,7 +114,7 @@
         v-if="isHomePage || settings.showSocialLinks.value"
         aria-label="Discord Community (opens in new tab)"
         class="bg-[#5865F2] text-white pa-1 inline-flex rounded opacity-90 hover:opacity-100"
-        href="https://discord.gg/vK6T89eNP7"
+        href="https://discord.gg/vuetify"
         rel="noopener noreferrer"
         target="_blank"
         title="Discord Community"

--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -29,7 +29,7 @@
   const footerRef = useTemplateRef<HTMLElement | null>('footer')
 
   const links = [
-    { icon: 'discord', href: 'https://discord.gg/vK6T89eNP7', label: 'Discord', bg: 'bg-discord' },
+    { icon: 'discord', href: 'https://discord.gg/vuetify', label: 'Discord', bg: 'bg-discord' },
     { icon: 'github', href: 'https://github.com/vuetifyjs/0', label: 'GitHub', bg: 'bg-[#24292f]' },
     { icon: 'heart', href: GITHUB_SPONSORS, label: 'Sponsor', bg: 'bg-[#bf3989]' },
   ]

--- a/apps/docs/src/components/docs/DocsCallout.vue
+++ b/apps/docs/src/components/docs/DocsCallout.vue
@@ -101,7 +101,7 @@
     if (props.type === 'askai' && props.question) {
       ask.ask(decodeQuestion(props.question))
     } else if (props.type === 'discord') {
-      window.open('https://discord.gg/vK6T89eNP7', '_blank', 'noopener,noreferrer')
+      window.open('https://discord.gg/vuetify', '_blank', 'noopener,noreferrer')
     } else if (props.type === 'tour' && props.tourId) {
       if (!tour.value) return
 

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -231,7 +231,7 @@
 
           <a
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
-            href="https://community.vuetifyjs.com/"
+            href="https://discord.gg/vuetify"
             rel="noopener"
             target="_blank"
             title="Discuss on Discord"

--- a/apps/docs/src/components/home/HomeCta.vue
+++ b/apps/docs/src/components/home/HomeCta.vue
@@ -15,7 +15,7 @@
     {
       title: 'Join Discord',
       description: 'Get help, share ideas, showcase your work.',
-      to: 'https://community.vuetifyjs.com',
+      to: 'https://discord.gg/vuetify',
       icon: 'discord',
     },
   ]

--- a/apps/docs/src/pages/introduction/code-of-conduct.md
+++ b/apps/docs/src/pages/introduction/code-of-conduct.md
@@ -47,7 +47,7 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 This Code of Conduct applies within all community spaces operated by the Vuetify team:
 
-- The [Vuetify Discord server](https://community.vuetifyjs.com) — support channels, showcase, and general chat
+- The [Vuetify Discord server](https://discord.gg/vuetify) — support channels, showcase, and general chat
 - The [vuetifyjs GitHub organization](https://github.com/vuetifyjs) — issues, discussions, pull requests, and code review
 - Official Vuetify social media accounts
 - Official events, online or offline

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -25,7 +25,7 @@ Before contributing, please:
 
 1. Read the [Getting Started](/introduction/getting-started) guide to understand the project
 2. Review existing [issues](https://github.com/vuetifyjs/0/issues)
-3. Join our [Discord community](https://community.vuetifyjs.com) for questions
+3. Join our [Discord community](https://discord.gg/vuetify) for questions
 
 ## Reporting Issues
 

--- a/apps/docs/src/pages/introduction/frequently-asked.md
+++ b/apps/docs/src/pages/introduction/frequently-asked.md
@@ -19,7 +19,7 @@ Common questions and answers about Vuetify0.
 
 <DocsPageFeatures :frontmatter />
 
-Have a question that isn't answered here? Try [Ask AI](/guide/essentials/using-the-docs#ask-ai) for instant answers, join our [Discord community](https://community.vuetifyjs.com), or open an [issue on GitHub](https://github.com/vuetifyjs/0/issues).
+Have a question that isn't answered here? Try [Ask AI](/guide/essentials/using-the-docs#ask-ai) for instant answers, join our [Discord community](https://discord.gg/vuetify), or open an [issue on GitHub](https://github.com/vuetifyjs/0/issues).
 
 ::: faq
 ??? What is Vuetify0?
@@ -84,7 +84,7 @@ See the [Contributing](/introduction/contributing) page for guidelines. The proj
 
 ??? Where can I get help?
 
-[GitHub Issues](https://github.com/vuetifyjs/0/issues) for bug reports and feature requests, or the [Vuetify Discord](https://community.vuetifyjs.com) community for real-time chat and questions.
+[GitHub Issues](https://github.com/vuetifyjs/0/issues) for bug reports and feature requests, or the [Vuetify Discord](https://discord.gg/vuetify) community for real-time chat and questions.
 :::
 
 ::: sponsor

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -89,7 +89,7 @@ Whether you want to explore in the browser, scaffold a project, or integrate wit
 
 **Report a bug or request a feature** — [Open an issue](https://github.com/vuetifyjs/0/issues) on GitHub.
 
-**Ask a question or join the conversation** — Find us on [Discord](https://community.vuetifyjs.com).
+**Ask a question or join the conversation** — Find us on [Discord](https://discord.gg/vuetify).
 
 **Contribute code** — PRs are welcome. See the [contributing guide](/introduction/contributing) for how to get started.
 
@@ -144,7 +144,7 @@ See the [contributing guide](/introduction/contributing). PRs are welcome for bu
 
 ??? Where can I get help?
 
-Join the [Discord](https://community.vuetifyjs.com) community. You can also use the AI assistant built into the docs — look for the Ask AI button on any page.
+Join the [Discord](https://discord.gg/vuetify) community. You can also use the AI assistant built into the docs — look for the Ask AI button on any page.
 :::
 
 ::: sponsor


### PR DESCRIPTION
Normalizes all Discord links across the repo to the vanity invite `discord.gg/vuetify`:

- Replaces the `discord.gg/vK6T89eNP7` invite in the docs AppBar, AppFooter, and DocsCallout.
- Replaces the legacy `community.vuetifyjs.com` (old Discourse-era community URL) across CODE_OF_CONDUCT.md, the close-invalid-issues workflow, and docs pages/components (roadmap, FAQ, contributing, code-of-conduct, DocsReleases, HomeCta).

The package README already used the canonical link.