### PR TITLE
fix(createValidation): keep isValidating owned by the latest non-silent run

### DIFF
--- a/.changeset/validation-isvalidating-silent-race-588.md
+++ b/.changeset/validation-isvalidating-silent-race-588.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createValidation): stop `isValidating` sticking `true` when a silent validation interleaves an async one (#588) — triggering a silent `validate()` while a non-silent async validation was still in flight left `isValidating` stuck at `true` (a permanent loading/validating state) until the next clean validation. The flag is now owned by the latest non-silent run and clears reliably.

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -257,6 +257,24 @@ describe('createValidation', () => {
       expect(validation.isValidating.value).toBe(false)
     })
 
+    it('should clear isValidating when a silent run interleaves an in-flight non-silent one', async () => {
+      const { calls, rule } = createRule()
+      const validation = createValidation({ rules: [rule] })
+
+      // Slow non-silent run begins → isValidating true, generation 1.
+      const nonSilent = validation.validate('x', false)
+      expect(validation.isValidating.value).toBe(true)
+
+      // A silent run interleaves → bumps the shared generation to 2.
+      const silent = validation.validate('x', true)
+
+      for (const call of calls) call.resolve(true)
+      await Promise.all([nonSilent, silent])
+
+      // The non-silent run must still own and clear the flag despite the bump.
+      expect(validation.isValidating.value).toBe(false)
+    })
+
     it('should catch throwing rules and surface error message', async () => {
       const validation = createValidation({
         rules: [() => {

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -131,6 +131,10 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   const isValid = shallowRef<boolean | null>(null)
   const isValidating = shallowRef(false)
   let generation = 0
+  // Generation of the most recent non-silent (visible) run — owns isValidating.
+  // Tracked separately from `generation` so a silent run bumping the shared
+  // counter can't strand the flag an in-flight non-silent run set.
+  let visible = 0
   let latest: ValidationRun | undefined
 
   function register (input: RuleInput | Partial<ValidationTicketInput>): ValidationTicket {
@@ -201,7 +205,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
 
       return false
     } finally {
-      if (gen === generation && !silent) {
+      if (!silent && gen === visible) {
         isValidating.value = false
       }
     }
@@ -212,6 +216,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     // path - invalidates any in-flight validation. Otherwise a slow rule
     // resolving after a later no-rules call would overwrite the newer state.
     const gen = ++generation
+    if (!silent) visible = gen
     const promise = run(gen, _value, silent)
     latest = { generation: gen, promise }
 


### PR DESCRIPTION
`isValidating` could stick at `true`. The `finally` reset was gated on `gen === generation`, but a **silent** `validate()` bumps the shared `generation` without ever setting the flag. When a silent call interleaved an in-flight non-silent run, that run's `finally` saw `gen !== generation` and skipped the reset — the spinner never cleared until the next clean non-silent validation.

## Change
Track the generation of the most recent non-silent (`visible`) run separately and clear `isValidating` only when the settling run still owns it (`gen === visible`). The existing stale-run guard on `errors`/`isValid` (`gen !== generation`) is deliberately untouched.

## Verification
Full `createValidation` suite green; adds a regression test for the silent-interleave race.