### PR TITLE
docs(DocsApi): filter API reference by component name

### DIFF
--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -95,7 +95,7 @@
     <template v-if="showInlineApi">
       <DocsSearchInput v-model="search" class="mt-8" :placeholder />
 
-      <hr class="mt-4 -mb-4">
+      <hr class="mt-4" :class="{ '-mb-4': !empty }">
 
       <template
         v-for="api in visibleApis"

--- a/apps/docs/src/components/docs/DocsApi.vue
+++ b/apps/docs/src/components/docs/DocsApi.vue
@@ -59,7 +59,7 @@
     return data.composables[name] || null
   })
 
-  const { search, visibleApis, placeholder, empty } = useApiFilter(componentApis, composableApi)
+  const { search, visibleApis, queryFor, placeholder, empty } = useApiFilter(componentApis, composableApi)
 </script>
 
 <template>
@@ -109,7 +109,7 @@
           :anchor-id="`${helpers.toKebab(api.name)}-props`"
           :items="api.props"
           kind="prop"
-          :query="search"
+          :query="queryFor(api)"
           title="Props"
         />
 
@@ -118,7 +118,7 @@
           class="mt-8"
           :items="api.events"
           kind="event"
-          :query="search"
+          :query="queryFor(api)"
           title="Events"
         />
 
@@ -127,7 +127,7 @@
           class="mt-8"
           :items="api.slots"
           kind="slot"
-          :query="search"
+          :query="queryFor(api)"
           title="Slots"
         />
       </template>

--- a/apps/docs/src/composables/useApiFilter.ts
+++ b/apps/docs/src/composables/useApiFilter.ts
@@ -51,11 +51,29 @@ export function useApiFilter (
 
   const matched = toRef(() => new Set(matches.value))
 
+  // Component-name matching. The item filter above only sees the flattened
+  // props/events/slots, so a search for a compound name (e.g. "Trigger" in
+  // Dialog.Trigger) never surfaces its group. Match the group names too.
+  const nameFilter = createFilter({ keys: ['name'] })
+  const { items: nameMatches } = nameFilter.apply(search, () => toValue(componentApis) as unknown as Item[])
+
+  const named = toRef(() => new Set(nameMatches.value))
+
+  function matchesName (api: ComponentApi) {
+    return named.value.has(api as unknown as Item)
+  }
+
   const visibleApis = toRef(() => {
     if (!search.value) return toValue(componentApis)
 
-    return toValue(componentApis).filter(api => group(api).some(item => matched.value.has(item)))
+    return toValue(componentApis).filter(api => matchesName(api) || group(api).some(item => matched.value.has(item)))
   })
+
+  // A group surfaced by its name shows every item, so its DocsApiSections must
+  // not re-filter by the query and empty themselves out.
+  function queryFor (api: ComponentApi) {
+    return matchesName(api) ? '' : search.value
+  }
 
   const placeholder = toRef(() =>
     isComponent.value
@@ -63,7 +81,7 @@ export function useApiFilter (
       : 'Filter functions, options, methods…',
   )
 
-  const empty = toRef(() => !!search.value && matches.value.length === 0)
+  const empty = toRef(() => !!search.value && matches.value.length === 0 && nameMatches.value.length === 0)
 
-  return { search, visibleApis, placeholder, empty }
+  return { search, visibleApis, queryFor, placeholder, empty }
 }

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -74,7 +74,7 @@
     return data.composables[itemName.value] || null
   })
 
-  const { search, visibleApis, placeholder, empty } = useApiFilter(componentApis, composableApi)
+  const { search, visibleApis, queryFor, placeholder, empty } = useApiFilter(componentApis, composableApi)
 
   const title = toRef(() => itemName.value ? `${itemName.value} API` : 'API Reference')
 
@@ -169,7 +169,7 @@
             :anchor-id="`${helpers.toKebab(api.name)}-props`"
             :items="api.props"
             kind="prop"
-            :query="search"
+            :query="queryFor(api)"
             title="Props"
           />
 
@@ -178,7 +178,7 @@
             class="mt-8"
             :items="api.events"
             kind="event"
-            :query="search"
+            :query="queryFor(api)"
             title="Events"
           />
 
@@ -187,7 +187,7 @@
             class="mt-8"
             :items="api.slots"
             kind="slot"
-            :query="search"
+            :query="queryFor(api)"
             title="Slots"
           />
         </template>

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -152,7 +152,7 @@
 
         <DocsSearchInput v-model="search" class="mt-8 mb-4" :placeholder />
 
-        <hr class="mt-4 -mb-6">
+        <hr class="mt-4" :class="{ '-mb-6': !empty }">
 
         <template
           v-for="api in visibleApis"


### PR DESCRIPTION
## Problem

The inline API-reference filter (props / events / slots) didn't filter on component names. On a compound component page like Dialog, the filter only matched against the flattened props/events/slots of each sub-component — the group name (`Dialog.Activator`, `Dialog.Content`, …) was never in the searchable set. Typing a sub-component name matched nothing and showed the empty state. The standalone `/api/{name}` pages shared the bug.

## Fix

`useApiFilter` now runs a second `createFilter` keyed on the group `name`:

- `visibleApis` keeps a group when **its name matches** OR one of its items matches.
- A group surfaced by a name match exposes `queryFor(api) === ''` so its `DocsApiSection`s render every item instead of re-filtering by the query and emptying themselves out.
- The empty state now accounts for name matches too.
- Both consumers updated: inline `DocsApi.vue` and standalone `pages/api/[name].vue`.

Item-level filtering is unchanged. Two `createFilter` instances are deliberate: the default matcher (`defaultFilter`) is module-private in v0, so a single `customFilter` predicate would have to duplicate its matching semantics in app code.

## Verification

Driven in-browser on `/components/disclosure/dialog` (inline API view) and `/api/Dialog` (standalone):

| Query | Result |
|-------|--------|
| _(empty)_ | all 6 groups |
| `Activator` | only `Dialog.Activator`, Props + Slots rendered in full |
| `modelValue` | only `Dialog.Root` (item match, unchanged) |
| `zzzznotathing` | empty state shown |