### PR TITLE
docs: fix dead /utilities links in maturity matrix and roadmap buckets

### DIFF
--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -74,7 +74,7 @@
         level: entry.level,
         since: entry.since,
         levelOrder: levels[entry.level]?.order ?? -1,
-        path: '/utilities',
+        path: '/guide/features/utilities',
         description: entry.description,
       })
     }

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -67,7 +67,7 @@ for (const [name, entry] of Object.entries(data.utilities)) {
     type: 'utility',
     category: entry.category,
     level: entry.level,
-    path: '/utilities',
+    path: '/guide/features/utilities',
   })
 }
 


### PR DESCRIPTION
Utility entries from `maturity.json` were given a hardcoded link target of `/utilities` in two places, but no such route exists — the utilities documentation lives at `/guide/features/utilities`. Every non-draft utility row (clamp, range, mergeDeep, the type guards, etc.) rendered a dead link.

Changed both hardcoded paths to the real route:
- `DocsMaturity.vue` — roadmap Maturity Matrix rows
- `roadmap-buckets.ts` — roadmap bucket feature chips