### PR TITLE
docs: dense-renumber guide nav ordering

### DIFF
--- a/apps/docs/src/pages/guide/essentials/glossary.md
+++ b/apps/docs/src/pages/guide/essentials/glossary.md
@@ -6,7 +6,7 @@ meta:
   - name: keywords
     content: "vuetify0, glossary, terminology, ticket, registry, trinity, context, namespace, model, selection, plugin, adapter, headless"
 features:
-  order: 0.6
+  order: 2
   level: 1
 related:
   - /guide/fundamentals/core

--- a/apps/docs/src/pages/guide/essentials/using-the-docs.md
+++ b/apps/docs/src/pages/guide/essentials/using-the-docs.md
@@ -6,7 +6,7 @@ meta:
   - name: keywords
     content: "documentation, navigation, ask ai, search, examples, learning tracks, keyboard shortcuts, accessibility"
 features:
-  order: 0.5
+  order: 1
   level: 1
 related:
   - /guide

--- a/apps/docs/src/pages/guide/features/palettes.md
+++ b/apps/docs/src/pages/guide/features/palettes.md
@@ -1,7 +1,7 @@
 ---
 title: Palettes - Pre-built Color Systems and Generators
 features:
-  order: 2
+  order: 3
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/features/utilities.md
+++ b/apps/docs/src/pages/guide/features/utilities.md
@@ -1,7 +1,7 @@
 ---
 title: Utilities Guide - Helper Functions for Vue 3
 features:
-  order: 3
+  order: 4
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/benchmarks.md
+++ b/apps/docs/src/pages/guide/fundamentals/benchmarks.md
@@ -1,7 +1,7 @@
 ---
 title: Benchmarks - Performance Metrics and Tiers
 features:
-  order: 5
+  order: 6
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/building-frameworks.md
+++ b/apps/docs/src/pages/guide/fundamentals/building-frameworks.md
@@ -1,7 +1,7 @@
 ---
 title: Building Frameworks - Using v0 as a Dependency
 features:
-  order: 6
+  order: 8
   level: 3
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/composables.md
+++ b/apps/docs/src/pages/guide/fundamentals/composables.md
@@ -1,7 +1,7 @@
 ---
 title: Composables Guide - Headless Logic for Vue 3
 features:
-  order: 3
+  order: 4
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/plugins.md
+++ b/apps/docs/src/pages/guide/fundamentals/plugins.md
@@ -1,7 +1,7 @@
 ---
 title: Plugins Guide - Extend Vuetify0 Functionality
 features:
-  order: 4
+  order: 5
   level: 3
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/reactivity.md
+++ b/apps/docs/src/pages/guide/fundamentals/reactivity.md
@@ -1,7 +1,7 @@
 ---
 title: Reactivity - Minimal by Design
 features:
-  order: 2
+  order: 3
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/styling.md
+++ b/apps/docs/src/pages/guide/fundamentals/styling.md
@@ -1,7 +1,7 @@
 ---
 title: Styling Headless Components - Data Attributes & Slot Props
 features:
-  order: 5
+  order: 7
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
+++ b/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
@@ -1,7 +1,7 @@
 ---
 title: Tree-Shaking - Bundle Size Optimization
 features:
-  order: 7
+  order: 9
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/integration/building-docs.md
+++ b/apps/docs/src/pages/guide/integration/building-docs.md
@@ -6,7 +6,7 @@ meta:
   - name: keywords
     content: vuetify0, documentation, vite-ssg, unocss, proof of concept, headless ui
 features:
-  order: 2
+  order: 3
   label: 'Building Docs'
   level: 2
 related:

--- a/apps/docs/src/pages/guide/integration/devkey.md
+++ b/apps/docs/src/pages/guide/integration/devkey.md
@@ -7,7 +7,7 @@ meta:
   - name: keywords
     content: vuetify0, devkey, starter, example project, vue 3, vite, typescript, unocss, scaffold, alpha
 features:
-  order: 0
+  order: 1
   label: 'DevKey'
   level: 1
 related:

--- a/apps/docs/src/pages/guide/integration/nuxt.md
+++ b/apps/docs/src/pages/guide/integration/nuxt.md
@@ -1,7 +1,7 @@
 ---
 title: Nuxt - SSR Integration Guide
 features:
-  order: 1
+  order: 2
   level: 2
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/integration/vapor.md
+++ b/apps/docs/src/pages/guide/integration/vapor.md
@@ -1,7 +1,7 @@
 ---
 title: Vapor - Vue Vapor Mode Compatibility
 features:
-  order: 2
+  order: 4
   level: 3
 meta:
   - name: description

--- a/apps/docs/src/pages/guide/tooling/vuetify-cli.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-cli.md
@@ -2,7 +2,7 @@
 title: Vuetify CLI - Project Scaffolding & Management
 features:
   label: Vuetify CLI
-  order: 1
+  order: 2
   level: 1
 meta:
   - name: description


### PR DESCRIPTION
## What

The Guide sidebar order is *derived*, not authored: `generate-nav.ts` sorts each subcategory by `features.order` ascending, then tie-breaks on the display name via `localeCompare`. An audit found the numbering had decayed:

- **7 pages sat on duplicate `order` values** with a sibling, so their real position was decided by an alphabetical filename accident rather than intent:
  - fundamentals: Components/Reactivity (both 2), Benchmarks/Styling (both 5)
  - features: Accessibility/Palettes (both 2)
  - integration: Building Docs/Vapor (both 2)
  - tooling: AI Tools/Vuetify CLI (both 1)
- **essentials used fractional orders** (0.5 / 0.6) — a symptom of inserting ahead of a `1` without renumbering.
- **gaps** at order 4 (features) and 2 (tooling).

## Change

Renumber every guide subcategory to a dense `1..n` with no ties or gaps, locking the current (reasonable) rendered order into explicit intent. **No visible order change** — this only removes the reliance on alphabetical tie-breaks so future renames/inserts don't silently reshuffle the nav.

Frontmatter-only edits across 16 pages; docs app, not published — no changeset.