### PR TITLE
fix(createSlider): thumb operations no-op while disabled

### DIFF
--- a/.changeset/fix-slider-disabled-guards.md
+++ b/.changeset/fix-slider-disabled-guards.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(createSlider): thumb operations (set, up, down, floor, ceil) now no-op while disabled, as documented

--- a/packages/0/src/composables/createSlider/index.test.ts
+++ b/packages/0/src/composables/createSlider/index.test.ts
@@ -177,6 +177,40 @@ describe('createSlider', () => {
     })
   })
 
+  describe('disabled mode', () => {
+    it('should not change value on set when disabled', () => {
+      const { slider, addThumb } = setup({ min: 0, max: 100, step: 1, disabled: true })
+      addThumb(50)
+      slider.set(0, 75)
+      expect(slider.values.value).toEqual([50])
+    })
+
+    it('should not change value on up or down when disabled', () => {
+      const { slider, addThumb } = setup({ min: 0, max: 100, step: 5, disabled: true })
+      addThumb(50)
+      slider.up(0)
+      expect(slider.values.value).toEqual([50])
+      slider.down(0)
+      expect(slider.values.value).toEqual([50])
+    })
+
+    it('should not change value on floor or ceil when disabled', () => {
+      const { slider, addThumb } = setup({ min: 10, max: 90, disabled: true })
+      addThumb(50)
+      slider.floor(0)
+      expect(slider.values.value).toEqual([50])
+      slider.ceil(0)
+      expect(slider.values.value).toEqual([50])
+    })
+
+    it('should still update values via apply when disabled', () => {
+      const { slider, addThumb } = setup({ min: 0, max: 100, step: 10, disabled: true })
+      addThumb(0)
+      slider.apply([33])
+      expect(slider.values.value).toEqual([30])
+    })
+  })
+
   describe('set with following thumb constraint', () => {
     it('should constrain first thumb below following thumb gap', () => {
       const { slider, addThumb } = setup({ min: 0, max: 100, step: 1, minStepsBetweenThumbs: 10 })

--- a/packages/0/src/composables/createSlider/index.ts
+++ b/packages/0/src/composables/createSlider/index.ts
@@ -315,7 +315,7 @@ export interface SliderContext extends Omit<
    * @param value Raw value to set.
    *
    * @remarks
-   * No-op when `readonly` is `true`. The value is snapped to step, clamped to min/max,
+   * No-op when `disabled` or `readonly` is `true`. The value is snapped to step, clamped to min/max,
    * and constrained by adjacent thumbs when `crossover` is `false`.
    *
    * @see {@link up} and {@link down} for relative adjustments.
@@ -550,7 +550,7 @@ export function createSlider (options: SliderOptions = {}): SliderContext {
   }
 
   function set (index: number, value: number): void {
-    if (readonly.value) return
+    if (disabled.value || readonly.value) return
     const snapped = snap(value)
     const current = values.value
 


### PR DESCRIPTION
## What

`set` guarded only `readonly`; the `disabled` option was returned but never consulted, so `set`/`up`/`down`/`floor`/`ceil` all mutated a disabled slider — contradicting the composable's own JSDoc ("When disabled, all thumb operations are no-ops").

`set` now bails on `disabled || readonly`, covering all five thumb operations through the single funnel. `apply` (the v-model path) intentionally stays unguarded: per the disabled-mutation ruling, programmatic value assignment works on disabled controls so wholesale state can always sync.

## Coverage

New disabled-mode block: thumb ops no-op, and `apply` still writes (snapped) while disabled.