### PR TITLE
docs(DocsApi): filter API items by name (inline + standalone pages)

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -159,6 +159,7 @@ declare module 'vue' {
     DocsReleases: typeof import('./components/docs/DocsReleases.vue')['default']
     DocsRoadmap: typeof import('./components/docs/DocsRoadmap.vue')['default']
     DocsSearch: typeof import('./components/docs/DocsSearch.vue')['default']
+    DocsSearchInput: typeof import('./components/docs/DocsSearchInput.vue')['default']
     DocsSkeleton: typeof import('./components/docs/DocsSkeleton.vue')['default']
     DocsSkillToggle: typeof import('./components/docs/meta/DocsSkillToggle.vue')['default']
     DocsSponsor: typeof import('./components/docs/DocsSponsor.vue')['default']

--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
   import apiData from 'virtual:api'
 
+  // Framework
+  import { createFilter } from '@vuetify/v0'
+
   // Composables
   import { useApiHelpers } from '@/composables/useApiHelpers'
   import { useSettings } from '@/composables/useSettings'
@@ -8,7 +11,7 @@
 
   // Utilities
   import { resolveItemName } from '@/utilities/strings'
-  import { computed, toRef } from 'vue'
+  import { computed, shallowRef, toRef } from 'vue'
   import { useRoute } from 'vue-router'
 
   // Types
@@ -58,6 +61,48 @@
     return data.composables[name] || null
   })
 
+  const search = shallowRef('')
+
+  const items = toRef(() => {
+    if (pageType.value === 'component') {
+      return componentApis.value.flatMap(api => [
+        ...api.props ?? [],
+        ...api.events ?? [],
+        ...api.slots ?? [],
+      ])
+    }
+
+    const api = composableApi.value
+    if (!api) return []
+
+    return [
+      ...api.functions ?? [],
+      ...api.options ?? [],
+      ...api.properties ?? [],
+      ...api.methods ?? [],
+    ]
+  })
+
+  const filter = createFilter({ keys: ['name', 'description'] })
+  const { items: matches } = filter.apply(search, items)
+
+  const matched = toRef(() => new Set(matches.value))
+
+  const visibleApis = toRef(() => {
+    if (!search.value) return componentApis.value
+
+    return componentApis.value.filter(api =>
+      [...api.props ?? [], ...api.events ?? [], ...api.slots ?? []].some(item => matched.value.has(item)),
+    )
+  })
+
+  const placeholder = toRef(() =>
+    pageType.value === 'component'
+      ? 'Filter props, events, slots…'
+      : 'Filter functions, options, methods…',
+  )
+
+  const empty = toRef(() => !!search.value && matches.value.length === 0)
 </script>
 
 <template>
@@ -91,8 +136,23 @@
     />
 
     <template v-if="showInlineApi">
+      <div class="relative mt-4">
+        <AppIcon
+          class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
+          icon="search"
+          :size="16"
+        />
+
+        <input
+          v-model="search"
+          class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+          :placeholder
+          type="text"
+        >
+      </div>
+
       <template
-        v-for="api in componentApis"
+        v-for="api in visibleApis"
         :key="api.name"
       >
         <DocsHeaderAnchor :id="helpers.toKebab(api.name)" class="mt-8">
@@ -103,6 +163,7 @@
           :anchor-id="`${helpers.toKebab(api.name)}-props`"
           :items="api.props"
           kind="prop"
+          :query="search"
           title="Props"
         />
 
@@ -111,6 +172,7 @@
           class="mt-8"
           :items="api.events"
           kind="event"
+          :query="search"
           title="Events"
         />
 
@@ -119,9 +181,14 @@
           class="mt-8"
           :items="api.slots"
           kind="slot"
+          :query="search"
           title="Slots"
         />
       </template>
+
+      <p v-if="empty" class="text-sm text-on-surface-variant mt-4">
+        No API items match "{{ search }}".
+      </p>
     </template>
   </div>
 
@@ -155,11 +222,27 @@
     />
 
     <template v-if="showInlineApi">
+      <div class="relative mt-4">
+        <AppIcon
+          class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
+          icon="search"
+          :size="16"
+        />
+
+        <input
+          v-model="search"
+          class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+          :placeholder
+          type="text"
+        >
+      </div>
+
       <DocsApiSection
         anchor-id="functions"
         class="mt-8"
         :items="composableApi.functions"
         kind="function"
+        :query="search"
         title="Functions"
       />
 
@@ -168,6 +251,7 @@
         class="mt-8"
         :items="composableApi.options"
         kind="option"
+        :query="search"
         title="Options"
       />
 
@@ -176,6 +260,7 @@
         class="mt-8"
         :items="composableApi.properties"
         kind="property"
+        :query="search"
         title="Properties"
       />
 
@@ -184,8 +269,13 @@
         class="mt-8"
         :items="composableApi.methods"
         kind="method"
+        :query="search"
         title="Methods"
       />
+
+      <p v-if="empty" class="text-sm text-on-surface-variant mt-4">
+        No API items match "{{ search }}".
+      </p>
     </template>
   </div>
 </template>

--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -93,20 +93,7 @@
     />
 
     <template v-if="showInlineApi">
-      <div class="relative mt-4">
-        <AppIcon
-          class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
-          icon="search"
-          :size="16"
-        />
-
-        <input
-          v-model="search"
-          class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
-          :placeholder
-          type="text"
-        >
-      </div>
+      <DocsSearchInput v-model="search" class="mt-4" :placeholder />
 
       <template
         v-for="api in visibleApis"
@@ -179,20 +166,7 @@
     />
 
     <template v-if="showInlineApi">
-      <div class="relative mt-4">
-        <AppIcon
-          class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
-          icon="search"
-          :size="16"
-        />
-
-        <input
-          v-model="search"
-          class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
-          :placeholder
-          type="text"
-        >
-      </div>
+      <DocsSearchInput v-model="search" class="mt-4" :placeholder />
 
       <DocsApiSection
         anchor-id="functions"

--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -1,17 +1,15 @@
 <script setup lang="ts">
   import apiData from 'virtual:api'
 
-  // Framework
-  import { createFilter } from '@vuetify/v0'
-
   // Composables
+  import { useApiFilter } from '@/composables/useApiFilter'
   import { useApiHelpers } from '@/composables/useApiHelpers'
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
 
   // Utilities
   import { resolveItemName } from '@/utilities/strings'
-  import { computed, shallowRef, toRef } from 'vue'
+  import { computed, toRef } from 'vue'
   import { useRoute } from 'vue-router'
 
   // Types
@@ -61,48 +59,7 @@
     return data.composables[name] || null
   })
 
-  const search = shallowRef('')
-
-  const items = toRef(() => {
-    if (pageType.value === 'component') {
-      return componentApis.value.flatMap(api => [
-        ...api.props ?? [],
-        ...api.events ?? [],
-        ...api.slots ?? [],
-      ])
-    }
-
-    const api = composableApi.value
-    if (!api) return []
-
-    return [
-      ...api.functions ?? [],
-      ...api.options ?? [],
-      ...api.properties ?? [],
-      ...api.methods ?? [],
-    ]
-  })
-
-  const filter = createFilter({ keys: ['name', 'description'] })
-  const { items: matches } = filter.apply(search, items)
-
-  const matched = toRef(() => new Set(matches.value))
-
-  const visibleApis = toRef(() => {
-    if (!search.value) return componentApis.value
-
-    return componentApis.value.filter(api =>
-      [...api.props ?? [], ...api.events ?? [], ...api.slots ?? []].some(item => matched.value.has(item)),
-    )
-  })
-
-  const placeholder = toRef(() =>
-    pageType.value === 'component'
-      ? 'Filter props, events, slots…'
-      : 'Filter functions, options, methods…',
-  )
-
-  const empty = toRef(() => !!search.value && matches.value.length === 0)
+  const { search, visibleApis, placeholder, empty } = useApiFilter(componentApis, composableApi)
 </script>
 
 <template>

--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -93,13 +93,15 @@
     />
 
     <template v-if="showInlineApi">
-      <DocsSearchInput v-model="search" class="mt-4" :placeholder />
+      <DocsSearchInput v-model="search" class="mt-8" :placeholder />
+
+      <hr class="mt-4 -mb-4">
 
       <template
         v-for="api in visibleApis"
         :key="api.name"
       >
-        <DocsHeaderAnchor :id="helpers.toKebab(api.name)" class="mt-8">
+        <DocsHeaderAnchor :id="helpers.toKebab(api.name)">
           {{ api.name }}
         </DocsHeaderAnchor>
 

--- a/apps/docs/src/components/docs/DocsApiSection.vue
+++ b/apps/docs/src/components/docs/DocsApiSection.vue
@@ -1,15 +1,27 @@
 <script setup lang="ts">
+  // Framework
+  import { createFilter } from '@vuetify/v0'
+
+  // Utilities
+  import { toRef } from 'vue'
+
   const props = defineProps<{
     anchorId: string
     title: string
     items?: { name: string }[]
     kind: 'prop' | 'event' | 'slot' | 'function' | 'option' | 'property' | 'method'
+    query?: string
     class?: string
   }>()
+
+  const filter = createFilter({ keys: ['name', 'description'] })
+  const { items: matches } = filter.apply(() => props.query ?? '', () => props.items ?? [])
+
+  const count = toRef(() => matches.value.length)
 </script>
 
 <template>
-  <template v-if="props.items?.length">
+  <template v-if="count">
     <DocsHeaderAnchor
       :id="anchorId"
       :class="$props.class"
@@ -19,7 +31,7 @@
 
     <div class="space-y-4">
       <DocsApiCard
-        v-for="item in props.items"
+        v-for="item in matches"
         :key="item.name"
         :item="(item as never)"
         :kind

--- a/apps/docs/src/components/docs/DocsSearchInput.vue
+++ b/apps/docs/src/components/docs/DocsSearchInput.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+  const { placeholder = 'Search…' } = defineProps<{
+    placeholder?: string
+  }>()
+
+  const model = defineModel<string>({ default: '' })
+</script>
+
+<template>
+  <div class="relative">
+    <AppIcon
+      class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
+      icon="search"
+      :size="16"
+    />
+
+    <input
+      v-model="model"
+      class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+      :placeholder
+      type="text"
+    >
+  </div>
+</template>

--- a/apps/docs/src/composables/useApiFilter.ts
+++ b/apps/docs/src/composables/useApiFilter.ts
@@ -1,0 +1,69 @@
+// Framework
+import { createFilter } from '@vuetify/v0'
+
+// Utilities
+import { shallowRef, toRef, toValue } from 'vue'
+
+// Types
+import type { ComponentApi, ComposableApi } from '@build/generate-api'
+import type { MaybeRefOrGetter } from 'vue'
+
+// Shared filter state for the API reference surfaces (inline <DocsApi /> and the
+// standalone /api/{name} pages). Owns the search query and derives which items,
+// sections, and component groups survive it. DocsApiSection self-filters its own
+// items with the same createFilter keys; this composable drives the query and the
+// component-group + empty-state visibility around them.
+export function useApiFilter (
+  componentApis: MaybeRefOrGetter<ComponentApi[]>,
+  composableApi: MaybeRefOrGetter<ComposableApi | null>,
+) {
+  // API item shapes (ApiProp, ApiSlot, …) carry no index signature, so cast to
+  // createFilter's structural FilterItem at the boundary. Object identity is
+  // preserved, which is what the visibleApis membership check relies on.
+  type Item = Record<string, unknown>
+
+  const search = shallowRef('')
+
+  const isComponent = toRef(() => toValue(componentApis).length > 0)
+
+  function group (api: ComponentApi) {
+    return [...api.props ?? [], ...api.events ?? [], ...api.slots ?? []] as unknown as Item[]
+  }
+
+  const items = toRef(() => {
+    if (isComponent.value) {
+      return toValue(componentApis).flatMap(group)
+    }
+
+    const api = toValue(composableApi)
+    if (!api) return [] as Item[]
+
+    return [
+      ...api.functions ?? [],
+      ...api.options ?? [],
+      ...api.properties ?? [],
+      ...api.methods ?? [],
+    ] as unknown as Item[]
+  })
+
+  const filter = createFilter({ keys: ['name', 'description'] })
+  const { items: matches } = filter.apply(search, items)
+
+  const matched = toRef(() => new Set(matches.value))
+
+  const visibleApis = toRef(() => {
+    if (!search.value) return toValue(componentApis)
+
+    return toValue(componentApis).filter(api => group(api).some(item => matched.value.has(item)))
+  })
+
+  const placeholder = toRef(() =>
+    isComponent.value
+      ? 'Filter props, events, slots…'
+      : 'Filter functions, options, methods…',
+  )
+
+  const empty = toRef(() => !!search.value && matches.value.length === 0)
+
+  return { search, visibleApis, placeholder, empty }
+}

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -150,7 +150,7 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
-        <DocsSearchInput v-model="search" class="mt-4" :placeholder />
+        <DocsSearchInput v-model="search" class="mt-4 -mb-3" :placeholder />
 
         <template
           v-for="api in visibleApis"
@@ -204,7 +204,7 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
-        <DocsSearchInput v-model="search" class="mt-4" :placeholder />
+        <DocsSearchInput v-model="search" class="mt-4 -mb-3" :placeholder />
 
         <DocsApiSection
           anchor-id="functions"

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -150,7 +150,9 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
-        <DocsSearchInput v-model="search" class="mt-4 -mb-3" :placeholder />
+        <DocsSearchInput v-model="search" class="mt-8 mb-4" :placeholder />
+
+        <hr class="mt-4 -mb-6">
 
         <template
           v-for="api in visibleApis"

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -150,20 +150,7 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
-        <div class="relative mt-4">
-          <AppIcon
-            class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
-            icon="search"
-            :size="16"
-          />
-
-          <input
-            v-model="search"
-            class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
-            :placeholder
-            type="text"
-          >
-        </div>
+        <DocsSearchInput v-model="search" class="mt-4" :placeholder />
 
         <template
           v-for="api in visibleApis"
@@ -217,20 +204,7 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
-        <div class="relative mt-4">
-          <AppIcon
-            class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
-            icon="search"
-            :size="16"
-          />
-
-          <input
-            v-model="search"
-            class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
-            :placeholder
-            type="text"
-          >
-        </div>
+        <DocsSearchInput v-model="search" class="mt-4" :placeholder />
 
         <DocsApiSection
           anchor-id="functions"

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -3,6 +3,7 @@
   import apiData from 'virtual:api'
 
   // Composables
+  import { useApiFilter } from '@/composables/useApiFilter'
   import { useApiHelpers } from '@/composables/useApiHelpers'
   import { useParams } from '@/composables/useRoute'
 
@@ -72,6 +73,8 @@
     if (!isComposable.value || !itemName.value) return null
     return data.composables[itemName.value] || null
   })
+
+  const { search, visibleApis, placeholder, empty } = useApiFilter(componentApis, composableApi)
 
   const title = toRef(() => itemName.value ? `${itemName.value} API` : 'API Reference')
 
@@ -147,8 +150,23 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
+        <div class="relative mt-4">
+          <AppIcon
+            class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
+            icon="search"
+            :size="16"
+          />
+
+          <input
+            v-model="search"
+            class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+            :placeholder
+            type="text"
+          >
+        </div>
+
         <template
-          v-for="api in componentApis"
+          v-for="api in visibleApis"
           :key="api.name"
         >
           <DocsHeaderAnchor
@@ -162,6 +180,7 @@
             :anchor-id="`${helpers.toKebab(api.name)}-props`"
             :items="api.props"
             kind="prop"
+            :query="search"
             title="Props"
           />
 
@@ -170,6 +189,7 @@
             class="mt-8"
             :items="api.events"
             kind="event"
+            :query="search"
             title="Events"
           />
 
@@ -178,9 +198,14 @@
             class="mt-8"
             :items="api.slots"
             kind="slot"
+            :query="search"
             title="Slots"
           />
         </template>
+
+        <p v-if="empty" class="text-on-surface-variant mt-4">
+          No API items match "{{ search }}".
+        </p>
       </div>
     </template>
 
@@ -192,10 +217,27 @@
 
         <DocsRelated :frontmatter="relatedFrontmatter" />
 
+        <div class="relative mt-4">
+          <AppIcon
+            class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
+            icon="search"
+            :size="16"
+          />
+
+          <input
+            v-model="search"
+            class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+            :placeholder
+            type="text"
+          >
+        </div>
+
         <DocsApiSection
           anchor-id="functions"
+          class="mt-8"
           :items="composableApi.functions"
           kind="function"
+          :query="search"
           title="Functions"
         />
 
@@ -204,6 +246,7 @@
           class="mt-8"
           :items="composableApi.options"
           kind="option"
+          :query="search"
           title="Options"
         />
 
@@ -212,6 +255,7 @@
           class="mt-8"
           :items="composableApi.properties"
           kind="property"
+          :query="search"
           title="Properties"
         />
 
@@ -220,8 +264,13 @@
           class="mt-8"
           :items="composableApi.methods"
           kind="method"
+          :query="search"
           title="Methods"
         />
+
+        <p v-if="empty" class="text-on-surface-variant mt-4">
+          No API items match "{{ search }}".
+        </p>
       </div>
     </template>
   </article>


### PR DESCRIPTION
## Summary

Adds a name/description filter to the API reference, on both surfaces:

- **Inline `<DocsApi />`** at the bottom of component/composable pages (inline mode).
- **Standalone `/api/{name}` pages** (`pages/api/[name].vue`).

Shared logic lives in a new `useApiFilter` composable so the two surfaces can't drift; `DocsApiSection` self-filters its own items with the same `createFilter({ keys: ['name', 'description'] })`.

Behavior:
- Context-aware placeholder ("Filter props, events, slots…" vs "…functions, options, methods…").
- Sections with no matches collapse their subheader; component sub-groups (e.g. `Dialog.Activator`) with zero matches hide entirely.
- "No API items match …" line when a query matches nothing.

Built on v0's `createFilter` — no hand-rolled matching.

## Verification

- `pnpm build:docs` — clean (271 pages).
- In-browser, inline (Dialog page) and standalone (`/api/dialog`, `/api/create-selection`): positive queries narrow correctly, empty sub-groups hide, non-matching query shows the empty-state line, clearing restores the full list.