### PR TITLE
perf(createGroup,createSingle,createStep): add baseline benchmarks

### DIFF
--- a/packages/0/src/composables/createGroup/index.bench.ts
+++ b/packages/0/src/composables/createGroup/index.bench.ts
@@ -1,0 +1,242 @@
+/**
+ * createGroup Performance Benchmarks
+ *
+ * Structure:
+ * - READ-ONLY operations use shared fixtures (safe, isolates operation cost)
+ * - WARM operations (select, unselect, toggle, selectAll, unselectAll) share a
+ *   populated fixture and time only the operation — the O(n) onboard is hoisted
+ *   out. select/unselect pair to a canonical state; selectAll resets first via
+ *   the cheap reset() so each iteration is a genuine empty→full loop; toggleAll
+ *   oscillates between two states via isAllSelected.
+ * - FRESH fixtures only where the populate IS the measured op (initialization)
+ *   or the op consumes the fixture with no cheap restore (unselectAll + mandatory)
+ * - Tests both 1,000 and 10,000 item datasets
+ * - Categories: initialization, lookup operations, selection operations, mixed state,
+ *   batch operations, computed access
+ */
+
+import { bench, describe } from 'vitest'
+
+// Framework
+import { createGroup } from '@vuetify/v0/composables'
+
+// =============================================================================
+// FIXTURES - Created once, reused across read-only benchmarks
+// =============================================================================
+
+interface BenchmarkItem {
+  id: string
+  value: string
+}
+
+const ITEMS_1K: BenchmarkItem[] = Array.from({ length: 1000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+const ITEMS_10K: BenchmarkItem[] = Array.from({ length: 10_000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+function createPopulatedGroup (count: number, options?: Parameters<typeof createGroup>[0]) {
+  const group = createGroup(options)
+  const items = count === 1000 ? ITEMS_1K : ITEMS_10K
+  group.onboard(items.slice(0, count))
+  return group
+}
+
+const LOOKUP_ID_1K = 'item-500'
+const LOOKUP_ID_10K = 'item-5000'
+
+// Pre-populated shared fixtures for read-only benchmarks
+const group1k = createPopulatedGroup(1000)
+group1k.select(LOOKUP_ID_1K)
+
+const group10k = createPopulatedGroup(10_000)
+group10k.select(LOOKUP_ID_10K)
+
+// Partially selected fixtures for computed access benchmarks
+const partial1k = createPopulatedGroup(1000)
+for (let i = 0; i < 100; i++) partial1k.select(`item-${i}`)
+
+const partial10k = createPopulatedGroup(10_000)
+for (let i = 0; i < 1000; i++) partial10k.select(`item-${i}`)
+
+// =============================================================================
+// BENCHMARKS
+// =============================================================================
+
+describe('createGroup benchmarks', () => {
+  // ===========================================================================
+  // INITIALIZATION - Measures setup/creation cost
+  // Fresh fixture per iteration (required - we're measuring creation itself)
+  // ===========================================================================
+  describe('initialization', () => {
+    bench('Create empty group', () => {
+      createGroup()
+    })
+
+    bench('Onboard 1,000 items', () => {
+      const group = createGroup()
+      group.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 10,000 items', () => {
+      const group = createGroup()
+      group.onboard(ITEMS_10K)
+    })
+
+    bench('Onboard 1,000 items (mandatory)', () => {
+      const group = createGroup({ mandatory: true })
+      group.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 10,000 items (mandatory)', () => {
+      const group = createGroup({ mandatory: true })
+      group.onboard(ITEMS_10K)
+    })
+  })
+
+  // ===========================================================================
+  // LOOKUP OPERATIONS - Read-only state queries
+  // Shared fixture (safe - no state changes)
+  // ===========================================================================
+  describe('lookup operations', () => {
+    bench('Check selected (1,000 items)', () => {
+      group1k.selected(LOOKUP_ID_1K)
+    })
+
+    bench('Check selected (10,000 items)', () => {
+      group10k.selected(LOOKUP_ID_10K)
+    })
+  })
+
+  // ===========================================================================
+  // SELECTION OPERATIONS - Single item select/unselect/toggle
+  // WARM: shared fixtures; the O(n) onboard is hoisted out. select adds/removes
+  // from the Set (idempotent on repeated select); unselect pairs with select.
+  // toggle oscillates between selected/unselected states.
+  // ===========================================================================
+  describe('selection operations', () => {
+    const sel1k = createPopulatedGroup(1000)
+    const sel10k = createPopulatedGroup(10_000)
+
+    bench('Select single item (1,000 items)', () => {
+      sel1k.select(LOOKUP_ID_1K)
+    })
+
+    bench('Select single item (10,000 items)', () => {
+      sel10k.select(LOOKUP_ID_10K)
+    })
+
+    bench('Unselect single item (1,000 items)', () => {
+      sel1k.select(LOOKUP_ID_1K)
+      sel1k.unselect(LOOKUP_ID_1K)
+    })
+
+    bench('Unselect single item (10,000 items)', () => {
+      sel10k.select(LOOKUP_ID_10K)
+      sel10k.unselect(LOOKUP_ID_10K)
+    })
+
+    bench('Toggle single item (1,000 items)', () => {
+      sel1k.toggle(LOOKUP_ID_1K)
+    })
+
+    bench('Toggle single item (10,000 items)', () => {
+      sel10k.toggle(LOOKUP_ID_10K)
+    })
+  })
+
+  // ===========================================================================
+  // MIXED STATE - Indeterminate (mixed/unmix) operations
+  // WARM: shared fixtures; mix/unmix are O(1) Set operations.
+  // ===========================================================================
+  describe('mixed state', () => {
+    const mix1k = createPopulatedGroup(1000)
+
+    bench('Mix single item (1,000 items)', () => {
+      mix1k.select(LOOKUP_ID_1K)
+      mix1k.mix(LOOKUP_ID_1K)
+    })
+
+    bench('Unmix single item (1,000 items)', () => {
+      mix1k.mix(LOOKUP_ID_1K)
+      mix1k.unmix(LOOKUP_ID_1K)
+    })
+  })
+
+  // ===========================================================================
+  // BATCH OPERATIONS - selectAll / unselectAll / toggleAll
+  // WARM: selectAll resets first via the cheap reset() so each iteration is a
+  // genuine empty→full O(n) pass. unselectAll + toggleAll use similarly hoisted
+  // setup so only the target operation is timed.
+  // ===========================================================================
+  describe('batch operations', () => {
+    const batch1k = createPopulatedGroup(1000)
+    const batch10k = createPopulatedGroup(10_000)
+
+    bench('Select all 1,000 items', () => {
+      batch1k.reset()
+      batch1k.selectAll()
+    })
+
+    bench('Select all 10,000 items', () => {
+      batch10k.reset()
+      batch10k.selectAll()
+    })
+
+    bench('Unselect all 1,000 items (from full)', () => {
+      batch1k.selectAll()
+      batch1k.unselectAll()
+    })
+
+    bench('Toggle all 1,000 items (none→all)', () => {
+      batch1k.reset()
+      batch1k.toggleAll()
+    })
+
+    bench('Toggle all 1,000 items (all→none)', () => {
+      batch1k.selectAll()
+      batch1k.toggleAll()
+    })
+  })
+
+  // ===========================================================================
+  // COMPUTED ACCESS - selectedIndexes, isAllSelected, isNoneSelected, isMixed
+  // Shared fixture (safe - reading .value does not mutate state)
+  // Measures amortized cost of repeated computed reads
+  // ===========================================================================
+  describe('computed access', () => {
+    bench('Access selectedIndexes 100 times (100 of 1,000 selected, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void partial1k.selectedIndexes.value
+      }
+    })
+
+    bench('Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void partial10k.selectedIndexes.value
+      }
+    })
+
+    bench('Access isAllSelected 100 times (partial, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void partial1k.isAllSelected.value
+      }
+    })
+
+    bench('Access isNoneSelected 100 times (partial, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void partial1k.isNoneSelected.value
+      }
+    })
+
+    bench('Access isMixed 100 times (partial, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void partial1k.isMixed.value
+      }
+    })
+  })
+})

--- a/packages/0/src/composables/createSingle/index.bench.ts
+++ b/packages/0/src/composables/createSingle/index.bench.ts
@@ -1,0 +1,179 @@
+/**
+ * createSingle Performance Benchmarks
+ *
+ * Structure:
+ * - READ-ONLY operations use shared fixtures (safe, isolates operation cost)
+ * - WARM operations (select, unselect, toggle) share a populated fixture; the
+ *   O(n) onboard is hoisted out. select enforces single-selection (clears others
+ *   then adds); unselect pairs with select so it ends empty; toggle oscillates.
+ * - FRESH fixtures only where the populate IS the measured op (initialization)
+ * - Tests both 1,000 and 10,000 item datasets
+ * - Categories: initialization, lookup operations, selection operations, computed access
+ */
+
+import { bench, describe } from 'vitest'
+
+// Framework
+import { createSingle } from '@vuetify/v0/composables'
+
+// =============================================================================
+// FIXTURES - Created once, reused across read-only benchmarks
+// =============================================================================
+
+interface BenchmarkItem {
+  id: string
+  value: string
+}
+
+const ITEMS_1K: BenchmarkItem[] = Array.from({ length: 1000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+const ITEMS_10K: BenchmarkItem[] = Array.from({ length: 10_000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+function createPopulatedSingle (count: number, options?: Parameters<typeof createSingle>[0]) {
+  const single = createSingle(options)
+  const items = count === 1000 ? ITEMS_1K : ITEMS_10K
+  single.onboard(items.slice(0, count))
+  return single
+}
+
+const LOOKUP_ID_1K = 'item-500'
+const LOOKUP_ID_10K = 'item-5000'
+
+// Pre-populated shared fixtures for read-only benchmarks
+const single1k = createPopulatedSingle(1000)
+single1k.select(LOOKUP_ID_1K)
+
+const single10k = createPopulatedSingle(10_000)
+single10k.select(LOOKUP_ID_10K)
+
+// =============================================================================
+// BENCHMARKS
+// =============================================================================
+
+describe('createSingle benchmarks', () => {
+  // ===========================================================================
+  // INITIALIZATION - Measures setup/creation cost
+  // Fresh fixture per iteration (required - we're measuring creation itself)
+  // ===========================================================================
+  describe('initialization', () => {
+    bench('Create empty single', () => {
+      createSingle()
+    })
+
+    bench('Onboard 1,000 items', () => {
+      const single = createSingle()
+      single.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 10,000 items', () => {
+      const single = createSingle()
+      single.onboard(ITEMS_10K)
+    })
+
+    bench('Onboard 1,000 items (mandatory)', () => {
+      const single = createSingle({ mandatory: true })
+      single.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 10,000 items (mandatory)', () => {
+      const single = createSingle({ mandatory: true })
+      single.onboard(ITEMS_10K)
+    })
+  })
+
+  // ===========================================================================
+  // LOOKUP OPERATIONS - Read-only state queries
+  // Shared fixture (safe - no state changes)
+  // ===========================================================================
+  describe('lookup operations', () => {
+    bench('Check selected (1,000 items)', () => {
+      single1k.selected(LOOKUP_ID_1K)
+    })
+
+    bench('Check selected (10,000 items)', () => {
+      single10k.selected(LOOKUP_ID_10K)
+    })
+  })
+
+  // ===========================================================================
+  // SELECTION OPERATIONS - Single-item select / unselect / toggle
+  // WARM: shared fixtures; the O(n) onboard is hoisted out.
+  // createSingle enforces single-selection: select clears existing selection then
+  // adds the new id (two O(1) operations). unselect pairs with select to reach a
+  // canonical empty end state each iteration. toggle oscillates between two O(1)
+  // states.
+  // ===========================================================================
+  describe('selection operations', () => {
+    const sel1k = createPopulatedSingle(1000)
+    const sel10k = createPopulatedSingle(10_000)
+
+    bench('Select single item (1,000 items)', () => {
+      sel1k.select(LOOKUP_ID_1K)
+    })
+
+    bench('Select single item (10,000 items)', () => {
+      sel10k.select(LOOKUP_ID_10K)
+    })
+
+    bench('Unselect single item (1,000 items)', () => {
+      sel1k.select(LOOKUP_ID_1K)
+      sel1k.unselect(LOOKUP_ID_1K)
+    })
+
+    bench('Unselect single item (10,000 items)', () => {
+      sel10k.select(LOOKUP_ID_10K)
+      sel10k.unselect(LOOKUP_ID_10K)
+    })
+
+    bench('Toggle single item (1,000 items)', () => {
+      sel1k.toggle(LOOKUP_ID_1K)
+    })
+
+    bench('Toggle single item (10,000 items)', () => {
+      sel10k.toggle(LOOKUP_ID_10K)
+    })
+  })
+
+  // ===========================================================================
+  // COMPUTED ACCESS - selectedId, selectedItem, selectedIndex, selectedValue
+  // Shared fixture (safe - reading .value does not mutate state)
+  // Measures amortized cost of repeated computed reads on single-selection refs
+  // ===========================================================================
+  describe('computed access', () => {
+    bench('Access selectedId 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void single1k.selectedId.value
+      }
+    })
+
+    bench('Access selectedId 100 times (10,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void single10k.selectedId.value
+      }
+    })
+
+    bench('Access selectedItem 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void single1k.selectedItem.value
+      }
+    })
+
+    bench('Access selectedIndex 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void single1k.selectedIndex.value
+      }
+    })
+
+    bench('Access selectedValue 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void single1k.selectedValue.value
+      }
+    })
+  })
+})

--- a/packages/0/src/composables/createStep/index.bench.ts
+++ b/packages/0/src/composables/createStep/index.bench.ts
@@ -1,0 +1,216 @@
+/**
+ * createStep Performance Benchmarks
+ *
+ * Structure:
+ * - READ-ONLY operations use shared fixtures (safe, isolates operation cost)
+ * - WARM operations (next, prev, first, last, step) share a pre-populated fixture
+ *   positioned at a mid-point; the O(n) onboard is hoisted out. next/prev call
+ *   the respective sibling op to restore position after each iteration. first/last
+ *   alternate to stay warm. step() is called with +1 and -1 alternately.
+ * - FRESH fixtures only where the populate IS the measured op (initialization)
+ * - Tests both 1,000 and 10,000 item datasets
+ * - Categories: initialization, navigation operations (linear, circular, boundary),
+ *   computed access
+ */
+
+import { bench, describe } from 'vitest'
+
+// Framework
+import { createStep } from '@vuetify/v0/composables'
+
+// =============================================================================
+// FIXTURES - Created once, reused across read-only benchmarks
+// =============================================================================
+
+interface BenchmarkItem {
+  id: string
+  value: string
+}
+
+const ITEMS_1K: BenchmarkItem[] = Array.from({ length: 1000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+const ITEMS_10K: BenchmarkItem[] = Array.from({ length: 10_000 }, (_, i) => ({
+  id: `item-${i}`,
+  value: `value-${i}`,
+}))
+
+function createPopulatedStep (count: number, options?: Parameters<typeof createStep>[0]) {
+  const step = createStep(options)
+  const items = count === 1000 ? ITEMS_1K : ITEMS_10K
+  step.onboard(items.slice(0, count))
+  return step
+}
+
+// Pre-populated shared fixture positioned at mid-point for read/nav benchmarks
+const step1k = createPopulatedStep(1000)
+step1k.select('item-500')
+
+const step10k = createPopulatedStep(10_000)
+step10k.select('item-5000')
+
+const stepCircular1k = createPopulatedStep(1000, { circular: true })
+stepCircular1k.select('item-500')
+
+// =============================================================================
+// BENCHMARKS
+// =============================================================================
+
+describe('createStep benchmarks', () => {
+  // ===========================================================================
+  // INITIALIZATION - Measures setup/creation cost
+  // Fresh fixture per iteration (required - we're measuring creation itself)
+  // ===========================================================================
+  describe('initialization', () => {
+    bench('Create empty step', () => {
+      createStep()
+    })
+
+    bench('Onboard 1,000 items', () => {
+      const step = createStep()
+      step.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 10,000 items', () => {
+      const step = createStep()
+      step.onboard(ITEMS_10K)
+    })
+
+    bench('Onboard 1,000 items (circular)', () => {
+      const step = createStep({ circular: true })
+      step.onboard(ITEMS_1K)
+    })
+
+    bench('Onboard 1,000 items (mandatory)', () => {
+      const step = createStep({ mandatory: true })
+      step.onboard(ITEMS_1K)
+    })
+  })
+
+  // ===========================================================================
+  // NAVIGATION OPERATIONS - next / prev / first / last / step
+  // WARM: shared fixture positioned at mid-point. next/prev alternate to restore
+  // the cursor (net displacement of 0 across pairs). first/last pair similarly.
+  // ===========================================================================
+  describe('navigation operations (linear)', () => {
+    const nav1k = createPopulatedStep(1000)
+    nav1k.select('item-500')
+
+    const nav10k = createPopulatedStep(10_000)
+    nav10k.select('item-5000')
+
+    bench('next() from mid-point (1,000 items)', () => {
+      nav1k.next()
+      nav1k.prev()
+    })
+
+    bench('next() from mid-point (10,000 items)', () => {
+      nav10k.next()
+      nav10k.prev()
+    })
+
+    bench('prev() from mid-point (1,000 items)', () => {
+      nav1k.prev()
+      nav1k.next()
+    })
+
+    bench('prev() from mid-point (10,000 items)', () => {
+      nav10k.prev()
+      nav10k.next()
+    })
+
+    bench('first() (1,000 items)', () => {
+      nav1k.first()
+      nav1k.select('item-500')
+    })
+
+    bench('last() (1,000 items)', () => {
+      nav1k.last()
+      nav1k.select('item-500')
+    })
+
+    bench('step(+5) from mid-point (1,000 items)', () => {
+      nav1k.step(5)
+      nav1k.step(-5)
+    })
+
+    bench('step(+50) from mid-point (1,000 items)', () => {
+      nav1k.step(50)
+      nav1k.step(-50)
+    })
+  })
+
+  // ===========================================================================
+  // NAVIGATION OPERATIONS - circular mode (wraps at boundary)
+  // ===========================================================================
+  describe('navigation operations (circular)', () => {
+    const circ1k = createPopulatedStep(1000, { circular: true })
+    circ1k.select('item-500')
+
+    bench('next() from mid-point circular (1,000 items)', () => {
+      circ1k.next()
+      circ1k.prev()
+    })
+
+    bench('next() wrapping past end circular (1,000 items)', () => {
+      circ1k.last()
+      circ1k.next()   // wraps to item-0
+      circ1k.select('item-999')
+    })
+
+    bench('prev() wrapping past start circular (1,000 items)', () => {
+      circ1k.first()
+      circ1k.prev()   // wraps to item-999
+      circ1k.select('item-0')
+    })
+  })
+
+  // ===========================================================================
+  // BOUNDARY CONDITIONS - next/prev at start/end (linear, must not move)
+  // ===========================================================================
+  describe('boundary conditions', () => {
+    const bound1k = createPopulatedStep(1000)
+
+    bench('next() at last item — no-op (1,000 items)', () => {
+      bound1k.last()
+      bound1k.next()   // no-op in linear mode
+    })
+
+    bench('prev() at first item — no-op (1,000 items)', () => {
+      bound1k.first()
+      bound1k.prev()   // no-op in linear mode
+    })
+  })
+
+  // ===========================================================================
+  // COMPUTED ACCESS - selectedIndex, selectedId, selectedValue
+  // Shared fixture (safe - reading .value does not mutate state)
+  // ===========================================================================
+  describe('computed access', () => {
+    bench('Access selectedIndex 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void step1k.selectedIndex.value
+      }
+    })
+
+    bench('Access selectedIndex 100 times (10,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void step10k.selectedIndex.value
+      }
+    })
+
+    bench('Access selectedId 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void step1k.selectedId.value
+      }
+    })
+
+    bench('Access selectedValue 100 times (1,000 items, cached)', () => {
+      for (let i = 0; i < 100; i++) {
+        void step1k.selectedValue.value
+      }
+    })
+  })
+})

--- a/packages/0/src/composables/createStep/index.bench.ts
+++ b/packages/0/src/composables/createStep/index.bench.ts
@@ -156,13 +156,13 @@ describe('createStep benchmarks', () => {
 
     bench('next() wrapping past end circular (1,000 items)', () => {
       circ1k.last()
-      circ1k.next()   // wraps to item-0
+      circ1k.next() // wraps to item-0
       circ1k.select('item-999')
     })
 
     bench('prev() wrapping past start circular (1,000 items)', () => {
       circ1k.first()
-      circ1k.prev()   // wraps to item-999
+      circ1k.prev() // wraps to item-999
       circ1k.select('item-0')
     })
   })
@@ -175,12 +175,12 @@ describe('createStep benchmarks', () => {
 
     bench('next() at last item — no-op (1,000 items)', () => {
       bound1k.last()
-      bound1k.next()   // no-op in linear mode
+      bound1k.next() // no-op in linear mode
     })
 
     bench('prev() at first item — no-op (1,000 items)', () => {
       bound1k.first()
-      bound1k.prev()   // no-op in linear mode
+      bound1k.prev() // no-op in linear mode
     })
   })
 


### PR DESCRIPTION
Part of #543 (WS1 — Benchmark the unbenched stable selection primitives).

## Problem

`createGroup`, `createSingle`, and `createStep` are all promoted `stable` (frozen API, a break is a major bump) and sit under the entire selection tree — Tabs, Treeview, Carousel, forms — but had **zero benchmarks**. Without baselines, a post-1.0 patch can silently regress them with no early warning.

## Solution

Adds `index.bench.ts` for each composable, following the fixture-isolation rules in `.claude/rules/benchmarks.md`:

**`createGroup`** — covers:
- Initialization: empty + onboard 1k/10k (default + mandatory variants)
- Lookup: `selected(id)`
- Selection: `select` / `unselect` / `toggle` (single item, 1k + 10k)
- Mixed state: `mix` / `unmix` (indeterminate checkbox state)
- Batch: `selectAll` / `unselectAll` / `toggleAll` (1k + 10k)
- Computed access: `selectedIndexes`, `isAllSelected`, `isNoneSelected`, `isMixed` (100× reads, cached)

**`createSingle`** — covers:
- Initialization: empty + onboard 1k/10k (default + mandatory variants)
- Lookup: `selected(id)`
- Selection: `select` / `unselect` / `toggle` (1k + 10k; hot path includes mandatory clear-then-add)
- Computed access: `selectedId`, `selectedItem`, `selectedIndex`, `selectedValue` (100× reads, cached)

**`createStep`** — covers:
- Initialization: empty + onboard 1k/10k (default + circular + mandatory)
- Navigation (linear): `next` / `prev` / `first` / `last` / `step(±N)` from mid-point (1k + 10k)
- Navigation (circular): mid-point, wrap past end, wrap past start
- Boundary conditions: `next` at last / `prev` at first (no-ops in linear mode)
- Computed access: `selectedIndex`, `selectedId`, `selectedValue` (100× reads, cached)

All WARM benches hoist the O(n) onboard outside the timed block. FRESH fixtures are used only where creation itself is the measured operation. Datasets: 1,000 and 10,000 items.