### PR TITLE
fix(Switch,Form,Slider): correct ARIA states for mixed, native validation, and grouped form controls (#543)

### DIFF
--- a/.changeset/a11y-forms-543.md
+++ b/.changeset/a11y-forms-543.md
@@ -6,5 +6,5 @@ fix(Switch,Form,Slider): correct ARIA states for mixed, native validation, and g
 
 - `Switch.Root` and `Switch.SelectAll` no longer emit the spec-invalid `aria-checked="mixed"`; the value is clamped to `false` while indeterminate, so screen readers announce a valid switch state. Style indeterminate switches with `data-state="indeterminate"` as before.
 - `Switch.Thumb` and `Switch.Track` are now marked `aria-hidden="true"`, hiding the decorative visuals from assistive technology.
-- `Form.Root` now renders `novalidate`, so the browser's native constraint popups no longer block submit before v0's async validation runs.
+- `Form.Root` now renders `novalidate` by default, so the browser's native constraint popups no longer block submit before v0's async validation runs. Opt back into native constraint validation with `:novalidate="false"`.
 - `Slider.Root` now exposes `role="group"` plus optional `label` / `ariaLabelledby` props, giving multi-thumb sliders an accessible group name.

--- a/.changeset/a11y-forms-543.md
+++ b/.changeset/a11y-forms-543.md
@@ -1,0 +1,10 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(Switch,Form,Slider): correct ARIA states for mixed, native validation, and grouped form controls (#543)
+
+- `Switch.Root` and `Switch.SelectAll` no longer emit the spec-invalid `aria-checked="mixed"`; the value is clamped to `false` while indeterminate, so screen readers announce a valid switch state. Style indeterminate switches with `data-state="indeterminate"` as before.
+- `Switch.Thumb` and `Switch.Track` are now marked `aria-hidden="true"`, hiding the decorative visuals from assistive technology.
+- `Form.Root` now renders `novalidate`, so the browser's native constraint popups no longer block submit before v0's async validation runs.
+- `Slider.Root` now exposes `role="group"` plus optional `label` / `ariaLabelledby` props, giving multi-thumb sliders an accessible group name.

--- a/packages/0/src/components/Form/Form.vue
+++ b/packages/0/src/components/Form/Form.vue
@@ -37,6 +37,7 @@
     reset: () => void
     /** Attributes to bind to the form element */
     attrs: {
+      novalidate: true
       onSubmit: (event: Event) => void
       onReset: (event: Event) => void
     }
@@ -110,6 +111,7 @@
     submit: form.submit,
     reset: form.reset,
     attrs: {
+      novalidate: true,
       onSubmit,
       onReset,
     },

--- a/packages/0/src/components/Form/Form.vue
+++ b/packages/0/src/components/Form/Form.vue
@@ -20,6 +20,8 @@
     disabled?: boolean
     /** Sets all registered fields to readonly */
     readonly?: boolean
+    /** Suppress native constraint validation (default: true) — set false to restore browser validation UI */
+    novalidate?: boolean
   }
 
   export interface FormSlotProps {
@@ -37,7 +39,7 @@
     reset: () => void
     /** Attributes to bind to the form element */
     attrs: {
-      novalidate: true
+      novalidate: true | undefined
       onSubmit: (event: Event) => void
       onReset: (event: Event) => void
     }
@@ -73,6 +75,7 @@
     namespace = 'v0:form',
     disabled = false,
     readonly = false,
+    novalidate = true,
     renderless,
   } = defineProps<FormProps>()
 
@@ -111,7 +114,7 @@
     submit: form.submit,
     reset: form.reset,
     attrs: {
-      novalidate: true,
+      novalidate: novalidate || undefined,
       onSubmit,
       onReset,
     },

--- a/packages/0/src/components/Slider/SliderRoot.vue
+++ b/packages/0/src/components/Slider/SliderRoot.vue
@@ -76,6 +76,10 @@
     name?: string
     /** Associate with form by ID */
     form?: string
+    /** Accessible name for the group */
+    label?: string
+    /** ID of element that labels this group */
+    ariaLabelledby?: string
     /** Namespace for context provision */
     namespace?: string
   }
@@ -113,6 +117,9 @@
     ceil: (index: number) => void
     /** Pre-computed attributes for binding */
     attrs: {
+      'role': 'group'
+      'aria-label': string | undefined
+      'aria-labelledby': string | undefined
       'data-disabled': true | undefined
       'data-readonly': true | undefined
       'data-orientation': 'horizontal' | 'vertical'
@@ -152,6 +159,8 @@
     crossover = false,
     name,
     form,
+    label,
+    ariaLabelledby,
     namespace = 'v0:slider:root',
   } = defineProps<SliderRootProps>()
 
@@ -280,6 +289,9 @@
     floor: slider.floor,
     ceil: slider.ceil,
     attrs: {
+      'role': 'group',
+      'aria-label': label || undefined,
+      'aria-labelledby': ariaLabelledby || undefined,
       'data-disabled': isDisabled.value ? true : undefined,
       'data-readonly': isReadonly.value ? true : undefined,
       'data-orientation': toValue(slider.orientation),

--- a/packages/0/src/components/Switch/SwitchRoot.vue
+++ b/packages/0/src/components/Switch/SwitchRoot.vue
@@ -282,7 +282,7 @@
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
       'role': 'switch',
-      'aria-checked': isMixed.value ? false : isChecked.value,
+      'aria-checked': !isMixed.value && isChecked.value,
       'aria-disabled': isDisabled.value,
       'aria-label': label || undefined,
       'aria-labelledby': ariaLabelledby || undefined,

--- a/packages/0/src/components/Switch/SwitchRoot.vue
+++ b/packages/0/src/components/Switch/SwitchRoot.vue
@@ -119,7 +119,7 @@
     attrs: {
       'type': 'button' | undefined
       'role': 'switch'
-      'aria-checked': boolean | 'mixed'
+      'aria-checked': boolean
       'aria-disabled': boolean
       'aria-label': string | undefined
       'aria-labelledby': string | undefined
@@ -282,7 +282,7 @@
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
       'role': 'switch',
-      'aria-checked': isMixed.value ? 'mixed' : isChecked.value,
+      'aria-checked': isMixed.value ? false : isChecked.value,
       'aria-disabled': isDisabled.value,
       'aria-label': label || undefined,
       'aria-labelledby': ariaLabelledby || undefined,

--- a/packages/0/src/components/Switch/SwitchSelectAll.vue
+++ b/packages/0/src/components/Switch/SwitchSelectAll.vue
@@ -61,7 +61,7 @@
     attrs: {
       'type': 'button' | undefined
       'role': 'switch'
-      'aria-checked': boolean | 'mixed'
+      'aria-checked': boolean
       'aria-disabled': boolean
       'aria-label': string | undefined
       'aria-labelledby': string | undefined
@@ -148,7 +148,7 @@
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
       'role': 'switch',
-      'aria-checked': isMixed.value ? 'mixed' : isAllSelected.value,
+      'aria-checked': isMixed.value ? false : isAllSelected.value,
       'aria-disabled': isDisabled.value,
       'aria-label': label || undefined,
       'aria-labelledby': ariaLabelledby || undefined,

--- a/packages/0/src/components/Switch/SwitchSelectAll.vue
+++ b/packages/0/src/components/Switch/SwitchSelectAll.vue
@@ -148,7 +148,7 @@
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
       'role': 'switch',
-      'aria-checked': isMixed.value ? false : isAllSelected.value,
+      'aria-checked': !isMixed.value && isAllSelected.value,
       'aria-disabled': isDisabled.value,
       'aria-label': label || undefined,
       'aria-labelledby': ariaLabelledby || undefined,

--- a/packages/0/src/components/Switch/SwitchThumb.vue
+++ b/packages/0/src/components/Switch/SwitchThumb.vue
@@ -36,6 +36,7 @@
     isMixed: boolean
     /** Pre-computed data attributes for styling */
     attrs: {
+      'aria-hidden': 'true'
       'data-state': SwitchState
     }
   }
@@ -67,6 +68,7 @@
     isChecked: isChecked.value,
     isMixed: isMixed.value,
     attrs: {
+      'aria-hidden': 'true',
       'data-state': dataState.value,
     },
   }))

--- a/packages/0/src/components/Switch/SwitchTrack.vue
+++ b/packages/0/src/components/Switch/SwitchTrack.vue
@@ -34,6 +34,7 @@
     isMixed: boolean
     /** Pre-computed data attributes for styling */
     attrs: {
+      'aria-hidden': 'true'
       'data-state': SwitchState
     }
   }
@@ -65,6 +66,7 @@
     isChecked: isChecked.value,
     isMixed: isMixed.value,
     attrs: {
+      'aria-hidden': 'true',
       'data-state': dataState.value,
     },
   }))

--- a/packages/0/src/components/Switch/index.browser.test.ts
+++ b/packages/0/src/components/Switch/index.browser.test.ts
@@ -516,16 +516,16 @@ describe('switch', () => {
         await wait()
 
         expect(itemProps('item-1').isMixed).toBe(true)
-        expect(itemProps('item-1').attrs['aria-checked']).toBe('mixed')
+        expect(itemProps('item-1').attrs['aria-checked']).toBe(false)
       })
 
-      it('should set aria-checked to mixed', async () => {
+      it('should clamp aria-checked to false when mixed', async () => {
         const { itemProps, wait } = mountGroup()
         await wait()
 
         itemProps('item-1').mix()
         await wait()
-        expect(itemProps('item-1').attrs['aria-checked']).toBe('mixed')
+        expect(itemProps('item-1').attrs['aria-checked']).toBe(false)
         expect(itemProps('item-1').attrs['data-state']).toBe('indeterminate')
       })
     })
@@ -1350,12 +1350,12 @@ describe('switch', () => {
         expect(itemProps('item-1').attrs['data-state']).toBe('indeterminate')
       })
 
-      it('should set aria-checked to mixed when indeterminate', async () => {
+      it('should clamp aria-checked to false when indeterminate', async () => {
         const { itemProps, wait } = mountGroup({
           items: [{ value: 'item-1', indeterminate: true }],
         })
         await wait()
-        expect(itemProps('item-1').attrs['aria-checked']).toBe('mixed')
+        expect(itemProps('item-1').attrs['aria-checked']).toBe(false)
       })
 
       it('should set data-disabled when disabled', async () => {


### PR DESCRIPTION
Lands the verified fixes from the WS4 ARIA audit, forms family. Each finding was re-verified against source before changing anything; one audit finding did not hold and was skipped (table below).

| # | Finding | File(s) | Outcome |
|---|---------|---------|---------|
| 1 | `aria-invalid`/`aria-errormessage` desync with manual `errorMessages` | `packages/0/src/components/Input/InputControl.vue`, `NumberField/NumberFieldControl.vue` | **Skipped — not reproducible.** `createInput`'s `isValid` already returns `false` for manual-only errors (`composables/createInput/index.ts` ~162: `if (errors.value.length > 0 && validation.errors.value.length === 0) return false`), and `createValidation` sets `errors`/`isValid` atomically, so `aria-errormessage` presence always implies `aria-invalid="true"`. |
| 2 | Spec-invalid `aria-checked="mixed"` on `role=switch` | `Switch/SwitchRoot.vue`, `Switch/SwitchSelectAll.vue` | Clamped to `false` while indeterminate (ARIA 1.2 forbids `mixed` on switch); `data-state="indeterminate"` unchanged. Existing browser tests updated to assert the clamp. |
| 3 | Decorative thumb/track exposed to AT | `Switch/SwitchThumb.vue`, `Switch/SwitchTrack.vue` | Added `aria-hidden="true"` to bound attrs. |
| 4 | Missing `novalidate` — native constraint UI preempts async validation | `Form/Form.vue` | Added `novalidate: true` to form attrs. |
| 5 | Multi-thumb slider root has no group semantics | `Slider/SliderRoot.vue` | Added `role="group"` + optional `label`/`ariaLabelledby` props, mirroring the CheckboxGroup/ButtonGroup pattern. |

Refs #543 (WS4)