### PR TITLE
feat(genesis): extract GnDocsCallout admonition primitive

### DIFF
--- a/.changeset/genesis-docs-callout.md
+++ b/.changeset/genesis-docs-callout.md
@@ -1,0 +1,7 @@
+---
+"@paper/genesis": minor
+---
+
+feat(genesis): add GnDocsCallout admonition primitive (#593)
+
+A headless callout/admonition component for `tip`, `note`, `warning`, `caution`, and `important` types. Colors inherit from the active v0 theme via severity tokens (with standalone fallbacks); the `icon` and `title` slots override the inline-SVG and label defaults.

--- a/.changeset/genesis-docs-callout.md
+++ b/.changeset/genesis-docs-callout.md
@@ -2,6 +2,8 @@
 "@paper/genesis": minor
 ---
 
-feat(genesis): add GnDocsCallout admonition primitive (#593)
+feat(genesis): add GnDocsCallout and an optional host icon renderer (#593)
 
-A headless callout/admonition component for `tip`, `note`, `warning`, `caution`, and `important` types. Colors inherit from the active v0 theme via severity tokens (with standalone fallbacks); the `icon` and `title` slots override the inline-SVG and label defaults.
+A presentational admonition for `tip`, `note`, `warning`, `caution`, and `important`. Colors follow the active v0 theme (`--v0-success` / `--v0-info` / `--v0-warning` / `--v0-error` / `--v0-accent`) with hex fallbacks; the `icon` and `title` slots override the defaults.
+
+Chrome icons (callout, peek, example actions) resolve through optional `provideGnIcons` — a host renderer keyed by genesis roles — then a component-local inline SVG. Named slots still win. No genesis icon plugin or glyph registry.

--- a/apps/docs/src/components/docs/DocsCallout.vue
+++ b/apps/docs/src/components/docs/DocsCallout.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { GnDocsCallout, type GnDocsCalloutType } from '@paper/genesis'
+
   // Framework
   import { useBreakpoints } from '@vuetify/v0'
 
@@ -65,6 +67,12 @@
 
   const config = toRef(() => getCalloutConfig(props.type))
 
+  // askai / discord / tour are clickable action cards — docs-only, not
+  // admonitions. The five standard types delegate their shell to GnDocsCallout.
+  const interactive = toRef(() =>
+    props.type === 'askai' || props.type === 'discord' || props.type === 'tour',
+  )
+
   const randomTip = shallowRef<CompiledTip>()
   const mounted = shallowRef(false)
 
@@ -123,11 +131,11 @@
 
 <template>
   <div
-    v-if="!suppress"
+    v-if="interactive"
     class="my-4 rounded-lg border-s-4 px-4 py-3"
     :class="config.classes"
-    :role="props.type === 'askai' || props.type === 'discord' || props.type === 'tour' ? 'button' : undefined"
-    :tabindex="props.type === 'askai' || props.type === 'discord' || props.type === 'tour' ? 0 : undefined"
+    role="button"
+    :tabindex="0"
     @click="onClick"
     @keydown.enter="onClick"
     @keydown.space.prevent="onClick"
@@ -156,7 +164,7 @@
       </div>
     </template>
 
-    <template v-else-if="props.type === 'tour'">
+    <template v-else>
       <div class="flex items-center gap-2 mb-1">
         <AppIcon :icon="config.icon" :size="18" />
 
@@ -170,15 +178,18 @@
         {{ tour?.description ?? 'Click to start this interactive tour' }}
       </div>
     </template>
+  </div>
 
-    <template v-else-if="props.type === 'tip' && randomTip">
-      <div class="flex items-center gap-2 font-semibold mb-1">
-        <AppIcon :icon="config.icon" :size="18" />
+  <GnDocsCallout
+    v-else-if="!suppress"
+    :type="(props.type as GnDocsCalloutType)"
+  >
+    <template #icon>
+      <AppIcon :icon="config.icon" :size="18" />
+    </template>
 
-        <span>{{ config.title }}</span>
-      </div>
-
-      <div class="docs-alert-content text-on-surface" v-html="randomTip.bodyHtml" />
+    <template v-if="props.type === 'tip' && randomTip">
+      <div class="docs-alert-content" v-html="randomTip.bodyHtml" />
 
       <RouterLink
         v-if="randomTip.link"
@@ -189,18 +200,10 @@
       </RouterLink>
     </template>
 
-    <template v-else>
-      <div class="flex items-center gap-2 font-semibold mb-1">
-        <AppIcon :icon="config.icon" :size="18" />
-
-        <span>{{ config.title }}</span>
-      </div>
-
-      <div class="docs-alert-content text-on-surface">
-        <slot />
-      </div>
-    </template>
-  </div>
+    <div v-else class="docs-alert-content">
+      <slot />
+    </div>
+  </GnDocsCallout>
 </template>
 
 <style scoped>

--- a/apps/docs/src/components/docs/DocsCallout.vue
+++ b/apps/docs/src/components/docs/DocsCallout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { GnDocsCallout, type GnDocsCalloutType } from '@paper/genesis'
+  import { GnDocsCallout } from '@paper/genesis'
 
   // Framework
   import { useBreakpoints } from '@vuetify/v0'
@@ -16,7 +16,7 @@
   import { useTips } from '@/composables/useTips'
 
   // Config
-  import { type CalloutType, getCalloutConfig } from './calloutConfig'
+  import { type CalloutType, getCalloutConfig, isAdmonition } from './calloutConfig'
 
   // Stores
   import { useSkillzStore } from '@/stores/skillz'
@@ -181,13 +181,9 @@
   </div>
 
   <GnDocsCallout
-    v-else-if="!suppress"
-    :type="(props.type as GnDocsCalloutType)"
+    v-else-if="!suppress && isAdmonition(props.type)"
+    :type="props.type"
   >
-    <template #icon>
-      <AppIcon :icon="config.icon" :size="18" />
-    </template>
-
     <template v-if="props.type === 'tip' && randomTip">
       <div class="docs-alert-content" v-html="randomTip.bodyHtml" />
 

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -202,30 +202,6 @@
       <slot name="description" />
     </template>
 
-    <template #toggle-icon="{ expanded }">
-      <AppChevron :open="expanded" :size="16" vertical />
-    </template>
-
-    <template #reset-icon>
-      <AppIcon icon="restart" :size="16" />
-    </template>
-
-    <template #playground-icon>
-      <AppIcon icon="vuetify-play" :size="16" />
-    </template>
-
-    <template #bin-icon>
-      <AppIcon icon="vuetify-bin" :size="16" />
-    </template>
-
-    <template #combine-icon>
-      <AppIcon icon="combine" :size="16" />
-    </template>
-
-    <template #split-icon>
-      <AppIcon icon="split" :size="16" />
-    </template>
-
     <template #code="{ code: paneCode, file: paneFile, language: paneLanguage }">
       <div
         class="docs-genesis-example-pane"

--- a/apps/docs/src/components/docs/calloutConfig.ts
+++ b/apps/docs/src/components/docs/calloutConfig.ts
@@ -1,3 +1,6 @@
+// Types
+import type { GnDocsCalloutType } from '@paper/genesis'
+
 /**
  * Configuration for DocsCallout component types.
  * Extracted for maintainability and potential reuse.
@@ -9,7 +12,12 @@ export interface CalloutConfig {
   classes: string
 }
 
-export type CalloutType = 'tip' | 'note' | 'warning' | 'caution' | 'important' | 'askai' | 'discord' | 'tour'
+export type InteractiveCalloutType = 'askai' | 'discord' | 'tour'
+export type CalloutType = GnDocsCalloutType | InteractiveCalloutType
+
+export function isAdmonition (type: CalloutType): type is GnDocsCalloutType {
+  return type === 'tip' || type === 'note' || type === 'warning' || type === 'caution' || type === 'important'
+}
 
 const CALLOUT_CONFIG: Record<CalloutType, CalloutConfig> = {
   tip: {

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -1,8 +1,12 @@
 import { createEmeraldIconsPlugin } from '@paper/emerald'
+import { provideGnIcons, type GnIconRole } from '@paper/genesis'
 
 // Framework
 import { createBreakpointsPlugin, createDatePlugin, createFeaturesPlugin, createHydrationPlugin, createLocalePlugin, createLoggerPlugin, createPermissionsPlugin, createRtlPlugin, createStackPlugin, createStoragePlugin, createThemePlugin, createTooltipPlugin, IN_BROWSER, useFeatures, V0UnheadThemeAdapter } from '@vuetify/v0'
 import { V0DateAdapter } from '@vuetify/v0/date'
+
+// Components
+import AppIcon from '@/components/app/AppIcon.vue'
 
 // Composables
 import { createDiscoveryPlugin } from '@/composables/useDiscovery'
@@ -14,11 +18,32 @@ import { getAllThemeConfigs } from '@/themes'
 // Plugins
 import { createIconPlugin } from './icons'
 
+// Utilities
+import { h } from 'vue'
+
 // Types
 import type { App } from 'vue'
 
+const gnIcons = {
+  'callout-caution': 'error',
+  'callout-important': 'alert-circle',
+  'callout-note': 'info',
+  'callout-tip': 'lightbulb',
+  'callout-warning': 'alert',
+  'example-bin': 'vuetify-bin',
+  'example-combine': 'combine',
+  'example-playground': 'vuetify-play',
+  'example-reset': 'restart',
+  'example-split': 'split',
+  'example-toggle': 'chevron-down',
+  'peek': 'chevron-down',
+} satisfies Record<GnIconRole, string>
+
 export default function zero (app: App) {
   app.use(createIconPlugin())
+  provideGnIcons({
+    render: (role, { size = 16 } = {}) => h(AppIcon, { icon: gnIcons[role], size }),
+  }, app)
   app.use(createEmeraldIconsPlugin())
   app.use(createLoggerPlugin({ devtools: true }))
   app.use(createHydrationPlugin())

--- a/packages/genesis/SPEC.md
+++ b/packages/genesis/SPEC.md
@@ -23,6 +23,7 @@ packages/genesis/
 │       ├── GnDocsExampleTabs/
 │       ├── GnDocsExamplePanel/
 │       ├── GnDocsExampleActions/
+│       ├── GnDocsCallout/
 │       └── GnPeek/
 ```
 
@@ -97,6 +98,24 @@ interface GnPeekProps {
 
 `v-model:expanded` drives state. The default slot exposes `{ expanded }` for the label; a separate `icon` slot defaults to an inline chevron that rotates 180° when expanded. Both slots are overridable.
 
+### `GnDocsCallout` — admonition shell
+
+A presentational admonition box (info / tip / warning / caution / important). Pure shell — no interactivity, no app dependencies. Consumers layer behavior on top (the v0 docs site keeps the `askai` / `discord` / `tour` interactive callout types in its own `DocsCallout` wrapper, which delegates the five standard types to this component).
+
+```ts
+interface GnDocsCalloutProps {
+  type?: 'tip' | 'note' | 'warning' | 'caution' | 'important' // default: 'note'
+}
+```
+
+`type` drives three things: the severity color, the default icon, and the default title. Color comes from a per-type v0 severity token consumed via the cascade with a standalone fallback — `tip → --v0-success`, `note → --v0-info`, `warning → --v0-warning`, `caution → --v0-error`, `important → --v0-accent`. These severity tokens are supplied by the consuming app (they are not part of v0's core token set); without them the hardcoded fallbacks render a reasonable standalone appearance.
+
+| Slot | Exposes | Default |
+|---|---|---|
+| `icon` | `{ type }` | inline MDI SVG per type |
+| `title` | `{ type }` | capitalized type name |
+| default | — | callout body |
+
 ## Icon strategy
 
 Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
@@ -155,7 +174,7 @@ Implementation sketch: `GnDocsExample` wraps its preview slot in `<div :data-the
 
 In priority order:
 
-1. `GnDocsCallout` (TIP / WARNING / ERROR / INFO admonitions)
+1. ~~`GnDocsCallout` (TIP / WARNING / ERROR / INFO admonitions)~~ — shipped; see below.
 2. `GnDocsCodeGroup` (tabbed code blocks)
 3. `GnDocsKbd`, `GnDocsBadge`, `GnDocsCard` (atomic primitives)
 4. `GnDocsApi` (API reference tables with prop / event / slot sections + hover popovers)

--- a/packages/genesis/SPEC.md
+++ b/packages/genesis/SPEC.md
@@ -6,7 +6,9 @@
 
 A focused **docs-primitives library**: Vue 3 components that documentation sites need
 (live examples, callouts, code groups, API tables, atomic primitives). Headless on the
-parts that vary across consumers — code highlighting and icons are slot-injected.
+parts that vary across consumers — code highlighting is slot-injected. Icons are
+slot-overridable; unused slot defaults resolve through an optional host
+`GnIconsContext` (`provideGnIcons`), else a component-local inline SVG.
 
 Genesis is a **thin component layer over v0's theme system**. Components consume
 `var(--v0-*)` tokens directly so they inherit whatever theme v0 has applied to the page.
@@ -26,7 +28,8 @@ packages/genesis/
 ├── package.json          # name: @paper/genesis ; deps: @vuetify/v0 only
 ├── SPEC.md               # this document
 ├── src/
-│   ├── index.ts          # re-exports components
+│   ├── index.ts          # re-exports components + provideGnIcons
+│   ├── icons.ts          # optional host renderer (createContext, not a plugin)
 │   └── components/
 │       ├── index.ts
 │       ├── GnActionButton/
@@ -37,7 +40,9 @@ packages/genesis/
 │       └── GnPeek/
 ```
 
-No `GnDocsIcon`, no `adapter.ts`, no `plugin.ts`, no `theme.ts`. Genesis is just components.
+No public icon component (`GnDocsIcon` / `GnIcon` is `@internal` chrome, not barreled),
+no `adapter.ts`, no `plugin.ts`, no `theme.ts`. `src/icons.ts` is the kit's one
+sanctioned context: optional inject, `null` when absent — not a plugin.
 
 ## Theme inheritance
 
@@ -168,7 +173,8 @@ interface GnActionButtonProps {
 }
 ```
 
-The icon goes in the default slot, rendered inside `Button.Icon`.
+The icon goes in the default slot, rendered inside `Button.Icon`. `GnActionButton`
+has no genesis icon role and no default glyph — the consumer supplies the artwork.
 
 ### `GnDotGrid` — decorative backdrop
 
@@ -221,31 +227,52 @@ interface GnDocsCalloutProps {
 
 | Slot | Exposes | Default |
 |---|---|---|
-| `icon` | `{ type }` | inline MDI SVG per type |
+| `icon` | `{ type }` | `GnIcon` for `callout-{type}` (host renderer, else local MDI path) |
 | `title` | `{ type }` | English title for the type (`Tip`, `Note`, …) |
 | default | — | callout body |
 
 ## Icon strategy
 
-Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
+Precedence, highest first:
 
-| Component | Slots | Default icon |
-|---|---|---|
-| `GnDocsExample` | `reset-icon` (single-file mode reset button), `toggle-icon` (show/hide-code button) | refresh / chevron-down |
-| `GnDocsExampleTabs` | `reset-icon`, `playground-icon`, `bin-icon`, `combine-icon`, `split-icon` | refresh / play / open-in-new / unfold-less / unfold-more |
-| `GnPeek` | `icon` (chevron, rotates when expanded) | chevron-down |
-| `GnDocsBadge` | `icon` | none — no generic badge icon to default to |
-| `GnDocsCallout` | `icon` (per-type glyph) | MDI path per type |
+1. Named icon slot (one-off override).
+2. Optional host `GnIconsContext.render(role)` from `provideGnIcons`.
+3. Component-local inline SVG (`d` kept next to the component that owns it — no
+   package-wide fallback map).
 
-```vue
-<GnDocsExampleTabs>
-  <template #reset-icon><MyIcon name="refresh" /></template>
-  <template #combine-icon><MyIcon name="merge" /></template>
-</GnDocsExampleTabs>
+Roles name genesis **chrome needs** (`callout-tip`, `example-reset`, `peek`), not
+glyphs. The host maps those onto its own icon set (`AppIcon`, `EmIcon`, …).
+`render` may return `null` to fall through to the local SVG (unknown role,
+version skew). `GnIcon` is internal; the public surface is `provideGnIcons` and
+`GnIconRole`.
+
+```ts
+import { provideGnIcons, type GnIconRole } from '@paper/genesis'
+import { h } from 'vue'
+
+const toApp = {
+  'callout-tip': 'lightbulb',
+  // …every GnIconRole
+} satisfies Record<GnIconRole, string>
+
+provideGnIcons({
+  render: (role, { size = 16 } = {}) => h(AppIcon, { icon: toApp[role], size }),
+}, app)
 ```
 
-Zero-config works for slots that ship a default; `GnDocsBadge`'s `icon` slot does not.
-Consumer can override per slot.
+| Component | Slots | Role(s) |
+|---|---|---|
+| `GnDocsExample` | `reset-icon`, `toggle-icon` | `example-reset`, `example-toggle` |
+| `GnDocsExampleTabs` | `reset-icon`, `playground-icon`, `bin-icon`, `combine-icon`, `split-icon` | `example-reset`, `example-playground`, `example-bin`, `example-combine`, `example-split` |
+| `GnPeek` | `icon` (wrapper rotates when expanded) | `peek` |
+| `GnDocsCallout` | `icon` | `callout-tip` / `note` / `warning` / `caution` / `important` |
+| `GnDocsBadge` | `icon` | — (no role, no default glyph) |
+| `GnActionButton` | default slot is the icon | — (no role, no default glyph) |
+
+Named slots remain the one-off escape hatch. Install `provideGnIcons` together
+with deleting routine host slot-fills, or not at all — a provider nothing reads
+is a third unused icon path. `GnDocsBadge`'s `icon` slot has no default — host
+must fill it or the badge is text-only.
 
 ## Code highlighting
 
@@ -271,7 +298,8 @@ integration.
   (`showPlayground` / `showBin`) and emits `playground` / `bin` with the current files;
   navigation stays a docs-site concern
 - Bundled Shiki — slot consumption only
-- Icon library — slot defaults with inline SVG
+- Icon library / genesis-owned glyph registry / `createGenesisIconsPlugin` —
+  host provides a renderer; components keep local SVG fallbacks. Named slots still win
 - Paper composables / V0Paper — not used
 - General-purpose buttons / forms / dialogs — out of scope (`GnActionButton` is docs-toolbar
   chrome wrapping v0's Button)

--- a/packages/genesis/SPEC.md
+++ b/packages/genesis/SPEC.md
@@ -31,6 +31,7 @@ packages/genesis/
 │       ├── index.ts
 │       ├── GnActionButton/
 │       ├── GnDocsBadge/
+│       ├── GnDocsCallout/
 │       ├── GnDocsExample/          # + Description, Preview, Code, Tabs, Panel, Actions
 │       ├── GnDotGrid/
 │       └── GnPeek/
@@ -69,13 +70,18 @@ pass an explicit `color`.
 | `--v0-on-primary` | Text on primary |
 | `--v0-pre` | Code pane background |
 | `--v0-on-background` | `GnDotGrid` dots and lines (no literal fallback) |
+| `--v0-success` | `GnDocsCallout` tip |
+| `--v0-info` | `GnDocsCallout` note |
+| `--v0-warning` | `GnDocsCallout` warning |
+| `--v0-error` | `GnDocsCallout` caution |
+| `--v0-accent` | `GnDocsCallout` important — not in v0 `SEMANTIC_COLORS`; host-supplied or hex fallback |
 
 ### Token bridge
 
 Genesis **does not** read `--emerald-*` (or any other DS prefix). A design-system docs
 app that mounts Genesis chrome must still provide `--v0-*` on the cascade. The preferred
 mechanism (family contract): the DS adapter also emits `--v0-*` aliases for the color
-roles Genesis consumes (`surface`, `on-surface`, `primary`, `on-background`, …), so Genesis
+roles Genesis consumes (`surface`, `on-surface`, `primary`, `on-background`, plus the severity tokens `success` / `info` / `warning` / `error` / `accent`), so Genesis
 blends without a Genesis-side theming contract. Alternatives (register a parallel v0 theme;
 host-side alias stylesheet) are allowed; the kit stays prefix-blind either way.
 
@@ -201,6 +207,24 @@ same "slot, not string" pattern as every other Genesis icon surface. The icon wr
 `aria-hidden` (decorative by contract; the label is the accessible name). Slotted icons
 keep their own dimensions — the badge does not resize them.
 
+### `GnDocsCallout` — admonition shell
+
+A presentational admonition box (note / tip / warning / caution / important). Pure shell — no interactivity, no app dependencies. Consumers layer behavior on top (the v0 docs site keeps the `askai` / `discord` / `tour` interactive types and the random-tip pool in its own `DocsCallout` wrapper, which delegates the five standard types to this component).
+
+```ts
+interface GnDocsCalloutProps {
+  type?: 'tip' | 'note' | 'warning' | 'caution' | 'important' // default: 'note'
+}
+```
+
+`type` drives three things: the severity color, the default icon, and the default title. Color comes from a per-type v0 token consumed via the cascade with a standalone fallback — `tip → --v0-success`, `note → --v0-info`, `warning → --v0-warning`, `caution → --v0-error`, `important → --v0-accent`. `success` / `info` / `warning` / `error` are v0 semantic colors. `--v0-accent` is not; hosts must publish it (or accept the hex fallback).
+
+| Slot | Exposes | Default |
+|---|---|---|
+| `icon` | `{ type }` | inline MDI SVG per type |
+| `title` | `{ type }` | English title for the type (`Tip`, `Note`, …) |
+| default | — | callout body |
+
 ## Icon strategy
 
 Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
@@ -211,6 +235,7 @@ Action buttons expose icon slots with inline `<svg>` defaults using MDI paths.
 | `GnDocsExampleTabs` | `reset-icon`, `playground-icon`, `bin-icon`, `combine-icon`, `split-icon` | refresh / play / open-in-new / unfold-less / unfold-more |
 | `GnPeek` | `icon` (chevron, rotates when expanded) | chevron-down |
 | `GnDocsBadge` | `icon` | none — no generic badge icon to default to |
+| `GnDocsCallout` | `icon` (per-type glyph) | MDI path per type |
 
 ```vue
 <GnDocsExampleTabs>
@@ -265,21 +290,17 @@ rule for every Tier A primitive:
 
 In priority order:
 
-1. `GnDocsCallout` — TIP / NOTE / WARNING / CAUTION / IMPORTANT admonition shell (severity
-   tokens via cascade; interactive types stay docs-site)
-2. `GnDocsCodeGroup` — tabbed code blocks
-3. `GnDocsCard` — atomic primitives (`GnDocsBadge` shipped)
-4. `GnDocsMarkup` — code block chrome with slot-injected highlighter (no URL actions)
-5. `GnDocsApi*` — presentation-only API tables/cards/sections; **data is injected** by the
+1. `GnDocsCodeGroup` — tabbed code blocks
+2. `GnDocsCard` — atomic primitives (`GnDocsBadge` shipped)
+3. `GnDocsMarkup` — code block chrome with slot-injected highlighter (no URL actions)
+4. `GnDocsApi*` — presentation-only API tables/cards/sections; **data is injected** by the
    host (props or provide). Do not import `virtual:api`
-6. `GnDocsToc`, `GnDocsHeaderAnchor`, `GnDocsNavigator` — heading scan / prev-next with
+5. `GnDocsToc`, `GnDocsHeaderAnchor`, `GnDocsNavigator` — heading scan / prev-next with
    nav data **injected**; no Discovery/Sponsor/Ask coupling
-7. `GnDocsBackToTop`, `GnDocsProgressBar`, `GnDocsSkeleton` — page chrome affordances
-8. `GnDocsThemeSwitcher` — **first-class** for design-system docs whose product *is*
+6. `GnDocsBackToTop`, `GnDocsProgressBar`, `GnDocsSkeleton` — page chrome affordances
+7. `GnDocsThemeSwitcher` — **first-class** for design-system docs whose product *is*
    theming; drives host `theme`/`adapter`/`plugin` rather than a thin local toggle
 
-Already open against `packages/genesis` (item 1 above, not a blocker for the rest of
-Phase 2): `GnDocsCallout` (#593).
 
 ### Phase 3 — design-system docs primitives
 

--- a/packages/genesis/src/components/GnDocsCallout/GnDocsCallout.vue
+++ b/packages/genesis/src/components/GnDocsCallout/GnDocsCallout.vue
@@ -1,0 +1,120 @@
+<script lang="ts">
+  export type GnDocsCalloutType = 'tip' | 'note' | 'warning' | 'caution' | 'important'
+
+  export interface GnDocsCalloutProps {
+    /** Admonition severity — drives color token, default icon, and default title */
+    type?: GnDocsCalloutType
+  }
+
+  /** Default MDI path per type; overridable via the `icon` slot */
+  const ICONS: Record<GnDocsCalloutType, string> = {
+    tip: 'M20,11H23V13H20V11M1,11H4V13H1V11M13,1V4H11V1H13M4.92,3.5L7.05,5.64L5.63,7.05L3.5,4.93L4.92,3.5M16.95,5.63L19.07,3.5L20.5,4.93L18.37,7.05L16.95,5.63M12,6A6,6 0 0,1 18,12C18,14.22 16.79,16.16 15,17.2V19A1,1 0 0,1 14,20H10A1,1 0 0,1 9,19V17.2C7.21,16.16 6,14.22 6,12A6,6 0 0,1 12,6M14,21V22A1,1 0 0,1 13,23H11A1,1 0 0,1 10,22V21H14M11,18H13V15.87C14.73,15.43 16,13.86 16,12A4,4 0 0,0 12,8A4,4 0 0,0 8,12C8,13.86 9.27,15.43 11,15.87V18Z',
+    note: 'M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z',
+    warning: 'M13 14H11V9H13M13 18H11V16H13M1 21H23L12 2L1 21Z',
+    caution: 'M13 13H11V7H13M11 15H13V17H11M15.73 3H8.27L3 8.27V15.73L8.27 21H15.73L21 15.73V8.27L15.73 3Z',
+    important: 'M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z',
+  }
+
+  /** Default title per type; overridable via the `title` slot */
+  const TITLES: Record<GnDocsCalloutType, string> = {
+    tip: 'Tip',
+    note: 'Note',
+    warning: 'Warning',
+    caution: 'Caution',
+    important: 'Important',
+  }
+</script>
+
+<script setup lang="ts">
+  // Utilities
+  import { toRef } from 'vue'
+
+  defineOptions({ name: 'GnDocsCallout' })
+
+  const { type = 'note' } = defineProps<GnDocsCalloutProps>()
+
+  const path = toRef(() => ICONS[type])
+  const label = toRef(() => TITLES[type])
+</script>
+
+<template>
+  <div class="genesis-docs-callout" :data-type="type">
+    <div class="genesis-docs-callout__header">
+      <slot name="icon" :type>
+        <svg
+          aria-hidden="true"
+          class="genesis-docs-callout__icon"
+          fill="currentColor"
+          height="18"
+          viewBox="0 0 24 24"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path :d="path" />
+        </svg>
+      </slot>
+
+      <span class="genesis-docs-callout__title">
+        <slot name="title" :type>{{ label }}</slot>
+      </span>
+    </div>
+
+    <div class="genesis-docs-callout__body">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .genesis-docs-callout {
+    /* Internal alias, resolved from v0 severity tokens with standalone fallbacks. */
+    --gn-callout-color: var(--v0-info, #3b82f6);
+
+    margin-block: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    border-inline-start: 4px solid color-mix(in srgb, var(--gn-callout-color) 50%, transparent);
+    background: color-mix(in srgb, var(--gn-callout-color) 10%, transparent);
+  }
+
+  .genesis-docs-callout[data-type='tip'] {
+    --gn-callout-color: var(--v0-success, #3fb950);
+  }
+
+  .genesis-docs-callout[data-type='warning'] {
+    --gn-callout-color: var(--v0-warning, #d29922);
+  }
+
+  .genesis-docs-callout[data-type='caution'] {
+    --gn-callout-color: var(--v0-error, #f85149);
+  }
+
+  .genesis-docs-callout[data-type='important'] {
+    --gn-callout-color: var(--v0-accent, #a371f7);
+  }
+
+  .genesis-docs-callout__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+    font-weight: 600;
+    color: var(--gn-callout-color);
+  }
+
+  .genesis-docs-callout__icon {
+    flex: none;
+  }
+
+  .genesis-docs-callout__body {
+    color: var(--v0-on-surface, #1a1c1e);
+  }
+
+  .genesis-docs-callout__body :deep(> p:first-child) {
+    margin-top: 0;
+  }
+
+  .genesis-docs-callout__body :deep(> p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/packages/genesis/src/components/GnDocsCallout/GnDocsCallout.vue
+++ b/packages/genesis/src/components/GnDocsCallout/GnDocsCallout.vue
@@ -1,21 +1,33 @@
 <script lang="ts">
+  // Types
+  import type { GnIconRole } from '../../icons'
+
+  // Context
+  import { GnIcon } from '../GnIcon'
+
   export type GnDocsCalloutType = 'tip' | 'note' | 'warning' | 'caution' | 'important'
 
   export interface GnDocsCalloutProps {
-    /** Admonition severity — drives color token, default icon, and default title */
+    /** Admonition type (default: 'note') — drives color token, default icon, and default title */
     type?: GnDocsCalloutType
   }
 
-  /** Default MDI path per type; overridable via the `icon` slot */
   const ICONS: Record<GnDocsCalloutType, string> = {
     tip: 'M20,11H23V13H20V11M1,11H4V13H1V11M13,1V4H11V1H13M4.92,3.5L7.05,5.64L5.63,7.05L3.5,4.93L4.92,3.5M16.95,5.63L19.07,3.5L20.5,4.93L18.37,7.05L16.95,5.63M12,6A6,6 0 0,1 18,12C18,14.22 16.79,16.16 15,17.2V19A1,1 0 0,1 14,20H10A1,1 0 0,1 9,19V17.2C7.21,16.16 6,14.22 6,12A6,6 0 0,1 12,6M14,21V22A1,1 0 0,1 13,23H11A1,1 0 0,1 10,22V21H14M11,18H13V15.87C14.73,15.43 16,13.86 16,12A4,4 0 0,0 12,8A4,4 0 0,0 8,12C8,13.86 9.27,15.43 11,15.87V18Z',
     note: 'M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z',
     warning: 'M13 14H11V9H13M13 18H11V16H13M1 21H23L12 2L1 21Z',
     caution: 'M13 13H11V7H13M11 15H13V17H11M15.73 3H8.27L3 8.27V15.73L8.27 21H15.73L21 15.73V8.27L15.73 3Z',
-    important: 'M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z',
+    important: 'M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z',
   }
 
-  /** Default title per type; overridable via the `title` slot */
+  const ROLES = {
+    tip: 'callout-tip',
+    note: 'callout-note',
+    warning: 'callout-warning',
+    caution: 'callout-caution',
+    important: 'callout-important',
+  } as const satisfies Record<GnDocsCalloutType, GnIconRole>
+
   const TITLES: Record<GnDocsCalloutType, string> = {
     tip: 'Tip',
     note: 'Note',
@@ -26,36 +38,25 @@
 </script>
 
 <script setup lang="ts">
-  // Utilities
-  import { toRef } from 'vue'
-
   defineOptions({ name: 'GnDocsCallout' })
 
   const { type = 'note' } = defineProps<GnDocsCalloutProps>()
-
-  const path = toRef(() => ICONS[type])
-  const label = toRef(() => TITLES[type])
 </script>
 
 <template>
   <div class="genesis-docs-callout" :data-type="type">
     <div class="genesis-docs-callout__header">
       <slot name="icon" :type>
-        <svg
-          aria-hidden="true"
+        <GnIcon
           class="genesis-docs-callout__icon"
-          fill="currentColor"
-          height="18"
-          viewBox="0 0 24 24"
-          width="18"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path :d="path" />
-        </svg>
+          :d="ICONS[type]"
+          :role="ROLES[type]"
+          :size="18"
+        />
       </slot>
 
       <span class="genesis-docs-callout__title">
-        <slot name="title" :type>{{ label }}</slot>
+        <slot name="title" :type>{{ TITLES[type] }}</slot>
       </span>
     </div>
 
@@ -65,7 +66,8 @@
   </div>
 </template>
 
-<style scoped>
+<!-- Unscoped: isolation is the genesis-* prefix (DESIGN_SYSTEMS.md ruling 3). -->
+<style>
   .genesis-docs-callout {
     /* Internal alias, resolved from v0 severity tokens with standalone fallbacks. */
     --gn-callout-color: var(--v0-info, #3b82f6);
@@ -110,11 +112,11 @@
     color: var(--v0-on-surface, #1a1c1e);
   }
 
-  .genesis-docs-callout__body :deep(> p:first-child) {
+  .genesis-docs-callout__body > p:first-child {
     margin-top: 0;
   }
 
-  .genesis-docs-callout__body :deep(> p:last-child) {
+  .genesis-docs-callout__body > p:last-child {
     margin-bottom: 0;
   }
 </style>

--- a/packages/genesis/src/components/GnDocsCallout/index.ts
+++ b/packages/genesis/src/components/GnDocsCallout/index.ts
@@ -1,0 +1,2 @@
+export type { GnDocsCalloutProps, GnDocsCalloutType } from './GnDocsCallout.vue'
+export { default as GnDocsCallout } from './GnDocsCallout.vue'

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
@@ -2,6 +2,9 @@
   // Types
   import type { GnDocsExampleFile } from './GnDocsExampleTabs.vue'
 
+  // Context
+  import { GnIcon } from '../GnIcon'
+
   export interface GnDocsExampleProps {
     /** Anchor id for deep linking */
     id?: string
@@ -39,6 +42,8 @@
     showBin?: boolean
   }
 
+  const RESET = 'M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z'
+  const TOGGLE = 'M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z'
 </script>
 
 <script setup lang="ts">
@@ -157,17 +162,12 @@
         @click="toggleCode"
       >
         <slot :expanded="showCode" name="toggle-icon">
-          <svg
-            aria-hidden="true"
+          <GnIcon
             class="genesis-docs-example__toggle-chevron"
-            fill="currentColor"
-            height="14"
-            viewBox="0 0 24 24"
-            width="14"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
-          </svg>
+            :d="TOGGLE"
+            role="example-toggle"
+            :size="14"
+          />
         </slot>
 
         <span v-if="hasMultipleFiles" class="genesis-docs-example__meta">
@@ -240,16 +240,7 @@
               @click="onReset"
             >
               <slot name="reset-icon">
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z" />
-                </svg>
+                <GnIcon :d="RESET" role="example-reset" />
               </slot>
             </GnActionButton>
           </GnDocsExampleActions>

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExampleTabs.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExampleTabs.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+  // Context
+  import { GnIcon } from '../GnIcon'
+
   export interface GnDocsExampleFile {
     name: string
     code: string
@@ -19,6 +22,12 @@
     /** Show "open in bin" action button (emits `bin` with current files) */
     showBin?: boolean
   }
+
+  const RESET = 'M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z'
+  const PLAYGROUND = 'M8,5.14V19.14L19,12.14L8,5.14Z'
+  const BIN = 'M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'
+  const SPLIT = 'M12,18.17L8.83,15L7.42,16.41L12,21L16.59,16.41L15.17,15M12,5.83L15.17,9L16.58,7.59L12,3L7.41,7.59L8.83,9L12,5.83Z'
+  const COMBINE = 'M16.59,5.41L15.17,4L12,7.17L8.83,4L7.41,5.41L12,10M7.41,18.59L8.83,20L12,16.83L15.17,20L16.58,18.59L12,14L7.41,18.59Z'
 </script>
 
 <script setup lang="ts">
@@ -165,16 +174,7 @@
             @click="onReset"
           >
             <slot name="reset-icon">
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z" />
-              </svg>
+              <GnIcon :d="RESET" role="example-reset" />
             </slot>
           </GnActionButton>
 
@@ -185,16 +185,7 @@
             @click="onPlayground"
           >
             <slot name="playground-icon">
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M8,5.14V19.14L19,12.14L8,5.14Z" />
-              </svg>
+              <GnIcon :d="PLAYGROUND" role="example-playground" />
             </slot>
           </GnActionButton>
 
@@ -205,16 +196,7 @@
             @click="onBin"
           >
             <slot name="bin-icon">
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
-              </svg>
+              <GnIcon :d="BIN" role="example-bin" />
             </slot>
           </GnActionButton>
 
@@ -225,29 +207,11 @@
             @click="onCombine"
           >
             <slot v-if="combined" name="split-icon">
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M12,18.17L8.83,15L7.42,16.41L12,21L16.59,16.41L15.17,15M12,5.83L15.17,9L16.58,7.59L12,3L7.41,7.59L8.83,9L12,5.83Z" />
-              </svg>
+              <GnIcon :d="SPLIT" role="example-split" />
             </slot>
 
             <slot v-else name="combine-icon">
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M16.59,5.41L15.17,4L12,7.17L8.83,4L7.41,5.41L12,10M7.41,18.59L8.83,20L12,16.83L15.17,20L16.58,18.59L12,14L7.41,18.59Z" />
-              </svg>
+              <GnIcon :d="COMBINE" role="example-combine" />
             </slot>
           </GnActionButton>
         </GnDocsExampleActions>

--- a/packages/genesis/src/components/GnIcon.ts
+++ b/packages/genesis/src/components/GnIcon.ts
@@ -1,0 +1,66 @@
+/**
+ * @internal Internal chrome renderer. Not a public icon component — do not
+ * barrel-export. Slot defaults call this; hosts override via `provideGnIcons`.
+ */
+
+// Framework
+import { isNullOrUndefined } from '@vuetify/v0'
+
+// Utilities
+import { defineComponent, h, mergeProps } from 'vue'
+
+// Types
+import type { PropType, VNode } from 'vue'
+
+import { type GnIconRole, useGnIcons } from '../icons'
+
+export const GnIcon = defineComponent({
+  name: 'GnIcon',
+  inheritAttrs: false,
+  props: {
+    /** Local MDI path used when no host renderer returns a VNode. */
+    d: {
+      type: String,
+      required: true,
+    },
+    role: {
+      type: String as PropType<GnIconRole>,
+      required: true,
+    },
+    size: {
+      type: Number,
+      default: 16,
+    },
+  },
+  setup (props, { attrs }) {
+    const icons = useGnIcons()
+
+    function fallback (): VNode {
+      return h('svg', {
+        'aria-hidden': 'true',
+        'fill': 'currentColor',
+        'height': props.size,
+        'viewBox': '0 0 24 24',
+        'width': props.size,
+        'xmlns': 'http://www.w3.org/2000/svg',
+      }, [h('path', { d: props.d })])
+    }
+
+    return () => {
+      const rendered = icons?.render(props.role, { size: props.size })
+      const child = isNullOrUndefined(rendered) ? fallback() : rendered
+
+      return h('span', mergeProps(attrs, {
+        'aria-hidden': 'true',
+        'class': 'genesis-icon',
+        'style': {
+          alignItems: 'center',
+          display: 'inline-flex',
+          flex: 'none',
+          justifyContent: 'center',
+          lineHeight: 0,
+        },
+      }), [child])
+    }
+  },
+})

--- a/packages/genesis/src/components/GnPeek/GnPeek.vue
+++ b/packages/genesis/src/components/GnPeek/GnPeek.vue
@@ -1,10 +1,15 @@
 <script lang="ts">
+  // Context
+  import { GnIcon } from '../GnIcon'
+
   export interface GnPeekProps {
     /** Label shown while expanded */
     expandedLabel?: string
     /** Label shown while collapsed */
     collapsedLabel?: string
   }
+
+  const PEEK = 'M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z'
 </script>
 
 <script setup lang="ts">
@@ -36,17 +41,7 @@
     </slot>
 
     <slot :expanded name="icon">
-      <svg
-        aria-hidden="true"
-        class="genesis-peek__chevron"
-        fill="currentColor"
-        height="14"
-        viewBox="0 0 24 24"
-        width="14"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
-      </svg>
+      <GnIcon class="genesis-peek__chevron" :d="PEEK" role="peek" :size="14" />
     </slot>
   </button>
 </template>

--- a/packages/genesis/src/components/index.ts
+++ b/packages/genesis/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './GnActionButton'
+export * from './GnDocsCallout'
 export * from './GnDocsExample'
 export * from './GnDotGrid'
 export * from './GnPeek'

--- a/packages/genesis/src/components/index.ts
+++ b/packages/genesis/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './GnActionButton'
 export * from './GnDocsBadge'
+export * from './GnDocsCallout'
 export * from './GnDocsExample'
 export * from './GnDotGrid'
 export * from './GnPeek'

--- a/packages/genesis/src/icons.ts
+++ b/packages/genesis/src/icons.ts
@@ -32,7 +32,7 @@ export interface GnIconsContext {
    * Draw this genesis chrome role. Return `null` to use the component-local
    * inline SVG (unknown role, version skew, or deliberate miss).
    */
-  render: (role: GnIconRole, props?: { size?: number }) => VNode | null
+  render: (role: GnIconRole, options?: { size?: number }) => VNode | null
 }
 
 export const [useGnIcons, provideGnIcons] = createContext<GnIconsContext | null>(

--- a/packages/genesis/src/icons.ts
+++ b/packages/genesis/src/icons.ts
@@ -1,0 +1,41 @@
+/**
+ * Optional host renderer for genesis chrome icons.
+ *
+ * Not a plugin and not a glyph registry. Hosts call `provideGnIcons` at app
+ * install (or in a parent setup) with a `render` function; chrome components
+ * fall back to a component-local inline SVG when nothing is provided or
+ * `render` returns `null`. Named icon slots still win.
+ */
+
+// Framework
+import { createContext } from '@vuetify/v0'
+
+// Types
+import type { VNode } from 'vue'
+
+export type GnIconRole =
+  | 'callout-caution'
+  | 'callout-important'
+  | 'callout-note'
+  | 'callout-tip'
+  | 'callout-warning'
+  | 'example-bin'
+  | 'example-combine'
+  | 'example-playground'
+  | 'example-reset'
+  | 'example-split'
+  | 'example-toggle'
+  | 'peek'
+
+export interface GnIconsContext {
+  /**
+   * Draw this genesis chrome role. Return `null` to use the component-local
+   * inline SVG (unknown role, version skew, or deliberate miss).
+   */
+  render: (role: GnIconRole, props?: { size?: number }) => VNode | null
+}
+
+export const [useGnIcons, provideGnIcons] = createContext<GnIconsContext | null>(
+  'genesis:icons',
+  null,
+)

--- a/packages/genesis/src/index.ts
+++ b/packages/genesis/src/index.ts
@@ -1,1 +1,4 @@
+export { provideGnIcons, useGnIcons } from './icons'
+export type { GnIconRole, GnIconsContext } from './icons'
+
 export * from './components'


### PR DESCRIPTION
## Description

The first item on the genesis docs-primitives Phase 2 roadmap: extract the callout admonition into a reusable `@paper/genesis` component.

`GnDocsCallout` is a headless admonition shell for the five standard types — `tip` / `note` / `warning` / `caution` / `important`. It consumes v0 severity tokens (`--v0-success` / `--v0-info` / `--v0-warning` / `--v0-error` / `--v0-accent`) via the cascade with standalone hex fallbacks, matching the genesis theme-inheritance convention (no genesis token namespace). Icon and title are slot-overridable, each with an inline-SVG / label default so zero-config works.

### Consumer wiring

`apps/docs` `DocsCallout` now delegates the five standard types to `GnDocsCallout`, injecting `AppIcon` into the `icon` slot to preserve the exact docs appearance. The docs-only interactive types (`askai` / `discord` / `tour`) and the random-tip pool stay local — per the genesis non-goals, "Ask / open-in actions are a docs-site concern."

### Scope boundary

The extractable core is the presentational shell; the interactive behaviors (routing, ask AI, tip pool) remain in the docs app. Colors are provably identical to the previous UnoCSS classes: uno maps `success → var(--v0-success)` and the old `.bg-success-10` is `color-mix(in srgb, var(--v0-success), transparent 90%)` — the same math `GnDocsCallout` uses.

## Verification

- `pnpm --filter @paper/genesis typecheck` — clean
- `vue-tsc` over `apps/docs` — 0 errors
- In-browser (docs dev server): all 5 types render via `GnDocsCallout` with correct per-type severity colors, icons, and titles; 0 legacy callout elements remain; interactive Ask AI / tour types still render correctly through the retained local branch.