### PR TITLE
fix(createNumberField): commit respects disabled and readonly

### DIFF
--- a/.changeset/fix-numberfield-commit-locked.md
+++ b/.changeset/fix-numberfield-commit-locked.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(createNumberField): commit now no-ops while disabled or readonly, matching increment and decrement

--- a/packages/0/src/composables/createNumberField/index.test.ts
+++ b/packages/0/src/composables/createNumberField/index.test.ts
@@ -274,6 +274,32 @@ describe('createNumberField', () => {
       field.commit()
       expect(field.value.value).toBeNull()
     })
+
+    it('should no-op when disabled', () => {
+      const field = setup({ value: ref(13), min: 0, max: 100, step: 5, disabled: true })
+      field.commit()
+      expect(field.value.value).toBe(13)
+      field.commit(42)
+      expect(field.value.value).toBe(13)
+    })
+
+    it('should no-op when readonly', () => {
+      const field = setup({ value: ref(13), min: 0, max: 100, step: 5, readonly: true })
+      field.commit()
+      expect(field.value.value).toBe(13)
+      field.commit(42)
+      expect(field.value.value).toBe(13)
+    })
+
+    it('should commit again once unlocked', () => {
+      const disabled = shallowRef(true)
+      const field = setup({ value: ref(13), min: 0, max: 100, step: 5, disabled })
+      field.commit()
+      expect(field.value.value).toBe(13)
+      disabled.value = false
+      field.commit()
+      expect(field.value.value).toBe(15)
+    })
   })
 
   describe('numeric context', () => {

--- a/packages/0/src/composables/createNumberField/index.ts
+++ b/packages/0/src/composables/createNumberField/index.ts
@@ -206,6 +206,7 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
   }
 
   function commit (next?: number | null): void {
+    if (isLocked()) return
     // Use the provided value when available — avoids reading a stale model on
     // the same tick as a write (parent-bound v-model hasn't round-tripped yet).
     const val = arguments.length === 0 ? value.value : next as number | null


### PR DESCRIPTION
## What

`commit` wrote the snapped value with no lock guard, while every sibling mutator (`increment`, `decrement`, `floor`, `ceil`) opens with `if (isLocked()) return`. A disabled or readonly number field could still have its value mutated through the blur/enter commit path.

`commit` now takes the same guard, placed before the optional-value handling so the `commit(next?)` semantics from #344 and the null-value no-op are unchanged.

## Coverage

Commit no-ops while disabled and while readonly (both the argless and explicit-value paths), and commits normally again once unlocked (reactive flip).