### PR TITLE
docs(skillz): fix tour complete popover keyboard activation and Back button radius

### DIFF
--- a/apps/docs/src/components/docs/DocsDiscoveryStep.vue
+++ b/apps/docs/src/components/docs/DocsDiscoveryStep.vue
@@ -144,7 +144,7 @@
         </Discovery.Skip>
 
         <div class="ml-auto flex gap-2">
-          <Discovery.Prev v-if="!isFirst" class="px-3 py-1.5 text-sm text-on-surface-variant hover:text-on-surface">
+          <Discovery.Prev v-if="!isFirst" class="px-3 py-1.5 text-sm rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-on-surface/10 transition-colors">
             Back
           </Discovery.Prev>
 

--- a/apps/docs/src/components/skillz/SkillzTour.vue
+++ b/apps/docs/src/components/skillz/SkillzTour.vue
@@ -16,11 +16,22 @@
   // Allowed keys during guided tours
   const GUIDED_ALLOWED_KEYS = new Set(['Escape', 'Tab', 'ArrowLeft', 'ArrowRight', 'Enter'])
 
+  // Whether the focused element is a control that owns its own Enter/Space
+  // activation (the tour popover's Back/Next/Complete/Exit buttons). Focus is
+  // trapped inside the popover during a guided tour, so any focused button is
+  // one of ours - defer to native activation instead of the tour shortcuts.
+  function isControlFocused () {
+    return !!(document.activeElement as HTMLElement | null)?.closest('button, a[href], [role="button"]')
+  }
+
   // Block keyboard input during guided tours
   useToggleScope(
     () => discovery.isActive.value && discovery.tours.selectedItem.value?.mode === 'guided',
     () => {
       useDocumentEventListener('keydown', (e: KeyboardEvent) => {
+        // Space activates a focused button/link on keyup; let it through so
+        // the popover's own controls work when tabbed to directly.
+        if (e.key === ' ' && isControlFocused()) return
         if (!GUIDED_ALLOWED_KEYS.has(e.key)) {
           e.preventDefault()
           e.stopImmediatePropagation()
@@ -30,7 +41,13 @@
   )
 
   const hotkeys = [
-    useHotkey('enter', () => discovery.next()),
+    // preventDefault is off so a focused button keeps its native Enter click;
+    // the shortcut only advances the tour when focus is on the popover body.
+    useHotkey('enter', e => {
+      if (isControlFocused()) return
+      e.preventDefault()
+      discovery.next()
+    }, { preventDefault: false }),
     useHotkey('right', () => discovery.next()),
     useHotkey('left', () => discovery.prev()),
     useHotkey('escape', () => discovery.stop()),


### PR DESCRIPTION
## Problem

Two issues on the guided-tour **complete** popover (final step showing **Back** + **Complete**):

1. **Enter/Space do nothing when a footer button is focused.** The guided-tour keyboard layer in `SkillzTour.vue` swallowed native activation:
   - **Space** was dropped by the capture-phase key blocker — it isn't in `GUIDED_ALLOWED_KEYS`, so the blocker `preventDefault`'d it before the button could activate.
   - **Enter** was consumed by the global `useHotkey('enter')`, which `preventDefault`s *before* running its callback, killing the native button click and instead calling `discovery.next()` — a no-op on the last step.
2. **Back button had no border radius** — it was the only footer control missing `rounded-lg`.

## Fix

- Add `isControlFocused()` — during a guided tour focus is trapped inside the popover, so any focused `button`/`a`/`[role=button]` is one of the tour's own controls.
- Let **Space** through the capture-phase blocker when a control is focused.
- Set `preventDefault: false` on the **enter** hotkey and gate it on `isControlFocused()`, so a focused button keeps its native Enter click while the shortcut still advances the tour when focus is on the popover body.
- Add `rounded-lg` + a matching hover background to the **Back** button (mirrors the **Exit** button).

## Verification

- `vue-tsc --noEmit` on `apps/docs` passes.
- ESLint clean.