### PR TITLE
docs: show peak-bench tier on home benchmark tiles

### DIFF
--- a/apps/docs/src/components/home/HomeBenchmarks.vue
+++ b/apps/docs/src/components/home/HomeBenchmarks.vue
@@ -119,7 +119,7 @@
           <div class="text-xs opacity-60">{{ comp.fastest.hzLabel }}</div>
         </div>
 
-        <BenchmarkTierBadge size="sm" :tier="comp.tier" />
+        <BenchmarkTierBadge size="sm" :tier="comp.fastest.tier" />
       </router-link>
     </div>
 

--- a/apps/docs/src/composables/useBenchmarkData.ts
+++ b/apps/docs/src/composables/useBenchmarkData.ts
@@ -80,7 +80,7 @@ export type TierState = Tier | 'unmeasured'
 export interface NormalizedComposable {
   name: string
   tier: TierState
-  fastest: { name: string, hz: number, hzLabel: string }
+  fastest: { name: string, hz: number, hzLabel: string, tier: TierState }
   groupCount: number
   benchmarkCount: number
   groups: NormalizedGroup[]
@@ -258,8 +258,8 @@ function normalizeFiles (
       name: composableName,
       tier,
       fastest: overallFastest
-        ? { name: overallFastest.name, hz: overallFastest.hz, hzLabel: overallFastest.hzLabel }
-        : { name: '', hz: 0, hzLabel: '0 ops/s' },
+        ? { name: overallFastest.name, hz: overallFastest.hz, hzLabel: overallFastest.hzLabel, tier: overallFastest.tier }
+        : { name: '', hz: 0, hzLabel: '0 ops/s', tier: 'unmeasured' },
       groupCount: groups.length,
       benchmarkCount: groups.reduce((sum, g) => sum + g.benchmarks.length, 0),
       groups,


### PR DESCRIPTION
## Problem

On the landing page, each benchmark tile shows a composable's **peak** throughput (`comp.fastest.hzLabel`) but binds the tier badge to `comp.tier` — the *worst-of-groups* roll-up. Two composables with near-identical peak numbers (e.g. `createNested` 16.4M vs `createRegistry` 16.2M, shown side by side) can carry different badges ("Blazing" vs "Good") because their *slowest* documented operations differ. Next to the peak number, that reads as a contradiction.

## Fix

Bind the home tile badge to the peak bench's own tier (`comp.fastest.tier`) so the icon matches the number displayed. Adds `tier: TierState` to the `NormalizedComposable.fastest` shape and populates it from the overall-fastest bench.

The worst-of-groups roll-up (`comp.tier`) is **unchanged** and still drives the Benchmark Explorer (`/guide/fundamentals/benchmarks`), where the honest "a feature is as fast as its slowest documented operation" framing is the point. This change is scoped to the marketing summary only.

## Verification

- `pnpm typecheck` (packages) green.
- `vue-tsc` on `apps/docs`: no errors attributable to this change (remaining TS6305/TS7006 are pre-existing project-reference/implicit-any noise on master).
- `BenchmarkTierBadge` prop is `tier: TierState`; the new `comp.fastest.tier` binding matches.