### PR TITLE
fix(createValidation): superseded validate resolves to the latest outcome

### DIFF
--- a/.changeset/fix-validation-superseded-result.md
+++ b/.changeset/fix-validation-superseded-result.md
@@ -1,0 +1,6 @@
+---
+'@vuetify/v0': patch
+---
+fix(createForm): submit no longer reports failure when a field validation was superseded by a newer concurrent call
+
+A superseded validate() now resolves to the latest validation's outcome instead of false, so double-submits and concurrent field validation report the form's actual validity.

--- a/packages/0/src/composables/createForm/index.test.ts
+++ b/packages/0/src/composables/createForm/index.test.ts
@@ -21,6 +21,23 @@ vi.mock('vue', async () => {
 const mockProvide = vi.mocked(provide)
 const mockInject = vi.mocked(inject)
 
+interface RuleCall {
+  value: unknown
+  resolve: (result: boolean | string) => void
+}
+
+function createRule () {
+  const calls: RuleCall[] = []
+
+  function rule (value: unknown): Promise<boolean | string> {
+    return new Promise(resolve => {
+      calls.push({ value, resolve })
+    })
+  }
+
+  return { calls, rule }
+}
+
 describe('createForm', () => {
   it('should register a validation context', () => {
     const form = createForm()
@@ -166,6 +183,50 @@ describe('createForm', () => {
 
       await promise
       expect(form.isValidating.value).toBe(false)
+    })
+
+    it('should return true from concurrent submits when the latest field validation passes', async () => {
+      const form = createForm()
+      const val = shallowRef('valid')
+      const { calls, rule } = createRule()
+
+      const validation = createValidation({ value: val, rules: [rule] })
+      form.register({ value: validation })
+
+      const first = form.submit()
+      const second = form.submit()
+
+      calls[1]!.resolve(true)
+      const secondResult = await second
+
+      calls[0]!.resolve(true)
+      const firstResult = await first
+
+      expect(secondResult).toBe(true)
+      expect(firstResult).toBe(true)
+      expect(form.isValid.value).toBe(true)
+    })
+
+    it('should not return false when a field validation supersedes submit validation', async () => {
+      const form = createForm()
+      const val = shallowRef('valid')
+      const { calls, rule } = createRule()
+
+      const validation = createValidation({ value: val, rules: [rule] })
+      form.register({ value: validation })
+
+      const submit = form.submit()
+      const field = validation.validate()
+
+      calls[1]!.resolve(true)
+      const fieldResult = await field
+
+      calls[0]!.resolve(true)
+      const submitResult = await submit
+
+      expect(fieldResult).toBe(true)
+      expect(submitResult).toBe(true)
+      expect(form.isValid.value).toBe(true)
     })
   })
 

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -28,6 +28,23 @@ vi.mock('#v0/composables/createForm', async () => {
 const mockUseRules = vi.mocked(useRules)
 const mockUseForm = vi.mocked(useForm)
 
+interface RuleCall {
+  value: unknown
+  resolve: (result: boolean | string) => void
+}
+
+function createRule () {
+  const calls: RuleCall[] = []
+
+  function rule (value: unknown): Promise<boolean | string> {
+    return new Promise(resolve => {
+      calls.push({ value, resolve })
+    })
+  }
+
+  return { calls, rule }
+}
+
 describe('createValidation', () => {
   describe('register', () => {
     it('should register a function rule', () => {
@@ -350,32 +367,69 @@ describe('createValidation', () => {
       expect(validation.errors.value).toEqual(['Error from call 2'])
     })
 
-    // Regression: the stale-check used to return `isValid.value ?? false`,
-    // leaking the newer call's result. createForm.submit() uses
-    // `results.every(Boolean)` so a stale failing call could resolve to true
-    // and flip the form to "valid".
-    it('should return false from a stale call even when newer call passed', async () => {
-      let callCount = 0
-      async function slowRule (v: unknown) {
-        const call = ++callCount
-        await new Promise(resolve => setTimeout(resolve, call === 1 ? 100 : 10))
-        // Call 1 fails; call 2 passes
-        return call === 1 ? `Error from call ${call}` : (v as string).length > 0
-      }
-
-      const validation = createValidation({ rules: [slowRule] })
+    // Regression: stale callers must not read `isValid.value` because that can
+    // leak unrelated state. They now wait for the latest generation's result.
+    it('should return the latest result from a stale call when the newer call passed', async () => {
+      const { calls, rule } = createRule()
+      const validation = createValidation({ rules: [rule] })
 
       const first = validation.validate('ab')
       const second = validation.validate('ab')
 
+      calls[1]!.resolve(true)
+      const secondResult = await second
+
+      calls[0]!.resolve('Error from call 1')
+      const firstResult = await first
+
+      expect(secondResult).toBe(true)
+      expect(firstResult).toBe(true)
+      expect(validation.isValid.value).toBe(true)
+      expect(validation.errors.value).toEqual([])
+    })
+
+    it('should return false from stale and winning calls when the newer call failed', async () => {
+      const { calls, rule } = createRule()
+      const validation = createValidation({ rules: [rule] })
+
+      const first = validation.validate('ab')
+      const second = validation.validate('ab')
+
+      calls[1]!.resolve('Error from call 2')
+      const secondResult = await second
+
+      calls[0]!.resolve(true)
+      const firstResult = await first
+
+      expect(secondResult).toBe(false)
+      expect(firstResult).toBe(false)
+      expect(validation.isValid.value).toBe(false)
+      expect(validation.errors.value).toEqual(['Error from call 2'])
+    })
+
+    it('should follow a superseded middle validation to the latest result', async () => {
+      const { calls, rule } = createRule()
+      const validation = createValidation({ rules: [rule] })
+
+      const first = validation.validate('ab')
+      const second = validation.validate('ab')
+
+      calls[0]!.resolve('Error from call 1')
+      await Promise.resolve()
+
+      const third = validation.validate('ab')
+
+      calls[2]!.resolve(true)
+      const thirdResult = await third
+
+      calls[1]!.resolve('Error from call 2')
       const [firstResult, secondResult] = await Promise.all([first, second])
 
-      // Newer call resolved truthy and updated isValid.value to true.
+      expect(thirdResult).toBe(true)
       expect(secondResult).toBe(true)
+      expect(firstResult).toBe(true)
       expect(validation.isValid.value).toBe(true)
-      // Older call must still report its own outcome (false), not leak the
-      // newer call's state.
-      expect(firstResult).toBe(false)
+      expect(validation.errors.value).toEqual([])
     })
 
     it('should not let an in-flight validate overwrite state set by a later no-rules call', async () => {

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -432,6 +432,63 @@ describe('createValidation', () => {
       expect(validation.errors.value).toEqual([])
     })
 
+    it('should follow the winner when a stale call\'s rules throw', async () => {
+      let reject: (error: Error) => void
+      let calls = 0
+      async function rule (_v: unknown) {
+        calls++
+        if (calls === 1) {
+          return new Promise<boolean>((_, r) => {
+            reject = r
+          })
+        }
+        return true
+      }
+
+      const validation = createValidation({ rules: [rule] })
+
+      const stale = validation.validate('first')
+      const winner = validation.validate('second')
+
+      reject!(new Error('boom'))
+
+      expect(await winner).toBe(true)
+      // The stale call's rejection routes through the catch-path reroute and
+      // resolves to the winning generation's outcome.
+      expect(await stale).toBe(true)
+      expect(validation.isValid.value).toBe(true)
+      expect(validation.errors.value).toEqual([])
+    })
+
+    it('should re-await when the winner it followed was itself superseded', async () => {
+      const gates: Array<(v: boolean) => void> = []
+      async function rule (_v: unknown) {
+        return new Promise<boolean>(resolve => {
+          gates.push(resolve)
+        })
+      }
+
+      const validation = createValidation({ rules: [rule] })
+
+      const first = validation.validate('a')
+      const second = validation.validate('b')
+
+      // Let the first call settle its rules and start following the second.
+      gates[0](true)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      const third = validation.validate('c')
+      gates[1](true)
+      gates[2](true)
+
+      expect(await third).toBe(true)
+      // The second call defers to the third; the first call awaited the
+      // second, found it superseded, and re-awaited the third.
+      expect(await second).toBe(true)
+      expect(await first).toBe(true)
+      expect(validation.isValid.value).toBe(true)
+    })
+
     it('should not let an in-flight validate overwrite state set by a later no-rules call', async () => {
       let resolveSlow: ((val: string | boolean) => void) | undefined
       function slowRule (_v: unknown) {

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -145,16 +145,17 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     return group.batch(() => rules.map(r => register(r)))
   }
 
-  async function wait (gen: number): Promise<boolean> {
-    while (gen !== generation) {
+  // A superseded call defers to the winning generation's outcome. Loops
+  // because the awaited winner may itself be superseded before settling;
+  // every iteration either returns or awaits a strictly newer generation.
+  async function wait (): Promise<boolean> {
+    while (true) {
       const current = latest
-      if (isUndefined(current) || current.generation !== generation) return false
+      if (isUndefined(current)) return false
 
       const result = await current.promise
       if (current.generation === generation) return result
     }
-
-    return false
   }
 
   async function run (gen: number, _value: unknown, silent: boolean): Promise<boolean> {
@@ -166,8 +167,6 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     }
 
     if (activeRules.length === 0) {
-      if (gen !== generation) return wait(gen)
-
       if (!silent) {
         errors.value = []
         isValid.value = true
@@ -180,7 +179,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
 
     try {
       const results = await Promise.all(activeRules.map(rule => rule(val)))
-      if (gen !== generation) return wait(gen)
+      if (gen !== generation) return wait()
 
       const errorMessages = results
         .filter(result => isString(result) || result === false)
@@ -193,7 +192,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
 
       return errorMessages.length === 0
     } catch (error) {
-      if (gen !== generation) return wait(gen)
+      if (gen !== generation) return wait()
 
       if (!silent) {
         errors.value = [error instanceof Error ? error.message : 'Validation error']

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -33,7 +33,7 @@ import { createGroup } from '#v0/composables/createGroup'
 import { isStandardSchema, useRules } from '#v0/composables/useRules'
 
 // Utilities
-import { isFunction, isString } from '#v0/utilities'
+import { isFunction, isString, isUndefined } from '#v0/utilities'
 import { onScopeDispose, shallowRef, toValue } from 'vue'
 
 // Types
@@ -85,6 +85,11 @@ export interface ValidationOptions extends GroupOptions {
   value?: MaybeRefOrGetter<unknown>
 }
 
+interface ValidationRun {
+  generation: number
+  promise: Promise<boolean>
+}
+
 const UNSET = /* @__PURE__ */ Symbol('unset')
 
 /**
@@ -126,6 +131,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   const isValid = shallowRef<boolean | null>(null)
   const isValidating = shallowRef(false)
   let generation = 0
+  let latest: ValidationRun | undefined
 
   function register (input: RuleInput | Partial<ValidationTicketInput>): ValidationTicket {
     if (isFunction(input) || isString(input) || isStandardSchema(input)) {
@@ -139,11 +145,19 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     return group.batch(() => rules.map(r => register(r)))
   }
 
-  async function validate (_value: unknown = UNSET, silent = false): Promise<boolean> {
-    // Bump generation up-front so every call — including the no-active-rules
-    // path below — invalidates any in-flight validation. Otherwise a slow rule
-    // resolving after a later no-rules call would overwrite the newer state.
-    const gen = ++generation
+  async function wait (gen: number): Promise<boolean> {
+    while (gen !== generation) {
+      const current = latest
+      if (isUndefined(current) || current.generation !== generation) return false
+
+      const result = await current.promise
+      if (current.generation === generation) return result
+    }
+
+    return false
+  }
+
+  async function run (gen: number, _value: unknown, silent: boolean): Promise<boolean> {
     const val = _value === UNSET ? toValue(valueSource) : _value
     const activeRules: FormValidationRule[] = []
 
@@ -152,6 +166,8 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     }
 
     if (activeRules.length === 0) {
+      if (gen !== generation) return wait(gen)
+
       if (!silent) {
         errors.value = []
         isValid.value = true
@@ -164,7 +180,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
 
     try {
       const results = await Promise.all(activeRules.map(rule => rule(val)))
-      if (gen !== generation) return false
+      if (gen !== generation) return wait(gen)
 
       const errorMessages = results
         .filter(result => isString(result) || result === false)
@@ -177,7 +193,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
 
       return errorMessages.length === 0
     } catch (error) {
-      if (gen !== generation) return false
+      if (gen !== generation) return wait(gen)
 
       if (!silent) {
         errors.value = [error instanceof Error ? error.message : 'Validation error']
@@ -192,11 +208,23 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     }
   }
 
+  async function validate (_value: unknown = UNSET, silent = false): Promise<boolean> {
+    // Bump generation up-front so every call - including the no-active-rules
+    // path - invalidates any in-flight validation. Otherwise a slow rule
+    // resolving after a later no-rules call would overwrite the newer state.
+    const gen = ++generation
+    const promise = run(gen, _value, silent)
+    latest = { generation: gen, promise }
+
+    return promise
+  }
+
   function reset () {
     errors.value = []
     isValid.value = null
     isValidating.value = false
     generation++
+    latest = undefined
   }
 
   // Register initial rules


### PR DESCRIPTION
## What

A `validate()` call superseded by a newer concurrent call returned a hardcoded `false`. `createForm.submit()` aggregates per-field results with `every(Boolean)`, so a double submit or a concurrent `field.validate()` (e.g. a blur handler) made `submit()` report the form invalid while `isValid === true` — surfacing as a false-negative `submit` event payload from `Form`.

A superseded call now awaits and returns the latest generation's outcome instead of `false`. This keeps the guarantee the previous hardcoded `false` existed for: a stale call can never leak a stale `true` — if the winning validation fails, every concurrent caller resolves `false`.

## Coverage

Rewrites the stale-call regression to the new contract (including the inverse: newer call fails → all callers get `false`), adds a three-call supersede chain, double-submit interleaving resolving `true` for both, and concurrent field validation during submit.