### PR TITLE
fix(createTokens): forward mutator event arg and type ticket.value under flat mode

### DIFF
--- a/.changeset/tokens-mutator-event-flat-value-564.md
+++ b/.changeset/tokens-mutator-event-flat-value-564.md
@@ -5,3 +5,5 @@
 fix(createTokens): mutators now forward their `event` argument and `ticket.value` is typed accurately under `flat: true` (#564)
 
 `upsert` (and the other registry mutators) silently dropped the optional `event` argument, so custom events never emitted for token registries; the wrappers now forward it and match the inherited `RegistryContext` signatures. `TokenValue` also widens to include `TokenCollection` so `ticket.value` reflects the nested objects stored under `flat: true` — the mode `useTheme`/`useFeatures` rely on — instead of claiming leaf/alias only.
+
+If you exhaustively narrow a `TokenValue` (or `ticket.value`) in a `switch`/type guard, add a `TokenCollection` (object) branch — the union now has an object member alongside the primitive and alias cases.

--- a/.changeset/tokens-mutator-event-flat-value-564.md
+++ b/.changeset/tokens-mutator-event-flat-value-564.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createTokens): mutators now forward their `event` argument and `ticket.value` is typed accurately under `flat: true` (#564)
+
+`upsert` (and the other registry mutators) silently dropped the optional `event` argument, so custom events never emitted for token registries; the wrappers now forward it and match the inherited `RegistryContext` signatures. `TokenValue` also widens to include `TokenCollection` so `ticket.value` reflects the nested objects stored under `flat: true` — the mode `useTheme`/`useFeatures` rely on — instead of claiming leaf/alias only.

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -51,7 +51,7 @@ export interface TokenAlias<T = unknown> {
 
 export type TokenPrimitive = string | number | boolean | null | Function
 
-export type TokenValue = TokenPrimitive | TokenAlias
+export type TokenValue = TokenPrimitive | TokenAlias | TokenCollection
 
 export interface TokenCollection {
   [key: string]: TokenValue | TokenCollection
@@ -276,22 +276,22 @@ export function createTokens<
     clear: _clear,
   } = registry
 
-  function register (registration: Partial<Z>) {
+  function register (registration?: Partial<Z & RegistryTicket>) {
     cache.clear()
     return _register(registration)
   }
 
-  function upsert (id: string, registration: Partial<Z>) {
+  function upsert (id: ID, registration?: Partial<Z>, event?: string) {
     cache.clear()
-    return _upsert(id, registration)
+    return _upsert(id, registration, event)
   }
 
-  function unregister (id: string) {
+  function unregister (id: ID) {
     cache.clear()
     return _unregister(id)
   }
 
-  function onboard (registrations: Partial<Z>[]) {
+  function onboard (registrations: Partial<Z & RegistryTicket>[]) {
     cache.clear()
     return _onboard(registrations)
   }
@@ -301,7 +301,7 @@ export function createTokens<
     return _offboard(ids)
   }
 
-  function move (id: string, index: number) {
+  function move (id: ID, index: number) {
     cache.clear()
     return _move(id, index)
   }
@@ -453,7 +453,7 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
       }
 
       if (flat) {
-        flattened.push({ id, value: value as unknown as TokenValue })
+        flattened.push({ id, value: value as TokenValue })
         continue
       }
 


### PR DESCRIPTION
Two frozen-surface corrections for the `createTokens` public type, landing while we're still in RC (rc.7) so 1.0.0 freezes the correct shape. Both are breaking-to-defer, which is why they rise to the RC bar (the remaining createTokens findings are non-breaking behavior/docs fixes → 1.0.x).

## #12 — `ticket.value` type lies under `flat: true`
`TokenValue` was `TokenPrimitive | TokenAlias`, but the flat path stores plain nested collections via `as unknown as TokenValue`. `value` is an output position (consumers read `ticket.value`), and `flat: true` is the primary storage mode for `useTheme`/`useFeatures` — so the most-consumed path mistyped its own value. Widened `TokenValue` to include `TokenCollection` and dropped the double-cast. Widening an output type after freeze would be breaking; done now it's additive.

## #8 — mutator wrappers diverge from the `RegistryContext` they extend
`TokenContext extends RegistryContext`, so the interface advertises `upsert(id: ID, patch?, event?)`, but the runtime wrapper was `upsert(id: string, registration)` — it **silently dropped the `event` argument** and narrowed `id`. `register`/`onboard`/`move` similarly narrowed `ID → string` and dropped the `& RegistryTicket` / optionality. Wrappers now forward `event` and match their parent signatures, restoring substitutability (PHILOSOPHY §2.6). Fixed by forwarding (non-narrowing), so the public type is unchanged and no consumer breaks — the runtime just stops lying.

## Verification
- `pnpm typecheck` (vue-tsc) clean on `@vuetify/v0` — no downstream breakage in useTheme/useFeatures/usePermissions/useLocale
- `createTokens` unit suite: 250/250 pass