### PR TITLE
perf(createDataGrid): skip row-order reorder on sort when no manual order is in effect

### DIFF
--- a/.changeset/datagrid-sort-reorder-perf.md
+++ b/.changeset/datagrid-sort-reorder-perf.md
@@ -3,3 +3,5 @@
 ---
 
 perf(createDataGrid): dramatically faster sorting, drag-reordering, and initialization on large grids (#555)
+
+Grids with thousands of rows are far faster to sort, drag-reorder, and build — a 10k-row sort is ~28× faster, drag-reordering ~6.5×, and initial construction ~2×. No API change and no migration: existing grids get the speedup on upgrade.

--- a/.changeset/datagrid-sort-reorder-perf.md
+++ b/.changeset/datagrid-sort-reorder-perf.md
@@ -2,11 +2,4 @@
 "@vuetify/v0": patch
 ---
 
-perf(createDataGrid): stop mirroring rows into a per-ticket-reactive sortable, and skip the row-order reorder on sort when no manual order is in effect.
-
-The grid mirrors every row into a parallel `createSortable` to track manual drag-reorder. Two costs came out of that:
-
-- It constructed the sortable with `reactive: true`, allocating a `shallowReactive` proxy per row — but the grid only ever reads the sortable's key *order*, never a per-ticket field. Row order now derives from `useProxyRegistry(sortable)` (event-driven, `reorder`/`move` emit `reindex:registry`), so `order` stays reactive with zero per-ticket proxies. ~2x faster construction and ~6.5x faster drag-reorder at 10k rows.
-- The `flush: 'sync'` sort-columns watch called `rows.reset()` on every sort, which unconditionally reordered every ticket even when the consumer had never dragged a row. `reset()` now early-returns while `dirty` is false (the sortable already matches registration order and isn't read for the page projection). Warm 10k-row sort drops from ~48ms to ~1.7ms per sort (~28x).
-
-Behavior is unchanged: a sort still discards an active manual reorder (when `dirty`, `reset()` still reorders and clears the flag), and `rows.order` reactivity is preserved.
+perf(createDataGrid): dramatically faster sorting, drag-reordering, and initialization on large grids (#555)

--- a/.changeset/datagrid-sort-reorder-perf.md
+++ b/.changeset/datagrid-sort-reorder-perf.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+perf(createDataGrid): skip the row-order reorder on sort changes when no manual order is in effect. The sort-columns watch called `rows.reset()` on every sort, which unconditionally reordered every sortable ticket — an O(n) pass across all rows on each header sort even when the consumer had never dragged a row. `reset()` now early-returns while `dirty` is false (the sortable already matches registration order and isn't read for the page projection), leaving the "sort change discards a manual reorder" behavior untouched. Warm 10k-row sort drops from ~48ms to ~1.7ms per sort (~28x).

--- a/.changeset/datagrid-sort-reorder-perf.md
+++ b/.changeset/datagrid-sort-reorder-perf.md
@@ -2,4 +2,11 @@
 "@vuetify/v0": patch
 ---
 
-perf(createDataGrid): skip the row-order reorder on sort changes when no manual order is in effect. The sort-columns watch called `rows.reset()` on every sort, which unconditionally reordered every sortable ticket — an O(n) pass across all rows on each header sort even when the consumer had never dragged a row. `reset()` now early-returns while `dirty` is false (the sortable already matches registration order and isn't read for the page projection), leaving the "sort change discards a manual reorder" behavior untouched. Warm 10k-row sort drops from ~48ms to ~1.7ms per sort (~28x).
+perf(createDataGrid): stop mirroring rows into a per-ticket-reactive sortable, and skip the row-order reorder on sort when no manual order is in effect.
+
+The grid mirrors every row into a parallel `createSortable` to track manual drag-reorder. Two costs came out of that:
+
+- It constructed the sortable with `reactive: true`, allocating a `shallowReactive` proxy per row — but the grid only ever reads the sortable's key *order*, never a per-ticket field. Row order now derives from `useProxyRegistry(sortable)` (event-driven, `reorder`/`move` emit `reindex:registry`), so `order` stays reactive with zero per-ticket proxies. ~2x faster construction and ~6.5x faster drag-reorder at 10k rows.
+- The `flush: 'sync'` sort-columns watch called `rows.reset()` on every sort, which unconditionally reordered every ticket even when the consumer had never dragged a row. `reset()` now early-returns while `dirty` is false (the sortable already matches registration order and isn't read for the page projection). Warm 10k-row sort drops from ~48ms to ~1.7ms per sort (~28x).
+
+Behavior is unchanged: a sort still discards an active manual reorder (when `dirty`, `reset()` still reorders and clears the flag), and `rows.order` reactivity is preserved.

--- a/packages/0/src/composables/createDataGrid/index.ts
+++ b/packages/0/src/composables/createDataGrid/index.ts
@@ -290,6 +290,11 @@ export function createDataGrid<T extends Record<string, unknown>> (
   }
 
   function reset () {
+    // With no manual order in effect the sortable already matches registration
+    // order and its order isn't read for the page projection, so there is
+    // nothing to discard — skip the O(n) reorder the sort-columns watch would
+    // otherwise fire across every ticket on each sort change.
+    if (!dirty.value) return
     if (sortable.size > 0) {
       sortable.reorder(table.keys() as ID[])
     }

--- a/packages/0/src/composables/createDataGrid/index.ts
+++ b/packages/0/src/composables/createDataGrid/index.ts
@@ -36,6 +36,7 @@ import { createContext, useContext } from '#v0/composables/createContext'
 import { createDataTable } from '#v0/composables/createDataTable'
 import { createSortable } from '#v0/composables/createSortable'
 import { createTrinity } from '#v0/composables/createTrinity'
+import { useProxyRegistry } from '#v0/composables/useProxyRegistry'
 import { useToggleScope } from '#v0/composables/useToggleScope'
 
 // Grid modules
@@ -229,7 +230,12 @@ export function createDataGrid<T extends Record<string, unknown>> (
 
   const table = createDataTable<T>(options)
 
-  const sortable = createSortable<SortableTicketInput<ID>>({ reactive: true })
+  // Row order is derived from the sortable's key order only — no per-ticket
+  // field is ever read reactively — so an event-driven proxy gives `order` its
+  // reactivity without allocating a reactive proxy per row. `reorder` / `move`
+  // both emit `reindex:registry`, which the proxy subscribes to.
+  const sortable = createSortable<SortableTicketInput<ID>>()
+  const sortableProxy = useProxyRegistry(sortable)
 
   // Tracks whether the consumer has explicitly reordered rows. While false the
   // grid passes the table's own sorted+paginated projection through untouched,
@@ -250,7 +256,7 @@ export function createDataGrid<T extends Record<string, unknown>> (
     dirty.value = false
   })
 
-  const order = toRef(() => sortable.keys() as ID[])
+  const order = toRef(() => sortableProxy.keys as ID[])
 
   // Sorted ticket ids parallel to `table.sortedItems`. Identity is the registry
   // ticket id, never `value.id`. Tickets are bucketed by value reference into an


### PR DESCRIPTION
Fixes two row-order performance problems in `createDataGrid`, both rooted in how the grid tracks manual drag-reorder. The grid mirrors every row into a parallel `createSortable` and derives `rows.order` from its key order.

## 1. `reactive: true` misuse (reactivity fix)

The sortable was built with `reactive: true`, allocating a `shallowReactive` proxy **per row** — but the grid never reads a per-ticket field reactively; it only reads the sortable's key *order*. That's the PHILOSOPHY §4.4 footgun: paying per-ticket reactivity to obtain what is only collection-order reactivity.

Row order now derives from `useProxyRegistry(sortable)`. `reorder`/`move` both emit `reindex:registry`, which the proxy subscribes to, so `order` stays reactive with **zero** per-ticket proxies. This is the same pattern `createDataTable` already uses for its own row registry.

## 2. Redundant reorder on every sort (the original finding)

A `flush: 'sync'` watch on `table.sort.columns` called `rows.reset()` on every sort, and `reset()` unconditionally reordered every sortable ticket — even when the consumer had never dragged a row. `reset()` now early-returns while `dirty` is `false`: the invariant **`dirty === false ⟹ the sortable already matches registration order`** holds (only `move` dirties; `reset` re-syncs before clearing), and the non-`dirty` branch of the `page` projection never reads the sortable.

Behavior is unchanged in both cases: a sort still discards an active manual reorder (when `dirty`, `reset()` still reorders and clears the flag), and `rows.order` reactivity is preserved.

## Impact (same-machine warm bench, 10k rows)

| Op | Before | After | Speedup |
|---|---|---|---|
| Sort (string column) | 20.7 ops/s (48 ms), ±2.8% | 582 ops/s (1.7 ms), ±1.0% | ~28× |
| Sort (custom comparator) | 19.2 ops/s (52 ms), ±3.1% | 227 ops/s (4.4 ms), ±1.5% | ~12× |
| Construction (Create grid) | 23.0 ops/s (44 ms), ±12% | 47.8 ops/s (21 ms), ±7.5% | ~2× |
| Drag-reorder (Move row, 1k) | 304 ops/s (3.3 ms) | 1975 ops/s (0.5 ms) | ~6.5× |

The grid now sorts in the same band as `createDataTable`, and the sort-bench RME collapses from >170% to <2% as the per-sort proxy churn disappears.

## Verification

- `createDataGrid` + `createSortable` + `createDataTable` suites: **248 passed** (reset/sort/move interaction incl. `preserveRowOrder` toggle re-arm, and `rows.order` reactivity, unchanged and green).
- `@vuetify/v0` typecheck clean.

## Commits

1. `perf: skip row-order reorder on sort when no manual order is in effect` — the redundant-reorder early-return.
2. `perf: derive row order from useProxyRegistry instead of a reactive:true sortable` — the reactivity fix.
