### PR TITLE
test(ssr): add SSR hydration smoke-test harness (issue #543 WS5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:coverage": "vitest run --coverage",
     "test:vapor": "pnpm --filter=@vuetify-private/vapor-tests test",
     "test:bench": "vitest --reporter=verbose bench --run",
+    "test:ssr": "vitest run --reporter=verbose hydration",
     "test:bench:json": "vitest bench --run --outputJson apps/docs/public/benchmarks.json",
     "bench": "vitest --reporter=default bench",
     "metrics": "pnpm test:coverage && pnpm build:0 && pnpm metrics:bench && node scripts/generate-metrics.js",

--- a/packages/0/src/components/Atom/index.hydration.test.ts
+++ b/packages/0/src/components/Atom/index.hydration.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { h } from 'vue'
 
 import { hydrate } from '#v0/test-utils/hydrate'
 
 import { Atom } from './index'
 
+// Utilities
+import { h } from 'vue'
+
 // Types
 import type { Component } from 'vue'
 
-describe('Atom SSR hydration', () => {
+describe('atom SSR hydration', () => {
   it('hydrates a stable Atom with zero mismatch warnings', async () => {
     const { html, mismatches } = await hydrate(
       () => h(Atom as unknown as Component, { as: 'span' }, () => 'Hydrated'),
@@ -18,7 +20,7 @@ describe('Atom SSR hydration', () => {
     expect(mismatches).toEqual([])
   })
 
-  it('CONTROL: detects a deliberate server/client mismatch', async () => {
+  it('control: detects a deliberate server/client mismatch', async () => {
     let n = 0
     const { mismatches } = await hydrate(() => h('span', String(n++)))
 

--- a/packages/0/src/components/Atom/index.hydration.test.ts
+++ b/packages/0/src/components/Atom/index.hydration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+
+import { hydrate } from '#v0/test-utils/hydrate'
+
+import { Atom } from './index'
+
+// Types
+import type { Component } from 'vue'
+
+describe('Atom SSR hydration', () => {
+  it('hydrates a stable Atom with zero mismatch warnings', async () => {
+    const { html, mismatches } = await hydrate(
+      () => h(Atom as unknown as Component, { as: 'span' }, () => 'Hydrated'),
+    )
+
+    expect(html).toContain('Hydrated')
+    expect(mismatches).toEqual([])
+  })
+
+  it('CONTROL: detects a deliberate server/client mismatch', async () => {
+    let n = 0
+    const { mismatches } = await hydrate(() => h('span', String(n++)))
+
+    expect(mismatches.length).toBeGreaterThan(0)
+    expect(mismatches.some(m => /hydration.*mismatch/i.test(m))).toBe(true)
+  })
+})

--- a/packages/0/src/components/Dialog/index.hydration.test.ts
+++ b/packages/0/src/components/Dialog/index.hydration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { h } from 'vue'
+
+import { hydrate } from '#v0/test-utils/hydrate'
+import { createStackPlugin } from '#v0/composables/useStack'
+
+import { Dialog } from './index'
+
+// Types
+import type { Component } from 'vue'
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn()
+  HTMLDialogElement.prototype.close = vi.fn()
+})
+
+describe('Dialog SSR hydration', () => {
+  it('hydrates a closed Dialog without mismatch warnings', async () => {
+    const { html, mismatches } = await hydrate(
+      () =>
+        h(Dialog.Root as unknown as Component, { id: 'test-dialog' }, () => [
+          h(Dialog.Activator as unknown as Component, {}, () => 'Open'),
+          h(Dialog.Content as unknown as Component, {}, () => [
+            h(Dialog.Title as unknown as Component, {}, () => 'Dialog Title'),
+            h(Dialog.Description as unknown as Component, {}, () => 'Dialog description.'),
+            h(Dialog.Close as unknown as Component, {}, () => 'Close'),
+          ]),
+        ]),
+      {
+        setup: app => app.use(createStackPlugin()),
+      },
+    )
+
+    expect(html).toContain('Open')
+    expect(html).toContain('Dialog Title')
+    expect(mismatches).toEqual([])
+  })
+})

--- a/packages/0/src/components/Dialog/index.hydration.test.ts
+++ b/packages/0/src/components/Dialog/index.hydration.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { h } from 'vue'
 
-import { hydrate } from '#v0/test-utils/hydrate'
+// Composables
 import { createStackPlugin } from '#v0/composables/useStack'
 
+import { hydrate } from '#v0/test-utils/hydrate'
+
 import { Dialog } from './index'
+
+// Utilities
+import { h } from 'vue'
 
 // Types
 import type { Component } from 'vue'
@@ -14,7 +18,7 @@ beforeEach(() => {
   HTMLDialogElement.prototype.close = vi.fn()
 })
 
-describe('Dialog SSR hydration', () => {
+describe('dialog SSR hydration', () => {
   it('hydrates a closed Dialog without mismatch warnings', async () => {
     const { html, mismatches } = await hydrate(
       () =>

--- a/packages/0/src/components/Tabs/index.hydration.test.ts
+++ b/packages/0/src/components/Tabs/index.hydration.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { h } from 'vue'
 
 import { hydrate } from '#v0/test-utils/hydrate'
 
 import { Tabs } from './index'
 
+// Utilities
+import { h } from 'vue'
+
 // Types
 import type { Component } from 'vue'
 
-const TabsFixture = () =>
-  h(Tabs.Root as unknown as Component, { modelValue: 'profile' }, () => [
+function TabsFixture () {
+  return h(Tabs.Root as unknown as Component, { modelValue: 'profile' }, () => [
     h(Tabs.List as unknown as Component, { label: 'Account settings' }, () => [
       h(Tabs.Item as unknown as Component, { value: 'profile' }, () => 'Profile'),
       h(Tabs.Item as unknown as Component, { value: 'password' }, () => 'Password'),
@@ -17,8 +19,9 @@ const TabsFixture = () =>
     h(Tabs.Panel as unknown as Component, { value: 'profile' }, () => 'Profile content'),
     h(Tabs.Panel as unknown as Component, { value: 'password' }, () => 'Password content'),
   ])
+}
 
-describe('Tabs SSR hydration', () => {
+describe('tabs SSR hydration', () => {
   it('hydrates with stable useId-derived ARIA IDs and zero mismatch warnings', async () => {
     const { html, mismatches } = await hydrate(TabsFixture)
 

--- a/packages/0/src/components/Tabs/index.hydration.test.ts
+++ b/packages/0/src/components/Tabs/index.hydration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+
+import { hydrate } from '#v0/test-utils/hydrate'
+
+import { Tabs } from './index'
+
+// Types
+import type { Component } from 'vue'
+
+const TabsFixture = () =>
+  h(Tabs.Root as unknown as Component, { modelValue: 'profile' }, () => [
+    h(Tabs.List as unknown as Component, { label: 'Account settings' }, () => [
+      h(Tabs.Item as unknown as Component, { value: 'profile' }, () => 'Profile'),
+      h(Tabs.Item as unknown as Component, { value: 'password' }, () => 'Password'),
+    ]),
+    h(Tabs.Panel as unknown as Component, { value: 'profile' }, () => 'Profile content'),
+    h(Tabs.Panel as unknown as Component, { value: 'password' }, () => 'Password content'),
+  ])
+
+describe('Tabs SSR hydration', () => {
+  it('hydrates with stable useId-derived ARIA IDs and zero mismatch warnings', async () => {
+    const { html, mismatches } = await hydrate(TabsFixture)
+
+    expect(html).toContain('Profile')
+    expect(html).toContain('Password')
+    // Verify ARIA wiring rendered server-side
+    expect(html).toMatch(/aria-controls="[^"]+panel[^"]*"/)
+    expect(html).toMatch(/aria-selected="true"/)
+    expect(mismatches).toEqual([])
+  })
+
+  it('renders the correct initial selection state', async () => {
+    const { html } = await hydrate(TabsFixture)
+
+    expect(html).toContain('Profile content')
+  })
+})

--- a/packages/0/src/test-utils/hydrate.ts
+++ b/packages/0/src/test-utils/hydrate.ts
@@ -1,6 +1,8 @@
-import { createSSRApp, defineComponent, nextTick } from 'vue'
-import { renderToString } from 'vue/server-renderer'
 import { vi } from 'vitest'
+import { renderToString } from 'vue/server-renderer'
+
+// Utilities
+import { createSSRApp, defineComponent, nextTick } from 'vue'
 
 // Types
 import type { App } from 'vue'
@@ -26,7 +28,9 @@ export interface HydrateOptions {
  */
 export async function hydrate (render: () => unknown, options?: HydrateOptions): Promise<HydrateResult> {
   const messages: string[] = []
-  const capture = (...args: unknown[]) => void messages.push(args.map(String).join(' '))
+  function capture (...args: unknown[]) {
+    messages.push(args.map(String).join(' '))
+  }
   const warn = vi.spyOn(console, 'warn').mockImplementation(capture)
   const error = vi.spyOn(console, 'error').mockImplementation(capture)
 

--- a/packages/0/src/test-utils/hydrate.ts
+++ b/packages/0/src/test-utils/hydrate.ts
@@ -1,0 +1,50 @@
+import { createSSRApp, defineComponent, nextTick } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { vi } from 'vitest'
+
+// Types
+import type { App } from 'vue'
+
+export interface HydrateResult {
+  html: string
+  mismatches: string[]
+  messages: string[]
+}
+
+export interface HydrateOptions {
+  /** Called with each App instance so callers can install plugins before render/hydrate. */
+  setup?: (app: App) => void
+}
+
+/**
+ * Renders a render function to SSR HTML, then hydrates that exact HTML with
+ * createSSRApp().mount() and captures Vue's hydration-mismatch console output.
+ *
+ * Unlike `@vue/test-utils` mount() (which hydrates a fresh container), this
+ * helper feeds the actual SSR HTML back to the client — the only path that
+ * exercises Vue's real hydration codepath and can produce mismatch warnings.
+ */
+export async function hydrate (render: () => unknown, options?: HydrateOptions): Promise<HydrateResult> {
+  const messages: string[] = []
+  const capture = (...args: unknown[]) => void messages.push(args.map(String).join(' '))
+  const warn = vi.spyOn(console, 'warn').mockImplementation(capture)
+  const error = vi.spyOn(console, 'error').mockImplementation(capture)
+
+  const serverApp = createSSRApp(defineComponent({ render }))
+  options?.setup?.(serverApp)
+  const html = await renderToString(serverApp)
+
+  const container = document.createElement('div')
+  container.innerHTML = html
+  const clientApp = createSSRApp(defineComponent({ render }))
+  options?.setup?.(clientApp)
+  clientApp.mount(container)
+  await nextTick()
+
+  warn.mockRestore()
+  error.mockRestore()
+  clientApp.unmount()
+
+  const mismatches = messages.filter(m => /hydrat|mismatch/i.test(m))
+  return { html, mismatches, messages }
+}


### PR DESCRIPTION
## What

Implements WS5 from #543 (RC → 1.0 hardening: freeze-confidence) — an isolated SSR hydration smoke-test harness.

## Why

Vue's hydration-mismatch warnings are only emitted when server-rendered HTML is fed back into `createSSRApp().mount()`. Using `@vue/test-utils`'s `mount()` always starts from a fresh container and silently skips the real hydration codepath, masking mismatches. This harness closes that gap for the components most exposed to SSR divergence.

## Changes

**`packages/0/src/test-utils/hydrate.ts`** — shared utility (harvested from `test/ssr-hydration-proto`)

```ts
hydrate(render, { setup? })
```

1. `renderToString(createSSRApp(…))` → captures the server HTML
2. Sets `container.innerHTML = html` → feeds the exact SSR bytes to the client
3. `createSSRApp(…).mount(container)` → exercises Vue's real hydration path
4. Captures `console.warn` / `console.error` via `vi.spyOn`; filters for `/hydrat|mismatch/i`
5. Returns `{ html, mismatches, messages }`

The optional `setup(app)` hook lets callers install plugins (e.g. `createStackPlugin()`) on both the SSR and client apps without duplicating the boilerplate.

**New hydration test suites**

| File | Component | SSR risk covered |
|---|---|---|
| `Atom/index.hydration.test.ts` | `Atom` | Baseline + CONTROL (proves detection works) |
| `Tabs/index.hydration.test.ts` | `Tabs.Root/List/Item/Panel` | `useId()`-derived `aria-controls` / `aria-selected` IDs must be stable across server → client |
| `Dialog/index.hydration.test.ts` | `Dialog.*` | `useStack` + `useId` lifecycle with `createStackPlugin()` |

**`package.json`** — adds `pnpm test:ssr` (`vitest run hydration`) for quick targeted iteration.

## Acceptance

```
pnpm test:ssr
```

All 33 tests pass (3 new hydration test files + the existing `useHydration` unit tests that match the filter).

Closes part of #543 (WS5).