### PR TITLE
ci(metrics): auto-regen benchmark history on every release

### DIFF
--- a/.github/workflows/metrics-regen.yml
+++ b/.github/workflows/metrics-regen.yml
@@ -4,15 +4,19 @@ name: Regenerate Metrics
 # then opens an auto-PR for review. Never pushes to master directly — close the
 # PR to discard a noisy run.
 #
-# Trigger: a published GitHub Release. In this changesets setup the aggregate
-# `v*` release is the terminal, success-gated artifact of a publish (it runs
-# last, only when a publish actually happened), so `release: published` is the
-# right moment — and it never fires on plain master pushes or "version packages"
-# PR churn. The harness installs each configured version from npm and benches it
-# with the current suite (fixed apparatus), so no git tags/worktrees are needed.
+# Trigger: completion of the Release workflow (NOT `on: release: published`).
+# The aggregate `v*` release is minted by scripts/github-release.js with the
+# default GITHUB_TOKEN, and GitHub deliberately does not fire event triggers for
+# actions taken by that token (recursion prevention) — so `release: published`
+# never runs on an automated publish. `workflow_run` fires when the upstream
+# workflow finishes regardless of the token that drove it, which is the
+# sanctioned chain. Release runs on every master push (most just open the
+# "Version Packages" PR and publish nothing), so the job gates on upstream
+# success AND a newly published 1.x version that has no snapshot yet — see `gate`.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -25,13 +29,12 @@ permissions:
 
 jobs:
   regen:
-    # Substrate `v*` releases only — skip the independent @paper/* design-system
-    # releases (which tag as `name@version`, not `v*`).
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04 # pinned, NOT ubuntu-latest — OS drift moves benchmark numbers
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: master # workflow_run checks out a detached SHA otherwise; create-pull-request needs a branch base
           fetch-depth: 0 # full history for create-pull-request
 
       - uses: pnpm/action-setup@v6
@@ -41,33 +44,55 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      # Discover published 1.x versions from npm and list those with no snapshot.
+      # On the automatic (workflow_run) path, skip the expensive bench when nothing
+      # new shipped. A manual dispatch always proceeds — e.g. to re-measure the
+      # whole series after a bench-suite change even though no version is new.
+      - name: Gate on new version
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          MISSING=$(node scripts/generate-metrics-history.ts --print-missing)
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ -z "$MISSING" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No new 1.x version to bench — skipping regen."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Regenerating — missing: ${MISSING:-<none; manual dispatch>}"
+          fi
+
       # Fixed apparatus: the current bench suite + toolchain measure each version's
-      # npm-installed dist, so the series is comparable. --force re-measures every
-      # configured version each run (each = npm install + bench); drop --force to
-      # generate only newly-added versions.
+      # npm-installed dist, so the series is comparable. The version set is
+      # discovered from npm per scripts/metrics-history.config.ts. --force
+      # re-measures every discovered version each run (each = npm install + bench)
+      # so old snapshots stay comparable with the current suite.
       - name: Regenerate history series
+        if: steps.gate.outputs.run == 'true'
         run: pnpm metrics:history --force
 
       - name: Regenerate current metrics
+        if: steps.gate.outputs.run == 'true'
         run: pnpm metrics
 
       - name: Open/update auto-PR
+        if: steps.gate.outputs.run == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          base: master # required — checkout is a detached commit on the workflow_run path
           commit-message: "chore: regenerate benchmark + history metrics"
           title: "chore: regenerate benchmark + history metrics"
           body: |
-            Auto-regenerated on release, pinned to `ubuntu-24.04` + Node from `.nvmrc`.
+            Auto-regenerated after a release, pinned to `ubuntu-24.04` + Node from `.nvmrc`.
 
             The full history series is re-measured on one runner (`metrics:history --force`)
-            so the per-row sparklines stay comparable across versions.
+            so the per-row sparklines stay comparable across versions. The version set is
+            discovered from npm — every published 1.x release is picked up automatically
+            (policy lives in `scripts/metrics-history.config.ts`; no per-release edit).
 
             Benchmark hz is jittery (~10–20% on shared CI runners), so near-threshold
             tier badges may flip without a code change. **Close this PR to discard the
             run** if the numbers look like noise.
-
-            To add a historical version, append it to `scripts/metrics-history.config.ts`
-            (must be published to npm; track the 1.x line).
           branch: chore/metrics-regen
           add-paths: |
             apps/docs/public/benchmarks.json

--- a/scripts/generate-metrics-history.ts
+++ b/scripts/generate-metrics-history.ts
@@ -5,7 +5,10 @@
  * against each version's code installed from npm. Only the library varies, so the
  * series is comparable across versions and survives future bench/toolchain changes.
  *
- * For each version in `metrics-history.config.ts`:
+ * The version set is DISCOVERED from npm per the policy in
+ * `metrics-history.config.ts` (major line + `since` floor + `exclude`), so new
+ * 1.x releases are benched automatically without editing config. For each
+ * discovered version:
  *   1. Skip if `apps/docs/src/data/metrics/<version>.json` exists (unless --force)
  *   2. `npm install @vuetify/v0@<version>` into an isolated temp dir
  *   3. Run the current benches with `V0_BENCH_TARGET=<install>/dist` so vitest
@@ -20,8 +23,11 @@
  *
  * Flags:
  *   --force             Regenerate even if the output file exists
- *   --only <version>    Process only the given version
- *   --list              Print what would be done; do not run
+ *   --only <version>    Process only the given version (skips discovery)
+ *   --list              Print discovered versions + snapshot status; do not run
+ *   --print-missing     Print space-separated discovered versions lacking a
+ *                       snapshot file, then exit. The CI gate uses this to decide
+ *                       whether a publish introduced anything new to bench.
  */
 
 import { execFileSync } from 'node:child_process'
@@ -31,7 +37,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { buildItemBenchmarks, extractName, type ItemBenchmarks } from './lib/benchmarks.ts'
-import { versions } from './metrics-history.config.ts'
+import { config } from './metrics-history.config.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -44,9 +50,85 @@ interface HistoryFile {
   error?: string
 }
 
-function parseArgs (argv: string[]): { force: boolean, only: string | null, list: boolean } {
+interface Semver {
+  major: number
+  minor: number
+  patch: number
+  /** Prerelease identifiers, e.g. `['beta', 3]`; empty for a stable release. */
+  pre: (string | number)[]
+}
+
+/** Parse `M.m.p` or `M.m.p-pre.n`. Throws on anything that isn't valid semver. */
+function parseVersion (version: string): Semver {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(version)
+  if (!match) throw new Error(`unparseable version: ${version}`)
+  const [, major, minor, patch, pre] = match
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    pre: pre ? pre.split('.').map(id => (/^\d+$/.test(id) ? Number(id) : id)) : [],
+  }
+}
+
+/**
+ * Semver precedence (SemVer §11). Numeric release parts compare numerically; a
+ * version WITH a prerelease sorts BELOW the same version without one; prerelease
+ * identifiers compare field-by-field (numeric < numeric numerically, otherwise
+ * ASCII, numeric identifiers always below non-numeric). Enough for the 1.x line's
+ * `alpha < beta < rc < <stable>` cuts without pulling in the `semver` dependency.
+ */
+function compareVersion (a: string, b: string): number {
+  const x = parseVersion(a)
+  const y = parseVersion(b)
+  if (x.major !== y.major) return x.major - y.major
+  if (x.minor !== y.minor) return x.minor - y.minor
+  if (x.patch !== y.patch) return x.patch - y.patch
+  // A prerelease has lower precedence than the associated stable release.
+  if (x.pre.length === 0 || y.pre.length === 0) {
+    return (x.pre.length === 0 ? 1 : 0) - (y.pre.length === 0 ? 1 : 0)
+  }
+  for (let i = 0; i < Math.max(x.pre.length, y.pre.length); i++) {
+    const l = x.pre[i]
+    const r = y.pre[i]
+    if (l === undefined) return -1 // shorter set of identifiers has lower precedence
+    if (r === undefined) return 1
+    if (l === r) continue
+    const ln = typeof l === 'number'
+    const rn = typeof r === 'number'
+    if (ln && rn) return l - (r as number)
+    if (ln !== rn) return ln ? -1 : 1 // numeric identifiers always rank below strings
+    return String(l) < String(r) ? -1 : 1
+  }
+  return 0
+}
+
+/**
+ * Discover the versions to bench from npm, applying the config policy: on the
+ * configured `major` line, at or above the `since` floor, minus `exclude`, sorted
+ * oldest → newest. Throws (rather than returning an empty set) if npm is
+ * unreachable, so a network blip fails loud instead of silently regenerating none.
+ */
+function discoverVersions (): string[] {
+  let raw: string
+  try {
+    raw = execFileSync('npm', ['view', '@vuetify/v0', 'versions', '--json'], { encoding: 'utf8' })
+  } catch (error) {
+    throw new Error(`npm view @vuetify/v0 versions failed: ${(error as Error).message}`, { cause: error })
+  }
+  const parsed: unknown = JSON.parse(raw)
+  const all: string[] = Array.isArray(parsed) ? parsed : [parsed as string]
+  return all
+    .filter(v => parseVersion(v).major === config.major)
+    .filter(v => compareVersion(v, config.since) >= 0)
+    .filter(v => !config.exclude.includes(v))
+    .toSorted(compareVersion)
+}
+
+function parseArgs (argv: string[]): { force: boolean, only: string | null, list: boolean, printMissing: boolean } {
   let force = false
   let list = false
+  let printMissing = false
   let only: string | null = null
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -59,13 +141,17 @@ function parseArgs (argv: string[]): { force: boolean, only: string | null, list
         list = true
         break
       }
+      case '--print-missing': {
+        printMissing = true
+        break
+      }
       case '--only': {
         only = argv[++i] ?? null
         break
       }
     }
   }
-  return { force, only, list }
+  return { force, only, list, printMissing }
 }
 
 function outputPath (version: string): string {
@@ -150,25 +236,31 @@ function processVersion (version: string, force: boolean): void {
 }
 
 function main (): void {
-  const { force, only, list } = parseArgs(process.argv.slice(2))
+  const { force, only, list, printMissing } = parseArgs(process.argv.slice(2))
 
-  const selected = only ? [only] : versions
-  if (only && !versions.includes(only)) {
-    console.warn(`--only ${only}: not in config, running anyway`)
-  }
+  // `--only` targets one explicit version and skips npm discovery entirely, so it
+  // stays usable offline / for one-off re-measures.
+  const discovered = only ? [only] : discoverVersions()
 
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true })
 
+  if (printMissing) {
+    // Machine-readable gate output: only the versions with no snapshot yet, on
+    // one line. The CI regen job skips the (expensive) bench run when empty.
+    console.log(discovered.filter(v => !existsSync(outputPath(v))).join(' '))
+    return
+  }
+
   if (list) {
-    console.log('Versions in config:')
-    for (const v of selected) {
+    console.log('Discovered versions:')
+    for (const v of discovered) {
       const status = existsSync(outputPath(v)) ? 'exists' : 'missing'
       console.log(`  ${v}  [${status}]`)
     }
     return
   }
 
-  for (const v of selected) processVersion(v, force)
+  for (const v of discovered) processVersion(v, force)
 }
 
 main()

--- a/scripts/metrics-history.config.ts
+++ b/scripts/metrics-history.config.ts
@@ -1,18 +1,30 @@
 /**
- * Versions to collect historical benchmark metrics for — must be published to npm.
+ * Policy for which published `@vuetify/v0` versions get a historical benchmark
+ * snapshot.
+ *
+ * Versions are DISCOVERED from npm at run time (see `generate-metrics-history.ts`)
+ * rather than hand-listed, so every new 1.x release is picked up automatically —
+ * no config edit per release. This file only tunes the filter:
+ *
+ *   - `major`   — only versions on this major line are tracked.
+ *   - `since`   — floor; versions ordered below this are ignored (skips the
+ *                 pre-`beta.0` alphas, which predate the comparable series).
+ *   - `exclude` — explicit versions to drop even if published (yanked/broken cuts).
  *
  * The harness installs `@vuetify/v0@<version>` and benches it with the CURRENT
- * suite + toolchain (see `generate-metrics-history.ts`), so versions are directly
- * comparable. Track the 1.0 line onward; append each 1.x release as it ships.
- *
- * Re-run `pnpm metrics:history` after adding an entry (existing per-version files
- * are skipped; `--force` re-measures all). To retire a version, delete its
- * `apps/docs/src/data/metrics/<version>.json` and remove it here — the docs trend
- * lines read whatever snapshot files remain in that directory.
+ * suite + toolchain, so versions stay directly comparable. To retire a version,
+ * delete its `apps/docs/src/data/metrics/<version>.json` and (if it would
+ * otherwise be rediscovered) add it to `exclude` — the docs trend lines read
+ * whatever snapshot files remain in that directory.
  */
-export const versions: string[] = [
-  '1.0.0-beta.0',
-  '1.0.0-beta.1',
-  '1.0.0-beta.2',
-  '1.0.0-beta.3',
-]
+interface HistoryConfig {
+  major: number
+  since: string
+  exclude: string[]
+}
+
+export const config: HistoryConfig = {
+  major: 1,
+  since: '1.0.0-beta.0',
+  exclude: [],
+}


### PR DESCRIPTION
The historical benchmark series was frozen at `1.0.0-beta.3` because the auto-regen pipeline never worked end-to-end. Three independent breaks, any one of which alone stalls the series:

## 1. The release trigger could never fire
`metrics-regen.yml` listened on `release: published`. But the aggregate `v*` release is minted by `scripts/github-release.js` using the default `GITHUB_TOKEN`, and GitHub deliberately does not fire event triggers for actions taken by that token (recursion prevention). So an automated publish never woke the workflow.

**Fix:** switch to `workflow_run` on the **Release** workflow completing — it fires regardless of which token drove the upstream run.

## 2. The PR step died on a detached-HEAD checkout
The one run that did fire (a manual `v1.0.0-beta.4` publish) benched for 35 min, then failed:

```
##[error]When the repository is checked out on a commit instead of a branch, the base input must be supplied.
```

**Fix:** check out `master` and pass `base: master` to `create-pull-request`.

## 3. The version set was a hand-maintained list ending at beta.3
`metrics-history.config.ts` was a literal array `[beta.0 … beta.3]`; the harness only measured what was listed, so beta.4/beta.5/rc.6 were never benched even on a successful run.

**Fix:** discover published `1.x` versions from npm at run time. The config is now declarative policy (`major` line + `since` floor + `exclude`); each release is picked up automatically. A small SemVer §11 comparator handles `alpha < beta < rc < stable` ordering without adding the `semver` dependency.

## Cost control
Release runs on every master push (most publish nothing). A new `--print-missing` gate lists discovered versions lacking a snapshot; the `workflow_run` path skips the expensive bench when nothing new shipped. Manual `workflow_dispatch` always re-measures the whole series (e.g. after a bench-suite change).

## Verification
- `--list` / `--print-missing` discover `beta.4 beta.5 rc.6` as the missing set, correctly ordered, alphas floored out.
- Comparator invariants asserted (stable > rc > beta > alpha, numeric patch/prerelease ordering).
- `pnpm lint`, `pnpm typecheck`, `pnpm repo:check` all green.
- Workflow YAML validated; `base: master` + `ref: master` guard the detached-HEAD path.

Once merged, a manual `workflow_dispatch` on **Regenerate Metrics** will catch the docs up through rc.6 on the pinned runner.