### PR TITLE
docs(ai-tools): add Grok Build

### DIFF
--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -6,9 +6,9 @@ features:
   level: 1
 meta:
   - name: description
-    content: Use llms.txt and llms-full.txt files to provide AI assistants like Claude, ChatGPT, and Cursor with comprehensive Vuetify0 documentation context.
+    content: Use llms.txt and llms-full.txt files to provide AI assistants like Claude, ChatGPT, Grok, and Cursor with comprehensive Vuetify0 documentation context.
   - name: keywords
-    content: llms.txt, AI tools, LLM, Claude, ChatGPT, Cursor, documentation, developer experience
+    content: llms.txt, AI tools, LLM, Claude, ChatGPT, Grok, Cursor, documentation, developer experience
 related:
   - /guide/tooling/vuetify-mcp
   - /guide/tooling/vuetify-cli
@@ -31,13 +31,13 @@ v0 provides machine-readable documentation files following the [llms.txt](https:
 | - | - | - | - |
 | <a href="/llms.txt" target="_blank" class="v0-link">llms.txt↗</a> | {{ llmsStats.llms.sizeFormatted }} | Curated index with links | Quick context, navigation |
 | <a href="/llms-full.txt" target="_blank" class="v0-link whitespace-nowrap">llms-full.txt↗</a> | {{ llmsStats.llmsFull.sizeFormatted }} | Complete documentation | Deep understanding, code generation |
-| <a href="/SKILL.md" target="_blank" class="v0-link">SKILL.md↗</a> | ~5KB | Patterns & anti-patterns | Claude Code, Cursor, Windsurf |
+| <a href="/SKILL.md" target="_blank" class="v0-link">SKILL.md↗</a> | ~5KB | Patterns & anti-patterns | Claude Code, Grok Build, Cursor, Windsurf |
 
 > [!ASKAI] How do I configure my AI agent to consume llms-full.txt?
 
 ## Usage
 
-Install SKILL.md via [skills.sh](https://www.skills.sh) — works with Claude Code, Cursor, Windsurf, Codex, and [35+ agents](https://github.com/vercel-labs/skills#supported-agents):
+Install SKILL.md via [skills.sh](https://www.skills.sh) — works with Claude Code, Grok Build, Cursor, Windsurf, Codex, and [35+ agents](https://github.com/vercel-labs/skills#supported-agents):
 
 ```bash
 npx skills add vuetifyjs/0
@@ -56,6 +56,20 @@ Or fetch docs directly in your session:
 ```text
 WebFetch https://0.vuetifyjs.com/llms-full.txt
 ```
+
+**Grok Build** — Add Vuetify MCP for structured API access:
+
+```bash
+grok mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
+```
+
+Or fetch docs directly in your session:
+
+```text
+WebFetch https://0.vuetifyjs.com/llms-full.txt
+```
+
+Grok also loads SKILL.md (via `npx skills add vuetifyjs/0` or `.grok/skills/`) and project rules from `AGENTS.md` / `CLAUDE.md`.
 
 **Cursor / Windsurf** — Add to .cursorrules or configure MCP:
 
@@ -166,7 +180,7 @@ Hallucinated v0 APIs fail to compile. Run `vue-tsc --noEmit` (or `tsc --noEmit`)
 
 **llms-full.txt** includes the complete content of every documentation page, stripped of Vue components and frontmatter for cleaner LLM consumption.
 
-**SKILL.md** is a compact reference optimized for AI coding assistants. It focuses on decision trees, code conventions, anti-patterns, and the composition hierarchy. Detailed API examples live in a separate [REFERENCE.md](/references/REFERENCE.md) that agents load on demand. Install via [skills.sh](https://www.skills.sh) (`npx skills add vuetifyjs/0`) to make it available across Claude Code, Cursor, Windsurf, and 35+ other agents.
+**SKILL.md** is a compact reference optimized for AI coding assistants. It focuses on decision trees, code conventions, anti-patterns, and the composition hierarchy. Detailed API examples live in a separate [REFERENCE.md](/references/REFERENCE.md) that agents load on demand. Install via [skills.sh](https://www.skills.sh) (`npx skills add vuetifyjs/0`) to make it available across Claude Code, Grok Build, Cursor, Windsurf, and 35+ other agents.
 
 ## How It Works
 


### PR DESCRIPTION
Add Grok Build to the AI Tools documentation page.

- Document MCP server setup via `grok mcp add`
- Note SKILL.md discovery and AGENTS.md/CLAUDE.md support
- Reorder mentions so Grok appears before Cursor/Windsurf in lists
- Update meta and compatibility notes