### PR TITLE
fix(createSelection): apply fully replaces the selection under multiple+mandatory

### DIFF
--- a/.changeset/fix-selection-apply-replace.md
+++ b/.changeset/fix-selection-apply-replace.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(createSelection): apply fully replaces the selection under multiple+mandatory instead of stranding a stale id

--- a/packages/0/src/composables/createSelection/index.test.ts
+++ b/packages/0/src/composables/createSelection/index.test.ts
@@ -1007,7 +1007,7 @@ describe('createSelection', () => {
         expect(selection.selectedIds.has('b')).toBe(true)
       })
 
-      it('should respect mandatory when applying empty array in multiple mode', () => {
+      it('should keep current selection when applying empty array under mandatory', () => {
         const selection = createSelection({ multiple: true, mandatory: true })
         selection.onboard([
           { id: 'a', value: 'A' },
@@ -1018,8 +1018,9 @@ describe('createSelection', () => {
 
         selection.apply([])
 
-        // Mandatory must keep at least one selected, like in non-multiple mode
-        expect(selection.selectedIds.size).toBe(1)
+        expect(selection.selectedIds.has('a')).toBe(true)
+        expect(selection.selectedIds.has('b')).toBe(true)
+        expect(selection.selectedIds.size).toBe(2)
       })
 
       it('should apply in multiple mode without Set.prototype.difference', () => {
@@ -1049,7 +1050,7 @@ describe('createSelection', () => {
         }
       })
 
-      it('should keep the mandatory survivor when apply swaps the last selected id', () => {
+      it('should replace the last selected id under mandatory', () => {
         const selection = createSelection({ multiple: true, mandatory: true })
         selection.onboard([
           { id: 'a', value: 'A' },
@@ -1059,9 +1060,48 @@ describe('createSelection', () => {
 
         selection.apply(['B'])
 
-        // Removals run before additions, so the mandatory guard keeps 'a'
+        expect(selection.selectedIds.has('a')).toBe(false)
+        expect(selection.selectedIds.has('b')).toBe(true)
+        expect(selection.selectedIds.size).toBe(1)
+      })
+
+      it('should fully replace multiple selected ids under mandatory', () => {
+        const selection = createSelection({ multiple: true, mandatory: true })
+        selection.onboard([
+          { id: 'a', value: 'A' },
+          { id: 'b', value: 'B' },
+          { id: 'c', value: 'C' },
+          { id: 'd', value: 'D' },
+        ])
+        selection.select('a')
+        selection.select('b')
+
+        selection.apply(['C', 'D'])
+
+        expect(selection.selectedIds.has('a')).toBe(false)
+        expect(selection.selectedIds.has('b')).toBe(false)
+        expect(selection.selectedIds.has('c')).toBe(true)
+        expect(selection.selectedIds.has('d')).toBe(true)
+        expect(selection.selectedIds.size).toBe(2)
+      })
+
+      it('should keep current selection when all applied targets are disabled under mandatory', () => {
+        const selection = createSelection({ multiple: true, mandatory: true })
+        selection.onboard([
+          { id: 'a', value: 'A' },
+          { id: 'b', value: 'B' },
+          { id: 'c', value: 'C', disabled: true },
+          { id: 'd', value: 'D', disabled: true },
+        ])
+        selection.select('a')
+        selection.select('b')
+
+        selection.apply(['C', 'D'])
+
         expect(selection.selectedIds.has('a')).toBe(true)
         expect(selection.selectedIds.has('b')).toBe(true)
+        expect(selection.selectedIds.has('c')).toBe(false)
+        expect(selection.selectedIds.has('d')).toBe(false)
         expect(selection.selectedIds.size).toBe(2)
       })
 

--- a/packages/0/src/composables/createSelection/index.ts
+++ b/packages/0/src/composables/createSelection/index.ts
@@ -245,24 +245,34 @@ export function createSelection<
     const currentIds = new Set(model.selectedIds)
     const targetIds = new Set<ID>()
 
-    for (const value of values) {
-      const ids = model.browse(toRaw(value))
-      if (ids) {
-        for (const id of ids) targetIds.add(id)
-      }
-    }
-
     if (isMultiple) {
+      for (const value of values) {
+        const ids = model.browse(toRaw(value))
+        if (isUndefined(ids)) continue
+
+        for (const id of ids) {
+          const ticket = model.get(id)
+          if (!ticket || toValue(ticket.disabled)) continue
+          targetIds.add(id)
+        }
+      }
+
+      if (toValue(mandatory) && targetIds.size === 0) return
+
       for (const id of currentIds) {
-        if (!targetIds.has(id)) unselect(id)
+        if (!targetIds.has(id)) model.selectedIds.delete(id)
       }
       for (const id of targetIds) {
-        if (currentIds.has(id)) continue
-        const ticket = model.get(id)
-        if (ticket && toValue(ticket.disabled)) continue
         model.selectedIds.add(id)
       }
     } else {
+      for (const value of values) {
+        const ids = model.browse(toRaw(value))
+        if (isUndefined(ids)) continue
+
+        for (const id of ids) targetIds.add(id)
+      }
+
       const next = targetIds.values().next().value
       const last = currentIds.values().next().value
       if (!isUndefined(last)) unselect(last)

--- a/packages/0/src/composables/useProxyModel/index.test.ts
+++ b/packages/0/src/composables/useProxyModel/index.test.ts
@@ -232,6 +232,24 @@ describe('useProxyModel', () => {
     expect(model.value).toBe('value-1')
   })
 
+  it('should keep v-model clean when multiple mandatory apply replaces selection', () => {
+    const selection = createSelection({ events: true, mandatory: true, multiple: true })
+    selection.onboard([
+      { id: 'a', value: 'A' },
+      { id: 'b', value: 'B' },
+    ])
+
+    const model = ref<string[]>(['A'])
+    useProxyModel(selection, model)
+
+    model.value = ['B']
+
+    expect(model.value).toEqual(['B'])
+    expect(selection.selectedIds.has('a')).toBe(false)
+    expect(selection.selectedIds.has('b')).toBe(true)
+    expect(selection.selectedIds.size).toBe(1)
+  })
+
   it('should treat non-array values as not equal in array mode', () => {
     // shallowEqual rejects when one side isn't an array — exercises the
     // `!isArray(a) || !isArray(b)` short-circuit.


### PR DESCRIPTION
## What

`apply` processed removals before additions, routing each removal through `unselect`, whose mandatory guard no-ops at `selectedIds.size === 1`. Under `multiple + mandatory`, every full replacement stranded one stale id: `apply(['B'])` after selecting `a` yielded `{a, b}`; `{a, b}` → `apply(['C', 'D'])` yielded `{b, c, d}`. `useProxyModel` routes v-model writes through `apply` and then echoed the corrupted set back to the parent — writing `['B']` to a v-model came back as `['A', 'B']`. This hits every multi+mandatory consumer: `Selection`, `Toggle`, `Select`, `Checkbox`, and `Group` roots.

`apply` now computes the final target set up front (skipping disabled tickets). If mandatory is on and the target set is empty, the whole operation is a no-op — mandatory semantics preserved at the operation level instead of per item. Otherwise the selection is replaced atomically. The single-select branch is unchanged.

## Coverage

Rewrites the two tests that pinned the stranded-survivor behavior, and adds: multi-id full replacement under mandatory, all-disabled-target no-op, and a `useProxyModel` round-trip asserting the v-model is not rewritten with stale ids.