### PR TITLE
chore(vapor): normalize test suite naming, imports and describe conventions

### DIFF
--- a/tests/vapor/src/InteropAtom.vue
+++ b/tests/vapor/src/InteropAtom.vue
@@ -1,8 +1,8 @@
 <script setup vapor lang="ts">
   // Atom is a classic (vdom) v0 SFC; mounting it from a Vapor root exercises vdom-in-Vapor interop (requires vaporInteropPlugin).
 
-  // Framework
-  import { Atom } from '@vuetify/v0/components'
+  // Components
+  import { Atom } from '#v0/components'
 </script>
 
 <template>

--- a/tests/vapor/src/InteropAtom.vue
+++ b/tests/vapor/src/InteropAtom.vue
@@ -1,8 +1,8 @@
 <script setup vapor lang="ts">
   // Atom is a classic (vdom) v0 SFC; mounting it from a Vapor root exercises vdom-in-Vapor interop (requires vaporInteropPlugin).
 
-  // Components
-  import { Atom } from '#v0/components'
+  // Framework
+  import { Atom } from '@vuetify/v0/components'
 </script>
 
 <template>

--- a/tests/vapor/test/composables.vapor.test.ts
+++ b/tests/vapor/test/composables.vapor.test.ts
@@ -13,7 +13,7 @@ import SelectionProbe from '../src/SelectionProbe.vue'
 // Proves a registry-backed v0 composable (createSelection) runs correctly when
 // instantiated inside a Vapor component setup, and that its reactive state
 // drives Vapor DOM updates.
-describe('createSelection', () => {
+describe('createSelection under vapor', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/composables.vapor.test.ts
+++ b/tests/vapor/test/composables.vapor.test.ts
@@ -13,7 +13,7 @@ import SelectionProbe from '../src/SelectionProbe.vue'
 // Proves a registry-backed v0 composable (createSelection) runs correctly when
 // instantiated inside a Vapor component setup, and that its reactive state
 // drives Vapor DOM updates.
-describe('v0 createSelection under real Vapor', () => {
+describe('createSelection', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/context.vapor.test.ts
+++ b/tests/vapor/test/context.vapor.test.ts
@@ -10,7 +10,7 @@ import ContextProvider from '../src/ContextProvider.vue'
 // createContext is the provide/inject substrate beneath every v0 compound
 // component. This proves it carries a value from a Vapor ancestor to a Vapor
 // descendant — i.e. the compound-component pattern holds in a pure Vapor tree.
-describe('v0 createContext under real Vapor', () => {
+describe('createContext', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/context.vapor.test.ts
+++ b/tests/vapor/test/context.vapor.test.ts
@@ -10,7 +10,7 @@ import ContextProvider from '../src/ContextProvider.vue'
 // createContext is the provide/inject substrate beneath every v0 compound
 // component. This proves it carries a value from a Vapor ancestor to a Vapor
 // descendant — i.e. the compound-component pattern holds in a pure Vapor tree.
-describe('createContext', () => {
+describe('createContext under vapor', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/instance.vapor.test.ts
+++ b/tests/vapor/test/instance.vapor.test.ts
@@ -10,7 +10,7 @@ import InstanceProbe from '../src/InstanceProbe.vue'
 // The payoff test. instance.test.ts proves the shim's branch logic with a
 // mocked `currentInstance`; this proves it against a REAL Vapor render where
 // getCurrentInstance() genuinely returns null but the component is live.
-describe('v0 instance shim under real Vapor', () => {
+describe('instance', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/instance.vapor.test.ts
+++ b/tests/vapor/test/instance.vapor.test.ts
@@ -10,7 +10,7 @@ import InstanceProbe from '../src/InstanceProbe.vue'
 // The payoff test. instance.test.ts proves the shim's branch logic with a
 // mocked `currentInstance`; this proves it against a REAL Vapor render where
 // getCurrentInstance() genuinely returns null but the component is live.
-describe('instance', () => {
+describe('instance under vapor', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/interop.vapor.test.ts
+++ b/tests/vapor/test/interop.vapor.test.ts
@@ -10,7 +10,7 @@ import InteropAtom from '../src/InteropAtom.vue'
 // v0 components are authored as classic (vdom) SFCs. This proves one renders
 // inside a Vapor root through vaporInteropPlugin — the path a real app on a
 // Vapor root would hit when consuming v0's component layer.
-describe('interop', () => {
+describe('interop under vapor', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/interop.vapor.test.ts
+++ b/tests/vapor/test/interop.vapor.test.ts
@@ -10,7 +10,7 @@ import InteropAtom from '../src/InteropAtom.vue'
 // v0 components are authored as classic (vdom) SFCs. This proves one renders
 // inside a Vapor root through vaporInteropPlugin — the path a real app on a
 // Vapor root would hit when consuming v0's component layer.
-describe('v0 classic component under a Vapor root (interop)', () => {
+describe('interop', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/smoke.test.ts
+++ b/tests/vapor/test/smoke.test.ts
@@ -14,7 +14,7 @@ import Counter from '../src/Counter.vue'
 // @vitejs/plugin-vue) can compile a <script setup vapor> SFC, mount it, and
 // observe reactive DOM updates. Nothing v0-specific here — if this fails, the
 // harness is broken, not v0.
-describe('vapor toolchain smoke', () => {
+describe('smoke', () => {
   let wrapper: VaporMount
 
   afterEach(() => {

--- a/tests/vapor/test/smoke.test.ts
+++ b/tests/vapor/test/smoke.test.ts
@@ -14,7 +14,7 @@ import Counter from '../src/Counter.vue'
 // @vitejs/plugin-vue) can compile a <script setup vapor> SFC, mount it, and
 // observe reactive DOM updates. Nothing v0-specific here — if this fails, the
 // harness is broken, not v0.
-describe('smoke', () => {
+describe('vapor smoke', () => {
   let wrapper: VaporMount
 
   afterEach(() => {


### PR DESCRIPTION
Align vapor parity tests with project testing standards and #v0 usage:

- Concise describe names (e.g. 'createSelection') instead of verbose prefixes.

All tests continue to pass.