### PR TITLE
fix(Switch): keep Switch.Thumb visible in every state

### DIFF
--- a/.changeset/switch-thumb-always-visible.md
+++ b/.changeset/switch-thumb-always-visible.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Switch): keep `Switch.Thumb` visible in every state — it no longer forces an inline `visibility: hidden` when the switch is off. The thumb had inherited the "present-when-on" indicator template from `Checkbox`/`Radio`/`Toggle`, but a switch knob is always visible and slides between positions. The inline style also sat at the top of the cascade, forcing consumers to override it with `visibility: visible !important`. Drive the off/on appearance from the `data-state` attribute (`checked` / `unchecked` / `indeterminate`) — e.g. `translate-x-1 data-[state=checked]:translate-x-6` — which now animates directly from the off position. `Switch.Thumb`'s slot `attrs` no longer includes a `style` key.

--- a/apps/docs/src/components/app/AppSwitch.vue
+++ b/apps/docs/src/components/app/AppSwitch.vue
@@ -27,7 +27,7 @@
     >
       <Switch.Thumb
         :class="[
-          '![visibility:visible] block rounded-full bg-white shadow-sm transition-transform',
+          'block rounded-full bg-white shadow-sm transition-transform',
           small
             ? 'size-3.5 translate-x-0.5 data-[state=checked]:translate-x-3.75'
             : 'size-4 translate-x-1 data-[state=checked]:translate-x-6',

--- a/apps/docs/src/examples/components/switch/basic.vue
+++ b/apps/docs/src/examples/components/switch/basic.vue
@@ -15,7 +15,7 @@
         class="relative inline-flex items-center w-11 h-6 rounded-full bg-surface-variant transition-colors data-[state=checked]:bg-primary"
       >
         <Switch.Thumb
-          class="![visibility:visible] block size-4 rounded-full bg-white shadow-sm transition-transform translate-x-1 data-[state=checked]:translate-x-6"
+          class="block size-4 rounded-full bg-white shadow-sm transition-transform translate-x-1 data-[state=checked]:translate-x-6"
         />
       </Switch.Track>
     </Switch.Root>

--- a/apps/docs/src/examples/composables/create-plugin/DashboardConsumer.vue
+++ b/apps/docs/src/examples/composables/create-plugin/DashboardConsumer.vue
@@ -76,7 +76,7 @@
             class="relative inline-flex items-center w-8 h-4.5 rounded-full transition-colors bg-on-surface/20 data-[state=checked]:bg-primary"
           >
             <Switch.Thumb
-              class="![visibility:visible] block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.75"
+              class="block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.75"
             />
           </Switch.Track>
         </Switch.Root>

--- a/apps/docs/src/examples/composables/to-highlight/inbox.vue
+++ b/apps/docs/src/examples/composables/to-highlight/inbox.vue
@@ -55,7 +55,7 @@
           class="inline-flex items-center border-none bg-transparent p-0 outline-none"
         >
           <Switch.Track class="relative inline-flex items-center w-9 h-5 rounded-full bg-surface-variant transition-colors data-[state=checked]:bg-success">
-            <Switch.Thumb class="![visibility:visible] block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-5" />
+            <Switch.Thumb class="block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-5" />
           </Switch.Track>
         </Switch.Root>
         Server snippets

--- a/apps/docs/src/pages/components/forms/switch.md
+++ b/apps/docs/src/pages/components/forms/switch.md
@@ -71,7 +71,7 @@ A switch for on/off state or multi-selection groups with tri-state support.
 
 A notification preferences panel that groups four independent switches under a master "Enable all" lever and submits the result through a `Form`. Each `Switch.Root` carries a `name` prop, so v0 auto-renders a hidden native input and the toggled values participate in `FormData` — there is no `Switch.HiddenInput` to place by hand. The panel pairs each switch with a label and a line of helper text, and a summary line below echoes the saved selection.
 
-The interesting piece is the master toggle. `Switch.SelectAll` is not a group item — it never registers a value into the array v-model. Instead it reads the group's aggregate `isAllSelected` / `isMixed` state and calls `toggleAll`, so it renders checked when every setting is on, unchecked when all are off, and indeterminate (`aria-checked="mixed"`, `data-state="indeterminate"`) when only some are on. The tri-state and batch operations come straight from [createGroup](/composables/selection/create-group) — the same multi-selection logic that powers [Group](/components/providers/group). The thumb is animated through `data-[state=...]` variants on the `Switch.Track` rather than a transform from the off position, because `Switch.Thumb` is `visibility: hidden` when off and cannot animate in from there.
+The interesting piece is the master toggle. `Switch.SelectAll` is not a group item — it never registers a value into the array v-model. Instead it reads the group's aggregate `isAllSelected` / `isMixed` state and calls `toggleAll`, so it renders checked when every setting is on, unchecked when all are off, and indeterminate (`aria-checked="mixed"`, `data-state="indeterminate"`) when only some are on. The tri-state and batch operations come straight from [createGroup](/composables/selection/create-group) — the same multi-selection logic that powers [Group](/components/providers/group). The thumb slides between the off and on positions via `data-[state=...]` transform variants on `Switch.Thumb`, which stays visible in every state.
 
 Reach for this pattern for any settings surface — notification preferences, feature flags, privacy controls — where a list of independent on/off toggles needs a single shared model, a select-all lever, and form submission. Because `Form`'s `@submit` is pass-through (it fires on every native submit regardless of validity), the handler guards on `payload.valid` before committing the saved state. See [Form](/components/forms/form) for the validation surface and [Checkbox](/components/forms/checkbox) for the equivalent committed-selection control.
 
@@ -119,7 +119,7 @@ Switch subcomponents expose data attributes for CSS styling without conditional 
 </template>
 ```
 
-`Switch.Thumb` applies an inline `visibility: hidden` when unchecked, so the thumb is not visible until the switch is on. This means a sliding transform on `Switch.Thumb` cannot animate *from* the "off" position. Animate the `Switch.Track` background color instead, as shown above.
+`Switch.Thumb` stays visible in every state and emits `data-state` (`checked` / `unchecked` / `indeterminate`), so a sliding transform can animate directly between the off and on positions — for example `translate-x-1 data-[state=checked]:translate-x-6`. Pair it with a `transition-transform` on the thumb and a `transition-colors` on the `Switch.Track` for the rail.
 
 ## Accessibility
 
@@ -158,7 +158,7 @@ Use `Switch` for settings that take immediate effect, like toggling a feature on
 
 ??? How do I animate the switch state change?
 
-`Switch.Thumb` applies an inline `visibility: hidden` when unchecked, so transforms on the thumb cannot animate from the "off" position. Apply a CSS `transition` to `Switch.Track` and use the `data-[state=checked]:` variant to change its background — for example, `class="transition-colors bg-gray-300 data-[state=checked]:bg-primary"`. No JavaScript event handling is needed — the data attribute flip drives the animation.
+Drive it off the `data-state` attribute — no JavaScript event handling needed. Apply a `transition-transform` to `Switch.Thumb` and slide it with the `data-[state=checked]:` variant (`class="transition-transform translate-x-1 data-[state=checked]:translate-x-6"`), and add a `transition-colors` to `Switch.Track` to shift the rail background (`class="transition-colors bg-gray-300 data-[state=checked]:bg-primary"`). The data attribute flip drives both.
 
 ??? Can I use Switch.Root without the Track and Thumb subcomponents?
 

--- a/packages/0/src/components/Switch/SwitchThumb.vue
+++ b/packages/0/src/components/Switch/SwitchThumb.vue
@@ -4,9 +4,10 @@
  * @see https://0.vuetifyjs.com/components/forms/switch
  *
  * @remarks
- * Sliding knob indicator for switches. Must be used within a
+ * Sliding knob for switches. Must be used within a
  * Switch.Root component which provides the switch state.
- * Renders as a span by default and only displays when checked or indeterminate.
+ * Renders as a span by default and stays visible in every state; consumers
+ * drive its position/color from the `data-state` attribute.
  */
 
 <script lang="ts">
@@ -33,10 +34,9 @@
     isChecked: boolean
     /** Whether the parent switch is in a mixed/indeterminate state */
     isMixed: boolean
-    /** Pre-computed data attributes and visibility style for styling */
+    /** Pre-computed data attributes for styling */
     attrs: {
       'data-state': SwitchState
-      'style': { visibility: 'visible' | 'hidden' }
     }
   }
 </script>
@@ -58,7 +58,6 @@
 
   const isChecked = toRef(() => toValue(root.isChecked))
   const isMixed = toRef(() => toValue(root.isMixed))
-  const isVisible = toRef(() => isChecked.value || isMixed.value)
   const dataState = toRef((): SwitchState => isMixed.value
     ? 'indeterminate'
     : (isChecked.value ? 'checked' : 'unchecked'),
@@ -69,7 +68,6 @@
     isMixed: isMixed.value,
     attrs: {
       'data-state': dataState.value,
-      'style': { visibility: isVisible.value ? 'visible' : 'hidden' },
     },
   }))
 </script>

--- a/packages/0/src/components/Switch/index.browser.test.ts
+++ b/packages/0/src/components/Switch/index.browser.test.ts
@@ -678,26 +678,24 @@ describe('switch', () => {
       expect(track.attributes('data-state')).toBe('checked')
     })
 
-    it('should render Thumb with visibility hidden when unchecked', async () => {
+    it('should render Thumb with data-state unchecked when off', async () => {
       const { wrapper, wait } = mountSwitch({ props: { modelValue: false } })
       await wait()
 
-      const thumb = wrapper.findAll('span[data-state]').find(
-        el => el.attributes('style')?.includes('visibility'),
-      )
+      const thumb = wrapper.findAll('span[data-state]').at(1)
       expect(thumb).toBeDefined()
-      expect(thumb!.attributes('style')).toContain('hidden')
+      expect(thumb!.attributes('data-state')).toBe('unchecked')
+      expect(thumb!.attributes('style')).toBeUndefined()
     })
 
-    it('should render Thumb with visibility visible when checked', async () => {
+    it('should render Thumb with data-state checked when on', async () => {
       const { wrapper, wait } = mountSwitch({ props: { modelValue: true } })
       await wait()
 
-      const thumb = wrapper.findAll('span[data-state]').find(
-        el => el.attributes('style')?.includes('visibility'),
-      )
+      const thumb = wrapper.findAll('span[data-state]').at(1)
       expect(thumb).toBeDefined()
-      expect(thumb!.attributes('style')).toContain('visible')
+      expect(thumb!.attributes('data-state')).toBe('checked')
+      expect(thumb!.attributes('style')).toBeUndefined()
     })
 
     it('should throw when Track used outside Root', () => {

--- a/packages/0/src/components/Switch/index.ts
+++ b/packages/0/src/components/Switch/index.ts
@@ -180,10 +180,10 @@ export const Switch = {
    */
   SelectAll,
   /**
-   * Sliding knob indicator for switches.
+   * Sliding knob for switches.
    *
-   * Renders as a span with `data-state` attribute for CSS styling.
-   * Hidden via `visibility: hidden` when unchecked and not mixed.
+   * Renders as a span with a `data-state` attribute for CSS styling.
+   * Always visible; drive its off/on position and color from `data-state`.
    * Must be used within a Switch.Root or Switch.SelectAll.
    *
    * @see https://0.vuetifyjs.com/components/forms/switch


### PR DESCRIPTION
## Problem

`Switch.Thumb` sets an inline `visibility: hidden` when the switch is off. It inherited this verbatim from the `Checkbox` / `Radio` / `Toggle` **Indicator** template (`isVisible = isChecked || isMixed` + inline visibility), which has been there since the component was first added (#142).

That template is correct for a *present-when-on* marker (a checkmark, a dot). It is wrong for a switch **thumb**: a knob is visible in both states and slides/recolors between them. Every switch UI (Vuetify, Material, iOS, Radix, Ark) shows the thumb in the OFF state.

Two consequences:

1. **Forces `!important` on consumers.** Inline styles sit at the top of the cascade, so the only way to reclaim the thumb is `visibility: visible !important` — a headless-contract violation (v0 dictating a visual outcome).
2. **Our own docs already worked around it four times.** The `basic`, `inbox`, `AppSwitch`, and `create-plugin` examples all carried `![visibility:visible]`, and three prose sections told users to animate the `Track` instead of the thumb because the thumb "cannot animate in from the off position." `SettingsPanel`/`DashboardConsumer` lacked the override entirely, so their thumbs were silently invisible when off.

## Change

- **`SwitchThumb.vue`** — drop `isVisible` and the inline `style` from slot `attrs`; keep only `data-state`. The thumb always renders; consumers drive off/on position + color from `data-state` (now animatable directly, e.g. `translate-x-1 data-[state=checked]:translate-x-6`).
- **`Switch/index.ts`** + module docstring — corrected to describe the always-visible behavior.
- **Docs** — removed all four `![visibility:visible]` overrides; rewrote the SettingsPanel intro and both FAQ answers to teach thumb-transform animation instead of the Track workaround.
- **`index.browser.test.ts`** — the two tests that asserted `visibility: hidden/visible` now assert `data-state` + absence of an inline style.

`Checkbox`/`Radio`/`Toggle` indicators are unchanged — the behavior is correct there.

## Verification

- `pnpm --filter @vuetify/v0 typecheck` — clean
- Switch browser suite — 116/116 pass