### PR TITLE
perf(createRegistry): memoize reactive keys/values/entries behind a version signal

### DIFF
--- a/.changeset/quick-donkeys-brake.md
+++ b/.changeset/quick-donkeys-brake.md
@@ -1,0 +1,13 @@
+---
+'@vuetify/v0': patch
+---
+
+perf(createRegistry): memoize reactive keys/values/entries behind a version signal
+
+Reactive-mode iteration reads previously bypassed the result cache and read the
+order array through its shallowReactive proxy — one trap per index and, inside
+an effect, one tracked dependency per index. Reads now touch a single version
+signal (bumped on every structural mutation) and share the non-reactive cache,
+making reactive reads O(1) between mutations and giving subscribing effects one
+dependency regardless of collection size. Mid-batch reads now always reflect
+mutations already applied instead of a stale pre-batch snapshot.

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -546,7 +546,7 @@ createOverflow({ gap: () => gap })
 
 ### 4.4 Registry reactivity
 
-`reactive: true` on a registry wraps the internal collection as `shallowReactive` and each registered ticket as a `shallowReactive` proxy. When this option is set, `values()` / `keys()` / `entries()` skip their result cache and re-iterate on every call, so Vue's dep tracking holds across computed re-runs. Template iteration, `registry.size` reads, `get(id)` reads, and per-ticket field mutations via `upsert` all propagate to consumers. [intent:253]
+`reactive: true` on a registry wraps the internal collection as `shallowReactive` and each registered ticket as a `shallowReactive` proxy. When this option is set, `values()` / `keys()` / `entries()` additionally register a single version dependency — a signal bumped on every structural mutation — so Vue's dep tracking holds across computed re-runs while iteration results stay cached between mutations. A subscribing effect holds one dependency regardless of collection size, and reactive reads cost the same as non-reactive ones. Template iteration, `registry.size` reads, `get(id)` reads, and per-ticket field mutations via `upsert` all propagate to consumers. [intent:253]
 
 `useProxyRegistry(registry)` (on a registry created with `events: true`) exposes `proxy.values` / `proxy.keys` / `proxy.entries` / `proxy.size` as properties on a reactive object, updated from `register:ticket` / `unregister:ticket` / `update:ticket` / `clear:registry` / `reindex:registry` events. It does not wrap the tickets themselves, and supports `{ deep: true }` for nested tracking. [intent:254]
 

--- a/packages/0/src/composables/createRegistry/index.bench.ts
+++ b/packages/0/src/composables/createRegistry/index.bench.ts
@@ -44,8 +44,8 @@ function createPopulatedRegistry (count: number): RegistryContext<RegistryTicket
   return registry
 }
 
-// Reactive variant: keys()/values()/entries() skip the read cache and recompute
-// on every call, so these fixtures isolate the uncached O(n) read cost.
+// Reactive variant: keys()/values()/entries() read through the version-memoized
+// cache; these fixtures isolate the reactive read path (touch signal + cache hit).
 function createReactiveRegistry (count: number): RegistryContext<RegistryTicket> {
   const registry = createRegistry({ reactive: true })
   const items = count === 1000 ? ITEMS_1K : ITEMS_10K
@@ -264,7 +264,7 @@ describe('createRegistry benchmarks', () => {
   })
 
   // ===========================================================================
-  // REACTIVE ACCESS - Uncached recompute path (reactive: true bypasses the cache)
+  // REACTIVE ACCESS - Version-memoized path (reactive: true tracks one signal)
   // Shared fixture (safe - read-only operations, no state changes)
   // Measures: full O(n) recompute of keys/values/entries on every call (the
   // `computed access` group above measures the cached path), plus the combined

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -977,7 +977,7 @@ describe('createRegistry', () => {
       ])
     })
 
-    it('should only invalidate cache once at end of batch', () => {
+    it('should keep mid-batch reads consistent and re-cache after batch', () => {
       const registry = createRegistry()
       registry.register({ id: 'initial' })
 
@@ -985,17 +985,19 @@ describe('createRegistry', () => {
 
       registry.batch(() => {
         registry.register({ id: 'item-1' })
-        const keysDuringBatch = registry.keys()
-        // During batch, cache should still be valid (same reference)
-        expect(keysDuringBatch).toBe(keys1)
+        // Mid-batch reads reflect mutations already applied — never a stale
+        // pre-batch snapshot (a reader mid-batch must not see removed tickets
+        // or miss registered ones).
+        expect(registry.keys()).toEqual(['initial', 'item-1'])
 
         registry.register({ id: 'item-2' })
       })
 
       const keys2 = registry.keys()
-      // After batch, cache should be invalidated
       expect(keys2).not.toBe(keys1)
       expect(keys2.length).toBe(3)
+      // Cache is warm again after the batch — repeat reads return the same array.
+      expect(registry.keys()).toBe(keys2)
     })
 
     it('should handle nested batch calls correctly', () => {

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -34,7 +34,7 @@ import { useLogger } from '#v0/composables/useLogger'
 
 // Utilities
 import { clamp, isUndefined, useId } from '#v0/utilities'
-import { shallowReactive } from 'vue'
+import { shallowReactive, shallowRef } from 'vue'
 
 // Types
 import type { ContextTrinity } from '#v0/composables/createTrinity'
@@ -712,7 +712,7 @@ export interface RegistryOptions {
    * Enable reactive behavior for registry operations
    *
    * @default false
-   * @remarks When enabled, the registry will use Vue's shallowReactive to track changes. This is useful for scenarios where you want to reactively update the registry state in response to changes.
+   * @remarks When enabled, tickets and the backing collection are shallowReactive, and `keys()`, `values()`, and `entries()` register a single version dependency so effects and templates re-evaluate on structural mutation. Iteration results stay cached between mutations — reactive reads cost the same as non-reactive ones.
    *
    * @example
    * ```ts
@@ -771,7 +771,13 @@ export function createRegistry<
   const listeners = new Map<string, Set<InternalEventCallback>>()
   // Canonical position sequence, kept in lockstep with `collection`. Holds
   // ticket refs so values()/entries()/reindex() read them without a Map lookup.
-  const order = (reactive ? shallowReactive([] as E[]) : []) as E[]
+  // Deliberately NOT shallowReactive: element-by-element reads of a reactive
+  // array pay a proxy trap per index and, inside an effect, track a dependency
+  // per index. Iteration reactivity comes from `version` instead — one signal
+  // bumped on every structural mutation — so a subscribing effect holds a
+  // single dependency regardless of collection size.
+  const order: E[] = []
+  const version = shallowRef(0)
 
   let indexDependentCount = 0
   let needsReindex = false
@@ -906,11 +912,9 @@ export function createRegistry<
   }
 
   function keys (): readonly ID[] {
-    if (reactive) {
-      // `order` is shallowReactive, so reading it here registers the dependency.
-      // Effects re-evaluate when order is mutated (register, unregister, move, …).
-      return order.map(ticket => ticket.id)
-    }
+    // Touching `version` registers the (single) dependency; effects re-evaluate
+    // when the registry is structurally mutated (register, unregister, move, …).
+    if (reactive) void version.value
 
     const cached = cache.get('keys')
     if (!isUndefined(cached)) return cached as readonly ID[]
@@ -923,9 +927,7 @@ export function createRegistry<
   }
 
   function values (): readonly E[] {
-    if (reactive) {
-      return order.slice()
-    }
+    if (reactive) void version.value
 
     const cached = cache.get('values')
     if (!isUndefined(cached)) return cached as readonly E[]
@@ -938,9 +940,7 @@ export function createRegistry<
   }
 
   function entries (): readonly [ID, E][] {
-    if (reactive) {
-      return order.map(ticket => [ticket.id, ticket] as [ID, E])
-    }
+    if (reactive) void version.value
 
     const cached = cache.get('entries')
     if (!isUndefined(cached)) return cached as readonly [ID, E][]
@@ -966,8 +966,13 @@ export function createRegistry<
   }
 
   function invalidate () {
-    if (isBatching) return
+    // Always drop the cache — a sync effect firing mid-batch (e.g. off a
+    // collection Map write) must rebuild from the already-compacted order,
+    // never read a pre-batch snapshot. The version bump alone is deferred to
+    // the end of a batch so subscribers are notified once per batch.
     cache.clear()
+    if (isBatching) return
+    version.value++
   }
 
   function batch<R> (fn: () => R): R {
@@ -990,6 +995,7 @@ export function createRegistry<
       isBatching = false
       batched = []
       cache.clear()
+      version.value++
     }
   }
 


### PR DESCRIPTION
## Problem

Reactive-mode iteration reads regressed **4–10× in 1.0.0-beta.1** and every release since carries it. The fixed-apparatus benchmark history (current suite + toolchain against each version's published dist) shows the cliff exactly at beta.1 and dead-stable after:

| bench (hz) | beta.0 | beta.1 | … | rc.6 |
|---|---|---|---|---|
| Access values ×100 (1k, reactive) | 273 | 32 | … | 32 |
| Access values ×100 (10k, reactive) | 31 | 3 | … | 3 |
| Access keys ×100 (10k, reactive) | 30 | 7 | … | 7 |
| (cached, non-reactive) | ~1M | ~1M | … | ~1M |

**Root cause:** #273 (`176cabc0e`) replaced the reactive read path. Before, `keys()/values()/entries()` iterated the `shallowReactive(Map)` — Vue's Map instrumentation registers **one** `ITERATE` dependency per call. After, reads went through `order.slice()/map()` over a `shallowReactive` **array**: `slice` isn't in Vue's optimized array instrumentation, so every index read pays a proxy trap — and inside an effect, **tracks a dependency per index**. Microbench at 10k items: Map-iterate 185μs/call (same in/out of effect); array slice 847μs outside an effect, 1574μs inside. Combined with the #209 cache skip, every read rebuilt O(n) through traps, and a rendering component subscribed to ~10k deps instead of 1.

This propagates to everything template-facing: `reactive: true` is the prescribed plugin pattern (useNotifications, useTheme, useLocale, useFeatures, useTooltip, createForm, createInput, createBreadcrumbs, createDataTable, createDataGrid), and `useProxyRegistry` routes through the same reads.

## Fix

Iteration reactivity now comes from a **single version signal** bumped on every structural mutation (`invalidate()` and batch-end are the existing choke points). Reads touch the signal and share the non-reactive result cache; `order` drops its `shallowReactive` wrapper entirely (nothing tracks it anymore — mutations get cheaper too).

- Reactive reads are O(1) between mutations: **values() ×100 @10k: 5.7 hz → 588,479 hz**, now size-independent (1k ≈ 10k)
- A subscribing effect holds **one** dependency regardless of collection size
- Mutation paths same-or-better (Onboard 10k: 231 hz; lookups unchanged ~14M hz)
- useProxyRegistry downstream unaffected

## Behavior change (deliberate)

Mid-batch reads now reflect mutations already applied instead of a stale pre-batch cache snapshot — `invalidate()` always clears the cache, deferring only the version notification to batch end. This matches what reactive mode always did and the compact-first invariant `offboard()` documents; the old contract let a mid-batch reader see already-removed tickets. One test updated to encode the corrected contract (`should keep mid-batch reads consistent and re-cache after batch`).

Notification granularity for reactive iteration is now per-structural-mutation (version bump) rather than per-index tracking — a strict superset of when consumers needed to re-run; `upsert` field patches still propagate through the shallowReactive tickets themselves.

## Verification

- Full packages/0 suite: 6249 passed / 3 skipped
- `vue-tsc` + lint clean
- PHILOSOPHY §4.4 updated in-PR (registry reactivity wording)
- Bench before/after on the same machine, same suite

Extracted from the benchmark-accountability investigation in #539 (built and verified there first; this is the standalone packages/0 change).