### PR TITLE
docs(DocsBenchmarks): move view benchmark source link below the benchmarks

### DIFF
--- a/apps/docs/src/components/docs/DocsBenchmarks.vue
+++ b/apps/docs/src/components/docs/DocsBenchmarks.vue
@@ -59,7 +59,12 @@
       Learn more in the <router-link class="v0-link" to="/guide/fundamentals/benchmarks">benchmarks guide</router-link>.
     </p>
 
-    <p v-if="githubLink" class="mb-4">
+    <BenchmarkExplorer
+      :composable="itemName"
+      hide-summary
+    />
+
+    <p v-if="githubLink" class="mt-4">
       <a
         class="v0-link"
         :href="githubLink"
@@ -67,10 +72,5 @@
         target="_blank"
       >View benchmark source↗</a>
     </p>
-
-    <BenchmarkExplorer
-      :composable="itemName"
-      hide-summary
-    />
   </div>
 </template>


### PR DESCRIPTION
Moves the "View benchmark source" link below the `BenchmarkExplorer` instead of above it. Swapped `mb-4` → `mt-4` so the spacing reads correctly under the benchmarks.