### PR TITLE
fix(Combobox): route ComboboxEmpty default slot text through useLocale

### DIFF
--- a/.changeset/combobox-empty-locale-528.md
+++ b/.changeset/combobox-empty-locale-528.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Combobox): route ComboboxEmpty default slot text through useLocale
+
+The hardcoded `"No results"` fallback in `ComboboxEmpty` was not going through `useLocale`, violating PHILOSOPHY §5.5 (locale-first strings). Added a `Combobox.noResults` key to the English message bundle and changed the default slot content to `{{ locale.ti('Combobox.noResults') ?? 'No results' }}`, matching the pattern used by `Dialog.Close` and other components. Consumers who override the default slot are unaffected.

--- a/packages/0/src/components/Combobox/ComboboxEmpty.vue
+++ b/packages/0/src/components/Combobox/ComboboxEmpty.vue
@@ -16,6 +16,9 @@
   // Context
   import { useComboboxContext } from './ComboboxRoot.vue'
 
+  // Composables
+  import { useLocale } from '#v0/composables/useLocale'
+
   // Utilities
   import { toRef } from 'vue'
 
@@ -47,6 +50,7 @@
   } = defineProps<ComboboxEmptyProps>()
 
   const context = useComboboxContext(namespace)
+  const locale = useLocale()
 
   const slotProps = toRef((): ComboboxEmptySlotProps => ({
     query: context.query.value,
@@ -55,6 +59,6 @@
 
 <template>
   <Atom v-if="context.isEmpty.value" :as :renderless>
-    <slot v-bind="slotProps">No results</slot>
+    <slot v-bind="slotProps">{{ locale.ti('Combobox.noResults') ?? 'No results' }}</slot>
   </Atom>
 </template>

--- a/packages/0/src/components/Combobox/index.test.ts
+++ b/packages/0/src/components/Combobox/index.test.ts
@@ -521,7 +521,7 @@ describe('combobox', () => {
       expect(empty.exists()).toBe(true)
     })
 
-    it('should fall back to hardcoded "No results" when no locale plugin is installed', async () => {
+    it('should fall back to the inline default "No results" when no locale plugin is configured', async () => {
       const wrapper = mount(
         defineComponent({
           render: () =>
@@ -551,7 +551,7 @@ describe('combobox', () => {
       expect(empty.text()).toBe('No results')
     })
 
-    it('should use locale-translated string when locale plugin is installed', async () => {
+    it('should use the translated string when locale plugin is configured', async () => {
       const plugin = createLocalePlugin({
         default: 'fr',
         messages: {

--- a/packages/0/src/components/Combobox/index.test.ts
+++ b/packages/0/src/components/Combobox/index.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Adapters
 import { ClientComboboxAdapter } from '#v0/composables/createCombobox/adapters/client'
 
+// Composables
+import { createLocalePlugin } from '#v0/composables'
+
 import { Combobox } from './index'
 
 // Utilities
@@ -516,6 +519,77 @@ describe('combobox', () => {
 
       const empty = wrapper.findComponent(Combobox.Empty as any)
       expect(empty.exists()).toBe(true)
+    })
+
+    it('should fall back to hardcoded "No results" when no locale plugin is installed', async () => {
+      const wrapper = mount(
+        defineComponent({
+          render: () =>
+            h(Combobox.Root as any, { adapter: new ClientComboboxAdapter() }, {
+              default: () => [
+                h(Combobox.Activator as any, {}, {
+                  default: () => h(Combobox.Control as any),
+                }),
+                h(Combobox.Content as any, {}, {
+                  default: () => h(Combobox.Empty as any),
+                }),
+              ],
+            }),
+        }),
+        { attachTo: document.body },
+      )
+      wrappers.push(wrapper)
+
+      const input = wrapper.find('input')
+      await input.trigger('focus')
+      await nextTick()
+      await input.setValue('zzzzz')
+      await input.trigger('input')
+      await nextTick()
+
+      const empty = wrapper.findComponent(Combobox.Empty as any)
+      expect(empty.text()).toBe('No results')
+    })
+
+    it('should use locale-translated string when locale plugin is installed', async () => {
+      const plugin = createLocalePlugin({
+        default: 'fr',
+        messages: {
+          fr: {
+            Combobox: {
+              noResults: 'Aucun résultat',
+            },
+          },
+        },
+      })
+
+      const wrapper = mount(
+        defineComponent({
+          render: () =>
+            h(Combobox.Root as any, { adapter: new ClientComboboxAdapter() }, {
+              default: () => [
+                h(Combobox.Activator as any, {}, {
+                  default: () => h(Combobox.Control as any),
+                }),
+                h(Combobox.Content as any, {}, {
+                  default: () => h(Combobox.Empty as any),
+                }),
+              ],
+            }),
+        }),
+        { global: { plugins: [plugin] }, attachTo: document.body },
+      )
+      wrappers.push(wrapper)
+
+      const input = wrapper.find('input')
+      await input.trigger('focus')
+      await nextTick()
+      await input.setValue('zzzzz')
+      await input.trigger('input')
+      await nextTick()
+
+      const empty = wrapper.findComponent(Combobox.Empty as any)
+      expect(empty.text()).toBe('Aucun résultat')
     })
 
     it('should hide filtered-out items via v-show', async () => {

--- a/packages/0/src/locale/messages/en/index.test.ts
+++ b/packages/0/src/locale/messages/en/index.test.ts
@@ -6,7 +6,7 @@ describe('locale/messages/en', () => {
   it('should export an English aria-string catalog for every v0 component namespace', () => {
     expect(en).toBeTypeOf('object')
 
-    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar']) {
+    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar']) {
       expect(en).toHaveProperty(key)
     }
   })

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -31,6 +31,9 @@ export default {
   Button: {
     label: 'Button',
   },
+  Combobox: {
+    noResults: 'No results',
+  },
   Carousel: {
     indicator: 'Go to slide {current} of {size}',
     indicators: 'Carousel indicators',

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -31,9 +31,6 @@ export default {
   Button: {
     label: 'Button',
   },
-  Combobox: {
-    noResults: 'No results',
-  },
   Carousel: {
     indicator: 'Go to slide {current} of {size}',
     indicators: 'Carousel indicators',
@@ -44,6 +41,9 @@ export default {
     progress: '{percent}% complete',
     progressLabel: 'Carousel progress',
     slide: 'Slide {current} of {size}',
+  },
+  Combobox: {
+    noResults: 'No results',
   },
   Dialog: {
     close: 'Close',


### PR DESCRIPTION
## Summary

Closes #528.

`ComboboxEmpty.vue:58` rendered a hardcoded English `"No results"` fallback with no `useLocale` path, violating PHILOSOPHY §5.5 (locale-first strings). Every other component resolves such strings via `locale.ti('Component.key') ?? 'fallback'`.

### Changes

- **`packages/0/src/locale/messages/en/index.ts`** — Add `Combobox.noResults: 'No results'` in alphabetical order (between `Button` and `Carousel`).
- **`ComboboxEmpty.vue`** — Import `useLocale`, call it in setup, replace the slot default text with `{{ locale.ti('Combobox.noResults') ?? 'No results' }}`.

Consumers who supply a `default` slot override are completely unaffected — the change only touches the fallback rendered when no slot content is provided.

### Tests

Two new cases in `index.test.ts` under `filtering`:

- **No plugin installed** — types a no-match query, asserts `Combobox.Empty` renders `"No results"` (the hardcoded `??` fallback).
- **Plugin installed** — installs a `fr` locale with `Combobox.noResults: 'Aucun résultat'`, types a no-match query, asserts the component renders the translated string.