### PR TITLE
fix(createNested): leaf-mode parent unselect respects mandatory atomically

### DIFF
--- a/.changeset/fix-nested-leaf-mandatory.md
+++ b/.changeset/fix-nested-leaf-mandatory.md
@@ -1,0 +1,4 @@
+---
+'@vuetify/v0': patch
+---
+fix(createNested): leaf-mode parent unselect respects mandatory atomically instead of half-clearing the branch

--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -936,6 +936,72 @@ describe('createNested', () => {
         expect(nested.selected('leaf-1')).toBe(false)
         expect(nested.selected('leaf-2')).toBe(false)
       })
+
+      it('should block parent unselect when mandatory leaf descendants are the entire selection', () => {
+        const nested = createNested({ selection: 'leaf', mandatory: true })
+
+        nested.register({ id: 'root', value: 'Root' })
+        nested.register({ id: 'leaf-1', value: 'Leaf 1', parentId: 'root' })
+        nested.register({ id: 'leaf-2', value: 'Leaf 2', parentId: 'root' })
+
+        nested.select('root')
+        nested.unselect('root')
+
+        expect(nested.selected('leaf-1')).toBe(true)
+        expect(nested.selected('leaf-2')).toBe(true)
+        expect(nested.mixed('root')).toBe(false)
+      })
+
+      it('should unselect parent leaves when mandatory selection remains in another branch', () => {
+        const nested = createNested({ selection: 'leaf', mandatory: true })
+
+        nested.register({ id: 'root', value: 'Root' })
+        nested.register({ id: 'leaf-1', value: 'Leaf 1', parentId: 'root' })
+        nested.register({ id: 'leaf-2', value: 'Leaf 2', parentId: 'root' })
+        nested.register({ id: 'other', value: 'Other' })
+        nested.register({ id: 'leaf-3', value: 'Leaf 3', parentId: 'other' })
+
+        nested.select('root')
+        nested.select('leaf-3')
+        nested.unselect('root')
+
+        expect(nested.selected('leaf-1')).toBe(false)
+        expect(nested.selected('leaf-2')).toBe(false)
+        expect(nested.selected('leaf-3')).toBe(true)
+      })
+
+      it('should block parent toggle off when mandatory leaf descendants are the entire selection', () => {
+        const nested = createNested({ selection: 'leaf', mandatory: true })
+
+        nested.register({ id: 'root', value: 'Root' })
+        nested.register({ id: 'leaf-1', value: 'Leaf 1', parentId: 'root' })
+        nested.register({ id: 'leaf-2', value: 'Leaf 2', parentId: 'root' })
+
+        nested.select('root')
+        nested.toggle('root')
+
+        expect(nested.selected('leaf-1')).toBe(true)
+        expect(nested.selected('leaf-2')).toBe(true)
+        expect(nested.mixed('root')).toBe(false)
+      })
+
+      it('should toggle parent leaves off when mandatory selection remains in another branch', () => {
+        const nested = createNested({ selection: 'leaf', mandatory: true })
+
+        nested.register({ id: 'root', value: 'Root' })
+        nested.register({ id: 'leaf-1', value: 'Leaf 1', parentId: 'root' })
+        nested.register({ id: 'leaf-2', value: 'Leaf 2', parentId: 'root' })
+        nested.register({ id: 'other', value: 'Other' })
+        nested.register({ id: 'leaf-3', value: 'Leaf 3', parentId: 'other' })
+
+        nested.select('root')
+        nested.select('leaf-3')
+        nested.toggle('root')
+
+        expect(nested.selected('leaf-1')).toBe(false)
+        expect(nested.selected('leaf-2')).toBe(false)
+        expect(nested.selected('leaf-3')).toBe(true)
+      })
     })
   })
 

--- a/packages/0/src/composables/createNested/index.ts
+++ b/packages/0/src/composables/createNested/index.ts
@@ -490,6 +490,22 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     return getDescendants(id).filter(did => isLeaf(did))
   }
 
+  function removeLeaves (leafIds: ID[]): void {
+    const { selectedIds, mixedIds } = group
+    const ids = new Set(leafIds)
+
+    if (toValue(mandatoryOption) && [...selectedIds].every(id => ids.has(id))) return
+
+    for (const id of ids) {
+      mixedIds.delete(id)
+      selectedIds.delete(id)
+    }
+
+    for (const id of ids) {
+      updateAncestors(id)
+    }
+  }
+
   function select (ids: ID | ID[]): void {
     if (toValue(group.disabled)) return
     for (const id of toArray(ids)) {
@@ -537,11 +553,9 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
         group.unselect(id)
       } else if (selectionMode === 'leaf') {
         if (isLeaf(id)) {
-          group.unselect(id)
+          removeLeaves([id])
         } else {
-          for (const lid of getLeafDescendants(id)) {
-            group.unselect(lid)
-          }
+          removeLeaves(getLeafDescendants(id))
         }
       } else {
         const { selectedIds, mixedIds } = group
@@ -578,9 +592,7 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
           const leafIds = getLeafDescendants(id)
           const allSelected = leafIds.every(lid => group.selected(lid))
           if (allSelected) {
-            for (const lid of leafIds) {
-              group.unselect(lid)
-            }
+            removeLeaves(leafIds)
           } else {
             for (const lid of leafIds) {
               group.select(lid)


### PR DESCRIPTION
## What

In `selection: 'leaf'` mode, unselecting (or toggling off) a parent cleared its leaves one at a time through `group.unselect`, so with `mandatory: true` the per-item guard blocked the last leaf and left the branch half-cleared — some leaves unselected, one still selected, parent stuck indeterminate.

`unselect` and `toggle` now perform an atomic bulk removal, mirroring the cascade branch: if mandatory would be violated by removing the branch's leaves, the whole operation is a no-op; otherwise the branch clears fully.

Reachable via `<Treeview.Root selection="leaf" mandatory>`.

## Coverage

Adds the previously untested leaf+mandatory matrix: full-block when the branch holds the entire selection, full-clear when selection exists elsewhere, via both `unselect` and `toggle`.