### PR TITLE
docs(DocsBrowserSupport): render slot content as markdown

### DIFF
--- a/apps/docs/src/components/docs/DocsBrowserSupport.vue
+++ b/apps/docs/src/components/docs/DocsBrowserSupport.vue
@@ -3,11 +3,15 @@
   import AppBrowserIcon from '@/components/app/AppBrowserIcon.vue'
   import AppIcon from '@/components/app/AppIcon.vue'
 
+  // Composables
+  import { renderInline } from '@/composables/useMarkdown'
+
   // Utilities
-  import { computed, toRef } from 'vue'
+  import { computed, toRef, useSlots } from 'vue'
 
   // Types
   import type { BrowserName } from '@/components/app/AppBrowserIcon.vue'
+  import type { VNode } from 'vue'
 
   export interface BrowserVersion {
     chrome?: string
@@ -51,6 +55,22 @@
   })
 
   const hasLimitedSupport = toRef(() => !versions.safari || versions.safari === '—')
+
+  const slots = useSlots()
+
+  function text (nodes: VNode[] | undefined): string {
+    if (!nodes) return ''
+
+    let out = ''
+    for (const node of nodes) {
+      if (typeof node.children === 'string') out += node.children
+      else if (Array.isArray(node.children)) out += text(node.children as VNode[])
+    }
+
+    return out
+  }
+
+  const content = toRef(() => renderInline(text(slots.default?.()).trim()))
 </script>
 
 <template>
@@ -77,7 +97,9 @@
     </div>
 
     <div class="mt-2 text-sm text-on-surface/80">
-      <slot>
+      <span v-if="content" v-html="content" />
+
+      <template v-else>
         This feature requires modern browser support.
         <RouterLink
           v-if="anchor"
@@ -86,7 +108,7 @@
         >
           Learn more
         </RouterLink>
-      </slot>
+      </template>
     </div>
   </div>
 </template>

--- a/apps/docs/src/components/docs/DocsBrowserSupport.vue
+++ b/apps/docs/src/components/docs/DocsBrowserSupport.vue
@@ -3,15 +3,11 @@
   import AppBrowserIcon from '@/components/app/AppBrowserIcon.vue'
   import AppIcon from '@/components/app/AppIcon.vue'
 
-  // Composables
-  import { renderInline } from '@/composables/useMarkdown'
-
   // Utilities
-  import { computed, toRef, useSlots } from 'vue'
+  import { computed, toRef } from 'vue'
 
   // Types
   import type { BrowserName } from '@/components/app/AppBrowserIcon.vue'
-  import type { VNode } from 'vue'
 
   export interface BrowserVersion {
     chrome?: string
@@ -55,22 +51,6 @@
   })
 
   const hasLimitedSupport = toRef(() => !versions.safari || versions.safari === '—')
-
-  const slots = useSlots()
-
-  function text (nodes: VNode[] | undefined): string {
-    if (!nodes) return ''
-
-    let out = ''
-    for (const node of nodes) {
-      if (typeof node.children === 'string') out += node.children
-      else if (Array.isArray(node.children)) out += text(node.children as VNode[])
-    }
-
-    return out
-  }
-
-  const content = toRef(() => renderInline(text(slots.default?.()).trim()))
 </script>
 
 <template>
@@ -96,10 +76,8 @@
       </span>
     </div>
 
-    <div class="mt-2 text-sm text-on-surface/80">
-      <span v-if="content" v-html="content" />
-
-      <template v-else>
+    <div class="docs-support-content mt-2 text-sm text-on-surface/80">
+      <slot>
         This feature requires modern browser support.
         <RouterLink
           v-if="anchor"
@@ -108,7 +86,17 @@
         >
           Learn more
         </RouterLink>
-      </template>
+      </slot>
     </div>
   </div>
 </template>
+
+<style scoped>
+  .docs-support-content :deep(> p:first-child) {
+    margin-top: 0;
+  }
+
+  .docs-support-content :deep(> p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/apps/docs/src/pages/components/disclosure/dialog.md
+++ b/apps/docs/src/pages/components/disclosure/dialog.md
@@ -27,7 +27,9 @@ A headless modal dialog component using the native HTML dialog element.
   :versions="{ chrome: '37+', edge: '79+', firefox: '98+', safari: '15.4+', opera: '24+' }"
   anchor="native-dialog"
 >
-  Uses the native dialog element with showModal(). Safari 15.4+ is required; older versions have no support.
+
+Uses the native dialog element with showModal(). Safari 15.4+ is required; older versions have no support.
+
 </DocsBrowserSupport>
 
 ## Usage

--- a/apps/docs/src/pages/components/disclosure/popover.md
+++ b/apps/docs/src/pages/components/disclosure/popover.md
@@ -27,7 +27,9 @@ A headless component for creating popovers and tooltips using modern CSS anchor 
   :versions="{ chrome: '125+', edge: '125+', firefox: '147+', safari: '26+' }"
   anchor="css-anchor-positioning"
 >
-  The component works in all browsers, but automatic anchor positioning requires CSS Anchor Positioning support. In older browsers without it, you'll need to position the popover manually or use [Floating UI](https://floating-ui.com).
+
+The component works in all browsers, but automatic anchor positioning requires CSS Anchor Positioning support. In older browsers without it, you'll need to position the popover manually or use [Floating UI](https://floating-ui.com).
+
 </DocsBrowserSupport>
 
 ## Usage


### PR DESCRIPTION
## Summary

`DocsBrowserSupport` slot content lives inside an HTML block in the markdown pages, so its markdown is passed through raw. Inline links written in the slot — e.g. `[Floating UI](https://floating-ui.com)` on the Popover page — rendered as literal text instead of anchors.

This flattens the default slot's text and runs it through the shared `renderInline` pipeline from `useMarkdown` (per the docs rule: never instantiate `Marked` in a component). Output gets the standard `processLinks` decoration — `v0-link` class, external-link `target=_blank` + `↗︎` suffix — matching build-time markdown. When no slot is provided it falls back to the default message + optional Learn more link, unchanged.

## Verification

- `vue-tsc --noEmit` on `apps/docs`: 0 errors
- Drove the dev server:
  - **Popover page** — `[Floating UI](...)` now renders as `<a href="https://floating-ui.com" class="v0-link" target="_blank">Floating UI↗︎</a>`
  - **Dialog page** — plain-text slot (no markdown) renders cleanly, no artifacts