### PR TITLE
docs(DocsToc): widen ToC to 210px so sponsor CTA fits on fewer lines

### DIFF
--- a/apps/docs/src/components/docs/DocsSponsorSlot.vue
+++ b/apps/docs/src/components/docs/DocsSponsorSlot.vue
@@ -48,6 +48,6 @@
       Your logo here
     </p>
 
-    <p class="text-xs mt-1">Become the Primary Sponsor →</p>
+    <p class="text-xs mt-1">Become the Primary Sponsor&nbsp;→</p>
   </router-link>
 </template>

--- a/apps/docs/src/components/docs/DocsSponsorSlot.vue
+++ b/apps/docs/src/components/docs/DocsSponsorSlot.vue
@@ -48,6 +48,6 @@
       Your logo here
     </p>
 
-    <p class="text-xs mt-1">Become the Primary Sponsor&nbsp;→</p>
+    <p class="text-xs mt-1">Become the Primary Sponsor →</p>
   </router-link>
 </template>

--- a/apps/docs/src/components/docs/DocsToc.vue
+++ b/apps/docs/src/components/docs/DocsToc.vue
@@ -31,7 +31,7 @@
   <Discovery.Activator
     v-if="toc.headings.value.length > 0 && !ask.isOpen.value"
     as="aside"
-    class="hidden xl:block rounded-lg fixed end-4 top-[calc(48px+var(--app-banner-h,24px)+28px)] w-[200px] max-h-[calc(100vh-121px-var(--app-banner-h,24px))] overflow-y-auto text-sm"
+    class="hidden xl:block rounded-lg fixed end-4 top-[calc(48px+var(--app-banner-h,24px)+28px)] w-[210px] max-h-[calc(100vh-121px-var(--app-banner-h,24px))] overflow-y-auto text-sm"
     :padding="8"
     step="toc"
   >


### PR DESCRIPTION
## Problem

In the fixed-width `200px` ToC column, the `DocsSponsorSlot` "Become the Primary Sponsor →" call-to-action wrapped awkwardly, dropping the `→` arrow toward its own line.

## Fix

Widen the fixed ToC column from `200px` to `210px` (`DocsToc.vue`) so the CTA has room. The initial `&nbsp;` approach was reverted — it clumped "Sponsor →" onto a second line, which read worse than the original.