### PR TITLE
feat(useStack): add app-wide defaultTeleport option to createStackPlugin

### DIFF
--- a/.changeset/feat-usestack-default-teleport-553.md
+++ b/.changeset/feat-usestack-default-teleport-553.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(useStack): add app-wide `default` teleport option to `createStackPlugin` (#603)
+
+Previously the only way to teleport all Portals to a non-default target was per-component (`<SnackbarPortal to="top-layer" />` on every instance) — there was no single place to configure the fallback for the whole app. `createStackPlugin({ default: 'top-layer' })` now sets that fallback once; `Portal` resolves its target through `to` prop → `stack.default` → `'body'`.

--- a/apps/docs/src/pages/components/primitives/portal.md
+++ b/apps/docs/src/pages/components/primitives/portal.md
@@ -25,7 +25,7 @@ Renderless teleport wrapper with automatic z-index stacking.
 
 ## Usage
 
-Portal wraps Vue's `<Teleport>` with automatic `useStack` integration. Content is teleported to `body` by default and receives a `zIndex` via slot props for proper overlay ordering.
+Portal wraps Vue's `<Teleport>` with automatic `useStack` integration. Content receives a `zIndex` via slot props for proper overlay ordering. The teleport target resolves as per-component `to` -> `stack.default` (from `createStackPlugin`) -> `'body'`.
 
 ::: gn-example
 /components/portal/basic
@@ -69,6 +69,10 @@ Teleported content lands outside your app's landmark structure — `body` is not
 ## FAQ
 
 ::: faq
+??? How do I change the default teleport target for all Portals?
+
+Install `createStackPlugin({ default: 'top-layer' })` (or a selector/`HTMLElement`). See [useStack](/composables/plugins/use-stack). A Portal `to` prop always overrides.
+
 ??? When should I use Portal vs native Teleport?
 
 Use Portal when your teleported content needs z-index coordination with other overlays. Portal auto-registers with `useStack` so your content stacks correctly alongside Dialogs, Snackbars, and other overlay components.

--- a/apps/docs/src/pages/composables/plugins/use-stack.md
+++ b/apps/docs/src/pages/composables/plugins/use-stack.md
@@ -33,7 +33,12 @@ import App from './App.vue'
 
 const app = createApp(App)
 
-app.use(createStackPlugin())
+app.use(
+  createStackPlugin({
+    // optional: app-wide Portal fallback when no per-component `to` is set
+    default: 'top-layer',
+  })
+)
 
 app.mount('#app')
 ```
@@ -110,6 +115,7 @@ Stack state and ticket properties are reactive for automatic UI updates.
 | `scrimZIndex` | <AppSuccessIcon /> | Z-index for scrim element |
 | `isBlocking` | <AppSuccessIcon /> | Top overlay blocks dismissal |
 | `topElement` | <AppSuccessIcon /> | Element of the topmost open modal (`<dialog>`), or `null`; consumed by `Portal`/`Snackbar.Portal` via `teleport="top-layer"` |
+| `default` | <AppSuccessIcon /> | App-wide Portal teleport fallback from `createStackPlugin({ default })` |
 | ticket `zIndex` | <AppSuccessIcon /> | Computed from selection order |
 | ticket `globalTop` | <AppSuccessIcon /> | True if topmost |
 | ticket `isSelected` | <AppSuccessIcon /> | Overlay active state |
@@ -155,6 +161,26 @@ const ticket = stack.register({
 
 Dialog and AlertDialog pass their `<dialog>` element automatically — this pattern is only needed when building a custom modal component from scratch.
 
+### Default Teleport
+
+Set an app-wide Portal fallback so every Portal without a `to` prop inherits the same target:
+
+```ts no-filename
+app.use(
+  createStackPlugin({
+    default: 'top-layer',
+  })
+)
+```
+
+Resolution order:
+
+1. per-component `to` prop
+2. `stack.default` (from the plugin option)
+3. `'body'`
+
+`'top-layer'` still resolves to the topmost open modal element (via `topElement`), then falls back to `'body'` when no modal is active - same as a per-component `to="top-layer"`.
+
 ### Scrim Integration
 
 Use the `Scrim` component alongside `useStack` to provide a backdrop for your overlays. The Scrim automatically positions itself below the topmost overlay:
@@ -178,6 +204,10 @@ The Scrim reads from the same stack context, so its z-index is always coordinate
 ??? Do I have to install the plugin to use useStack?
 
 Not for client-only apps — you can use the default `stack` singleton directly. Install `createStackPlugin` for SSR, where it ensures each request gets its own isolated stack instance instead of sharing one across requests.
+
+??? How do I teleport every Portal to the top layer by default?
+
+`createStackPlugin({ default: 'top-layer' })`. Per-component `to` still wins when set.
 
 ??? How do I give a nested group of overlays its own z-index range?
 

--- a/packages/0/src/components/Portal/Portal.vue
+++ b/packages/0/src/components/Portal/Portal.vue
@@ -59,7 +59,7 @@
   }>()
 
   const {
-    to = 'body',
+    to,
     disabled = false,
     blocking = false,
     scrim = true,
@@ -78,9 +78,10 @@
   })
   ticket.select()
 
-  const target = toRef(() => (
-    to === 'top-layer' ? stack.topElement.value ?? 'body' : to
-  ))
+  const target = toRef(() => {
+    const resolvedTo = to ?? stack.default.value ?? 'body'
+    return resolvedTo === 'top-layer' ? stack.topElement.value ?? 'body' : resolvedTo
+  })
 
   const slotProps = toRef((): PortalSlotProps => ({
     zIndex: ticket.zIndex.value,

--- a/packages/0/src/composables/useStack/index.test.ts
+++ b/packages/0/src/composables/useStack/index.test.ts
@@ -208,6 +208,16 @@ describe('createStack', () => {
         expect(ticket1.id).not.toBe(ticket2.id)
       })
 
+      it('should expose default teleport from options', () => {
+        const stack = createStack({ default: 'top-layer' })
+        expect(stack.default.value).toBe('top-layer')
+      })
+
+      it('should have undefined default when not set', () => {
+        const stack = createStack()
+        expect(stack.default.value).toBeUndefined()
+      })
+
       it('should handle toggle', async () => {
         const stack = createStack()
         const ticket = stack.register()
@@ -318,6 +328,46 @@ describe('createStack', () => {
         })
 
         expect(contextFound).toBe(true)
+      })
+
+      it('should expose default teleport option via stack.default', () => {
+        const plugin = createStackPlugin({ default: 'top-layer' })
+
+        let defaultValue: string | HTMLElement | undefined
+
+        const TestComponent = defineComponent({
+          setup () {
+            const ctx = useStack()
+            defaultValue = ctx.default.value
+            return () => null
+          },
+        })
+
+        mount(TestComponent, {
+          global: { plugins: [plugin] },
+        })
+
+        expect(defaultValue).toBe('top-layer')
+      })
+
+      it('should have undefined default when no default option is given', () => {
+        const plugin = createStackPlugin()
+
+        let defaultValue: string | HTMLElement | undefined = 'sentinel'
+
+        const TestComponent = defineComponent({
+          setup () {
+            const ctx = useStack()
+            defaultValue = ctx.default.value
+            return () => null
+          },
+        })
+
+        mount(TestComponent, {
+          global: { plugins: [plugin] },
+        })
+
+        expect(defaultValue).toBeUndefined()
       })
     })
 

--- a/packages/0/src/composables/useStack/index.ts
+++ b/packages/0/src/composables/useStack/index.ts
@@ -42,6 +42,7 @@ import { onScopeDispose, toRef, toValue } from 'vue'
 // Types
 import type { SelectionContext, SelectionOptions, SelectionTicket, SelectionTicketInput } from '#v0/composables/createSelection'
 import type { ContextTrinity } from '#v0/composables/createTrinity'
+import type { Extensible } from '#v0/types'
 import type { App, ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 
 /**
@@ -161,6 +162,11 @@ export interface StackContext<
    */
   isBlocking: Readonly<Ref<boolean>>
   /**
+   * App-wide default teleport target, as set via `createStackPlugin({ default: … })`.
+   * Portal reads this when no per-component `to` prop is given.
+   */
+  default: Readonly<Ref<Extensible<'top-layer'> | HTMLElement | undefined>>
+  /**
    * Element of the topmost selected modal overlay that has a resolvable DOM
    * element (a top-layer `<dialog>`), or `null`.
    *
@@ -210,6 +216,20 @@ export interface StackOptions extends SelectionOptions {
    * overlay-internal elements (dropdowns, tooltips within dialogs).
    */
   increment?: number
+  /**
+   * App-wide default teleport target for all Portals.
+   *
+   * @remarks When set, every Portal that has no explicit `to` prop inherits
+   * this target. A per-component `to` prop always takes precedence.
+   * `'top-layer'` resolves to the topmost open modal element (a `<dialog>`),
+   * falling back to `'body'` when no modal is active.
+   *
+   * @example
+   * ```ts
+   * app.use(createStackPlugin({ default: 'top-layer' }))
+   * ```
+   */
+  default?: Extensible<'top-layer'> | HTMLElement
 }
 
 export interface StackContextOptions extends StackOptions {
@@ -247,6 +267,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
   const {
     baseZIndex = 2000,
     increment = 10,
+    default: defaultTeleport,
     ...options
   } = _options
 
@@ -333,6 +354,8 @@ export function createStack (_options: StackOptions = {}): StackContext {
     return ticket as StackTicket
   }
 
+  const defaultRef = toRef(() => defaultTeleport)
+
   return {
     ...selection,
     register,
@@ -341,6 +364,7 @@ export function createStack (_options: StackOptions = {}): StackContext {
     scrimZIndex,
     isBlocking,
     topElement,
+    default: defaultRef,
     get size () {
       return selection.size
     },


### PR DESCRIPTION
Closes #553

## Problem

Today the only way to teleport all Portals to a non-default target is per-component: every `<SnackbarPortal to="top-layer" />`, every Dialog, every Toast must opt in individually. There is no single place to configure the fallback for the whole app.

## Solution

Add a `default` option to `createStackPlugin` (and to `createStack`/`StackOptions`):

```ts
app.use(createStackPlugin({ default: 'top-layer' }))
```

`Portal` reads `stack.default` as its fallback when no `to` prop is given, resolving the precedence chain:

```
per-component `to` prop  →  stack.default  →  'body'
```

`'top-layer'` is handled identically to the per-component case — it resolves to `stack.topElement.value` (the topmost open `<dialog>`) and falls back to `'body'` when no modal is active.

## Changes

- `StackOptions`: new `default?: Extensible<'top-layer'> | HTMLElement` field
- `StackContext`: new `default: Readonly<Ref<…>>` property
- `createStack()`: extracts and wraps `default` in a `toRef`, exposes it on the returned context
- `Portal.vue`: `to` prop destructured without a hardcoded `'body'` default; target resolution now: `to ?? stack.default.value ?? 'body'`
- Tests: `createStack({ default })` exposes the value; `createStackPlugin({ default })` flows through to `useStack().default`