### PR TITLE
docs: package-manager-aware home install command

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -178,6 +178,7 @@ declare module 'vue' {
     HomeEcosystem: typeof import('./components/home/HomeEcosystem.vue')['default']
     HomeFoundation: typeof import('./components/home/HomeFoundation.vue')['default']
     HomeHero: typeof import('./components/home/HomeHero.vue')['default']
+    HomeInstallCommand: typeof import('./components/home/HomeInstallCommand.vue')['default']
     HomePrimarySponsor: typeof import('./components/home/HomePrimarySponsor.vue')['default']
     HomeSpecialSponsor: typeof import('./components/home/HomeSpecialSponsor.vue')['default']
     QuestionFeedback: typeof import('./components/discovery/Question/QuestionFeedback.vue')['default']

--- a/apps/docs/src/components/home/HomeCta.vue
+++ b/apps/docs/src/components/home/HomeCta.vue
@@ -33,7 +33,7 @@
 
     <!-- Install command -->
     <div class="flex justify-center mb-12">
-      <HomeCopyCommand command="pnpm add @vuetify/v0" />
+      <HomeInstallCommand />
     </div>
 
     <!-- Action cards -->

--- a/apps/docs/src/components/home/HomeHero.vue
+++ b/apps/docs/src/components/home/HomeHero.vue
@@ -91,7 +91,7 @@
         </button>
       </div>
 
-      <HomeCopyCommand command="pnpm add @vuetify/v0" />
+      <HomeInstallCommand />
     </div>
 
     <div class="relative grid grid-cols-2 md:flex gap-4 md:gap-12 justify-center text-center">

--- a/apps/docs/src/components/home/HomeInstallCommand.vue
+++ b/apps/docs/src/components/home/HomeInstallCommand.vue
@@ -7,15 +7,25 @@
   import { useSettings, type PackageManager } from '@/composables/useSettings'
 
   // Utilities
-  import { shallowRef, toRef } from 'vue'
+  import { shallowRef, toRef, watch } from 'vue'
+
+  // Types
+  import type { SingleSelectOption } from '@/components/app/settings/AppSettingsSingleSelect.vue'
 
   const PACKAGE = '@vuetify/v0'
 
-  const MANAGERS: { id: PackageManager, verb: string }[] = [
-    { id: 'pnpm', verb: 'add' },
-    { id: 'npm', verb: 'install' },
-    { id: 'yarn', verb: 'add' },
-    { id: 'bun', verb: 'add' },
+  const VERBS: Record<PackageManager, string> = {
+    pnpm: 'add',
+    npm: 'install',
+    yarn: 'add',
+    bun: 'add',
+  }
+
+  const options: SingleSelectOption<PackageManager>[] = [
+    { id: 'pnpm', value: 'pnpm', label: 'pnpm' },
+    { id: 'npm', value: 'npm', label: 'npm' },
+    { id: 'yarn', value: 'yarn', label: 'yarn' },
+    { id: 'bun', value: 'bun', label: 'bun' },
   ]
 
   const settings = useSettings()
@@ -23,13 +33,12 @@
 
   const isOpen = shallowRef(false)
 
-  const verb = toRef(() => MANAGERS.find(manager => manager.id === settings.packageManager.value)?.verb ?? 'add')
-  const command = toRef(() => `${settings.packageManager.value} ${verb.value} ${PACKAGE}`)
+  const command = toRef(() => `${settings.packageManager.value} ${VERBS[settings.packageManager.value]} ${PACKAGE}`)
 
-  function select (id: PackageManager) {
-    settings.packageManager.value = id
+  // Close the menu once a manager is chosen
+  watch(() => settings.packageManager.value, () => {
     isOpen.value = false
-  }
+  })
 </script>
 
 <template>
@@ -48,31 +57,21 @@
       </Popover.Activator>
 
       <Popover.Content
-        aria-label="Package manager"
-        class="p-1 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-1"
+        class="p-1.5 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-1"
         position-area="bottom span-right"
         position-try="bottom span-right, bottom span-left, top span-right, top span-left"
-        role="menu"
       >
-        <button
-          v-for="manager in MANAGERS"
-          :key="manager.id"
-          :aria-checked="settings.packageManager.value === manager.id"
-          class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg transition-colors text-left font-mono"
-          :class="settings.packageManager.value === manager.id
-            ? 'bg-primary/10 text-primary'
-            : 'hover:bg-surface-tint text-on-surface'"
-          role="menuitemradio"
-          type="button"
-          @click="select(manager.id)"
-        >
-          <span>{{ manager.id }}</span>
-          <AppIcon v-if="settings.packageManager.value === manager.id" icon="check" :size="14" />
-        </button>
+        <AppSettingsSingleSelect
+          v-model="settings.packageManager.value"
+          aria-label="Package manager"
+          class="font-mono"
+          layout="list"
+          :options
+        />
       </Popover.Content>
     </Popover.Root>
 
-    <code class="flex-1 truncate opacity-80 !bg-transparent !p-0 !rounded-none">{{ verb }} {{ PACKAGE }}</code>
+    <code class="flex-1 truncate opacity-80 !bg-transparent !p-0 !rounded-none">{{ VERBS[settings.packageManager.value] }} {{ PACKAGE }}</code>
 
     <button
       :aria-label="copied ? 'Copied!' : 'Copy command'"

--- a/apps/docs/src/components/home/HomeInstallCommand.vue
+++ b/apps/docs/src/components/home/HomeInstallCommand.vue
@@ -57,7 +57,7 @@
       </Popover.Activator>
 
       <Popover.Content
-        class="p-1.5 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-1"
+        class="p-1.5 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-[9px]"
         position-area="bottom span-right"
         position-try="bottom span-right, bottom span-left, top span-right, top span-left"
       >

--- a/apps/docs/src/components/home/HomeInstallCommand.vue
+++ b/apps/docs/src/components/home/HomeInstallCommand.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+  // Framework
+  import { Popover } from '@vuetify/v0'
+
+  // Composables
+  import { useClipboard } from '@/composables/useClipboard'
+  import { useSettings, type PackageManager } from '@/composables/useSettings'
+
+  // Utilities
+  import { shallowRef, toRef } from 'vue'
+
+  const PACKAGE = '@vuetify/v0'
+
+  const MANAGERS: { id: PackageManager, verb: string }[] = [
+    { id: 'pnpm', verb: 'add' },
+    { id: 'npm', verb: 'install' },
+    { id: 'yarn', verb: 'add' },
+    { id: 'bun', verb: 'add' },
+  ]
+
+  const settings = useSettings()
+  const { copied, copy } = useClipboard()
+
+  const isOpen = shallowRef(false)
+
+  const verb = toRef(() => MANAGERS.find(manager => manager.id === settings.packageManager.value)?.verb ?? 'add')
+  const command = toRef(() => `${settings.packageManager.value} ${verb.value} ${PACKAGE}`)
+
+  function select (id: PackageManager) {
+    settings.packageManager.value = id
+    isOpen.value = false
+  }
+</script>
+
+<template>
+  <div
+    class="inline-flex items-center gap-1.5 px-1.5 py-1 rounded-full border bg-surface font-mono text-sm max-w-full"
+    :title="command"
+  >
+    <Popover.Root v-model="isOpen">
+      <Popover.Activator
+        aria-label="Change package manager"
+        class="inline-flex items-center gap-1 pl-2.5 pr-2 py-1 rounded-full text-primary hover:bg-surface-tint transition-colors cursor-pointer"
+        title="Change package manager"
+      >
+        <span>{{ settings.packageManager.value }}</span>
+        <AppChevron :open="isOpen" :size="12" vertical />
+      </Popover.Activator>
+
+      <Popover.Content
+        aria-label="Package manager"
+        class="p-1 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-1"
+        position-area="bottom span-right"
+        position-try="bottom span-right, bottom span-left, top span-right, top span-left"
+        role="menu"
+      >
+        <button
+          v-for="manager in MANAGERS"
+          :key="manager.id"
+          :aria-checked="settings.packageManager.value === manager.id"
+          class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg transition-colors text-left font-mono"
+          :class="settings.packageManager.value === manager.id
+            ? 'bg-primary/10 text-primary'
+            : 'hover:bg-surface-tint text-on-surface'"
+          role="menuitemradio"
+          type="button"
+          @click="select(manager.id)"
+        >
+          <span>{{ manager.id }}</span>
+          <AppIcon v-if="settings.packageManager.value === manager.id" icon="check" :size="14" />
+        </button>
+      </Popover.Content>
+    </Popover.Root>
+
+    <code class="flex-1 truncate opacity-80 !bg-transparent !p-0 !rounded-none">{{ verb }} {{ PACKAGE }}</code>
+
+    <button
+      :aria-label="copied ? 'Copied!' : 'Copy command'"
+      class="shrink-0 size-7 rounded-full flex items-center justify-center hover:bg-surface-tint transition-colors"
+      :class="copied && 'text-success'"
+      type="button"
+      @click="copy(command)"
+    >
+      <AppIcon :icon="copied ? 'check' : 'copy'" :size="14" />
+    </button>
+  </div>
+</template>


### PR DESCRIPTION
## Problem

The home page hero and CTA showed a hardcoded `pnpm add @vuetify/v0` install pill. It ignored the visitor's chosen package manager and — unlike the rest of the docs — wasn't tied to any persisted setting.

## Change

New `HomeInstallCommand` component replaces the two `@vuetify/v0` install pills (hero + CTA). It:

- Renders the install command for the active package manager (`pnpm add` / `npm install` / `yarn add` / `bun add`).
- Exposes a click-to-open dropdown on the package-manager token (built on v0's `Popover` — native popover API, no hand-rolled click-outside/escape).
- Reads **and writes** the shared `useSettings().packageManager` store (`v0:packageManager`, via v0 `useStorage`).

Because it's the same store the docs code-groups already read, a choice made on the home page persists into the main docs — and a change in the settings sheet flows back to the home pill. Bidirectional by construction.

The generic `HomeCopyCommand` is left untouched — `HomeAiFirst` still uses it for arbitrary commands (MCP add, `npx skills`, `create vuetify0`) that aren't package-manager-swappable.

## Verified in-browser

- Home: dropdown opens with all four managers, active one checked; selecting `npm` updates both pills to `npm install @vuetify/v0`, copies the full command, closes the menu, and writes `v0:packageManager = "npm"`.
- Navigated to `/composables/plugins/use-date` — its install code-group preselected the **npm** tab from the persisted setting.