### PR TITLE
docs: fix accuracy gaps across ten documentation pages

### DIFF
--- a/apps/docs/src/pages/components/disclosure/alert-dialog.md
+++ b/apps/docs/src/pages/components/disclosure/alert-dialog.md
@@ -81,13 +81,15 @@ AlertDialog uses `role="alertdialog"` instead of `role="dialog"`, signaling to a
 
 | Key | Behavior |
 |-----|----------|
-| `Tab` | Moves focus between Cancel and Action buttons |
+| `Tab` | Cycles focus through focusable controls inside Content (trapped by `showModal()`) |
 | `Escape` | Blocked by default (opt-in via `closeOnEscape` prop) |
 | `Enter` / `Space` | Activates the focused button |
 
 ### Focus management
 
-Focus moves to the Cancel button on open, as it represents the safest action. This follows the WAI-ARIA alertdialog pattern where destructive actions should not receive initial focus.
+Focus is handled by the native dialog: `showModal()` moves focus to the **first focusable** control inside Content. AlertDialog does not retarget focus to Cancel on its own.
+
+For the WAI-ARIA alertdialog pattern — safe action first, destructive confirm not initially focused — put Cancel (or another non-destructive control) **first among focusables** in DOM order. The shipped examples do this. If something focusable must appear before Cancel, put `autofocus` on Cancel (or call `.focus()` yourself after open).
 
 ## FAQ
 

--- a/apps/docs/src/pages/composables/data/create-virtual.md
+++ b/apps/docs/src/pages/composables/data/create-virtual.md
@@ -165,6 +165,14 @@ createVirtual windows whatever array you pass, so filter or sort first and feed 
 
 Call `scrollTo(index, options?)` — it accepts `behavior`, `block`, and `offset`, so `scrollTo(500, { behavior: 'smooth' })` brings item 500 into view. Bound the index with `clamp` so it can't point past the data.
 
+??? How do I reverse the list for chat-style UIs?
+
+Pass `direction: 'reverse'`. The scroller pins to the bottom on mount and keeps the view anchored when new items append — the usual pattern for message threads. Pair with `anchor: 'end'` when you also need explicit end-anchoring across data changes.
+
+??? How do I load more items as the user approaches the edge?
+
+Pass `onEndReached` (and/or `onStartReached`). Each callback receives the distance in pixels from that edge; use `endThreshold` / `startThreshold` (default `0`) to fire before the user hits the absolute edge. Append to the source array inside the handler — `createVirtual` watches the items ref and reflows. Edge checks run from `scroll()`, so keep `@scroll="scroll"` on the container.
+
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/composables/selection/create-single.md
+++ b/apps/docs/src/pages/composables/selection/create-single.md
@@ -89,6 +89,9 @@ Single-selection state is **always reactive**. All computed properties update au
 > [!TIP] Perfect for UI controls
 > `selectedId`, `selectedValue`, and `selectedIndex` work directly in templates without any extra setup.
 
+> [!NOTE] Prefer the Single component for `v-model`
+> For a ready-made `v-model` surface, use [Single](/components/providers/single). This composable is the logic layer underneath — drive it with `select()` / `selectedId` / `selectedValue`, or wrap it in your own component.
+
 ## Examples
 
 ::: gn-example
@@ -122,7 +125,15 @@ createSingle is exclusive selection with no inherent order. Reach for [createSte
 
 ??? How do I prevent an empty "nothing selected" state?
 
-Pass `mandatory: true`. Once an item is active, clicking it again is a no-op, so the selection never empties — preselect on mount with `seek('first')?.select()` so the UI starts valid.
+`mandatory` accepts three modes (inherited from [createSelection](/composables/selection/create-selection)):
+
+| Value | Behavior |
+| - | - |
+| `false` (default) | Empty selection allowed |
+| `true` | Blocks deselecting the last item; does **not** auto-select on register |
+| `'force'` | Auto-selects the first non-disabled item on register/onboard **and** blocks empty |
+
+With `true`, preselect on mount (`seek('first')?.select()`) so the UI starts valid. With `'force'`, registration itself picks the first item — you usually skip the manual seek.
 
 ??? Can I read the selected value directly, not just its id?
 

--- a/apps/docs/src/pages/guide/features/palettes.md
+++ b/apps/docs/src/pages/guide/features/palettes.md
@@ -61,7 +61,7 @@ app.use(
 
 ## Generator Adapters
 
-Generator adapters take a single brand color and produce a complete `palette` + `themes` object ready to pass to `createThemePlugin`. Each adapter wraps a third-party color algorithm.
+Generator adapters take a single brand color and produce a complete `palette` + `themes` object ready to pass to `createThemePlugin`. Each adapter wraps a third-party color algorithm. The color libraries are **optional peer dependencies** — install the peer for the generator you import; without it, module resolution fails at load time.
 
 ### Material
 
@@ -95,7 +95,12 @@ const { palette, themes } = material('#6750A4')
 app.use(createThemePlugin({ palette, themes }))
 ```
 
-The `variant` option controls how the seed color influences secondary and tertiary roles: `tonalSpot` (default), `vibrant`, `expressive`, `fidelity`, `monochrome`, `neutral`.
+Options (second argument):
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `variant` | `'tonalSpot' \| 'vibrant' \| 'expressive' \| 'fidelity' \| 'monochrome' \| 'neutral'` | `'tonalSpot'` | How the seed influences secondary and tertiary roles |
+| `contrast` | `number` | `0` | Contrast preference passed through to Material's dynamic scheme |
 
 ### Ant Design
 
@@ -129,6 +134,12 @@ const { palette, themes } = ant('#1677ff')
 app.use(createThemePlugin({ palette, themes }))
 ```
 
+Options (second argument):
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `background` | `string` | `'#141414'` | Background hex used when generating the dark ramp |
+
 ### Leonardo
 
 Uses Adobe's `@adobe/leonardo-contrast-colors` to generate perceptually uniform ramps based on target contrast ratios against a background.
@@ -160,6 +171,13 @@ const { palette, themes } = leonardo('#0ea5e9')
 
 app.use(createThemePlugin({ palette, themes }))
 ```
+
+Options (second argument):
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `ratios` | `number[]` | `[1.25, 1.5, 2, 3, 4.5, 7, 11]` | Target contrast ratios against the background |
+| `colorSpace` | `'CAM02' \| 'CAM02p' \| 'HSL' \| 'HSLuv' \| 'HSV' \| 'LAB' \| 'LCH' \| 'OKLAB' \| 'OKLCH' \| 'RGB'` | Leonardo's default | Color space for ramp generation |
 
 ## Overriding Colors
 
@@ -222,3 +240,21 @@ const myGenerator: PaletteGenerator<{ variant?: 'vibrant' | 'muted' }> = (seed, 
   return { palette, themes }
 }
 ```
+
+## FAQ
+
+::: faq
+
+??? What seed format do generators accept?
+
+A CSS hex string with a leading `#` — 3, 6, or 8 hex digits (e.g. `#6750A4`, `#0ea`, `#6750A4FF`). Anything else throws `V0_PALETTE_INVALID_SEED`. Use `isV0Error(err, 'V0_PALETTE_INVALID_SEED')` when asserting in tests — see [Testing](/guide/tooling/testing).
+
+??? What happens if I pass an unknown Material `variant`?
+
+`material()` throws `V0_PALETTE_UNKNOWN_VARIANT`. Stick to `tonalSpot`, `vibrant`, `expressive`, `fidelity`, `monochrome`, or `neutral`.
+
+??? Do I need every palette peer dependency installed?
+
+No. Peers are optional until you import a `/generate` entry. Install only the library for the generator you use (`@material/material-color-utilities`, `@ant-design/colors`, or `@adobe/leonardo-contrast-colors`). Static palette imports need no peers.
+
+:::

--- a/apps/docs/src/pages/guide/fundamentals/components.md
+++ b/apps/docs/src/pages/guide/fundamentals/components.md
@@ -34,12 +34,14 @@ v0 components are Vue wrappers around composables. Composables hold logic, compo
 
 | Category | Purpose | Examples |
 | - | - | - |
-| **Primitives** | Base building blocks | [Atom](/components/primitives/atom) |
-| **Providers** | Pure state management, no DOM | [Selection](/components/providers/selection), [Single](/components/providers/single), [Group](/components/providers/group), [Step](/components/providers/step) |
-| **Actions** | Interactive controls that trigger behavior | [Button](/components/actions/button), [Toggle](/components/actions/toggle) |
-| **Forms** | Form controls with accessibility | [Checkbox](/components/forms/checkbox) |
-| **Semantic** | Meaningful HTML defaults | [Avatar](/components/semantic/avatar), [Pagination](/components/semantic/pagination) |
-| **Disclosure** | Show/hide patterns | [Dialog](/components/disclosure/dialog), [ExpansionPanel](/components/disclosure/expansion-panel), [Popover](/components/disclosure/popover) |
+| **Primitives** | Base building blocks | [Atom](/components/primitives/atom), [Presence](/components/primitives/presence) — [all primitives](/components#primitives) |
+| **Providers** | Pure state management, no DOM | [Selection](/components/providers/selection), [Theme](/components/providers/theme) — [all providers](/components#providers) |
+| **Actions** | Interactive controls that trigger behavior | [Button](/components/actions/button), [Toggle](/components/actions/toggle) — [all actions](/components#actions) |
+| **Forms** | Form controls with accessibility | [Checkbox](/components/forms/checkbox), [Select](/components/forms/select), [Form](/components/forms/form) — [all forms](/components#forms) |
+| **Semantic** | Meaningful HTML defaults | [Avatar](/components/semantic/avatar), [Pagination](/components/semantic/pagination) — [all semantic](/components#semantic) |
+| **Disclosure** | Show/hide patterns | [Dialog](/components/disclosure/dialog), [AlertDialog](/components/disclosure/alert-dialog), [Tabs](/components/disclosure/tabs) — [all disclosure](/components#disclosure) |
+
+Full inventory with descriptions: [Components](/components).
 
 ## Atom: The Foundation
 
@@ -75,7 +77,7 @@ The `Atom` component is a polymorphic base element supporting any HTML tag:
 
 ## Slot Props Pattern
 
-Every component exposes `attrs` in its default slot. Spread onto your element for behavior and accessibility:
+Every component exposes `attrs` in its default slot. Spread onto your element for behavior and accessibility — `attrs` already includes the click handler plus ARIA and `data-*` attributes. Do not also bind `@click` when spreading `attrs`, or both handlers fire.
 
 ```vue playground
 <script setup lang="ts">
@@ -86,11 +88,10 @@ Every component exposes `attrs` in its default slot. Spread onto your element fo
 
 <template>
   <Selection.Root>
-    <Selection.Item v-for="item in items" v-slot="{ attrs, isSelected, toggle }">
+    <Selection.Item v-for="item in items" v-slot="{ attrs, isSelected }">
       <button
         v-bind="attrs"
         :class="{ 'bg-primary': isSelected }"
-        @click="toggle"
       >
         {{ item }}
       </button>

--- a/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
+++ b/apps/docs/src/pages/guide/fundamentals/tree-shaking.md
@@ -50,7 +50,7 @@ Subpath imports narrow the module scope, giving bundlers less work to analyze. T
 
 ### Adapter Subpaths
 
-Composables with optional adapters have dedicated subpaths that isolate their dependencies:
+Composables with optional adapters have dedicated subpaths that isolate their dependencies. Prefer these over root imports when you need a hard boundary around peer-heavy entry points:
 
 ```ts
 import { useDate } from '@vuetify/v0/date'
@@ -60,10 +60,13 @@ import { useTheme } from '@vuetify/v0/theme'
 import { useLocale } from '@vuetify/v0/locale'
 import { useLogger } from '@vuetify/v0/logger'
 import { usePermissions } from '@vuetify/v0/permissions'
+import { useNotifications } from '@vuetify/v0/notifications'
+import { useRules } from '@vuetify/v0/rules'
 import { createDataTable } from '@vuetify/v0/data-table'
+import { material } from '@vuetify/v0/palettes/material/generate'
 ```
 
-These are primarily useful for **framework authors** who want to guarantee that adapter peer dependencies (like `date-fns` or `flagsmith`) don't leak into consumer bundles.
+Nested adapter packages (e.g. `@vuetify/v0/features/adapters/flagsmith`, `@vuetify/v0/locale/adapters/vue-i18n`) hang off these entry points. These subpaths are primarily useful for **framework authors** who want to guarantee that adapter peer dependencies (like `date-fns` or `flagsmith`) don't leak into consumer bundles.
 
 ## Bundle Size
 
@@ -143,7 +146,7 @@ function isObject(value: unknown): value is object {
 
 ### 3. Subpath Exports
 
-The `package.json` defines [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) that map to individual entry points:
+The `package.json` defines [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) that map to individual entry points. The block below is a **representative excerpt** — the published map is much larger (adapters, palettes, nested data-table paths, and more). For the isolation-oriented imports that matter day to day, see [Adapter Subpaths](#adapter-subpaths).
 
 ```json
 {

--- a/apps/docs/src/pages/guide/integration/building-docs.md
+++ b/apps/docs/src/pages/guide/integration/building-docs.md
@@ -36,27 +36,49 @@ This documentation site is itself a proof of concept for v0. Every pattern docum
 
 ### Tabbed Code Groups
 
-The `DocsCodeGroup` component powers all tabbed code examples. It uses `createSingle` for exclusive selection and `useProxyRegistry` for keyboard navigation.
+The `DocsCodeGroup` component powers all tabbed code examples. It uses `createSingle` for exclusive selection and `useProxyRegistry` so registered tabs are iterable for rendering and keyboard focus.
 
 ```vue DocsCodeGroup.vue collapse
 <script setup lang="ts">
   import { createSingle, useProxyRegistry } from '@vuetify/v0'
+  import { useId } from 'vue'
 
-  // Events are required for useProxyRegistry
+  // events: true is required for useProxyRegistry snapshots
   const single = createSingle({ mandatory: 'force', events: true })
   const proxy = useProxyRegistry(single)
+  const uid = useId()
 
+  // Manual activation: arrows move focus only; Enter/Space selects (native button)
   function onKeydown (event: KeyboardEvent) {
     const tabs = Array.from(proxy.values)
     const currentIndex = tabs.findIndex(t => t.isSelected.value)
+    let nextIndex = currentIndex
 
     switch (event.key) {
       case 'ArrowLeft':
-        // Move to previous tab
+        nextIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1
+        event.preventDefault()
         break
       case 'ArrowRight':
-        // Move to next tab
+        nextIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0
+        event.preventDefault()
         break
+      case 'Home':
+        nextIndex = 0
+        event.preventDefault()
+        break
+      case 'End':
+        nextIndex = tabs.length - 1
+        event.preventDefault()
+        break
+      default:
+        return
+    }
+
+    if (nextIndex !== currentIndex) {
+      document.querySelector<HTMLButtonElement>(
+        `#${CSS.escape(`${uid}-tab-${tabs[nextIndex].id}`)}`,
+      )?.focus()
     }
   }
 </script>
@@ -65,9 +87,11 @@ The `DocsCodeGroup` component powers all tabbed code examples. It uses `createSi
   <div role="tablist" @keydown="onKeydown">
     <button
       v-for="tab in proxy.values"
+      :id="`${uid}-tab-${tab.id}`"
       :key="tab.id"
       :aria-selected="tab.isSelected.value"
       role="tab"
+      :tabindex="tab.isSelected.value ? 0 : -1"
       @click="tab.toggle"
     >
       {{ tab.value }}
@@ -77,7 +101,7 @@ The `DocsCodeGroup` component powers all tabbed code examples. It uses `createSi
 ```
 
 > [!NOTE]
-> **Why this works:** `createSingle` handles the selection logic. `useProxyRegistry` exposes registered items for iteration. The component owns all styling and accessibility attributes.
+> **Why this works:** `createSingle` owns exclusive selection. `useProxyRegistry` exposes tickets for iteration — keyboard handling is hand-rolled roving tabindex + manual activation on top of that list. The component owns styling and the remaining ARIA wiring.
 
 ### Mobile Navigation
 
@@ -164,12 +188,12 @@ The homepage demo uses `Selection` to show v0's component pattern:
     <Selection.Item
       v-for="item in items"
       :key="item.id"
-      v-slot="{ isSelected, toggle }"
+      v-slot="{ attrs, isSelected }"
       :value="item.id"
     >
       <button
+        v-bind="attrs"
         :class="isSelected ? 'bg-primary' : 'bg-surface'"
-        @click="toggle"
       >
         {{ item.label }}
       </button>

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -128,7 +128,7 @@ If a name below covers the need, use it — never hand-roll an equivalent.
 - createSelection — multi/single selection with mandatory guards
 - createForm — form state + field coordination
 - useHotkey — keyboard shortcuts
-- useVirtual — virtual scrolling for large lists
+- createVirtual — virtual scrolling for large lists
 <!-- ...full export list... -->
 ```
 
@@ -173,9 +173,9 @@ Hallucinated v0 APIs fail to compile. Run `vue-tsc --noEmit` (or `tsc --noEmit`)
 
 **llms.txt** contains categorized links to:
 
-- 10 guide pages (introduction, theming, accessibility, etc.)
+- Guide pages (fundamentals, features, tooling, integration, and more)
 - <DocsCount type="component" /> headless components (Atom, Avatar, Pagination, etc.)
-- <DocsCount type="composable" /> composables across 7 categories
+- <DocsCount type="composable" /> composables across categories
 - FAQ and contributing guides
 
 **llms-full.txt** includes the complete content of every documentation page, stripped of Vue components and frontmatter for cleaner LLM consumption.

--- a/apps/docs/src/pages/guide/tooling/testing.md
+++ b/apps/docs/src/pages/guide/tooling/testing.md
@@ -6,7 +6,7 @@ features:
   level: 2
 meta:
   - name: description
-    content: Test v0-based code with Vitest and @vue/test-utils. Covers setup, Vue DI mocking, plugin mocking, fake timers, SSR-only tests, and asserting v0 errors and warnings.
+    content: Test v0-based code with Vitest and @vue/test-utils. Covers setup, plugin installation, fake timers, asserting v0 errors and warnings, and package-internal DI/SSR patterns for contributors.
   - name: keywords
     content: vuetify0, testing, vitest, vue test utils, unit tests, component tests, mocking, V0Error, isV0Error, happy-dom
 related:
@@ -17,7 +17,7 @@ related:
 
 # Testing
 
-This guide covers testing patterns for v0 consumers — from environment setup through asserting errors, warnings, and locale-safe output.
+Patterns for testing apps that use v0, plus the package-internal techniques used when contributing to `@vuetify/v0`.
 
 <DocsPageFeatures :frontmatter />
 
@@ -59,36 +59,9 @@ export default defineConfig({
 })
 ```
 
-## Mocking Vue DI
+## Installing plugins
 
-Many v0 composables use `provide` / `inject` internally. Mock them at the top of any test file that exercises these composables:
-
-```ts
-import { vi } from 'vitest'
-
-vi.mock('vue', () => ({
-  provide: vi.fn(),
-  inject: vi.fn(),
-}))
-```
-
-When the composable also calls `hasInjectionContext()` to guard against use outside a component, extend the mock to keep that gate truthy:
-
-```ts
-vi.mock('vue', async () => {
-  const actual = await vi.importActual('vue')
-  return {
-    ...actual,
-    provide: vi.fn(),
-    inject: vi.fn(),
-    hasInjectionContext: vi.fn(() => true),
-  }
-})
-```
-
-## Mocking plugins
-
-Use `global.plugins` in `@vue/test-utils` mount options to install v0 plugins. This covers Stack, Theme, and any other plugin-based contexts:
+When a component under test calls plugin-backed composables (`useStack`, `useTheme`, and similar), install those plugins in `@vue/test-utils` mount options. Prefer real providers over mocking Vue's `provide` / `inject`:
 
 ```ts
 import { mount } from '@vue/test-utils'
@@ -104,7 +77,7 @@ const wrapper = mount(MyComponent, {
 
 ## Fake timers
 
-Composables that schedule work via `setTimeout` or `setInterval` (such as `useTimer`, `useDelay`, and `usePopover`) require fake timers. Enable them in `beforeEach` and restore in `afterEach`:
+Composables that schedule work via `setTimeout` or `setInterval` (such as `useTimer`, `useDelay`, and `usePopover`) require fake timers. Enable them in `beforeEach` and restore real timers in `afterEach`:
 
 ```ts
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
@@ -115,7 +88,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 it('should fire handler after duration', () => {
@@ -187,9 +160,45 @@ it('should warn on duplicate registration', () => {
 
 Never silently swallow warnings — always assert that the spy was called.
 
-## SSR-only tests
+## Locale-safe assertions
 
-`vi.mock` is hoisted and applies file-wide, so mixing client and SSR branches in the same file causes the mock to leak. Split SSR-only tests into a sibling `*.ssr.test.ts` file and hoist the `IN_BROWSER` mock there:
+v0 formats user-visible strings through the locale system. Pin assertions to structure, not English text, so tests pass under any locale:
+
+```ts
+// Right — locale-safe
+expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBeDefined()
+
+// Wrong — breaks under non-English locales
+expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBe('Close dialog')
+```
+
+## Contributing to v0
+
+The patterns below apply when unit-testing composables **inside the `@vuetify/v0` package**. When testing your own components, prefer [Installing plugins](#installing-plugins) and real provide/inject instead.
+
+### Mocking Vue DI
+
+Many package tests isolate composables by stubbing `provide` / `inject` (and `hasInjectionContext` when the composable guards against use outside a component). Always spread `importActual` so the rest of Vue stays real:
+
+```ts
+import { vi } from 'vitest'
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    provide: vi.fn(),
+    inject: vi.fn(),
+    hasInjectionContext: vi.fn(() => true),
+  }
+})
+```
+
+### SSR-only tests
+
+`vi.mock` is hoisted and applies file-wide, so mixing client and SSR branches in the same file causes the mock to leak. Split SSR-only tests into a sibling `*.ssr.test.ts` file.
+
+The package resolves internals via the `#v0/*` import map (`package.json` `imports`). That specifier is **not available to app consumers** — only monorepo tests that run against package source can mock it:
 
 ```ts index.ssr.test.ts
 // Must be the first statement — vi.mock is hoisted
@@ -206,15 +215,3 @@ it('should throw when called outside a component in SSR', () => {
 ```
 
 The corresponding client tests live in `index.test.ts` and are unaffected by the SSR mock.
-
-## Locale-safe assertions
-
-v0 formats user-visible strings through the locale system. Pin assertions to structure, not English text, so tests pass under any locale:
-
-```ts
-// Right — locale-safe
-expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBeDefined()
-
-// Wrong — breaks under non-English locales
-expect(wrapper.find('[aria-label]').element.getAttribute('aria-label')).toBe('Close dialog')
-```


### PR DESCRIPTION
## Summary

Random-sample docs audit of ten pages. Only substantive accuracy / teaching gaps:

- **createVirtual** — FAQ for reverse (chat) and infinite-scroll edge callbacks
- **AlertDialog** — focus is first focusable via `showModal()`, not a Cancel guarantee
- **Components guide** — stop double-binding `@click` when spreading `attrs`; category table links to full inventory
- **AI tools** — surface map uses `createVirtual`; drop stale guide counts
- **Testing** — consumer path first; package-internal DI/SSR mocks labeled as contributor-only
- **Building docs** — real DocsCodeGroup keyboard (manual activation); Selection demo uses `attrs`
- **Tree-shaking** — exports JSON marked as excerpt; link to Adapter Subpaths; expand isolation imports
- **Palettes** — generator options tables + seed/variant/peer FAQ
- **createSingle** — `mandatory` modes (`true` vs `'force'`); callout to Single for `v-model`

Docs app only — no package source changes.