### PR TITLE
docs(createTokens): fix FAQ and quick-start accuracy against source behavior

### DIFF
--- a/apps/docs/src/pages/composables/registration/create-tokens.md
+++ b/apps/docs/src/pages/composables/registration/create-tokens.md
@@ -31,12 +31,12 @@ The `createTokens` composable allows you to define a collection of design tokens
 ```ts collapse
 import { createTokens } from '@vuetify/v0'
 
-// Default behavior (depth = Infinity): fully flatten nested objects
+// Default behavior: fully flatten nested objects into dot-notation ids
 const tokens = createTokens({
   color: {
     primary: '#3b82f6',
     secondary: '#64748b',
-    info: '{primary}'
+    info: '{color.primary}'
   },
   radius: {
     sm: '4px',
@@ -147,17 +147,17 @@ A design system with four token categories — color palettes, semantic aliases,
 ## FAQ
 
 ::: faq
-??? What's the difference between `depth: Infinity` and `flat: true`?
+??? What's the difference between the default flattening and `flat: true`?
 
 They control how nested objects are processed:
 
 | Option | Behavior | Token IDs |
 | - | - | - |
-| `depth: Infinity` (default) | Recursively flatten all nested objects | `color.primary`, `color.secondary` |
+| default | Recursively flatten all nested objects | `color.primary`, `color.secondary` |
 | `flat: true` | Keep objects as-is at their base key | `rtl` → `{ value: true, ... }` |
 
 ```ts
-// depth: Infinity (default) - flattens nested objects
+// default - flattens nested objects
 const colors = createTokens({
   color: { primary: '#3b82f6', secondary: '#64748b' }
 })
@@ -175,18 +175,17 @@ Use `flat: true` when your token values are objects you want to keep intact (e.g
 
 ??? Can token aliases be circular? What happens?
 
-Circular aliases will cause infinite recursion. The resolver doesn't detect cycles:
+The resolver detects cycles. It tracks visited aliases while resolving, and when it revisits one it logs a warning and returns `undefined` instead of recursing forever — no stack overflow:
 
 ```ts
-// DON'T DO THIS - infinite loop
 const tokens = createTokens({
   a: '{b}',
   b: '{a}', // circular reference
 })
-tokens.resolve('a') // Maximum call stack exceeded
+tokens.resolve('a') // undefined — warns: Circular alias detected for "a"
 ```
 
-Design your token hierarchy as a directed acyclic graph (DAG). The [Design Tokens spec](https://www.designtokens.org/tr/drafts/format/#aliases-references) recommends keeping alias chains shallow:
+Even though cycles fail safe, design your token hierarchy as a directed acyclic graph (DAG). The [Design Tokens spec](https://www.designtokens.org/tr/drafts/format/#aliases-references) recommends keeping alias chains shallow:
 
 ```mermaid "Valid Token Graph"
 flowchart TD
@@ -222,7 +221,7 @@ No. Aliases only resolve within the same `createTokens` instance:
 const colors = createTokens({ primary: '#3b82f6' })
 const spacing = createTokens({ gap: '{primary}' }) // Won't resolve - different instance
 
-spacing.resolve('gap') // '{primary}' - returned as literal string
+spacing.resolve('gap') // undefined - '{primary}' isn't registered in this instance (warns)
 ```
 
 To share tokens across collections, use a single unified token set or compose at the application level.

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -10,10 +10,10 @@
  * - Alias resolution with circular reference detection
  * - Nested token flattening with dot notation
  * - W3C Design Tokens format ($value, $type, $description, $extensions)
- * - Path-based resolution (e.g., {colors}.blue.500)
- * - Resolution caching for performance (~28,590 ops/sec)
+ * - Path-based resolution (e.g., {colors.blue.500} or colors.blue.500)
+ * - Resolution caching for performance
  *
- * Used by useTheme, useLocale, and useFeatures for token-based configuration.
+ * Used by useTheme, useLocale, useFeatures, and usePermissions for token-based configuration.
  *
  * @example
  * ```ts


### PR DESCRIPTION
Group C of the createTokens inspection follow-ups — documentation/JSDoc that contradicts what the code actually does. Targeted at **v1.0.0** (docs deploy from master and shouldn't ship inaccurate with the stable release). No package behavior change, so no changeset.

## Fixes
- **#3 circular-alias FAQ** claimed `resolve('a')` throws "Maximum call stack exceeded" and that the resolver doesn't detect cycles. It does: a `visited` set trips a warning and returns `undefined`. Corrected the prose and example.
- **#4 quick-start** aliased `info: '{primary}'` under a `color` group, but flattening registers `color.primary`, so `{primary}` resolves to `undefined` + a warning. Fixed to `{color.primary}`.
- **#9 invented `depth: Infinity` option** — the only options are `flat` and `prefix`. Removed it from the usage comment and the FAQ table/example. Also corrected the cross-instance FAQ (`spacing.resolve('gap')` returns `undefined` + warns; it does not return a literal `'{primary}'`).
- **#10 / #15 JSDoc** — the `@module` block used the non-working `{colors}.blue.500` path form (fixed to `{colors.blue.500}` / `colors.blue.500`), carried a stale hardcoded `~28,590 ops/sec` figure (dropped), and omitted `usePermissions` from the consumer list (added).

## Verification
- Prose/JSDoc-only; no directives, frontmatter, example imports, or nav touched.
- Every corrected `// →` comment matches a behavior confirmed by the source and the existing test suite (e.g. the circular-detection tests, the alias-not-found warning path).
- CI `docs-check` validates the page build.