### PR TITLE
chore(release): drop browser tests from pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-push": "pnpm lint && pnpm typecheck && pnpm test:run && pnpm repo:check"
+    "pre-push": "pnpm lint && pnpm typecheck && pnpm test:run --project '!v0:browser' && pnpm repo:check"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",


### PR DESCRIPTION
## Problem

Merging #179 red the **Release** workflow ([run](https://github.com/vuetifyjs/0/actions/runs/28974395389/job/85977802013)).

Root cause: the `simple-git-hooks` **pre-push** hook runs `pnpm test:run` (all vitest projects). #179 added the `v0:browser` project to that run, so the hook now needs a Chromium binary on **every `git push`**. The Release job runs `pnpm install` (which installs the hook via `prepare`), then the changesets action does an internal `git push` to update the *Version Packages* PR — with no browser installed:

```
browserType.launch: Executable doesn't exist at .../chrome-headless-shell
error: failed to push some refs to 'https://github.com/vuetifyjs/0'
```

Nothing published this time (the failure was on the version-PR push, before any publish). But left unfixed it would bite on the **publish path**: when the Version Packages PR is merged, the action runs `changeset publish` (npm) **then** pushes tags → the hook fails → npm has the packages, git has no tags/release = partial publish.

## Fix

Exclude the browser project from the pre-push gate:

```
pnpm test:run --project '!v0:browser'
```

Consistent with the CI split from #179 — browser tests run in the dedicated `browser` CI job on every PR, not on every push. A local pre-push gate (and CI's internal release pushes) can't assume Chromium is present.

## Verify

- Pushing this branch exercised the regenerated hook (lint + typecheck + `test:run --project '!v0:browser'` + repo:check) and succeeded with no Chromium requirement.
- Run `pnpm install` (or `pnpm prepare`) to regenerate the local hook.

> Follow-up (not in this PR): the release job re-running the full validate suite via the pre-push hook on its internal push is redundant with pr-checks — worth pushing with `--no-verify` from the release flow, but out of scope here.
