### PR TITLE
fix(useProxyModel): reconcile pending values against the current model

### DIFF
--- a/.changeset/proxymodel-pending-late-register-587.md
+++ b/.changeset/proxymodel-pending-late-register-587.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useProxyModel): apply the current v-model to late-registering tickets (#587) — when the v-model changed before a value's ticket registered (e.g. tabs, carousels, or button groups whose items load asynchronously), the stale value was still selected once the ticket arrived, leaving the registry out of sync with the v-model. Late registration now honours the current model value.

--- a/packages/0/src/composables/useProxyModel/index.test.ts
+++ b/packages/0/src/composables/useProxyModel/index.test.ts
@@ -282,4 +282,24 @@ describe('useProxyModel', () => {
     model.value = ['value-1', 'unknown']
     expect(model.value).toEqual(['value-1'])
   })
+
+  it('should not resurrect a stale value the model dropped before its ticket registered', () => {
+    const selection = createSelection({ events: true })
+    const model = shallowRef<string>('a')
+
+    useProxyModel(selection, model)
+
+    // Ticket for 'a' has not registered yet; the model moves on to 'b'.
+    model.value = 'b'
+
+    // 'b' then 'a' register late. Only 'b' — the current model — should select.
+    selection.onboard([
+      { id: 'ticket-b', value: 'b' },
+      { id: 'ticket-a', value: 'a' },
+    ])
+
+    expect(model.value).toBe('b')
+    expect(selection.selected('ticket-b')).toBe(true)
+    expect(selection.selected('ticket-a')).toBe(false)
+  })
 })

--- a/packages/0/src/composables/useProxyModel/index.ts
+++ b/packages/0/src/composables/useProxyModel/index.ts
@@ -102,18 +102,22 @@ export function useProxyModel (
     ? undefined
     : { multiple: toValue(multiple) as boolean }
 
-  // Initialize: apply current model value, track unresolved values
-  const modelAsArray = transformIn(model)
-  const pending = new Set(modelAsArray)
+  // Values from the model with no registered ticket yet. Rebuilt on every apply
+  // so late registration reflects the CURRENT model, never a stale initial value.
+  const pending = new Set<unknown>()
 
-  context.apply(modelAsArray, applyOptions)
+  function reconcile (values: unknown[]) {
+    context.apply(values, applyOptions)
 
-  const selected = new Set(context.selectedValues.value)
-  for (const value of modelAsArray) {
-    if (selected.has(value)) {
-      pending.delete(value)
+    const selected = new Set(context.selectedValues.value)
+    pending.clear()
+    for (const value of values) {
+      if (!selected.has(value)) pending.add(value)
     }
   }
+
+  // Initialize: apply current model value, track unresolved values
+  reconcile(transformIn(model))
 
   let syncing = false
 
@@ -126,9 +130,14 @@ export function useProxyModel (
   const contextWatch = watch(context.selectedValues as Ref, val => {
     if (syncing) return
 
+    // Mark the write as internal so the paused modelWatch — which Vue replays on
+    // resume() rather than dropping — bails instead of reconciling pending
+    // against this context-driven value.
+    syncing = true
     modelWatch.pause()
     model.value = transformOut(Array.from(toValue(val)))
     modelWatch.resume()
+    syncing = false
   }, { flush: 'sync' })
 
   const modelWatch = watch(model, val => {
@@ -136,7 +145,7 @@ export function useProxyModel (
 
     syncing = true
     contextWatch.pause()
-    context.apply(transformIn(val), applyOptions)
+    reconcile(transformIn(val))
     // Sync model back to actual selection state (apply may have rejected due to disabled/mandatory)
     const actual = transformOut(Array.from(context.selectedValues.value))
     if (!shallowEqual(val, actual)) model.value = actual


### PR DESCRIPTION
`useProxyModel` seeded its `pending` set once from the initial v-model value and only ever shrank it. If the external model changed before a value's ticket registered, the stale value stayed pending and was force-selected on late registration — diverging the registry from the current v-model.

## Change
- Rebuild `pending` from the last-applied model on every apply (extracted `reconcile`), so late registration honours the current model, not the initial value.
- Mark context-driven model writes as internal (`syncing`) so the model watcher — which Vue **replays** on `resume()` rather than dropping — bails instead of reconciling `pending` against an internal selection (e.g. a `mandatory: 'force'` step selecting its first item before the desired ticket arrives).

## Verification
Full `v0:unit` suite green, including `Carousel` (a `createStep` + `useProxyModel` consumer that exercises the late-registration path). Adds a regression test.