### PR TITLE
docs: adopt shared DocsSearchInput across docs search surfaces

### DIFF
--- a/apps/docs/src/components/docs/DocsFaq.vue
+++ b/apps/docs/src/components/docs/DocsFaq.vue
@@ -28,29 +28,17 @@
   })
 
   const show = toRef(() => count.value >= 5)
-
-  function onInput (e: Event) {
-    filter.query.value = (e.target as HTMLInputElement).value
-  }
 </script>
 
 <template>
   <div class="my-6">
-    <div v-if="show" class="relative mb-3">
-      <AppIcon
-        class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
-        icon="search"
-        :size="16"
-      />
-
-      <input
-        class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
-        placeholder="Search FAQ..."
-        type="text"
-        :value="filter.query.value"
-        @input="onInput"
-      >
-    </div>
+    <DocsSearchInput
+      v-if="show"
+      class="mb-3"
+      :model-value="filter.query.value"
+      placeholder="Search FAQ..."
+      @update:model-value="filter.query.value = $event"
+    />
 
     <ExpansionPanel.Group class="flex flex-col gap-3" :multiple>
       <slot />

--- a/apps/docs/src/components/docs/DocsFreshnessTable.vue
+++ b/apps/docs/src/components/docs/DocsFreshnessTable.vue
@@ -48,10 +48,6 @@
     table.pagination.first()
   })
 
-  function onSearch (event: Event) {
-    table.search((event.target as HTMLInputElement).value)
-  }
-
   function formatAge (ms: number): string {
     const days = Math.round(ms / DAY_MS)
     if (days <= 0) return 'today'
@@ -79,13 +75,12 @@
     </header>
 
     <div class="flex items-center gap-2 mb-4">
-      <input
-        class="flex-1 px-4 py-2 rounded-lg border border-divider bg-surface text-on-surface text-sm placeholder-on-surface-variant/50 outline-none transition-colors focus:border-primary"
+      <DocsSearchInput
+        class="flex-1"
+        :model-value="table.query.value"
         placeholder="Search by page or category..."
-        type="text"
-        :value="table.query.value"
-        @input="onSearch"
-      >
+        @update:model-value="table.search($event)"
+      />
 
       <Select.Root v-model="pageSize">
         <Select.Activator class="flex items-center gap-2 min-w-[140px] px-3 py-2 rounded-lg border border-divider bg-surface text-on-surface text-sm cursor-pointer focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2">

--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -146,10 +146,6 @@
     table.onboard(items.map(item => ({ id: item.id, value: item })))
   }, { immediate: true })
 
-  function onSearch (event: Event) {
-    table.search((event.target as HTMLInputElement).value)
-  }
-
   // Feature pages deep-link here with `?category=&feature=` so the reader's
   // category is auto-expanded and their feature's row is highlighted, instead
   // of being buried among collapsed groups.
@@ -269,13 +265,12 @@
 
     <!-- Search + expand toggle -->
     <div class="flex items-center gap-2 mb-4">
-      <input
-        class="flex-1 px-4 py-2 rounded-lg border border-divider bg-surface text-on-surface text-sm placeholder-on-surface-variant/50 outline-none transition-colors focus:border-primary"
+      <DocsSearchInput
+        class="flex-1"
+        :model-value="table.query.value"
         placeholder="Search by name, type, or category..."
-        type="text"
-        :value="table.query.value"
-        @input="onSearch"
-      >
+        @update:model-value="table.search($event)"
+      />
 
       <button
         class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-on-surface-variant bg-transparent border-0 cursor-pointer transition-colors hover:text-on-surface whitespace-nowrap"

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -151,12 +151,11 @@
         class="bg-surface border-t border-divider rounded-b-lg max-h-80 overflow-auto shadow-lg w-[anchor-size(width)]"
         position-area="bottom"
       >
-        <input
+        <DocsSearchInput
           v-model="search"
-          class="w-full px-4 py-2 bg-transparent border-none border-b border-divider font-inherit text-inherit outline-none focus-visible:bg-surface-tint"
+          class="p-2"
           placeholder="Search releases..."
-          type="text"
-        >
+        />
 
         <div v-if="filteredReleases.length === 0" class="px-4 py-3 text-center opacity-50">
           No releases found

--- a/apps/docs/src/components/docs/benchmark/BenchmarkFilters.vue
+++ b/apps/docs/src/components/docs/benchmark/BenchmarkFilters.vue
@@ -100,14 +100,12 @@
 
     <!-- Search + expand toggle -->
     <div class="flex items-center gap-2 mb-4">
-      <input
-        aria-label="Search benchmarks"
-        class="flex-1 px-4 py-2 rounded-lg border border-divider bg-surface text-on-surface text-sm placeholder-on-surface-variant/50 outline-none transition-colors focus:border-primary"
+      <DocsSearchInput
+        class="flex-1"
+        :model-value="searchQuery"
         placeholder="Search benchmarks..."
-        type="search"
-        :value="searchQuery"
-        @input="emit('update:searchQuery', ($event.target as HTMLInputElement).value)"
-      >
+        @update:model-value="emit('update:searchQuery', $event)"
+      />
 
       <button
         v-if="showExpand"


### PR DESCRIPTION
## Summary

Follows up #577. `DocsSearchInput` (introduced there for the API filter) is now the single search-input primitive across the docs — the five spots that previously hand-rolled the same icon+input markup now consume it.

Migrated:
- `DocsFaq` — FAQ search (exact style match).
- `DocsMaturity`, `DocsFreshnessTable` — table filter toolbars (`flex-1`, bound to `table.search()`).
- `BenchmarkFilters` — benchmark filter (bridges the `searchQuery` prop/`update:searchQuery` emit).
- `DocsReleases` — release-selector popover search.

This unifies appearance on the filled icon-inside style (per request) and removes the duplicated markup + `onSearch`/`onInput` handlers. `DocsReleases` gets a `p-2` inset so it sits cleanly inside the dropdown.

Two small deltas from unifying: `BenchmarkFilters` drops its bespoke `aria-label`/`type="search"` to match the shared component (consistent with the other four, which had neither); every input keeps its placeholder.

## Verification

- `pnpm build:docs` — clean (271 pages).
- In-browser (dev): each surface renders the filled input and filters correctly — Maturity (32→4 rows), Freshness (25→2), Benchmarks (emit round-trips), FAQ (query round-trips), Releases (popover search opens and looks clean).