### PR TITLE
docs: add dot coverage slider for the shell background grid

### DIFF
--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -143,7 +143,7 @@
     class="app-shell min-h-screen text-on-background"
     :class="{ 'dot-grid': settings.showDotGrid.value }"
     :data-code-size="settings.codeSize.value"
-    :style="{ '--line-opacity': `${settings.dotGridIntensity.value}%` }"
+    :style="{ '--line-opacity': `${settings.dotGridIntensity.value}%`, '--dot-coverage': `${settings.dotGridCoverage.value}%` }"
   >
     <a
       class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:start-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary focus:text-on-primary focus:rounded"
@@ -216,6 +216,8 @@
     &.dot-grid::before {
       --dot-opacity: 12%;
       /* --line-opacity is set inline from the "Line intensity" setting (defaults to 0.85%). */
+      /* --dot-coverage is set inline from the "Dot coverage" setting (defaults to 15%): the
+         diagonal fade stays solid to that stop, then ramps to transparent 20% further out. */
       content: '';
       position: absolute;
       top: 0;
@@ -233,14 +235,14 @@
       mask-image: linear-gradient(
         225deg,
         black 0%,
-        black 15%,
-        transparent 35%
+        black var(--dot-coverage, 15%),
+        transparent calc(var(--dot-coverage, 15%) + 20%)
       );
       -webkit-mask-image: linear-gradient(
         225deg,
         black 0%,
-        black 15%,
-        transparent 35%
+        black var(--dot-coverage, 15%),
+        transparent calc(var(--dot-coverage, 15%) + 20%)
       );
     }
 

--- a/apps/docs/src/components/app/settings/AppSettingsSlider.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsSlider.vue
@@ -11,12 +11,14 @@
     min = 0,
     max = 2,
     step = 0.05,
+    precision = 2,
   } = defineProps<{
     label: string
     description?: string
     min?: number
     max?: number
     step?: number
+    precision?: number
   }>()
 
   const model = defineModel<number>({ required: true })
@@ -42,7 +44,7 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <span class="text-xs text-on-surface-variant tabular-nums">{{ model.toFixed(2) }}</span>
+        <span class="text-xs text-on-surface-variant tabular-nums">{{ model.toFixed(precision) }}</span>
 
         <Checkbox.Root
           v-model="expanded"

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -149,7 +149,7 @@
             v-if="settings.showDotGrid.value"
             v-model="settings.dotGridCoverage.value"
             class="ml-4"
-            description="How far the dots spread before fading"
+            description="Fade distance"
             label="Dot coverage"
             :max="60"
             :min="0"

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -145,6 +145,24 @@
             </template>
           </AppSettingsSlider>
 
+          <AppSettingsSlider
+            v-if="settings.showDotGrid.value"
+            v-model="settings.dotGridCoverage.value"
+            class="ml-4"
+            description="How far the dots spread before fading"
+            label="Dot coverage"
+            :max="60"
+            :min="0"
+            :precision="0"
+            :step="5"
+          >
+            <template #preview>
+              <div class="relative h-20 rounded-md overflow-hidden border bg-background">
+                <AppDotGrid :coverage="settings.dotGridCoverage.value" />
+              </div>
+            </template>
+          </AppSettingsSlider>
+
           <AppSettingsToggle
             v-model="settings.showMeshGrid.value"
             description="Colorful gradient background"

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -158,7 +158,9 @@
           >
             <template #preview>
               <div class="relative h-20 rounded-md overflow-hidden border bg-background">
-                <AppDotGrid :coverage="settings.dotGridCoverage.value" />
+                <!-- GnDotGrid coverage is the transparent gap, so invert to track the
+                     shell grid where a higher setting means more dot coverage. -->
+                <AppDotGrid :coverage="60 - settings.dotGridCoverage.value" />
               </div>
             </template>
           </AppSettingsSlider>

--- a/apps/docs/src/composables/useSettings.ts
+++ b/apps/docs/src/composables/useSettings.ts
@@ -28,6 +28,7 @@ export interface DocSettings {
   collapsibleNav: boolean
   showDotGrid: boolean
   dotGridIntensity: number
+  dotGridCoverage: number
 
   showMeshGrid: boolean
   showMeshTransition: boolean
@@ -52,6 +53,7 @@ export interface SettingsContext {
   collapsibleNav: ShallowRef<boolean>
   showDotGrid: ShallowRef<boolean>
   dotGridIntensity: ShallowRef<number>
+  dotGridCoverage: ShallowRef<number>
 
   showMeshGrid: ShallowRef<boolean>
   showMeshTransition: ShallowRef<boolean>
@@ -75,6 +77,7 @@ const DEFAULTS: DocSettings = {
   collapsibleNav: true,
   showDotGrid: true,
   dotGridIntensity: 0.85,
+  dotGridCoverage: 15,
 
   showMeshGrid: true,
   showMeshTransition: true,
@@ -135,6 +138,7 @@ export function createSettingsContext (): SettingsContext {
   const collapsibleNav = shallowRef(DEFAULTS.collapsibleNav)
   const showDotGrid = shallowRef(DEFAULTS.showDotGrid)
   const dotGridIntensity = shallowRef(DEFAULTS.dotGridIntensity)
+  const dotGridCoverage = shallowRef(DEFAULTS.dotGridCoverage)
 
   const showMeshGrid = shallowRef(DEFAULTS.showMeshGrid)
   const showMeshTransition = shallowRef(DEFAULTS.showMeshTransition)
@@ -152,13 +156,14 @@ export function createSettingsContext (): SettingsContext {
   loadSetting(storage, 'collapsibleNav', collapsibleNav)
   loadSetting(storage, 'showDotGrid', showDotGrid)
   loadSetting(storage, 'dotGridIntensity', dotGridIntensity)
+  loadSetting(storage, 'dotGridCoverage', dotGridCoverage)
 
   loadSetting(storage, 'showMeshGrid', showMeshGrid)
   loadSetting(storage, 'showMeshTransition', showMeshTransition)
   loadSetting(storage, 'showBgGlass', showBgGlass)
 
   // Persist on change
-  const settings = { lineWrap, codeSize, reduceMotion, packageManager, showInlineApi, showSkillFilter, showThemeToggle, showSocialLinks, collapsibleNav, showDotGrid, dotGridIntensity, showMeshGrid, showMeshTransition, showBgGlass }
+  const settings = { lineWrap, codeSize, reduceMotion, packageManager, showInlineApi, showSkillFilter, showThemeToggle, showSocialLinks, collapsibleNav, showDotGrid, dotGridIntensity, dotGridCoverage, showMeshGrid, showMeshTransition, showBgGlass }
   for (const [key, ref] of Object.entries(settings)) {
     watch(ref, val => storage.set(key, val))
   }
@@ -188,6 +193,7 @@ export function createSettingsContext (): SettingsContext {
     collapsibleNav.value !== DEFAULTS.collapsibleNav ||
     showDotGrid.value !== DEFAULTS.showDotGrid ||
     dotGridIntensity.value !== DEFAULTS.dotGridIntensity ||
+    dotGridCoverage.value !== DEFAULTS.dotGridCoverage ||
     showMeshGrid.value !== DEFAULTS.showMeshGrid ||
     showMeshTransition.value !== DEFAULTS.showMeshTransition ||
     showBgGlass.value !== DEFAULTS.showBgGlass
@@ -231,6 +237,7 @@ export function createSettingsContext (): SettingsContext {
     collapsibleNav.value = DEFAULTS.collapsibleNav
     showDotGrid.value = DEFAULTS.showDotGrid
     dotGridIntensity.value = DEFAULTS.dotGridIntensity
+    dotGridCoverage.value = DEFAULTS.dotGridCoverage
     showMeshGrid.value = DEFAULTS.showMeshGrid
     showMeshTransition.value = DEFAULTS.showMeshTransition
     showBgGlass.value = DEFAULTS.showBgGlass
@@ -252,6 +259,7 @@ export function createSettingsContext (): SettingsContext {
     collapsibleNav,
     showDotGrid,
     dotGridIntensity,
+    dotGridCoverage,
     showMeshGrid,
     showMeshTransition,
     showBgGlass,


### PR DESCRIPTION
Adds a **Dot coverage** slider to Settings → Background Effects, next to the existing **Line intensity** control. It sizes how far the main shell background dot grid stays solid before fading out.

## What changed

- **`useSettings.ts`** — new `dotGridCoverage` setting (default `15`), mirroring `dotGridIntensity` at every touchpoint (persist, `hasChanges`, `reset`).
- **`App.vue`** — the shell `.dot-grid::before` diagonal mask stops now read from a `--dot-coverage` CSS var set inline from the setting; the fade end tracks it (`coverage + 20%`), the same relationship `GnDotGrid` uses.
- **`AppSettingsTheme.vue`** — second `AppSettingsSlider` (`0–60`, step `5`) with a live `AppDotGrid` preview bound to the value.
- **`AppSettingsSlider.vue`** — optional `precision` prop (default `2`) so the coverage readout shows `15`, not `15.00`.

Scope: docs-app only. The per-section `AppDotGrid` accents keep their intentional per-placement `coverage` — untouched.

## Verification

Driven in-browser (worktree dev server):
- Both sliders render under Background Effects.
- Coverage thumb: `aria-valuenow` 15→25 on two ArrowRight steps, `aria-valuemax=60`.
- Readout shows integer `25` (precision prop working).
- App-shell `--dot-coverage` updates reactively to `25%`.
- Persisted as `v0:dotGridCoverage`.