### PR TITLE
docs: fix spurious type errors in v0 playground examples

### DIFF
--- a/apps/docs/src/components/home/HomeArchitecture.vue
+++ b/apps/docs/src/components/home/HomeArchitecture.vue
@@ -44,7 +44,14 @@
     {{ item.value }}
   </button>
 
-  <p>Selected: {{ [...selection.selectedIds].join(', ') }}</p>
+  <p>
+    Selected:
+    <span
+      v-for="item in items"
+      v-show="item.isSelected.value"
+      :key="item.id"
+    >{{ item.value }}</span>
+  </p>
 </template>`,
 
     component: `<script setup lang="ts">
@@ -111,8 +118,14 @@
       </button>
     </div>
 
-    <p class="text-sm opacity-60">
-      Selected: <span class="font-mono">{{ [...selection.selectedIds].join(', ') || 'none' }}</span>
+    <p class="text-sm opacity-60 flex items-center gap-1.5">
+      <span>Selected:</span>
+      <span
+        v-for="item in items"
+        v-show="item.isSelected.value"
+        :key="item.id"
+        class="font-mono px-1.5 py-0.5 rounded bg-surface-variant"
+      >{{ item.value }}</span>
     </p>
   </div>
 </template>`,

--- a/apps/playground/src/data/presets.ts
+++ b/apps/playground/src/data/presets.ts
@@ -33,13 +33,11 @@ export const DEFAULT_APP = `<script lang="ts" setup>
 
   const single = createSingle({ mandatory: 'force' })
 
-  single.onboard([
+  const tabs = single.onboard([
     { id: 'home', value: 'Home' },
     { id: 'profile', value: 'Profile' },
     { id: 'settings', value: 'Settings' },
   ])
-
-  const tabs = single.values()
 </script>
 
 <template>


### PR DESCRIPTION
Two examples that open in the v0 playground rendered a red type-error squiggle to every visitor, caused by the playground's in-browser TS resolver failing to resolve v0's generic accessor types (it collapses them to `{}`). Real `tsc` accepts the code; the squiggle is a resolver artifact — but it's the first thing a visitor sees. Both fixes stay within the one pattern the resolver handles reliably: `v-for` iteration over the `onboard()` return.

Verified each fix by reproducing the exact `usePlayground` encoding (fflate zlib → base64 hash, generated `App.vue` wrapper) in node and driving the real playground to the resulting URL — byte-for-byte what the "Open in Playground" button produces.

## 1. Playground default template — `apps/playground/src/data/presets.ts`

`single.values()` (inherited three `Omit<>` layers up from `RegistryContext`) failed to resolve on `SingleContext`, surfacing `Property 'values' does not exist` on line 12 on first open. Fixed by capturing the `onboard()` return directly (`const tabs = single.onboard([...])`) — `onboard` is declared directly on `SingleContext`.

**Verified**: reproduced the original error live (red squiggle on `single.values()`), confirmed the fix renders with 0 errors.

## 2. Home page composable example — `apps/docs/src/components/home/HomeArchitecture.vue`

The Composable tab's `[...selection.selectedIds].join(', ')` readout flagged `Property 'join' does not exist on type '{}'` — the resolver collapses the `Reactive<Set<ID>>` accessor to `{}`. Confirmed spread, `Array.from`, and `.filter/.map` on the v0 Set accessors all trip it; only `v-for` resolves. Rewrote the readout as `v-for` chips over `items` (filtered with `v-show="item.isSelected.value"`). Updated the displayed snippet to match.

**Verified**: 0 errors on the source-extracted snippet; chips update on toggle (clicked Option B → "Selected: Option B"). The Component tab example was already clean.