### PR TITLE
fix(createProgress): fromValue offsets by min so fill width matches the ARIA percent

### DIFF
--- a/.changeset/fix-progress-fromvalue-min.md
+++ b/.changeset/fix-progress-fromvalue-min.md
@@ -1,0 +1,4 @@
+---
+'@vuetify/v0': patch
+---
+fix(createProgress): fromValue offsets by min so ProgressFill width matches the ARIA percent

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -201,6 +201,15 @@ describe('createProgress', () => {
       expect(progress.fromValue(-10)).toBe(0)
     })
 
+    it('should handle custom min/max', () => {
+      const progress = setup({ min: 20, max: 80 })
+      expect(progress.fromValue(20)).toBe(0)
+      expect(progress.fromValue(50)).toBe(50)
+      expect(progress.fromValue(80)).toBe(100)
+      expect(progress.fromValue(10)).toBe(0)
+      expect(progress.fromValue(90)).toBe(100)
+    })
+
     it('should return 0 when extent is zero', () => {
       const progress = setup({ min: 50, max: 50 })
       expect(progress.fromValue(50)).toBe(0)

--- a/packages/0/src/composables/createProgress/index.ts
+++ b/packages/0/src/composables/createProgress/index.ts
@@ -125,7 +125,7 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
 
   function fromValue (value: number): number {
     if (extent === 0) return 0
-    return (clamp(value, 0, extent) / extent) * 100
+    return ((clamp(value, min, max) - min) / extent) * 100
   }
 
   function register (registration: Partial<ProgressTicketInput> = {}): ProgressTicket {


### PR DESCRIPTION
## What

`fromValue` computed `(clamp(value, 0, extent) / extent) * 100`, ignoring `min` — while the `percent` computed correctly offsets by it. With `min="20" max="80"`, a value of 50 rendered `ProgressFill` at ~83% width while ARIA announced 50%; at `value === min` the fill showed ~33% instead of 0%.

Now `((clamp(value, min, max) - min) / extent) * 100`, matching `percent`, `ProgressBuffer`, and `createNumeric.fromValue`. No behavior change for the default `min: 0`.

## Coverage

Adds non-zero-min assertions (min 20 / max 80: 20→0, 50→50, 80→100) plus out-of-range clamping.