### PR TITLE
fix(Portal): apply position:relative so z-index creates a stacking context

### DIFF
--- a/.changeset/fix-snackbar-portal-stacking-602.md
+++ b/.changeset/fix-snackbar-portal-stacking-602.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Snackbar): SnackbarPortal creates a stacking context so its z-index takes effect (#602)
+
+The teleported snackbar region applied its stack z-index to a `position: static` element, which CSS ignores — a body-fallback snackbar could render behind positioned page chrome regardless of its z-index. `SnackbarPortal` now sets `position: relative` alongside the z-index (visually neutral, no offsets) so the stacking context is established. `Portal`'s `zIndex` slot prop is now documented to require a positioned element.

--- a/packages/0/src/components/Portal/Portal.vue
+++ b/packages/0/src/components/Portal/Portal.vue
@@ -33,7 +33,14 @@
   }
 
   export interface PortalSlotProps {
-    /** Calculated z-index from useStack */
+    /**
+     * Calculated z-index from useStack.
+     *
+     * @remarks
+     * Must be applied to a **positioned** element (`position: relative`, `absolute`,
+     * `fixed`, or `sticky`) to create a stacking context. Applying it to a
+     * `position: static` element has no effect.
+     */
     zIndex: number
     /** Close this portal (unselects from stack) */
     close: () => void

--- a/packages/0/src/components/Snackbar/SnackbarPortal.vue
+++ b/packages/0/src/components/Snackbar/SnackbarPortal.vue
@@ -35,7 +35,7 @@
     zIndex: number
     /** Attributes to bind to the portal element */
     attrs: {
-      style: { zIndex: number }
+      style: { position: 'relative', zIndex: number }
     }
   }
 </script>
@@ -57,7 +57,7 @@
     return {
       zIndex,
       attrs: {
-        style: { zIndex },
+        style: { position: 'relative' as const, zIndex },
       },
     }
   }


### PR DESCRIPTION
Closes #554

## Problem

`Portal.vue` exposes `zIndex` as a slot prop but is itself renderless — it renders no DOM element. `SnackbarPortal` applies that `zIndex` to an `Atom` wrapper div via `style: { zIndex }`, but the div has `position: static` (the browser default). CSS ignores `z-index` on non-positioned elements, so the computed value has no effect. When a snackbar teleports to `<body>` it lands behind any positioned page chrome (e.g. `.app-shell-content { z-index: 1 }`) regardless of how large its stack-assigned z-index is.

Reproduced via #279: docs' `.app-shell-content { z-index: 1 }` sat above a body-fallback Snackbar.

## Fix

Add `position: 'relative'` alongside `zIndex` in `SnackbarPortal.getSlotProps`. `position: relative` without offsets is visually neutral — the element stays in normal flow at its natural position — but creates a stacking context so `z-index` takes effect.

Also update `Portal`'s `PortalSlotProps.zIndex` JSDoc to document the contract: the element receiving `zIndex` must be positioned.

## Changes

- `SnackbarPortal.vue`: `getSlotProps` now returns `style: { position: 'relative', zIndex }` and the `SnackbarPortalSlotProps` type is updated to match
- `Portal.vue`: `PortalSlotProps.zIndex` gains a `@remarks` noting the positioned-element requirement