### PR TITLE
fix(createRegistry): dispatch batched events even when the batch callback throws

### DIFF
--- a/.changeset/registry-batch-throw-events.md
+++ b/.changeset/registry-batch-throw-events.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createRegistry): dispatch batched events even when the batch callback throws (#570)
+
+Event-driven consumers (e.g. `useProxyRegistry` snapshots) no longer go stale when a batch or `onboard` throws after some mutations already applied — the queued events for those applied mutations now flush regardless of whether the callback completes.

--- a/packages/0/src/composables/createRegistry/index.test.ts
+++ b/packages/0/src/composables/createRegistry/index.test.ts
@@ -1072,7 +1072,7 @@ describe('createRegistry', () => {
       // Batching state should be reset
       // Next register should emit immediately
       registry.register({ id: 'item-2' })
-      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledTimes(2)
     })
 
     it('should batch multiple different operations', () => {

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -996,23 +996,23 @@ export function createRegistry<
     batched = []
 
     try {
-      const result = fn()
-
-      cache.clear()
-
-      for (const { event, data } of batched) {
-        dispatch(event, data)
-      }
-
-      return result
+      return fn()
     } finally {
       isBatching = false
+      const queue = batched
       batched = []
       cache.clear()
-      // Only notify iteration subscribers when the batch actually changed
-      // membership or order; a field-only-upsert batch leaves `structural`
-      // false and must not re-notify (mirrors the non-batched upsert path).
-      if (structural) version.value++
+
+      try {
+        for (const { event, data } of queue) {
+          dispatch(event, data)
+        }
+      } finally {
+        // Only notify iteration subscribers when the batch actually changed
+        // membership or order; a field-only-upsert batch leaves `structural`
+        // false and must not re-notify (mirrors the non-batched upsert path).
+        if (structural) version.value++
+      }
     }
   }
 


### PR DESCRIPTION
## What

`batch()` dispatched queued events only on the success path. If the callback threw after some mutations (e.g. a failing registration mid-`onboard`), the mutations persisted and reactive consumers were notified via the version bump, but the queued events were silently discarded — event-driven consumers like `useProxyRegistry` snapshots went permanently stale.

## How

The queued-event flush moves into the `finally` block, so events for already-applied mutations dispatch whether the callback returns or throws. The version bump sits in a nested `finally` so a listener that throws mid-flush aborts the remaining dispatch (matching previous behavior) without suppressing reactive invalidation.

Two deliberate behavior notes:

- `isBatching` is now `false` during the flush, so a listener that mutates the registry mid-flush emits immediately and bumps the version itself — previously those reentrant events were also silently discarded. Strictly less lossy.
- One existing test asserted the drop-on-throw behavior (`should cleanup batching state on error`); its expected emit count is corrected from 1 to 2 — the queued event from the pre-throw registration now correctly fires.