### PR TITLE
docs: separate anatomy siblings with blank lines on component pages

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -124,7 +124,7 @@ Providers that require plugin setup (`locale`, `scrim`) prepend an optional **In
 | Section | Component pages | Composable pages |
 |---------|----------------|-----------------|
 | **Usage** | `::: gn-example` with `basic` (no extension, peek — strip inline heading/description) **or** code fence + prose when the page needs explanatory text before the demo [intent:302] | `` ```ts collapse `` `` code fence [intent:302] |
-| **Anatomy** | `` ```vue Anatomy no-filename `` `` — `<script setup>` import + bare compound skeleton (Root + one of each named child, no props) [intent:345] | — |
+| **Anatomy** | `` ```vue Anatomy no-filename `` `` — `<script setup>` import + bare compound skeleton (Root + one of each named child, no props). Separate every pair of adjacent same-level siblings with one blank line for visual scanning; an only-child gets none [intent:345] | — |
 | **Examples** | `::: gn-example` with 2+ files [intent:304] | `::: gn-example` with 2+ files [intent:304] |
 | **Recipes** | Code fence or single-file `::: gn-example` [intent:303] | Code fence or single-file `::: gn-example` [intent:303] |
 

--- a/apps/docs/src/pages/components/actions/button.md
+++ b/apps/docs/src/pages/components/actions/button.md
@@ -41,7 +41,9 @@ The Button component renders as a native `<button>` by default (or an anchor, ro
 <template>
   <Button.Root>
     <Button.Icon />
+
     <Button.Content />
+
     <Button.Loading />
   </Button.Root>
 

--- a/apps/docs/src/pages/components/disclosure/alert-dialog.md
+++ b/apps/docs/src/pages/components/disclosure/alert-dialog.md
@@ -40,11 +40,16 @@ AlertDialog mirrors Dialog but with stricter defaults: no close on click outside
 <template>
   <AlertDialog.Root>
     <AlertDialog.Activator />
+
     <AlertDialog.Content>
       <AlertDialog.Title />
+
       <AlertDialog.Description />
+
       <AlertDialog.Close />
+
       <AlertDialog.Cancel />
+
       <AlertDialog.Action />
     </AlertDialog.Content>
   </AlertDialog.Root>

--- a/apps/docs/src/pages/components/disclosure/dialog.md
+++ b/apps/docs/src/pages/components/disclosure/dialog.md
@@ -50,9 +50,12 @@ The Dialog component leverages the native `showModal()` API for proper modal beh
 <template>
   <Dialog.Root>
     <Dialog.Activator />
+
     <Dialog.Content>
       <Dialog.Title />
+
       <Dialog.Description />
+
       <Dialog.Close />
     </Dialog.Content>
   </Dialog.Root>

--- a/apps/docs/src/pages/components/forms/form.md
+++ b/apps/docs/src/pages/components/forms/form.md
@@ -42,6 +42,7 @@ Wrap your inputs in `<Form>`. Native `<button type="submit">` and `<button type=
   <Form>
     <Input.Root>
       <Input.Control />
+
       <Input.Error />
     </Input.Root>
   </Form>

--- a/apps/docs/src/pages/components/forms/input.md
+++ b/apps/docs/src/pages/components/forms/input.md
@@ -44,7 +44,9 @@ The Input supports text, email, password, and other native input types. Validati
 <template>
   <Input.Root>
     <Input.Control />
+
     <Input.Description />
+
     <Input.Error />
   </Input.Root>
 </template>

--- a/apps/docs/src/pages/components/forms/radio.md
+++ b/apps/docs/src/pages/components/forms/radio.md
@@ -40,6 +40,7 @@ A radio button for single-selection groups with roving focus and shared v-model 
   <Radio.Group>
     <Radio.Root>
       <Radio.Indicator />
+
       <Radio.HiddenInput />
     </Radio.Root>
   </Radio.Group>

--- a/apps/docs/src/pages/components/forms/rating.md
+++ b/apps/docs/src/pages/components/forms/rating.md
@@ -40,6 +40,7 @@ Rating supports whole and half-star modes. Items expose their state via data att
 <template>
   <Rating.Root>
     <Rating.Item />
+
     <Rating.HiddenInput />
   </Rating.Root>
 </template>

--- a/apps/docs/src/pages/components/forms/select.md
+++ b/apps/docs/src/pages/components/forms/select.md
@@ -43,7 +43,9 @@ The Select component provides a compound pattern for building accessible dropdow
   <Select.Root>
     <Select.Activator>
       <Select.Value />
+
       <Select.Placeholder />
+
       <Select.Cue />
     </Select.Activator>
 

--- a/apps/docs/src/pages/components/forms/slider.md
+++ b/apps/docs/src/pages/components/forms/slider.md
@@ -43,6 +43,7 @@ The Slider supports single-value and range modes. Add one `Slider.Thumb` for a s
     </Slider.Track>
 
     <Slider.Thumb />
+
     <Slider.HiddenInput />
   </Slider.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/avatar.md
+++ b/apps/docs/src/pages/components/semantic/avatar.md
@@ -41,14 +41,17 @@ The Avatar component provides a robust image loading system with automatic fallb
 <template>
   <Avatar.Root>
     <Avatar.Image />
+
     <Avatar.Fallback />
   </Avatar.Root>
 
   <Avatar.Group>
     <Avatar.Root>
       <Avatar.Image />
+
       <Avatar.Fallback />
     </Avatar.Root>
+
     <Avatar.Indicator />
   </Avatar.Group>
 </template>

--- a/apps/docs/src/pages/components/semantic/breadcrumbs.md
+++ b/apps/docs/src/pages/components/semantic/breadcrumbs.md
@@ -46,9 +46,13 @@ The Breadcrumbs component provides a compound component pattern for building nav
       <Breadcrumbs.Item>
         <Breadcrumbs.Link />
       </Breadcrumbs.Item>
+
       <Breadcrumbs.Divider />
+
       <Breadcrumbs.Ellipsis />
+
       <Breadcrumbs.Divider />
+
       <Breadcrumbs.Item>
         <Breadcrumbs.Page />
       </Breadcrumbs.Item>

--- a/apps/docs/src/pages/components/semantic/carousel.md
+++ b/apps/docs/src/pages/components/semantic/carousel.md
@@ -43,10 +43,15 @@ The Carousel provides slide navigation with native drag/swipe via CSS scroll-sna
     <Carousel.Viewport>
       <Carousel.Item />
     </Carousel.Viewport>
+
     <Carousel.Indicator />
+
     <Carousel.Previous />
+
     <Carousel.Next />
+
     <Carousel.Progress />
+
     <Carousel.LiveRegion />
   </Carousel.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/image.md
+++ b/apps/docs/src/pages/components/semantic/image.md
@@ -41,7 +41,9 @@ Headless image component with state-driven placeholder and error fallback. Track
 <template>
   <Image.Root>
     <Image.Img />
+
     <Image.Placeholder />
+
     <Image.Fallback />
   </Image.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/overflow.md
+++ b/apps/docs/src/pages/components/semantic/overflow.md
@@ -56,6 +56,7 @@ Headless responsive truncation primitive. Children render until the container ru
 <template>
   <Overflow.Root>
     <Overflow.Item />
+
     <Overflow.Indicator />
   </Overflow.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/pagination.md
+++ b/apps/docs/src/pages/components/semantic/pagination.md
@@ -52,11 +52,17 @@ The two core props are `size` (total item count) and `items-per-page` (items per
 <template>
   <Pagination.Root>
     <Pagination.Status />
+
     <Pagination.First />
+
     <Pagination.Prev />
+
     <Pagination.Ellipsis />
+
     <Pagination.Item />
+
     <Pagination.Next />
+
     <Pagination.Last />
   </Pagination.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/progress.md
+++ b/apps/docs/src/pages/components/semantic/progress.md
@@ -39,11 +39,15 @@ The Progress supports single-value and multi-segment modes. Bind a number for a 
 <template>
   <Progress.Root>
     <Progress.Label />
+
     <Progress.Track>
       <Progress.Fill />
+
       <Progress.Buffer />
     </Progress.Track>
+
     <Progress.Value />
+
     <Progress.HiddenInput />
   </Progress.Root>
 </template>

--- a/apps/docs/src/pages/components/semantic/splitter.md
+++ b/apps/docs/src/pages/components/semantic/splitter.md
@@ -39,7 +39,9 @@ The Splitter provides resizable panels separated by draggable handles. Panel siz
 <template>
   <Splitter.Root>
     <Splitter.Panel />
+
     <Splitter.Handle />
+
     <Splitter.Panel />
   </Splitter.Root>
 </template>


### PR DESCRIPTION
Separates every pair of adjacent same-level sibling elements in each component page's **Anatomy** skeleton with one blank line, so the compound structure is easier to scan visually. Only-children stay unspaced.

## Scope

- 17 component pages re-spaced (Pagination, Dialog, Progress, Button, Breadcrumbs, AlertDialog, Image, Rating, Radio, Avatar, Carousel, Overflow, Splitter, Input, Select, Slider, Form). The other 23 anatomy blocks were already compliant or are single-element.
- Additions-only — blank lines inside the Anatomy fences; no prose or script blocks touched.
- Records the convention in `.claude/rules/docs.md` (Anatomy row).

## Why manual, not lint-enforced

Anatomy blocks are hand-authored fence text inside `.md` files (not sourced from real `.vue` files like the gn-example blocks), so `vue/padding-line-between-tags` can't reach them. A bespoke markdown-fence linter wasn't worth it for ~40 pages; the convention note keeps new pages consistent.