### PR TITLE
docs(DocsReleases): install snippet, channel + breaking badges, body search

### DIFF
--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { GnActionButton } from '@paper/genesis'
+
   // Framework
   import { createFilter, IN_BROWSER, isString, Popover, useDate } from '@vuetify/v0'
 
@@ -322,15 +324,14 @@
         <AppIcon class="opacity-50 shrink-0" icon="package" :size="16" />
         <code class="text-sm truncate flex-1 bg-surface-variant">{{ install }}</code>
 
-        <button
+        <GnActionButton
           aria-label="Copy install command"
-          class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none shrink-0"
+          class="shrink-0"
           :title="installClipboard.copied.value ? 'Copied!' : 'Copy install command'"
-          type="button"
           @click="copyInstall"
         >
           <AppIcon :icon="installClipboard.copied.value ? 'success' : 'copy'" :size="16" />
-        </button>
+        </GnActionButton>
       </div>
 
       <!-- Body -->

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -8,6 +8,7 @@
   // Composables
   import { useClipboard } from '@/composables/useClipboard'
   import { useMarkdown } from '@/composables/useMarkdown'
+  import { useSettings } from '@/composables/useSettings'
 
   // Constants
   import { EMOJIS } from '@/constants/emoji'
@@ -25,6 +26,7 @@
   const router = useRouter()
   const store = useReleasesStore()
   const date = useDate()
+  const settings = useSettings()
   const linkClipboard = useClipboard()
   const markdownClipboard = useClipboard()
   const installClipboard = useClipboard()
@@ -72,7 +74,9 @@
   const install = toRef(() => {
     if (!model.value) return undefined
     const { name, version } = parseTag(model.value.tag_name)
-    return `pnpm add ${name}@${version}`
+    const pm = settings.packageManager.value
+    const verb = pm === 'npm' ? 'install' : 'add'
+    return `${pm} ${verb} ${name}@${version}`
   })
 
   const channel = toRef(() => model.value ? channelOf(parseTag(model.value.tag_name).version) : undefined)

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -76,6 +76,7 @@
   })
 
   const channel = toRef(() => model.value ? channelOf(parseTag(model.value.tag_name).version) : undefined)
+  const channelLabel = toRef(() => channel.value === 'rc' ? 'RC' : channel.value)
 
   function genEmoji (count: number) {
     if (count >= 100) return '\uD83D\uDCAB'
@@ -258,7 +259,7 @@
               'bg-warning text-on-warning': channel === 'beta',
               'bg-error text-on-error': channel === 'alpha',
             }"
-          >{{ channel }}</span>
+          >{{ channelLabel }}</span>
 
           <span
             v-if="isBreaking(model)"
@@ -313,13 +314,13 @@
       </div>
 
       <!-- Install -->
-      <div v-if="install" class="flex items-center gap-2 px-4 py-2 border-b border-divider bg-surface-tint">
+      <div v-if="install" class="flex items-center gap-2 px-4 py-2 border-b border-divider bg-surface-variant">
         <AppIcon class="opacity-50 shrink-0" icon="package" :size="16" />
-        <code class="text-sm truncate flex-1">{{ install }}</code>
+        <code class="text-sm truncate flex-1 bg-surface-variant">{{ install }}</code>
 
         <button
           aria-label="Copy install command"
-          class="p-1.5 rounded hover:bg-surface focus-visible:bg-surface inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none shrink-0"
+          class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none shrink-0"
           :title="installClipboard.copied.value ? 'Copied!' : 'Copy install command'"
           type="button"
           @click="copyInstall"

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { createFilter, IN_BROWSER, Popover, useDate } from '@vuetify/v0'
+  import { createFilter, IN_BROWSER, isString, Popover, useDate } from '@vuetify/v0'
 
   // Context
   import DocsSkeleton from './DocsSkeleton.vue'
@@ -27,6 +27,7 @@
   const date = useDate()
   const linkClipboard = useClipboard()
   const markdownClipboard = useClipboard()
+  const installClipboard = useClipboard()
 
   const model = shallowRef<Release>()
   const search = shallowRef('')
@@ -45,8 +46,36 @@
   })
 
   const releases = toRef(() => store.releases)
-  const filter = createFilter({ keys: ['tag_name', 'name'] })
+  const filter = createFilter({ keys: ['tag_name', 'name', 'body'] })
   const { items: filteredReleases } = filter.apply(search, releases)
+
+  // Splits a release tag into the npm package and its version. Substrate tags are
+  // `v<version>` (package `@vuetify/v0`); design-system tags are `@scope/name@<version>`.
+  function parseTag (tag: string) {
+    const scoped = /^(@[^@]+)@(.+)$/.exec(tag)
+    if (scoped) return { name: scoped[1], version: scoped[2] }
+    return { name: '@vuetify/v0', version: tag.replace(/^v/, '') }
+  }
+
+  function channelOf (version: string) {
+    return /-(alpha|beta|rc)\./.exec(version)?.[1] ?? 'stable'
+  }
+
+  // Heuristic: changeset bodies surface breaking work under a "Major Changes"
+  // heading; conventional footers use "BREAKING CHANGE".
+  function isBreaking (release: Release) {
+    const body = release.body
+    if (!isString(body)) return false
+    return /breaking change/i.test(body) || /^#{1,6}\s*major changes/im.test(body)
+  }
+
+  const install = toRef(() => {
+    if (!model.value) return undefined
+    const { name, version } = parseTag(model.value.tag_name)
+    return `pnpm add ${name}@${version}`
+  })
+
+  const channel = toRef(() => model.value ? channelOf(parseTag(model.value.tag_name).version) : undefined)
 
   function genEmoji (count: number) {
     if (count >= 100) return '\uD83D\uDCAB'
@@ -70,6 +99,11 @@
   async function copyReleaseMarkdown () {
     if (!model.value?.body) return
     await markdownClipboard.copy(model.value.body)
+  }
+
+  async function copyInstall () {
+    if (!install.value) return
+    await installClipboard.copy(install.value)
   }
 
   function selectRelease (release: Release) {
@@ -175,8 +209,17 @@
             {{ release.name }}
           </span>
 
-          <span v-if="release.reactions?.total_count" class="ml-auto">
-            {{ genEmoji(release.reactions.total_count) }}
+          <span class="ml-auto flex items-center gap-1.5">
+            <AppIcon
+              v-if="isBreaking(release)"
+              class="text-error"
+              icon="alert"
+              :size="14"
+            />
+
+            <span v-if="release.reactions?.total_count">
+              {{ genEmoji(release.reactions.total_count) }}
+            </span>
           </span>
         </button>
 
@@ -202,9 +245,28 @@
     <div v-if="model?.author" class="border-t border-divider">
       <!-- Header -->
       <div class="flex items-center justify-between px-4 py-3 border-b border-divider">
-        <div class="flex items-center gap-2 text-sm">
+        <div class="flex items-center gap-2 text-sm flex-wrap">
           <AppIcon class="opacity-50" icon="calendar" :size="16" />
           <span>{{ publishedOn }}</span>
+
+          <span
+            v-if="channel"
+            class="text-xs font-medium px-2 py-0.5 rounded-full capitalize"
+            :class="{
+              'bg-success text-on-success': channel === 'stable',
+              'bg-info text-on-info': channel === 'rc',
+              'bg-warning text-on-warning': channel === 'beta',
+              'bg-error text-on-error': channel === 'alpha',
+            }"
+          >{{ channel }}</span>
+
+          <span
+            v-if="isBreaking(model)"
+            class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-error text-on-error"
+          >
+            <AppIcon icon="alert" :size="12" />
+            Breaking
+          </span>
         </div>
 
         <div class="flex items-center gap-2">
@@ -248,6 +310,22 @@
             <AppIcon icon="github" :size="18" />
           </a>
         </div>
+      </div>
+
+      <!-- Install -->
+      <div v-if="install" class="flex items-center gap-2 px-4 py-2 border-b border-divider bg-surface-tint">
+        <AppIcon class="opacity-50 shrink-0" icon="package" :size="16" />
+        <code class="text-sm truncate flex-1">{{ install }}</code>
+
+        <button
+          aria-label="Copy install command"
+          class="p-1.5 rounded hover:bg-surface focus-visible:bg-surface inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none shrink-0"
+          :title="installClipboard.copied.value ? 'Copied!' : 'Copy install command'"
+          type="button"
+          @click="copyInstall"
+        >
+          <AppIcon :icon="installClipboard.copied.value ? 'success' : 'copy'" :size="16" />
+        </button>
       </div>
 
       <!-- Body -->

--- a/apps/docs/src/pages/guide/tooling/vuetify-cli.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-cli.md
@@ -114,6 +114,7 @@ bun create vuetify0
 | `vuetify add mcp` | Add MCP server configuration |
 | `vuetify update` | Update Vuetify packages |
 | `vuetify docs` | Open version-specific documentation |
+| `vuetify release-notes` | Print release notes for a package |
 | `vuetify analyze` | Scan codebase for usage patterns |
 | `vuetify upgrade` | Self-upgrade the CLI |
 
@@ -251,6 +252,47 @@ bunx @vuetify/cli docs
 
 > [!NOTE]
 > The CLI auto-detects your installed Vuetify version and opens the correct documentation site.
+
+### release-notes
+
+Print the release notes for a Vuetify package without leaving the terminal:
+
+::: code-group no-filename
+
+```bash pnpm
+# Latest v0 release
+pnpm dlx @vuetify/cli release-notes v0
+
+# A specific version
+pnpm dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+```
+
+```bash npm
+npx @vuetify/cli release-notes v0
+npx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+```
+
+```bash yarn
+yarn dlx @vuetify/cli release-notes v0
+yarn dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+```
+
+```bash bun
+bunx @vuetify/cli release-notes v0
+bunx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+```
+
+:::
+
+The command prints the release name, tag, publish date, and full notes, along with links to the documentation and the GitHub release.
+
+| Argument | Default | Description |
+| - | - | - |
+| `package` | `vuetify` | Package to fetch — `vuetify` or `v0` (aliases: `vuetify0`, `0`) |
+| `--version`, `-v` | `latest` | Release version; `latest` resolves to the newest core release |
+
+> [!TIP]
+> Pass `v0` to read the [Vuetify0 release notes](/releases). Omitting `--version` shows the latest release.
 
 ### analyze
 

--- a/apps/docs/src/pages/releases.md
+++ b/apps/docs/src/pages/releases.md
@@ -20,4 +20,7 @@ related:
 
 Stay up to date with the latest releases and changes in Vuetify v0. Select a version below to view its release notes.
 
+> [!TIP]
+> Prefer the terminal? Read any release without leaving your shell with the Vuetify CLI: `npx vuetify release-notes v0`. Add `-v <version>` for a specific release (defaults to the latest).
+
 <DocsReleases />


### PR DESCRIPTION
## Description

Enhances the release notes page (`/releases`) to make each release more actionable and findable, and documents the CLI's new `release-notes` command. No store or data-layer behavior changes.

### What's added

- **Install snippet** — a copyable `<pm> add <pkg>@<version>` bar under the release header. Reads the site's `settings.packageManager` (pnpm/npm/yarn/bun; only npm uses `install`), reactive to the setting. `parseTag` handles substrate tags (`v1.0.0-beta.0` → `@vuetify/v0@1.0.0-beta.0`) and scoped design-system tags (`@paper/genesis@1.2.3`). Uses `bg-surface-variant` so it reads distinct from the dropdown's `surface-tint`.
- **Channel badge** — alpha / beta / rc / stable derived from the tag, rendered as a color-coded pill in the header (`rc` displays as `RC`).
- **Breaking-change badge** — a header pill plus a per-row alert icon in the selector, detected from `BREAKING CHANGE` / `Major Changes` in the release body.
- **Body search** — added `body` to the `createFilter` keys so a search matches release contents (e.g. a composable name or fix keyword), not just the tag/name.
- **CLI pointer** — a tip on `/releases` and a full `release-notes` section on the Vuetify CLI page ([vuetifyjs/cli#23](https://github.com/vuetifyjs/cli/pull/23)): Commands-table row plus per-package-manager examples, an argument table, and a link back to `/releases`.

### Verification

- `pnpm build:docs` — full SSG build passes (exit 0); `/releases` and the CLI page render.
- `@vuetify/v0` `isString` is a type predicate, so the body-guard narrowing is sound.

### Follow-ups (intentionally out of scope)

Flagged during investigation, held for separate PRs as they're larger UX/behavior calls:

- Chronological **timeline view** (render N releases stacked/collapsed instead of one-at-a-time via the selector) — the biggest UX win, but a rearchitecture.
- Store-level: only page 1 is cached (Load-more pages refetch each visit); `find()` silently no-ops for tags < 6 chars.
- Wiring the already-built-but-unused `releaseAlias()` (short labels) and `release.props.prependIcon` (substrate vs DS icon) into this page.