### PR TITLE
fix(Avatar,Scrim,Popover,Tooltip,Select,Toggle): restore dropped alt text and complete missing ARIA wiring (#543)

### DIFF
--- a/.changeset/a11y-overlays-543.md
+++ b/.changeset/a11y-overlays-543.md
@@ -1,0 +1,12 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(Avatar,Scrim,Popover,Tooltip,Select,Toggle): restore dropped alt text and complete missing ARIA wiring (#543)
+
+- `Avatar.Image` now accepts an `alt` prop and passes consumer attributes (`alt`, `aria-label`, ...) through to the rendered element — previously they were silently dropped
+- `Scrim` backdrops are hidden from assistive technology with `aria-hidden="true"`
+- `Popover.Activator` explicitly exposes `aria-expanded` and `aria-controls` instead of relying on inconsistent native `popovertarget` mapping
+- `Tooltip.Content` closes on Escape when focus is inside interactive tooltip content
+- `Select.Activator` reflects the disabled state (`aria-disabled` + native `disabled`) and stays keyboard-focusable when rendered as a non-button element; `Select.Content` names its listbox via `aria-labelledby`
+- `Toggle.Group` gains `label`, `ariaLabelledby`, and `ariaDescribedby` props so the group can be named

--- a/apps/docs/src/pages/components/providers/scrim.md
+++ b/apps/docs/src/pages/components/providers/scrim.md
@@ -45,6 +45,9 @@ app.mount('#app')
 
 The Scrim component renders a backdrop that appears when any overlay is active. It automatically positions itself below the topmost overlay using z-index management from the stack context.
 
+> [!IMPORTANT]
+> The scrim is rendered with `aria-hidden` — it is decorative. Don't place interactive or focusable content in its default slot; keep controls inside the overlay itself.
+
 ::: gn-example
 /components/scrim/basic
 :::

--- a/packages/0/src/components/Avatar/AvatarImage.vue
+++ b/packages/0/src/components/Avatar/AvatarImage.vue
@@ -30,6 +30,8 @@
   export interface AvatarImageProps extends AtomProps {
     /** Image source URL */
     src?: string
+    /** Accessible alt text. */
+    alt?: string
     /** Priority for display order (higher = more preferred) */
     priority?: number
     /** Namespace for retrieving avatar context */
@@ -56,6 +58,7 @@
     attrs: {
       role: 'img'
       src?: string
+      alt?: string
       onLoad: (e: Event) => void
       onError: (e: Event) => void
     }
@@ -63,10 +66,7 @@
 </script>
 
 <script setup lang="ts">
-  defineOptions({
-    name: 'AvatarImage',
-    inheritAttrs: false,
-  })
+  defineOptions({ name: 'AvatarImage' })
 
   defineSlots<{
     default: (props: AvatarImageSlotProps) => any
@@ -76,6 +76,7 @@
     as = 'img',
     renderless,
     src,
+    alt,
     priority = 0,
     namespace = 'v0:avatar',
   } = defineProps<AvatarImageProps>()
@@ -143,6 +144,7 @@
     attrs: {
       role: 'img',
       src: image.source.value,
+      alt,
       onLoad,
       onError,
     },

--- a/packages/0/src/components/Popover/PopoverActivator.vue
+++ b/packages/0/src/components/Popover/PopoverActivator.vue
@@ -24,6 +24,8 @@
     attrs: {
       'popovertarget': string
       'type': 'button' | undefined
+      'aria-expanded': boolean
+      'aria-controls': string
       'data-open': true | undefined
       'style': Record<string, string>
     }
@@ -64,6 +66,8 @@
     attrs: {
       'popovertarget': toValue(popovertarget),
       'type': as === 'button' ? 'button' : undefined,
+      'aria-expanded': context.isOpen.value,
+      'aria-controls': toValue(popovertarget),
       'data-open': context.isOpen.value || undefined,
       'style': style.value,
     },

--- a/packages/0/src/components/Scrim/Scrim.vue
+++ b/packages/0/src/components/Scrim/Scrim.vue
@@ -48,8 +48,9 @@
     dismiss: () => void
     /** Attributes to bind to the scrim element */
     attrs: {
-      style: { zIndex: number }
-      onClick: () => void
+      'aria-hidden': 'true'
+      'style': { zIndex: number }
+      'onClick': () => void
     }
   }
 </script>
@@ -97,8 +98,9 @@
       isBlocking: ticket.blocking.value,
       dismiss: () => onDismiss(ticket),
       attrs: {
-        style: { zIndex },
-        onClick: () => onDismiss(ticket),
+        'aria-hidden': 'true',
+        'style': { zIndex },
+        'onClick': () => onDismiss(ticket),
       },
     }
   }

--- a/packages/0/src/components/Select/SelectActivator.vue
+++ b/packages/0/src/components/Select/SelectActivator.vue
@@ -18,7 +18,7 @@
 
   // Utilities
   import { isUndefined } from '#v0/utilities'
-  import { toRef, useTemplateRef, watchEffect } from 'vue'
+  import { toRef, toValue, useTemplateRef, watchEffect } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
@@ -39,6 +39,9 @@
       'aria-expanded': boolean
       'aria-haspopup': 'listbox'
       'aria-controls': string
+      'aria-disabled': boolean
+      'disabled': true | undefined
+      'tabindex': 0 | undefined
       'data-open': true | undefined
       'style': Record<string, string>
       'onClick': () => void
@@ -122,6 +125,9 @@
       'aria-expanded': context.isOpen.value,
       'aria-haspopup': 'listbox',
       'aria-controls': context.listboxId,
+      'aria-disabled': toValue(context.disabled),
+      'disabled': toValue(context.disabled) || undefined,
+      'tabindex': as === 'button' ? undefined : 0,
       'data-open': context.isOpen.value || undefined,
       'style': context.popover.anchorStyles.value,
       onClick,

--- a/packages/0/src/components/Select/SelectContent.vue
+++ b/packages/0/src/components/Select/SelectContent.vue
@@ -43,6 +43,7 @@
       'id': string
       'popover': ''
       'role': 'listbox'
+      'aria-labelledby': string
       'aria-multiselectable': true | undefined
       'tabindex': -1
       'style': Record<string, string>
@@ -77,6 +78,7 @@
       ...context.popover.contentAttrs.value,
       'id': context.listboxId,
       'role': 'listbox',
+      'aria-labelledby': context.activatorId,
       'aria-multiselectable': context.multiple || undefined,
       'tabindex': -1,
       'style': context.popover.contentStyles.value,

--- a/packages/0/src/components/Toggle/ToggleGroup.vue
+++ b/packages/0/src/components/Toggle/ToggleGroup.vue
@@ -43,6 +43,12 @@
     mandatory?: boolean | 'force'
     /** Layout direction for ARIA */
     orientation?: ToggleOrientation
+    /** Accessible name for the group */
+    label?: string
+    /** ID of element that labels this group */
+    ariaLabelledby?: string
+    /** ID of element that describes this group */
+    ariaDescribedby?: string
   }
 
   export interface ToggleGroupSlotProps {
@@ -51,6 +57,9 @@
     /** Attributes to bind to the root element */
     attrs: {
       'role': 'group'
+      'aria-label': string | undefined
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'aria-orientation': ToggleOrientation
       'aria-disabled': boolean
       'data-orientation': ToggleOrientation
@@ -84,10 +93,13 @@
     as = 'div',
     renderless,
     namespace = 'v0:toggle:group',
+    ariaLabelledby,
+    ariaDescribedby,
     disabled = false,
     multiple = false,
     mandatory = false,
     orientation = 'horizontal',
+    label,
   } = defineProps<ToggleGroupProps>()
 
   const model = defineModel<T | T[]>()
@@ -116,6 +128,9 @@
     isDisabled: toValue(disabled),
     attrs: {
       'role': 'group',
+      'aria-label': label || undefined,
+      'aria-labelledby': ariaLabelledby || undefined,
+      'aria-describedby': ariaDescribedby || undefined,
       'aria-orientation': orientation,
       'aria-disabled': disabled,
       'data-orientation': orientation,

--- a/packages/0/src/components/Tooltip/TooltipContent.vue
+++ b/packages/0/src/components/Tooltip/TooltipContent.vue
@@ -40,6 +40,7 @@
       'data-interactive': true | undefined
       'onPointerenter': (e: PointerEvent) => void
       'onPointerleave': (e: PointerEvent) => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
     styles: Record<string, string>
   }
@@ -75,6 +76,12 @@
     root.close()
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      root.close()
+    }
+  }
+
   const slotProps = toRef((): TooltipContentSlotProps => ({
     isOpen: root.isOpen.value,
     isInteractive: root.isInteractive.value,
@@ -85,6 +92,7 @@
       'data-interactive': root.isInteractive.value || undefined,
       'onPointerenter': onPointerenter,
       'onPointerleave': onPointerleave,
+      'onKeydown': onKeydown,
     },
     styles: root.contentStyles.value,
   }))


### PR DESCRIPTION
Six small, verified accessibility fixes from the WS4 ARIA audit. All changes are additive attribute wiring; no behavior changes outside ARIA/attrs.

| Fix | Component | Evidence | Change |
|---|---|---|---|
| 1 | `Avatar.Image` | `inheritAttrs: false` + `v-bind="slotProps.attrs"` without `useAttrs()` merge dropped consumer `alt`/`aria-label` despite hardcoded `role="img"` | Mirror `ImageImg`: attrs fall through, explicit `alt` prop |
| 2 | `Scrim` | `getSlotProps` bound only `style`/`onClick` — decorative backdrop exposed to AT | `aria-hidden="true"` on each layer |
| 3 | `Popover.Activator` | Only `popovertarget`/`type` bound; native implicit ARIA mapping is inconsistent | Explicit `aria-expanded` from `context.isOpen`, `aria-controls` -> content id (`target ?? context.id`) |
| 4 | `Tooltip.Content` | Activator handled Escape, content had no keydown — Escape dead with focus inside interactive tooltips | Same Escape-close handler on content |
| 5 | `Select` | Activator lacked disabled ARIA + focusability fallback; listbox unnamed | `aria-disabled` + native `disabled` (mirrors `ComboboxControl`), `tabindex="0"` for non-button `as`, `aria-labelledby` -> activator id on content (mirrors `ComboboxContent`) |
| 6 | `Toggle.Group` | `role="group"` with no naming surface | `label` / `ariaLabelledby` / `ariaDescribedby` props, mirroring `ButtonGroup` exactly |

Refs #543 (WS4)