### PR TITLE
docs: keep example-tour popovers on-screen on mobile

### DIFF
--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -84,28 +84,58 @@
         transform: 'translate(-50%, -50%)',
         width: 'max-content',
         height: 'max-content',
+        maxWidth: `calc(100vw - ${offset * 2}px)`,
         maxHeight: `calc(100vh - ${offset * 2}px)`,
         overflow: noOverflow ? 'visible' : 'auto',
       }
     }
 
     if (supportsAnchor) {
-      return {
+      const base = {
         position: 'fixed' as const,
-        inset: `${offset}px`,
         width: 'max-content',
         height: 'max-content',
-        // maxWidth: `calc(100vw - ${offset * 2}px)`,
+        maxWidth: `calc(100vw - ${offset * 2}px)`,
         maxHeight: `calc(100vh - ${offset * 2}px)`,
         overflow: noOverflow ? 'visible' : 'auto',
         positionAnchor: `--discovery-${root.step}`,
+      }
+
+      // On mobile, only anchor the popover's vertical edge to the target and keep
+      // it centered in the viewport horizontally. A narrow screen has no room for
+      // left/right placement (those collapse to top/bottom via placementMobile),
+      // and position-area centers on the anchor's own box - a target pinned to (or
+      // overflowing) a screen edge would drag the popover off-screen. Decoupling
+      // the horizontal axis keeps the box fully visible regardless of where its
+      // target sits.
+      if (breakpoints.smAndDown.value && (currentPlacement === 'top' || currentPlacement === 'bottom')) {
+        const vertical = currentPlacement === 'bottom'
+          ? { top: 'anchor(bottom)', marginTop: `${offset}px` }
+          : { bottom: 'anchor(top)', marginBottom: `${offset}px` }
+        return {
+          ...base,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          ...vertical,
+        }
+      }
+
+      return {
+        ...base,
+        inset: `${offset}px`,
         ...placementStyles[currentPlacement] ?? placementStyles.bottom,
       }
     }
     // Fallback for browsers without anchor positioning (Safari/iOS)
     // Centers popover at viewport edge since we can't anchor to elements
     // Reset inset to avoid top-layer default positioning
-    const base = { inset: 'auto', position: 'fixed' as const }
+    const base = {
+      inset: 'auto',
+      position: 'fixed' as const,
+      maxWidth: `calc(100vw - ${offset * 2}px)`,
+      maxHeight: `calc(100vh - ${offset * 2}px)`,
+      overflow: noOverflow ? 'visible' : 'auto',
+    }
     const fallbackStyles: Record<string, Record<string, string>> = {
       bottom: { bottom: `${offset}px`, left: '50%', transform: 'translateX(-50%)' },
       top: { top: `${offset}px`, left: '50%', transform: 'translateX(-50%)' },

--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -84,7 +84,7 @@
         transform: 'translate(-50%, -50%)',
         width: 'max-content',
         height: 'max-content',
-        maxWidth: `calc(100vw - ${offset * 2}px)`,
+        maxWidth: `min(20rem, calc(100vw - ${offset * 2}px))`,
         maxHeight: `calc(100vh - ${offset * 2}px)`,
         overflow: noOverflow ? 'visible' : 'auto',
       }
@@ -95,7 +95,7 @@
         position: 'fixed' as const,
         width: 'max-content',
         height: 'max-content',
-        maxWidth: `calc(100vw - ${offset * 2}px)`,
+        maxWidth: `min(20rem, calc(100vw - ${offset * 2}px))`,
         maxHeight: `calc(100vh - ${offset * 2}px)`,
         overflow: noOverflow ? 'visible' : 'auto',
         positionAnchor: `--discovery-${root.step}`,

--- a/apps/docs/src/skillz/tours/beginner/using-examples/index.json
+++ b/apps/docs/src/skillz/tours/beginner/using-examples/index.json
@@ -16,7 +16,8 @@
       "title": "Live Examples",
       "task": "Most component and composable pages ship live examples - real Vue components running on the page, not screenshots.",
       "hint": "",
-      "learn": "Recognize a live example"
+      "learn": "Recognize a live example",
+      "placement": "top"
     },
     {
       "id": "preview",
@@ -24,7 +25,7 @@
       "task": "This is the real component running. We just selected \"apple\" to show it responding to state.",
       "hint": "",
       "learn": "Interact with a live example",
-      "placement": "bottom"
+      "placement": "top"
     },
     {
       "id": "source",
@@ -32,7 +33,7 @@
       "task": "Every example ships the exact code that produces it. We expanded it for you - the Expand pill collapses it again anytime.",
       "hint": "",
       "learn": "Read the source behind an example",
-      "placement": "bottom"
+      "placement": "top"
     },
     {
       "id": "copy",
@@ -41,7 +42,7 @@
       "hint": "",
       "learn": "Copy an example's source",
       "placement": "left",
-      "placementMobile": "bottom"
+      "placementMobile": "top"
     },
     {
       "id": "playground",
@@ -50,7 +51,7 @@
       "hint": "",
       "learn": "Open an example in the Playground",
       "placement": "left",
-      "placementMobile": "bottom"
+      "placementMobile": "top"
     },
     {
       "id": "tune",
@@ -59,7 +60,7 @@
       "hint": "",
       "learn": "Adjust code size and line wrap",
       "placement": "left",
-      "placementMobile": "bottom"
+      "placementMobile": "top"
     },
     {
       "id": "files",
@@ -67,7 +68,7 @@
       "task": "Bigger examples span several real files - this one builds an async picker from a composable, a component, and the app wiring them together. We opened its code to show the file tabs.",
       "hint": "",
       "learn": "Navigate multi-file examples",
-      "placement": "bottom"
+      "placement": "top"
     },
     {
       "id": "file-tabs",
@@ -75,7 +76,7 @@
       "task": "Each tab is one source file of the same example - we switched to UserPicker.vue. The last file is the one running in the preview.",
       "hint": "",
       "learn": "Switch between an example's files",
-      "placement": "bottom"
+      "placement": "top"
     },
     {
       "id": "file-actions",
@@ -84,7 +85,7 @@
       "hint": "",
       "learn": "Open every file in Play or Bin at once",
       "placement": "left",
-      "placementMobile": "bottom"
+      "placementMobile": "top"
     },
     {
       "id": "recipes",
@@ -92,7 +93,7 @@
       "task": "Recipes are the other example type - terse, single-purpose snippets in a plain code fence, ready to lift straight into your app.",
       "hint": "",
       "learn": "Recognize a recipe",
-      "placement": "bottom"
+      "placement": "top"
     },
     {
       "id": "recipe-play",
@@ -101,7 +102,7 @@
       "hint": "",
       "learn": "Take a recipe into the Playground",
       "placement": "left",
-      "placementMobile": "bottom"
+      "placementMobile": "top"
     },
     {
       "id": "codegroups",

--- a/apps/docs/src/skillz/tours/beginner/using-examples/index.json
+++ b/apps/docs/src/skillz/tours/beginner/using-examples/index.json
@@ -40,7 +40,8 @@
       "task": "This button copies the whole file to your clipboard in one click.",
       "hint": "",
       "learn": "Copy an example's source",
-      "placement": "left"
+      "placement": "left",
+      "placementMobile": "bottom"
     },
     {
       "id": "playground",
@@ -48,7 +49,8 @@
       "task": "This button opens the example live in the Playground - full editing, no setup.",
       "hint": "",
       "learn": "Open an example in the Playground",
-      "placement": "left"
+      "placement": "left",
+      "placementMobile": "bottom"
     },
     {
       "id": "tune",
@@ -56,7 +58,8 @@
       "task": "The rest of the toolbar tunes the reading view - code size cycling and line wrap for long lines.",
       "hint": "",
       "learn": "Adjust code size and line wrap",
-      "placement": "left"
+      "placement": "left",
+      "placementMobile": "bottom"
     },
     {
       "id": "files",
@@ -80,7 +83,8 @@
       "task": "For multi-file examples, Play and Bin carry every file across, and the combine action stitches them into one scrollable view.",
       "hint": "",
       "learn": "Open every file in Play or Bin at once",
-      "placement": "left"
+      "placement": "left",
+      "placementMobile": "bottom"
     },
     {
       "id": "recipes",
@@ -96,7 +100,8 @@
       "task": "Recipe fences are playground-ready too - one click and the snippet is running in Play.",
       "hint": "",
       "learn": "Take a recipe into the Playground",
-      "placement": "left"
+      "placement": "left",
+      "placementMobile": "bottom"
     },
     {
       "id": "codegroups",


### PR DESCRIPTION
## Problem

The **Using Examples** tour (`skillz/tours/beginner/using-examples`) set only desktop `placement` on its steps — unlike its sibling `using-the-docs` tour, which sets `placementMobile` on every off-axis step. On a phone, its five `left`-placed steps (copy, playground, tune, file-actions, recipe-play) reused `left`, cramming the 320px popover flush against the viewport edge and crowding the right-edge toolbar target it was pointing at.

Switching those to `bottom` on mobile then exposed a second issue: `position-area` centers the popover on the **anchor's own box**, so a target pinned to (or overflowing) the right edge dragged the popover off-screen (the Next button got clipped).

## Fix

- **`using-examples/index.json`** — add `placementMobile: "bottom"` to the five `left` steps.
- **`DiscoveryContent.vue`** — on mobile (`smAndDown`), for `top`/`bottom` placements, anchor only the popover's *vertical* edge via `anchor()` and center it in the **viewport** horizontally (`left: 50%` + `translateX(-50%)`), decoupling the horizontal axis from the target. Desktop keeps `position-area` anchor-hugging unchanged.
- Re-enable the `maxWidth` clamp (`calc(100vw - offset*2)`) across all placement branches so a popover can never overflow a narrow (<352px) viewport.

## Verification

Drove the full tour in Chromium at 390×844 (mobile) and 1440×900 (desktop):

- Mobile — the `left` steps (4, 9) and the `top` step (12) now render a viewport-centered popover above/below the highlighted target, fully on-screen with all controls visible. Previously flush-left / clipped.
- Desktop — unchanged; popovers still hug their targets.