### PR TITLE
fix(createTokens): follow a {alias} reached through a segment path

### DIFF
--- a/.changeset/tokens-segment-alias-followthrough.md
+++ b/.changeset/tokens-segment-alias-followthrough.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createTokens): follow a `{alias}` reached through a segment path (#566)
+
+`resolve()` now re-resolves an alias that a dotted-segment lookup lands on, instead of returning the raw `'{alias}'` string. This is visible under `flat: true` (where nested groups are stored whole and addressed by segment), so `useTheme` — which resolves theme colors through a `flat: true` token table — no longer drops or leaks an unresolved `{alias}` for a palette entry that is itself an alias. The leaf-value branch already followed terminal aliases; the segment branch now matches it.

--- a/packages/0/src/composables/createTokens/index.test.ts
+++ b/packages/0/src/composables/createTokens/index.test.ts
@@ -1259,6 +1259,37 @@ describe('createTokens', () => {
       })
     })
 
+    describe('segment-path terminal alias (#566)', () => {
+      it('should follow a {alias} reached through a segment path', () => {
+        const context = createTokens({
+          colors: { primary: '#00f' },
+          group: { blue: '{colors.primary}' },
+        }, { flat: true })
+
+        expect(context.resolve('{group.blue}')).toBe('#00f')
+      })
+
+      it('should follow a multi-hop chain reached through a segment path', () => {
+        const context = createTokens({
+          colors: { base: '#0f0', primary: '{colors.base}' },
+          group: { blue: '{colors.primary}' },
+        }, { flat: true })
+
+        expect(context.resolve('{group.blue}')).toBe('#0f0')
+      })
+
+      it('should detect a circular reference reached through a segment path', () => {
+        const context = createTokens({
+          a: { x: '{b.y}' },
+          b: { y: '{a.x}' },
+        }, { flat: true })
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        expect(context.resolve('{a.x}')).toBeUndefined()
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Circular alias detected'))
+      })
+    })
+
     describe('cache behavior', () => {
       it('should cache resolved values', () => {
         const tokens: TokenCollection = {

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -248,6 +248,8 @@ export function createTokens<
         return undefined
       }
 
+      if (isString(current) && isAlias(current)) return resolve(current, visited)
+
       result = current
     } else {
       if (isTokenAlias(current)) {


### PR DESCRIPTION
Extracts the RB-5 root fix from #566 (Group A, item #1) as a minimal, RC-scoped patch. Only the segment-path alias correctness is here; #566's other three changes (direct-`TokenAlias`-literal semantics, outer-key caching, `resolve<T>` type param) stay in that PR for post-RC.

## The bug
`resolve()`'s segment-path branch assigned the terminal value to `result` without following a trailing `{alias}`. A dotted-segment lookup that lands on an alias string returned the raw `'{alias}'` instead of its resolved value. The leaf-value branch already re-resolved terminal aliases; the segment branch didn't.

```ts
createTokens(
  { colors: { primary: '#00f' }, group: { blue: '{colors.primary}' } },
  { flat: true },
).resolve('{group.blue}') // was '{colors.primary}', now '#00f'
```

## Why it matters for RC
`useTheme` resolves theme colors through a `flat: true` token table, where nested groups are stored whole and addressed by segment. A palette entry that is itself an alias, referenced by a theme via a dotted alias, produced an unresolved `{alias}`:

- Through the built-in adapters it was **dropped** — `ThemeAdapter.generate()`'s `UNSAFE_CSS` guard rejects any value containing `{`/`}`, so the CSS variable went missing (wrong/unset color).
- Read directly off `theme.colors.value` (inline `:style`, canvas, handing colors to another lib) it **leaked the literal `{alias}` string**.

`useTheme` is marked `stable`, so this is a frozen-surface correctness bug. Fix is at the single source (`createTokens.resolve`); no `useTheme` change needed.

## The fix
Mirror the leaf branch's terminal alias-follow into the segment branch, reusing the `visited` set so circular detection still holds:

```ts
if (isString(current) && isAlias(current)) return resolve(current, visited)
```

## Tests
Three regression cases under `segment-path terminal alias (#566)` — single-hop resolution, multi-hop chain, and a circular reference reached through a segment path. All three fail against the pre-fix branch (return raw `{alias}`; the circular case bypasses detection entirely) and pass with the fix.

## Verification
- `createTokens` unit suite 253/253; `useTheme` / `useFeatures` / `useLocale` / `usePermissions` 304/304
- `pnpm typecheck` clean (0/paper/genesis); `knip` + `sherif` clean

## Relationship to open PRs
- #566 — supersedes this via a broader `resolve()` refactor; if #566 lands first, close this. If this lands first, #566 rebases (its unified branch subsumes the change).
- #567 — independent (cache invalidation); no overlap with this diff's region.