### PR TITLE
docs(DocsReleases): drop search icon from releases filter input

### DIFF
--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -154,6 +154,7 @@
         <DocsSearchInput
           v-model="search"
           class="p-2"
+          :icon="false"
           placeholder="Search releases..."
         />
 

--- a/apps/docs/src/components/docs/DocsSearchInput.vue
+++ b/apps/docs/src/components/docs/DocsSearchInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-  const { placeholder = 'Search…' } = defineProps<{
+  const { icon = true, placeholder = 'Search…' } = defineProps<{
+    icon?: boolean
     placeholder?: string
   }>()
 
@@ -9,6 +10,7 @@
 <template>
   <div class="relative">
     <AppIcon
+      v-if="icon"
       class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none"
       icon="search"
       :size="16"
@@ -16,7 +18,8 @@
 
     <input
       v-model="model"
-      class="w-full pl-9 pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+      class="w-full pr-3 py-2 text-sm bg-surface-tint border border-divider rounded-lg outline-none focus:border-primary transition-colors placeholder:text-on-surface-variant"
+      :class="icon ? 'pl-9' : 'pl-3'"
       :placeholder
       type="text"
     >


### PR DESCRIPTION
Removes the search icon from the release-changelog filter input.

`DocsSearchInput` is shared across 8 call sites, so rather than removing the icon globally it now takes an opt-out `icon` prop (defaults `true`; input padding drops from `pl-9` to `pl-3` when off). Only `DocsReleases` sets `:icon="false"`; every other consumer is unchanged.