### PR TITLE
refactor: introduce AppTooltip, replace native title tooltips across docs + playground chrome — #495

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -79,6 +79,7 @@ declare module 'vue' {
     AppThemeSystemButton: typeof import('./components/app/theme/mode/AppThemeSystemButton.vue')['default']
     AppThemeToggle: typeof import('./components/app/AppThemeToggle.vue')['default']
     AppThemeTritanopiaButton: typeof import('./components/app/theme/a11y/AppThemeTritanopiaButton.vue')['default']
+    AppTooltip: typeof import('./components/app/AppTooltip.vue')['default']
     AppVersionChip: typeof import('./components/app/AppVersionChip.vue')['default']
     BenchmarkExplorer: typeof import('./components/docs/benchmark/BenchmarkExplorer.vue')['default']
     BenchmarkFilters: typeof import('./components/docs/benchmark/BenchmarkFilters.vue')['default']

--- a/apps/docs/src/components/app/AppAccount.vue
+++ b/apps/docs/src/components/app/AppAccount.vue
@@ -31,16 +31,16 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
     v-if="!auth.isAuthenticated"
     aria-label="Sign in"
     class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer border-0"
-    title="Sign in"
-    type="button"
+    position-area="bottom"
+    text="Sign in"
     @click="auth.dialog = true"
   >
     <AppIcon icon="account" />
-  </button>
+  </AppTooltip>
 
   <Discovery.Activator v-else class="inline-flex rounded-full" step="settings">
     <button

--- a/apps/docs/src/components/app/AppAccount.vue
+++ b/apps/docs/src/components/app/AppAccount.vue
@@ -43,11 +43,11 @@
   </AppTooltip>
 
   <Discovery.Activator v-else class="inline-flex rounded-full" step="settings">
-    <button
+    <AppTooltip
       aria-label="Account settings"
       class="inline-flex items-center justify-center rounded-full cursor-pointer border-0 bg-transparent p-0 hover:ring-2 hover:ring-primary/50 transition-all"
-      title="Account settings"
-      type="button"
+      position-area="bottom"
+      text="Account settings"
       @click="settings.toggle"
     >
       <Avatar.Root class="size-6 rounded-full overflow-hidden">
@@ -61,7 +61,7 @@
           {{ initial }}
         </Avatar.Fallback>
       </Avatar.Root>
-    </button>
+    </AppTooltip>
   </Discovery.Activator>
 
   <Dialog.Root v-model="auth.dialog">

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -110,29 +110,33 @@
 
       <AppThemeToggle v-if="isHomePage || settings.showThemeToggle.value" />
 
-      <a
+      <AppTooltip
         v-if="isHomePage || settings.showSocialLinks.value"
         aria-label="Discord Community (opens in new tab)"
+        as="a"
         class="bg-[#5865F2] text-white pa-1 inline-flex rounded opacity-90 hover:opacity-100"
         href="https://discord.gg/vuetify"
+        position-area="bottom"
         rel="noopener noreferrer"
         target="_blank"
-        title="Discord Community"
+        text="Discord Community"
       >
         <AppIcon class="!opacity-100" icon="discord" />
-      </a>
+      </AppTooltip>
 
-      <a
+      <AppTooltip
         v-if="isHomePage || settings.showSocialLinks.value"
         aria-label="GitHub Repository (opens in new tab)"
+        as="a"
         class="bg-[#24292f] text-white pa-1 inline-flex rounded opacity-90 hover:opacity-100"
         href="https://github.com/vuetifyjs/0"
+        position-area="bottom"
         rel="noopener noreferrer"
         target="_blank"
-        title="GitHub Repository"
+        text="GitHub Repository"
       >
         <AppIcon class="!opacity-100" icon="github" />
-      </a>
+      </AppTooltip>
 
       <AppAccount v-if="!isHomePage" />
 

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -91,7 +91,6 @@
         <button
           aria-label="Search (Ctrl+K)"
           :class="['inline-flex items-center gap-1.5 rounded-full md:border md:border-divider md:pl-1.5 md:pr-1.5 md:py-1.5 hover:border-primary/50 transition-colors', settings.showBgGlass.value ? 'md:bg-glass-surface' : 'md:bg-surface']"
-          title="Search (Ctrl+K)"
           type="button"
           @click="search.focus()"
         >

--- a/apps/docs/src/components/app/AppBrowserIcon.vue
+++ b/apps/docs/src/components/app/AppBrowserIcon.vue
@@ -26,11 +26,15 @@
 </script>
 
 <template>
-  <AppIcon
-    class="align-sub"
-    :class="config.color"
-    :icon="config.icon"
-    :size
-    :title="config.title"
-  />
+  <AppTooltip
+    as="span"
+    class="inline-flex align-sub"
+    :text="config.title"
+  >
+    <AppIcon
+      :class="config.color"
+      :icon="config.icon"
+      :size
+    />
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/app/AppCloseButton.vue
+++ b/apps/docs/src/components/app/AppCloseButton.vue
@@ -20,15 +20,14 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
     :aria-label="label"
     class="close-button"
     :style="{
       width: `${sizes[size].button}px`,
       height: `${sizes[size].button}px`,
     }"
-    :title="label"
-    type="button"
+    :text="label"
     @click="$emit('click', $event)"
   >
     <svg
@@ -42,10 +41,13 @@
     >
       <path d="M18 6L6 18M6 6l12 12" />
     </svg>
-  </button>
+  </AppTooltip>
 </template>
 
-<style scoped>
+<!-- Unscoped: AppTooltip renders a multi-root fragment, so the parent scope-id
+     is not forwarded to its rendered <button>; a scoped .close-button selector
+     would not match. See scoped-css-multiroot-child (#359). -->
+<style>
 .close-button {
   display: flex;
   align-items: center;

--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -96,17 +96,18 @@
               <div class="w-px h-4 bg-divider" />
             </template>
 
-            <a
+            <AppTooltip
               v-if="app.stats.commit"
+              as="a"
               class="flex items-center gap-1 hover:text-primary hover:underline"
               :href="app.stats.commit.html_url"
               rel="noopener nofollow"
               target="_blank"
-              :title="`Last Commit: ${new Date(app.stats.commit.commit.author.date).toLocaleString()}`"
+              :text="`Last Commit: ${new Date(app.stats.commit.commit.author.date).toLocaleString()}`"
             >
               <AppIcon :class="outOfDate && 'text-warning'" icon="history" :size="14" />
               {{ app.stats.commit.sha.slice(0, 7) }}
-            </a>
+            </AppTooltip>
           </div>
         </template>
       </div>

--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -136,15 +136,14 @@
 
         <div class="hidden md:block w-px h-5 bg-divider" />
 
-        <button
+        <AppTooltip
           :aria-label="toggle.title.value"
           class="w-9 h-9 rounded-lg flex items-center justify-center hover:bg-surface-tint transition-colors text-on-surface"
-          :title="toggle.title.value"
-          type="button"
+          :text="toggle.title.value"
           @click="toggle.toggle"
         >
           <AppIcon :icon="toggle.icon.value" :size="20" />
-        </button>
+        </AppTooltip>
       </div>
     </div>
   </footer>

--- a/apps/docs/src/components/app/AppNavFooter.vue
+++ b/apps/docs/src/components/app/AppNavFooter.vue
@@ -18,14 +18,19 @@
   <div class="shrink-0 p-2 border-t border-divider/50 flex items-center justify-between gap-2">
     <AppVersionChip />
 
-    <router-link
+    <AppTooltip
       v-if="devmode?.isSelected.value"
-      :aria-label="freshnessLabel"
-      class="inline-flex items-center justify-center w-7 h-7 rounded-lg hover:bg-surface-tint transition-colors"
-      :title="freshnessLabel"
-      to="/health"
+      as="span"
+      class="inline-flex"
+      :text="freshnessLabel"
     >
-      <AppIcon icon="freshness-avocado" :size="22" />
-    </router-link>
+      <router-link
+        :aria-label="freshnessLabel"
+        class="inline-flex items-center justify-center w-7 h-7 rounded-lg hover:bg-surface-tint transition-colors"
+        to="/health"
+      >
+        <AppIcon icon="freshness-avocado" :size="22" />
+      </router-link>
+    </AppTooltip>
   </div>
 </template>

--- a/apps/docs/src/components/app/AppSearchInline.vue
+++ b/apps/docs/src/components/app/AppSearchInline.vue
@@ -8,11 +8,11 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
     aria-label="Search (Ctrl+K)"
     :class="['inline-flex items-center gap-1.5 rounded-full border border-divider pl-1.5 pr-1.5 py-1.5 hover:border-primary/50 focus-visible:border-primary focus-visible:outline-none transition-colors', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
-    title="Search (Ctrl+K)"
-    type="button"
+    position-area="bottom"
+    text="Search (Ctrl+K)"
     @click="search.open"
   >
     <span class="shrink-0 size-6 rounded-full bg-primary text-on-primary flex items-center justify-center">
@@ -21,5 +21,5 @@
 
     <span class="text-sm text-on-surface-variant">Search the docs...</span>
     <kbd class="shrink-0 px-1.5 py-0.5 rounded bg-surface-tint text-on-surface-tint text-[10px] font-mono inline-flex items-center rounded-r-lg">Ctrl+K</kbd>
-  </button>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/app/AppSettings.vue
+++ b/apps/docs/src/components/app/AppSettings.vue
@@ -13,15 +13,15 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
     aria-label="Open settings"
     class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
-    title="Settings"
-    type="button"
+    position-area="bottom"
+    text="Settings"
     @click="settings.toggle"
     @focus="preload"
     @mouseenter="preload"
   >
     <AppIcon icon="cog" />
-  </button>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/app/AppSettingsSheet.vue
+++ b/apps/docs/src/components/app/AppSettingsSheet.vue
@@ -114,15 +114,15 @@
           <div class="text-xs text-on-surface-variant capitalize">{{ auth.user?.role }}</div>
         </div>
 
-        <button
+        <AppTooltip
           aria-label="Sign out"
           class="pa-1 cursor-pointer bg-transparent border-0 inline-flex items-center justify-center rounded hover:bg-surface-variant transition-colors text-on-surface-variant hover:text-error"
-          title="Sign out"
-          type="button"
+          position-area="bottom"
+          text="Sign out"
           @click="auth.logout()"
         >
           <AppIcon icon="logout" :size="16" />
-        </button>
+        </AppTooltip>
       </div>
 
       <!-- Theme -->

--- a/apps/docs/src/components/app/AppSkillFilter.vue
+++ b/apps/docs/src/components/app/AppSkillFilter.vue
@@ -20,20 +20,26 @@
 
 <template>
   <Popover.Root v-model="isOpen" class="hidden md:block">
-    <Popover.Activator
-      aria-label="Filter by skill level"
-      class="relative bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
-      title="Filter by skill level"
+    <AppTooltip
+      as="span"
+      class="inline-flex"
+      position-area="bottom"
+      text="Filter by skill level"
     >
-      <AppIcon icon="tune" />
-
-      <span
-        v-if="levelFilter.selectedLevels.size > 0"
-        class="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-on-primary rounded-full flex items-center justify-center"
+      <Popover.Activator
+        aria-label="Filter by skill level"
+        class="relative bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
       >
-        {{ levelFilter.selectedLevels.size }}
-      </span>
-    </Popover.Activator>
+        <AppIcon icon="tune" />
+
+        <span
+          v-if="levelFilter.selectedLevels.size > 0"
+          class="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-on-primary rounded-full flex items-center justify-center"
+        >
+          {{ levelFilter.selectedLevels.size }}
+        </span>
+      </Popover.Activator>
+    </AppTooltip>
 
     <Popover.Content class="p-2 rounded-lg bg-surface border border-divider shadow-lg min-w-[160px] !mt-1" position-area="bottom span-left">
       <!-- Header -->

--- a/apps/docs/src/components/app/AppThemeSelector.vue
+++ b/apps/docs/src/components/app/AppThemeSelector.vue
@@ -39,13 +39,19 @@
 
 <template>
   <Popover.Root id="theme-selector" v-model="isOpen">
-    <Popover.Activator
-      aria-label="Select theme"
-      class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
-      :title="toggle.title.value"
+    <AppTooltip
+      as="span"
+      class="inline-flex"
+      position-area="bottom"
+      :text="toggle.title.value"
     >
-      <AppIcon :icon="toggle.icon.value" />
-    </Popover.Activator>
+      <Popover.Activator
+        aria-label="Select theme"
+        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
+      >
+        <AppIcon :icon="toggle.icon.value" />
+      </Popover.Activator>
+    </AppTooltip>
 
     <Popover.Content
       id="theme-selector"

--- a/apps/docs/src/components/app/AppTooltip.vue
+++ b/apps/docs/src/components/app/AppTooltip.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+  // Framework
+  import { Tooltip } from '@vuetify/v0'
+
+  defineOptions({ inheritAttrs: false })
+
+  const {
+    text,
+    as = 'button',
+    openDelay = 500,
+    closeDelay = 200,
+    positionArea = 'top',
+  } = defineProps<{
+    /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
+    text?: string
+    /** Element the trigger renders as; forwarded to Tooltip.Activator. */
+    as?: string
+    openDelay?: number
+    closeDelay?: number
+    positionArea?: string
+  }>()
+</script>
+
+<template>
+  <Tooltip.Root
+    v-if="text"
+    :close-delay
+    :open-delay
+    :position-area
+  >
+    <Tooltip.Activator :as v-bind="$attrs">
+      <slot />
+    </Tooltip.Activator>
+
+    <Tooltip.Content
+      class="max-w-64 whitespace-normal rounded border border-divider bg-surface px-2 py-1 text-xs text-on-surface shadow-lg"
+      :style="{ margin: '6px 0' }"
+    >
+      {{ text }}
+    </Tooltip.Content>
+  </Tooltip.Root>
+
+  <component :is="as" v-else v-bind="$attrs">
+    <slot />
+  </component>
+</template>

--- a/apps/docs/src/components/app/AppTooltip.vue
+++ b/apps/docs/src/components/app/AppTooltip.vue
@@ -10,6 +10,7 @@
     openDelay = 500,
     closeDelay = 200,
     positionArea = 'top',
+    disabled = false,
   } = defineProps<{
     /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
     text?: string
@@ -18,6 +19,8 @@
     openDelay?: number
     closeDelay?: number
     positionArea?: string
+    /** Disables the trigger and suppresses the tooltip. Declared so a caller's `:disabled` survives Tooltip.Activator's attr merge. */
+    disabled?: boolean
   }>()
 </script>
 
@@ -25,6 +28,7 @@
   <Tooltip.Root
     v-if="text"
     :close-delay
+    :disabled
     :open-delay
     :position-area
   >
@@ -40,7 +44,7 @@
     </Tooltip.Content>
   </Tooltip.Root>
 
-  <component :is="as" v-else v-bind="$attrs">
+  <component :is="as" v-else :disabled="disabled || undefined" v-bind="$attrs">
     <slot />
   </component>
 </template>

--- a/apps/docs/src/components/app/AppTooltip.vue
+++ b/apps/docs/src/components/app/AppTooltip.vue
@@ -2,8 +2,15 @@
   // Framework
   import { Tooltip } from '@vuetify/v0'
 
+  // Types
+  import type { AtomProps, TooltipRootProps } from '@vuetify/v0'
+
   defineOptions({ inheritAttrs: false })
 
+  // openDelay/closeDelay/positionArea/disabled forward to Tooltip.Root; their
+  // types come from TooltipRootProps so this wrapper can't drift. `disabled` is
+  // a declared prop (not a fall-through attr) so a caller's `:disabled` is not
+  // clobbered by Tooltip.Activator's mergeProps.
   const {
     text,
     as = 'button',
@@ -15,13 +22,8 @@
     /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
     text?: string
     /** Element the trigger renders as; forwarded to Tooltip.Activator. */
-    as?: string
-    openDelay?: number
-    closeDelay?: number
-    positionArea?: string
-    /** Disables the trigger and suppresses the tooltip. Declared so a caller's `:disabled` survives Tooltip.Activator's attr merge. */
-    disabled?: boolean
-  }>()
+    as?: AtomProps['as']
+  } & Pick<TooltipRootProps, 'closeDelay' | 'disabled' | 'openDelay' | 'positionArea'>>()
 </script>
 
 <template>

--- a/apps/docs/src/components/app/AppVersionChip.vue
+++ b/apps/docs/src/components/app/AppVersionChip.vue
@@ -40,22 +40,27 @@
 </script>
 
 <template>
-  <AppLink
+  <AppTooltip
     v-if="latest"
-    :aria-label="label"
-    class="relative inline-flex items-center gap-1 px-2 py-1 text-sm rounded text-on-surface-variant hover:bg-surface-tint hover:text-on-surface transition-colors"
-    :title
-    :to="`/releases?version=${latest.tag_name}`"
+    as="span"
+    class="inline-flex"
+    :text="title"
   >
-    <AppIcon icon="tag" :size="14" />
-    {{ latest.tag_name }}
+    <AppLink
+      :aria-label="label"
+      class="relative inline-flex items-center gap-1 px-2 py-1 text-sm rounded text-on-surface-variant hover:bg-surface-tint hover:text-on-surface transition-colors"
+      :to="`/releases?version=${latest.tag_name}`"
+    >
+      <AppIcon icon="tag" :size="14" />
+      {{ latest.tag_name }}
 
-    <span
-      v-if="fresh"
-      aria-hidden="true"
-      class="absolute top-0 end-0 w-2 h-2 rounded-[2px] bg-success"
-    />
-  </AppLink>
+      <span
+        v-if="fresh"
+        aria-hidden="true"
+        class="absolute top-0 end-0 w-2 h-2 rounded-[2px] bg-success"
+      />
+    </AppLink>
+  </AppTooltip>
 
   <span
     v-else

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -44,14 +44,14 @@
         <AppIcon icon="paint" size="16" />
         <span>Theme</span>
 
-        <button
+        <AppTooltip
+          aria-label="Copy theme as Vuetify0 config"
           class="ml-auto p-1 rounded hover:bg-surface-tint transition-colors inline-flex items-center justify-center shrink-0"
-          title="Copy theme as Vuetify0 config"
-          type="button"
+          text="Copy theme as Vuetify0 config"
           @click="exportTheme"
         >
           <AppIcon :icon="clipboard.copied.value ? 'check-circle' : 'copy'" size="14" />
-        </button>
+        </AppTooltip>
       </h3>
 
       <!-- Mode -->

--- a/apps/docs/src/components/app/theme/AppThemeCustomButton.vue
+++ b/apps/docs/src/components/app/theme/AppThemeCustomButton.vue
@@ -43,15 +43,15 @@
       <AppIcon :icon="theme.icon" size="16" />
       <span class="font-medium truncate">{{ theme.label }}</span>
 
-      <button
+      <AppTooltip
         v-if="editable"
+        aria-label="Edit theme"
         class="ml-auto opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-surface-tint transition-all"
-        title="Edit theme"
-        type="button"
+        text="Edit theme"
         @click="onEdit"
       >
         <AppIcon icon="edit" size="12" />
-      </button>
+      </AppTooltip>
     </div>
 
     <AppThemePreview :theme="themeId" />

--- a/apps/docs/src/components/app/theme/AppThemeSwatchButton.vue
+++ b/apps/docs/src/components/app/theme/AppThemeSwatchButton.vue
@@ -9,15 +9,14 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
     :aria-label="`${label} theme`"
     :aria-pressed="active"
     class="h-9 w-6 shrink-0 inline-flex items-center justify-center rounded border transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background opacity-50 hover:opacity-100 data-[active]:border-primary data-[active]:ring-2 data-[active]:ring-primary/50 data-[active]:opacity-100"
     :data-active="active || undefined"
     :style="{ backgroundColor: color, color: onColor }"
-    :title="label"
-    type="button"
+    :text="label"
   >
     <AppIcon :icon size="14" />
-  </button>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/docs/DocsActionChip.vue
+++ b/apps/docs/src/components/docs/DocsActionChip.vue
@@ -18,22 +18,22 @@
 </script>
 
 <template>
-  <a
+  <AppTooltip
     v-if="href"
+    as="a"
     :href
     :rel="isExternal ? 'noopener noreferrer' : undefined"
     :target="isExternal ? '_blank' : undefined"
-    :title
+    :text="title"
   >
     <AppChip :color :icon :text />
-  </a>
+  </AppTooltip>
 
   <AppChip
     v-else
     :color
     :icon
     :text
-    :title
     @click="emit('click', $event)"
   />
 </template>

--- a/apps/docs/src/components/docs/DocsAskForm.vue
+++ b/apps/docs/src/components/docs/DocsAskForm.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  // Framework
+  import { Tooltip } from '@vuetify/v0'
+
   // Composables
   import { useSettings } from '@/composables/useSettings'
 
@@ -77,15 +80,31 @@
       <AppIcon icon="stop" size="12" />
     </AppTooltip>
 
-    <button
+    <Tooltip.Root
       v-else
-      aria-label="Send question"
-      class="shrink-0 size-6 rounded-full bg-primary text-on-primary flex items-center justify-center hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
-      :disabled="!question.trim()"
-      title="Send"
-      type="submit"
+      :close-delay="200"
+      :open-delay="500"
     >
-      <AppIcon icon="send" size="12" />
-    </button>
+      <!-- Renderless: the trigger is a native type="submit" button; binding
+           attrs + styles keeps the tooltip wiring without the activator forcing
+           type="button". Requires Tooltip.Activator exposing anchor styles. -->
+      <Tooltip.Activator v-slot="{ attrs, styles }" renderless>
+        <button
+          aria-label="Send question"
+          class="shrink-0 size-6 rounded-full bg-primary text-on-primary flex items-center justify-center hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          :style="styles"
+          v-bind="{ ...attrs, type: 'submit', disabled: !question.trim() }"
+        >
+          <AppIcon icon="send" size="12" />
+        </button>
+      </Tooltip.Activator>
+
+      <Tooltip.Content
+        class="max-w-64 whitespace-normal rounded border border-divider bg-surface px-2 py-1 text-xs text-on-surface shadow-lg"
+        :style="{ margin: '6px 0' }"
+      >
+        Send
+      </Tooltip.Content>
+    </Tooltip.Root>
   </form>
 </template>

--- a/apps/docs/src/components/docs/DocsAskForm.vue
+++ b/apps/docs/src/components/docs/DocsAskForm.vue
@@ -67,16 +67,15 @@
       class="shrink-0 px-1.5 py-0.5 rounded bg-surface-tint text-on-surface-tint text-[10px] font-mono inline-flex items-center"
     >Ctrl+/</kbd>
 
-    <button
+    <AppTooltip
       v-if="isLoading"
       aria-label="Stop generating"
       class="shrink-0 size-6 rounded-full bg-error text-on-error flex items-center justify-center hover:opacity-90 transition-opacity"
-      title="Stop generating"
-      type="button"
+      text="Stop generating"
       @click="emit('stop')"
     >
       <AppIcon icon="stop" size="12" />
-    </button>
+    </AppTooltip>
 
     <button
       v-else

--- a/apps/docs/src/components/docs/DocsAskPanel.vue
+++ b/apps/docs/src/components/docs/DocsAskPanel.vue
@@ -178,45 +178,45 @@
         </div>
 
         <div class="flex items-center gap-0.5">
-          <button
+          <AppTooltip
             v-if="messages.length > 0"
+            aria-label="Open in Bin"
             class="inline-flex p-1.5 rounded-lg hover:bg-surface-variant transition-colors text-on-surface/60 hover:text-on-surface-variant"
-            title="Open in Bin"
-            type="button"
+            text="Open in Bin"
             @click="openInBin"
           >
             <AppIcon icon="vuetify-bin" size="16" />
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             v-if="messages.length > 0"
+            aria-label="Copy conversation"
             class="inline-flex p-1.5 rounded-lg hover:bg-surface-variant transition-colors text-on-surface/60 hover:text-on-surface-variant"
-            :title="clipboard.copied.value ? 'Copied!' : 'Copy conversation'"
-            type="button"
+            :text="clipboard.copied.value ? 'Copied!' : 'Copy conversation'"
             @click="copyConversation"
           >
             <AppIcon :icon="clipboard.copied.value ? 'success' : 'copy'" size="16" />
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             v-if="messages.length > 0"
+            aria-label="Reset conversation"
             class="inline-flex p-1.5 rounded-lg hover:bg-surface-variant transition-colors text-on-surface/60 hover:text-on-surface-variant"
-            title="Reset conversation"
-            type="button"
+            text="Reset conversation"
             @click="emit('clear')"
           >
             <AppIcon icon="restart" size="16" />
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             v-if="isDesktop"
+            :aria-label="fullscreen ? 'Exit fullscreen' : 'Fullscreen'"
             class="inline-flex p-1.5 rounded-lg hover:bg-surface-variant transition-colors text-on-surface/60 hover:text-on-surface-variant"
-            :title="fullscreen ? 'Exit fullscreen' : 'Fullscreen'"
-            type="button"
+            :text="fullscreen ? 'Exit fullscreen' : 'Fullscreen'"
             @click="emit('update:fullscreen', !fullscreen)"
           >
             <AppIcon :icon="fullscreen ? 'fullscreen-exit' : 'fullscreen'" size="16" />
-          </button>
+          </AppTooltip>
 
           <AppCloseButton @click="emit('close')" />
         </div>

--- a/apps/docs/src/components/docs/DocsBadge.vue
+++ b/apps/docs/src/components/docs/DocsBadge.vue
@@ -49,13 +49,14 @@
 </script>
 
 <template>
-  <span
+  <AppTooltip
+    as="span"
     class="badge-base"
     :class="shapeClass"
     :style="badgeStyle"
-    :title
+    :text="title"
   >
     <AppIcon v-if="icon && showIcon" :icon :size="iconSize" />
     <span v-if="showLabel">{{ label }}</span>
-  </span>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/docs/DocsDiscoveryStep.vue
+++ b/apps/docs/src/components/docs/DocsDiscoveryStep.vue
@@ -96,14 +96,15 @@
     >
       <!-- Header -->
       <div v-if="!isLastStep" class="flex justify-between items-center mb-4">
-        <span
+        <AppTooltip
+          as="span"
           class="skillz-badge inline-flex items-center gap-1 text-xs font-bold uppercase tracking-wide px-2 py-1 rounded"
           :style="levelMeta ? { '--level-color': levelMeta.color } : undefined"
-          :title="levelMeta ? `${levelMeta.label} level` : undefined"
+          :text="levelMeta ? `${levelMeta.label} level` : undefined"
         >
           SKILLZ
           <AppIcon v-if="levelMeta" :icon="levelMeta.icon" :size="14" />
-        </span>
+        </AppTooltip>
 
         <Discovery.Progress class="text-xs text-on-surface-variant" />
       </div>
@@ -164,7 +165,11 @@
   </Discovery.Root>
 </template>
 
-<style scoped>
+<!-- Unscoped: AppTooltip renders a multi-root fragment (activator + popover
+     content), so the parent scope-id is not forwarded to the .skillz-badge
+     activator element — a scoped rule would no longer match. See
+     scoped-css-multiroot-child (#359). -->
+<style>
 .skillz-badge {
   background: color-mix(in srgb, var(--level-color, var(--v0-primary)) 15%, transparent);
   color: var(--level-color, var(--v0-primary));

--- a/apps/docs/src/components/docs/DocsExample.vue
+++ b/apps/docs/src/components/docs/DocsExample.vue
@@ -336,14 +336,14 @@
         </span>
 
         <div class="ml-auto flex items-center gap-1">
-          <button
+          <AppTooltip
+            aria-label="Reset example"
             class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-            title="Reset example"
-            type="button"
+            text="Reset example"
             @click="onReset"
           >
             <AppIcon icon="restart" :size="16" />
-          </button>
+          </AppTooltip>
         </div>
       </div>
 
@@ -455,41 +455,41 @@
           </span>
 
           <div class="ml-auto flex items-center gap-1">
-            <button
+            <AppTooltip
+              aria-label="Reset example"
               class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Reset example"
-              type="button"
+              text="Reset example"
               @click="onReset"
             >
               <AppIcon icon="restart" :size="16" />
-            </button>
+            </AppTooltip>
 
-            <button
+            <AppTooltip
+              aria-label="Open in Playground"
               class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Open in Playground"
-              type="button"
+              text="Open in Playground"
               @click="openAllInPlayground"
             >
               <AppIcon icon="vuetify-play" :size="16" />
-            </button>
+            </AppTooltip>
 
-            <button
+            <AppTooltip
+              aria-label="Open in Bin"
               class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Open in Bin"
-              type="button"
+              text="Open in Bin"
               @click="openAllInBin"
             >
               <AppIcon icon="vuetify-bin" :size="16" />
-            </button>
+            </AppTooltip>
 
-            <button
+            <AppTooltip
+              :aria-label="combinedView ? 'Split files' : 'Combine files'"
               class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              :title="combinedView ? 'Split files' : 'Combine files'"
-              type="button"
+              :text="combinedView ? 'Split files' : 'Combine files'"
               @click="combinedView = !combinedView"
             >
               <AppIcon :icon="combinedView ? 'split' : 'combine'" :size="16" />
-            </button>
+            </AppTooltip>
           </div>
         </div>
 

--- a/apps/docs/src/components/docs/DocsExampleCodePane.vue
+++ b/apps/docs/src/components/docs/DocsExampleCodePane.vue
@@ -115,16 +115,15 @@
         :title="title || fileName"
       />
 
-      <button
+      <AppTooltip
         v-if="shouldPeek && expanded"
         aria-label="Collapse code"
         class="inline-flex items-center justify-center size-7 text-on-primary bg-primary rounded cursor-pointer transition-200 hover:bg-primary/85"
-        title="Collapse code"
-        type="button"
+        text="Collapse code"
         @click="expanded = false"
       >
         <AppIcon icon="fullscreen-exit" :size="16" />
-      </button>
+      </AppTooltip>
     </div>
 
     <div

--- a/apps/docs/src/components/docs/DocsExampleDescription.vue
+++ b/apps/docs/src/components/docs/DocsExampleDescription.vue
@@ -69,16 +69,15 @@
         <AppIcon icon="down" :size="14" />
       </button>
 
-      <button
+      <AppTooltip
         v-if="!collapse || expanded"
         :aria-label="`${expanded ? 'Collapse' : 'Expand'} description`"
         class="absolute top-3 right-3 z-10 inline-flex items-center justify-center size-7 text-on-primary bg-primary rounded cursor-pointer transition-200 hover:bg-primary/85"
-        :title="`${expanded ? 'Collapse' : 'Expand'} description`"
-        type="button"
+        :text="`${expanded ? 'Collapse' : 'Expand'} description`"
         @click="expanded = !expanded"
       >
         <AppIcon :icon="expanded ? 'fullscreen-exit' : 'fullscreen'" :size="16" />
-      </button>
+      </AppTooltip>
     </template>
   </div>
 </template>

--- a/apps/docs/src/components/docs/DocsFeedback.vue
+++ b/apps/docs/src/components/docs/DocsFeedback.vue
@@ -101,17 +101,16 @@
       <span class="text-sm text-on-surface-variant">Was this page helpful?</span>
 
       <div class="flex gap-1">
-        <button
+        <AppTooltip
           v-for="option in RATING_OPTIONS"
           :key="option.value"
           :aria-label="option.label"
           class="inline-flex items-center justify-center w-10 h-10 rounded-lg border border-transparent hover:border-divider hover:bg-surface-variant transition-colors text-xl"
-          :title="option.label"
-          type="button"
+          :text="option.label"
           @click="selectRating(option.value)"
         >
           {{ option.emoji }}
-        </button>
+        </AppTooltip>
       </div>
     </div>
 

--- a/apps/docs/src/components/docs/DocsLastCommit.vue
+++ b/apps/docs/src/components/docs/DocsLastCommit.vue
@@ -44,16 +44,17 @@
 </script>
 
 <template>
-  <a
+  <AppTooltip
     v-if="app.stats.commit"
+    as="a"
     class="icon-text"
     :href="app.stats.commit.html_url"
     rel="noopener nofollow"
     target="_blank"
-    :title="`Latest commit: ${app.stats.commit.sha}`"
+    :text="`Latest commit: ${app.stats.commit.sha}`"
   >
     <strong>Latest commit:</strong>
     {{ app.stats.commit.sha.slice(0, 7) }}
     <AppIcon icon="open-in-new" size="1em" />
-  </a>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/docs/DocsMermaid.vue
+++ b/apps/docs/src/components/docs/DocsMermaid.vue
@@ -300,52 +300,48 @@
 
         <!-- Zoom controls -->
         <div class="flex items-center gap-1">
-          <button
+          <AppTooltip
             aria-label="Zoom out"
             class="btn-icon"
-            title="Zoom out"
-            type="button"
+            text="Zoom out"
             @click="zoomOut"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
             </svg>
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             aria-label="Zoom in"
             class="btn-icon"
-            title="Zoom in"
-            type="button"
+            text="Zoom in"
             @click="zoomIn"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v6m3-3H7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
             </svg>
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             aria-label="Reset view"
             class="btn-icon"
-            title="Reset view"
-            type="button"
+            text="Reset view"
             @click="resetZoom"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
             </svg>
-          </button>
+          </AppTooltip>
 
           <div class="w-px h-4 bg-divider mx-1" />
         </div>
 
         <!-- Action buttons -->
         <div class="flex items-center gap-1">
-          <button
-            :aria-label="clipboard.copied.value ? 'Copied!' : 'Copy SVG'"
+          <AppTooltip
+            aria-label="Copy SVG"
             class="btn-icon"
-            :title="clipboard.copied.value ? 'Copied!' : 'Copy SVG'"
-            type="button"
+            :text="clipboard.copied.value ? 'Copied!' : 'Copy SVG'"
             @click="copySvg"
           >
             <svg
@@ -367,19 +363,18 @@
             >
               <path d="M5 13l4 4L19 7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
             </svg>
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             aria-label="Download SVG"
             class="btn-icon"
-            title="Download SVG"
-            type="button"
+            text="Download SVG"
             @click="downloadSvg"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
             </svg>
-          </button>
+          </AppTooltip>
 
           <div class="w-px h-4 bg-divider mx-1" />
 

--- a/apps/docs/src/components/docs/DocsPalettePreview.vue
+++ b/apps/docs/src/components/docs/DocsPalettePreview.vue
@@ -59,7 +59,7 @@
       >
         <!-- Tab nav -->
         <div class="flex gap-3 mb-3 border-b border-solid pb-1" :style="{ borderColor: definition.themes[mode]?.colors?.['outline'] as string }">
-          <button
+          <AppTooltip
             v-for="(tab, index) in tabs"
             :key="tab"
             class="cursor-pointer text-xs font-medium pb-1 bg-transparent border-none border-b-2 border-solid"
@@ -71,7 +71,7 @@
                 ? (definition.themes[mode]?.colors?.['primary'] as string)
                 : 'transparent',
             }"
-            :title="(index === 0
+            :text="(index === 0
               ? definition.themes[mode]?.colors?.['primary']
               : definition.themes[mode]?.colors?.['on-surface-variant']) as string"
             @click="onCopy((index === 0
@@ -85,12 +85,12 @@
                 : definition.themes[mode]?.colors?.['on-surface-variant']) as string)"
               class="text-[10px] ml-1 op-70"
             >Copied!</span>
-          </button>
+          </AppTooltip>
         </div>
 
         <!-- Stat cards -->
         <div class="flex gap-2 mb-3">
-          <button
+          <AppTooltip
             v-for="stat in stats"
             :key="stat.label"
             class="cursor-pointer flex-1 rounded-md px-2 py-1.5 border-none"
@@ -98,7 +98,7 @@
               backgroundColor: definition.themes[mode]?.colors?.[stat.bg] as string,
               color: definition.themes[mode]?.colors?.[stat.fg] as string,
             }"
-            :title="`bg: ${definition.themes[mode]?.colors?.[stat.bg]} / text: ${definition.themes[mode]?.colors?.[stat.fg]}`"
+            :text="`bg: ${definition.themes[mode]?.colors?.[stat.bg]} / text: ${definition.themes[mode]?.colors?.[stat.fg]}`"
             @click="onCopy(definition.themes[mode]?.colors?.[stat.bg] as string)"
           >
             <div class="text-[10px] op-80">{{ stat.label }}</div>
@@ -108,7 +108,7 @@
               v-if="isCopied(definition.themes[mode]?.colors?.[stat.bg] as string)"
               class="text-[10px] op-70"
             >Copied!</span>
-          </button>
+          </AppTooltip>
         </div>
 
         <!-- Task list -->

--- a/apps/docs/src/components/docs/DocsQuestion.vue
+++ b/apps/docs/src/components/docs/DocsQuestion.vue
@@ -316,14 +316,15 @@
           Question {{ index + 1 }} of {{ total }}
         </span>
 
-        <span
+        <AppTooltip
+          as="span"
           class="skillz-badge ml-auto inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-bold uppercase tracking-wide"
           :style="currentLevelMeta ? { '--level-color': currentLevelMeta.color } : undefined"
-          :title="currentLevelMeta ? `${currentLevelMeta.label} level` : undefined"
+          :text="currentLevelMeta ? `${currentLevelMeta.label} level` : undefined"
         >
           SKILLZ
           <AppIcon v-if="currentLevelMeta" :icon="currentLevelMeta.icon" :size="14" />
-        </span>
+        </AppTooltip>
       </div>
 
       <Question.Root
@@ -486,7 +487,11 @@
   </div>
 </template>
 
-<style scoped>
+<!-- Unscoped: AppTooltip renders a multi-root fragment (activator + popover
+     content), so the parent scope-id is not forwarded to the .skillz-badge
+     activator element — a scoped rule would no longer match. See
+     scoped-css-multiroot-child (#359). -->
+<style>
   .skillz-badge {
     background: color-mix(in srgb, var(--level-color, var(--v0-primary)) 15%, transparent);
     color: var(--level-color, var(--v0-primary));

--- a/apps/docs/src/components/docs/DocsQuestion.vue
+++ b/apps/docs/src/components/docs/DocsQuestion.vue
@@ -293,15 +293,14 @@
           Apply {{ verdict?.label }} to filter
         </button>
 
-        <button
+        <AppTooltip
           class="inline-flex items-center gap-2 rounded-md border border-divider px-3 py-1.5 text-sm text-on-surface transition-colors hover:bg-surface-variant"
-          title="Try again"
-          type="button"
+          text="Try again"
           @click="onStart"
         >
           <AppIcon icon="restart" :size="16" />
           Try again
-        </button>
+        </AppTooltip>
       </div>
     </div>
 
@@ -407,26 +406,24 @@
         </Question.Feedback>
 
         <div class="mt-4 flex items-center gap-2">
-          <button
+          <AppTooltip
             aria-label="Restart quiz"
             class="inline-flex size-9 items-center justify-center rounded-md border border-divider text-on-surface-variant transition-colors hover:bg-surface-variant"
-            title="Restart quiz"
-            type="button"
+            text="Restart quiz"
             @click="begin"
           >
             <AppIcon icon="restart" :size="16" />
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             aria-label="Previous question"
             class="inline-flex size-9 items-center justify-center rounded-md border border-divider text-on-surface transition-colors hover:bg-surface-variant disabled:opacity-40"
             :disabled="index === 0"
-            title="Back"
-            type="button"
+            text="Back"
             @click="onPrev"
           >
             <AppIcon icon="left" :size="16" />
-          </button>
+          </AppTooltip>
 
           <div class="flex flex-1 flex-wrap items-center justify-center gap-1.5">
             <button
@@ -446,16 +443,15 @@
           </div>
 
           <template v-if="!isSubmitted">
-            <button
+            <AppTooltip
               v-if="!isLast"
               aria-label="Skip question"
               class="inline-flex size-9 items-center justify-center rounded-md border border-divider text-on-surface transition-colors hover:bg-surface-variant"
-              title="Skip"
-              type="button"
+              text="Skip"
               @click="onSkip"
             >
               <AppIcon icon="right" :size="16" />
-            </button>
+            </AppTooltip>
 
             <button
               v-else

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -278,25 +278,23 @@
         </div>
 
         <div class="flex items-center gap-2">
-          <button
+          <AppTooltip
             aria-label="Copy markdown"
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
-            :title="markdownClipboard.copied.value ? 'Copied!' : 'Copy markdown'"
-            type="button"
+            :text="markdownClipboard.copied.value ? 'Copied!' : 'Copy markdown'"
             @click="copyReleaseMarkdown"
           >
             <AppIcon :icon="markdownClipboard.copied.value ? 'success' : 'copy'" :size="18" />
-          </button>
+          </AppTooltip>
 
-          <button
+          <AppTooltip
             aria-label="Copy link"
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
-            :title="linkClipboard.copied.value ? 'Copied!' : 'Copy link'"
-            type="button"
+            :text="linkClipboard.copied.value ? 'Copied!' : 'Copy link'"
             @click="copyReleaseLink"
           >
             <AppIcon :icon="linkClipboard.copied.value ? 'success' : 'share'" :size="18" />
-          </button>
+          </AppTooltip>
 
           <a
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"

--- a/apps/docs/src/components/docs/DocsReleases.vue
+++ b/apps/docs/src/components/docs/DocsReleases.vue
@@ -296,25 +296,27 @@
             <AppIcon :icon="linkClipboard.copied.value ? 'success' : 'share'" :size="18" />
           </AppTooltip>
 
-          <a
+          <AppTooltip
+            as="a"
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
             href="https://discord.gg/vuetify"
             rel="noopener"
             target="_blank"
-            title="Discuss on Discord"
+            text="Discuss on Discord"
           >
             <AppIcon icon="discord" :size="18" />
-          </a>
+          </AppTooltip>
 
-          <a
+          <AppTooltip
+            as="a"
             class="p-1.5 rounded hover:bg-surface-tint focus-visible:bg-surface-tint inline-flex opacity-50 hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
             :href="model.html_url"
             rel="noopener"
             target="_blank"
-            title="View on GitHub"
+            text="View on GitHub"
           >
             <AppIcon icon="github" :size="18" />
-          </a>
+          </AppTooltip>
         </div>
       </div>
 

--- a/apps/docs/src/components/docs/DocsSearch.vue
+++ b/apps/docs/src/components/docs/DocsSearch.vue
@@ -272,18 +272,19 @@
                     <span class="text-xs text-on-surface-variant ml-2">{{ result.category }}</span>
                   </div>
 
-                  <span
+                  <AppTooltip
                     aria-label="Remove from favorites"
+                    as="span"
                     class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                     role="button"
                     tabindex="0"
-                    title="Remove from favorites"
+                    text="Remove from favorites"
                     @click="onRemove($event, result.id)"
                     @keydown.enter.stop="onRemove($event, result.id)"
                     @keydown.space.stop.prevent="onRemove($event, result.id)"
                   >
                     <AppIcon aria-hidden="true" icon="close" size="16" />
-                  </span>
+                  </AppTooltip>
                 </div>
               </Discovery.Activator>
 
@@ -330,31 +331,33 @@
 
                   <div class="flex items-center gap-1 shrink-0">
                     <!-- Favorite toggle -->
-                    <span
+                    <AppTooltip
                       aria-label="Add to favorites"
+                      as="span"
                       class="btn-action text-on-surface/60 hover:text-warning focus-visible:text-warning opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
-                      title="Add to favorites"
+                      text="Add to favorites"
                       @click="toggleFavorite($event, result.id)"
                       @keydown.enter.stop="toggleFavorite($event, result.id)"
                       @keydown.space.stop.prevent="toggleFavorite($event, result.id)"
                     >
                       <AppIcon aria-hidden="true" icon="star-outline" size="16" />
-                    </span>
+                    </AppTooltip>
                     <!-- Remove button -->
-                    <span
+                    <AppTooltip
                       aria-label="Remove from recent searches"
+                      as="span"
                       class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
-                      title="Remove from recent"
+                      text="Remove from recent"
                       @click="onRemove($event, result.id)"
                       @keydown.enter.stop="onRemove($event, result.id)"
                       @keydown.space.stop.prevent="onRemove($event, result.id)"
                     >
                       <AppIcon aria-hidden="true" icon="close" size="16" />
-                    </span>
+                    </AppTooltip>
                   </div>
                 </div>
               </Discovery.Activator>
@@ -436,15 +439,16 @@
                       :padding="4"
                       step="search-favorite"
                     >
-                      <span
+                      <AppTooltip
                         :aria-label="search.isFavorite(group.items[0].id) ? 'Remove from favorites' : 'Add to favorites'"
+                        as="span"
                         :class="[
                           'btn-action cursor-pointer',
                           search.isFavorite(group.items[0].id) || discovery.isActive.value ? 'opacity-100 text-warning' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
                         ]"
                         role="button"
                         tabindex="0"
-                        :title="search.isFavorite(group.items[0].id) ? 'Remove from favorites' : 'Add to favorites'"
+                        :text="search.isFavorite(group.items[0].id) ? 'Remove from favorites' : 'Add to favorites'"
                         @click="toggleFavorite($event, group.items[0].id)"
                         @keydown.enter.stop="toggleFavorite($event, group.items[0].id)"
                         @keydown.space.stop.prevent="toggleFavorite($event, group.items[0].id)"
@@ -454,7 +458,7 @@
                           :icon="search.isFavorite(group.items[0].id) ? 'star' : 'star-outline'"
                           size="16"
                         />
-                      </span>
+                      </AppTooltip>
                     </Discovery.Activator>
 
                     <!-- Ask AI button -->
@@ -463,21 +467,22 @@
                       :padding="4"
                       step="search-ask-ai"
                     >
-                      <span
+                      <AppTooltip
                         aria-label="Ask AI about this page"
+                        as="span"
                         :class="[
                           'btn-action text-on-surface/60 hover:text-primary focus-visible:text-primary cursor-pointer',
                           discovery.isActive.value ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
                         ]"
                         role="button"
                         tabindex="0"
-                        title="Ask AI"
+                        text="Ask AI"
                         @click="askAbout($event, group.items[0])"
                         @keydown.enter.stop="askAbout($event, group.items[0])"
                         @keydown.space.stop.prevent="askAbout($event, group.items[0])"
                       >
                         <AppIcon aria-hidden="true" icon="create" size="16" />
-                      </span>
+                      </AppTooltip>
                     </Discovery.Activator>
 
                     <!-- Dismiss button -->
@@ -486,21 +491,22 @@
                       :padding="4"
                       step="search-dismiss"
                     >
-                      <span
+                      <AppTooltip
                         aria-label="Dismiss result"
+                        as="span"
                         :class="[
                           'btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant cursor-pointer',
                           discovery.isActive.value ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
                         ]"
                         role="button"
                         tabindex="0"
-                        title="Dismiss result"
+                        text="Dismiss result"
                         @click="dismissResult($event, group.items[0].id)"
                         @keydown.enter.stop="dismissResult($event, group.items[0].id)"
                         @keydown.space.stop.prevent="dismissResult($event, group.items[0].id)"
                       >
                         <AppIcon aria-hidden="true" icon="close" size="16" />
-                      </span>
+                      </AppTooltip>
                     </Discovery.Activator>
                   </div>
                 </div>
@@ -535,15 +541,16 @@
 
                   <div class="flex items-center gap-1 shrink-0">
                     <!-- Favorite toggle -->
-                    <span
+                    <AppTooltip
                       :aria-label="search.isFavorite(result.id) ? 'Remove from favorites' : 'Add to favorites'"
+                      as="span"
                       :class="[
                         'btn-action cursor-pointer',
                         search.isFavorite(result.id) ? 'opacity-100 text-warning' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
                       ]"
                       role="button"
                       tabindex="0"
-                      :title="search.isFavorite(result.id) ? 'Remove from favorites' : 'Add to favorites'"
+                      :text="search.isFavorite(result.id) ? 'Remove from favorites' : 'Add to favorites'"
                       @click="toggleFavorite($event, result.id)"
                       @keydown.enter.stop="toggleFavorite($event, result.id)"
                       @keydown.space.stop.prevent="toggleFavorite($event, result.id)"
@@ -553,33 +560,35 @@
                         :icon="search.isFavorite(result.id) ? 'star' : 'star-outline'"
                         size="16"
                       />
-                    </span>
+                    </AppTooltip>
                     <!-- Ask AI button -->
-                    <span
+                    <AppTooltip
                       aria-label="Ask AI about this page"
+                      as="span"
                       class="btn-action text-on-surface/60 hover:text-primary focus-visible:text-primary opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
-                      title="Ask AI"
+                      text="Ask AI"
                       @click="askAbout($event, result)"
                       @keydown.enter.stop="askAbout($event, result)"
                       @keydown.space.stop.prevent="askAbout($event, result)"
                     >
                       <AppIcon aria-hidden="true" icon="create" size="16" />
-                    </span>
+                    </AppTooltip>
                     <!-- Dismiss button -->
-                    <span
+                    <AppTooltip
                       aria-label="Dismiss result"
+                      as="span"
                       class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
-                      title="Dismiss result"
+                      text="Dismiss result"
                       @click="dismissResult($event, result.id)"
                       @keydown.enter.stop="dismissResult($event, result.id)"
                       @keydown.space.stop.prevent="dismissResult($event, result.id)"
                     >
                       <AppIcon aria-hidden="true" icon="close" size="16" />
-                    </span>
+                    </AppTooltip>
                   </div>
                 </div>
               </div>

--- a/apps/docs/src/components/docs/meta/DocsMetaItem.vue
+++ b/apps/docs/src/components/docs/meta/DocsMetaItem.vue
@@ -18,32 +18,39 @@
 </script>
 
 <template>
-  <a
+  <AppTooltip
     v-if="href"
+    as="a"
     class="docs-meta-item icon-text hover:text-on-surface transition-colors"
     :href
     :rel="isExternal ? 'noopener noreferrer' : undefined"
     :target="isExternal ? '_blank' : undefined"
-    :title
+    :text="title"
     @click="emit('click', $event)"
   >
     <AppIcon :class="color" :icon size="1em" />
     <span>{{ text }}</span>
-  </a>
+  </AppTooltip>
 
-  <span
+  <AppTooltip
     v-else
+    as="span"
     class="docs-meta-item icon-text"
-    :title
+    :text="title"
   >
     <AppIcon :class="color" :icon size="1em" />
     <span>{{ text }}</span>
-  </span>
+  </AppTooltip>
 </template>
 
-<style scoped>
+<!-- Unscoped + general-sibling (~) selector: AppTooltip renders a multi-root
+     fragment (activator + popover content), so the parent scope-id is not
+     forwarded to the .docs-meta-item element, and the tooltip content node sits
+     between adjacent items — an adjacent-sibling (+) selector would no longer
+     match. See scoped-css-multiroot-child (#359). -->
+<style>
   @media (min-width: 640px) {
-    .docs-meta-item + .docs-meta-item::before {
+    .docs-meta-item ~ .docs-meta-item::before {
       content: '·';
       margin-inline: 0.5rem;
       opacity: 0.4;

--- a/apps/docs/src/components/docs/meta/DocsSkillToggle.vue
+++ b/apps/docs/src/components/docs/meta/DocsSkillToggle.vue
@@ -32,14 +32,14 @@
 </script>
 
 <template>
-  <button
+  <AppTooltip
+    aria-label="Toggle filter"
     :aria-pressed="checked"
     class="w-5 h-5 rounded border flex items-center justify-center cursor-pointer transition-colors"
     :class="checked ? colorClass : 'border-divider hover:border-on-surface-variant'"
-    title="Toggle filter"
-    type="button"
+    text="Toggle filter"
     @click="levelFilter.toggle(level)"
   >
     <AppIcon v-if="checked" icon="check" size="14" />
-  </button>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/components/home/HomeDx.vue
+++ b/apps/docs/src/components/home/HomeDx.vue
@@ -119,12 +119,13 @@
 
         <!-- Theme swatches -->
         <div v-if="feature.swatches" class="flex items-center gap-2">
-          <div
+          <AppTooltip
             v-for="swatch in feature.swatches"
             :key="swatch.id"
+            as="div"
             class="w-5 h-5 rounded-full border border-divider"
             :style="{ background: swatch.color }"
-            :title="swatch.label"
+            :text="swatch.label"
           />
 
           <span class="text-xs opacity-40 ml-1">+{{ Object.keys(themes).length - 6 }} more</span>

--- a/apps/docs/src/components/home/HomeInstallCommand.vue
+++ b/apps/docs/src/components/home/HomeInstallCommand.vue
@@ -47,14 +47,15 @@
     :title="command"
   >
     <Popover.Root v-model="isOpen">
-      <Popover.Activator
-        aria-label="Change package manager"
-        class="inline-flex items-center gap-1 pl-2.5 pr-2 py-1 rounded-full text-primary hover:bg-surface-tint transition-colors cursor-pointer"
-        title="Change package manager"
-      >
-        <span>{{ settings.packageManager.value }}</span>
-        <AppChevron :open="isOpen" :size="12" vertical />
-      </Popover.Activator>
+      <AppTooltip as="span" class="inline-flex" text="Change package manager">
+        <Popover.Activator
+          aria-label="Change package manager"
+          class="inline-flex items-center gap-1 pl-2.5 pr-2 py-1 rounded-full text-primary hover:bg-surface-tint transition-colors cursor-pointer"
+        >
+          <span>{{ settings.packageManager.value }}</span>
+          <AppChevron :open="isOpen" :size="12" vertical />
+        </Popover.Activator>
+      </AppTooltip>
 
       <Popover.Content
         class="p-1.5 rounded-lg bg-surface border border-divider shadow-lg min-w-[140px] !mt-[9px]"

--- a/apps/docs/src/components/skillz/SkillMasteredBadge.vue
+++ b/apps/docs/src/components/skillz/SkillMasteredBadge.vue
@@ -8,10 +8,11 @@
 </script>
 
 <template>
-  <span
+  <AppTooltip
+    as="span"
     class="icon-text text-warning"
-    title="You've completed this skill!"
+    text="You've completed this skill!"
   >
     <AppIcon icon="medal" :size />
-  </span>
+  </AppTooltip>
 </template>

--- a/apps/docs/src/pages/skillz.[id].vue
+++ b/apps/docs/src/pages/skillz.[id].vue
@@ -126,14 +126,14 @@
             <SkillDuration class="text-sm text-on-surface-variant" :minutes="tour.minutes" />
 
             <!-- Reset button (shows when there's progress) -->
-            <button
+            <AppTooltip
               v-if="progress"
               class="px-3 py-1.5 text-sm font-medium text-on-surface-variant bg-transparent border border-divider rounded-lg cursor-pointer transition-colors hover:bg-surface-variant hover:text-on-surface whitespace-nowrap"
-              title="Reset progress"
+              text="Reset progress"
               @click="onReset()"
             >
               Reset
-            </button>
+            </AppTooltip>
 
             <!-- Completed with next tour: Next is primary, Restart is secondary -->
             <template v-if="isCompleted && nextTour">

--- a/apps/playground/src/components.d.ts
+++ b/apps/playground/src/components.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     AppSelect: typeof import('./components/app/AppSelect.vue')['default']
     AppSkeleton: typeof import('./components/app/AppSkeleton.vue')['default']
     AppThemeToggle: typeof import('./components/app/AppThemeToggle.vue')['default']
+    AppTooltip: typeof import('./components/app/AppTooltip.vue')['default']
     PlaygroundApp: typeof import('./components/playground/app/PlaygroundApp.vue')['default']
     PlaygroundAppBar: typeof import('./components/playground/app/PlaygroundAppBar.vue')['default']
     PlaygroundAppContent: typeof import('./components/playground/app/PlaygroundAppContent.vue')['default']

--- a/apps/playground/src/components/app/AppTooltip.vue
+++ b/apps/playground/src/components/app/AppTooltip.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+  // Framework
+  import { Tooltip } from '@vuetify/v0'
+
+  defineOptions({ inheritAttrs: false })
+
+  const {
+    text,
+    as = 'button',
+    openDelay = 500,
+    closeDelay = 200,
+    positionArea = 'top',
+  } = defineProps<{
+    /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
+    text?: string
+    /** Element the trigger renders as; forwarded to Tooltip.Activator. */
+    as?: string
+    openDelay?: number
+    closeDelay?: number
+    positionArea?: string
+  }>()
+</script>
+
+<template>
+  <Tooltip.Root
+    v-if="text"
+    :close-delay
+    :open-delay
+    :position-area
+  >
+    <Tooltip.Activator :as v-bind="$attrs">
+      <slot />
+    </Tooltip.Activator>
+
+    <Tooltip.Content
+      class="max-w-64 whitespace-normal rounded border border-divider bg-surface px-2 py-1 text-xs text-on-surface shadow-lg"
+      :style="{ margin: '6px 0' }"
+    >
+      {{ text }}
+    </Tooltip.Content>
+  </Tooltip.Root>
+
+  <component :is="as" v-else v-bind="$attrs">
+    <slot />
+  </component>
+</template>

--- a/apps/playground/src/components/app/AppTooltip.vue
+++ b/apps/playground/src/components/app/AppTooltip.vue
@@ -10,6 +10,7 @@
     openDelay = 500,
     closeDelay = 200,
     positionArea = 'top',
+    disabled = false,
   } = defineProps<{
     /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
     text?: string
@@ -18,6 +19,8 @@
     openDelay?: number
     closeDelay?: number
     positionArea?: string
+    /** Disables the trigger and suppresses the tooltip. Declared so a caller's `:disabled` survives Tooltip.Activator's attr merge. */
+    disabled?: boolean
   }>()
 </script>
 
@@ -25,6 +28,7 @@
   <Tooltip.Root
     v-if="text"
     :close-delay
+    :disabled
     :open-delay
     :position-area
   >
@@ -40,7 +44,7 @@
     </Tooltip.Content>
   </Tooltip.Root>
 
-  <component :is="as" v-else v-bind="$attrs">
+  <component :is="as" v-else :disabled="disabled || undefined" v-bind="$attrs">
     <slot />
   </component>
 </template>

--- a/apps/playground/src/components/app/AppTooltip.vue
+++ b/apps/playground/src/components/app/AppTooltip.vue
@@ -2,8 +2,15 @@
   // Framework
   import { Tooltip } from '@vuetify/v0'
 
+  // Types
+  import type { AtomProps, TooltipRootProps } from '@vuetify/v0'
+
   defineOptions({ inheritAttrs: false })
 
+  // openDelay/closeDelay/positionArea/disabled forward to Tooltip.Root; their
+  // types come from TooltipRootProps so this wrapper can't drift. `disabled` is
+  // a declared prop (not a fall-through attr) so a caller's `:disabled` is not
+  // clobbered by Tooltip.Activator's mergeProps.
   const {
     text,
     as = 'button',
@@ -15,13 +22,8 @@
     /** Tooltip text. When empty the trigger renders on its own, no tooltip. */
     text?: string
     /** Element the trigger renders as; forwarded to Tooltip.Activator. */
-    as?: string
-    openDelay?: number
-    closeDelay?: number
-    positionArea?: string
-    /** Disables the trigger and suppresses the tooltip. Declared so a caller's `:disabled` survives Tooltip.Activator's attr merge. */
-    disabled?: boolean
-  }>()
+    as?: AtomProps['as']
+  } & Pick<TooltipRootProps, 'closeDelay' | 'disabled' | 'openDelay' | 'positionArea'>>()
 </script>
 
 <template>

--- a/apps/playground/src/components/playground/app/PlaygroundAppBar.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundAppBar.vue
@@ -64,26 +64,28 @@
         <AppIcon :icon="playground.editor.value ? 'editor' : 'eye'" />
       </button>
 
-      <button
+      <AppTooltip
+        aria-label="Copy share link"
         class="pa-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity"
         :class="copied ? 'opacity-80' : 'opacity-50'"
-        :title="copied ? 'Link copied!' : 'Copy share link'"
-        type="button"
+        position-area="bottom"
+        :text="copied ? 'Link copied!' : 'Copy share link'"
         @click="onShare"
       >
         <AppIcon :icon="copied ? 'check' : 'link'" />
-      </button>
+      </AppTooltip>
 
-      <button
+      <AppTooltip
+        aria-label="Settings"
         :aria-pressed="open"
         class="pa-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity"
         :class="open ? 'opacity-80' : 'opacity-50'"
-        title="Settings"
-        type="button"
+        position-area="bottom"
+        text="Settings"
         @click="open = true"
       >
         <AppIcon icon="cog" />
-      </button>
+      </AppTooltip>
 
       <AppThemeToggle />
     </div>


### PR DESCRIPTION
Part of #495 — replacing native `title` browser tooltips with the v0 `Tooltip` compound across docs and playground.

## What this PR does

### 1. `AppTooltip` wrapper (both apps)
An app-local `AppTooltip` (`apps/docs/…/app/AppTooltip.vue`, `apps/playground/…/app/AppTooltip.vue`), built directly on the v0 `Tooltip.Root/Activator/Content` compound. `text` prop + default-slot trigger, `as`/`positionArea`/`disabled` props, forwards `$attrs` (class/aria/listeners) to `Tooltip.Activator`, surface-card styling matching the `BenchmarkRow`/`DocsMaturity` convention.

**Why app-local, not `GnTooltip` in genesis:** docs depends on `@paper/genesis` but playground depends only on `@vuetify/v0`, so one genesis wrapper can't serve both; and app chrome shouldn't couple to a released DS package. Matches the repo's existing per-app chrome duplication (`AppCloseButton` exists in both apps).

### 2. Conversions
- **App bars** — docs `AppBar` (Discord/GitHub), playground `PlaygroundAppBar` (share-link + settings).
- **Docs icon-button sweep** (~37 sites) — releases/ask panels, example + mermaid toolbars, question/skill/palette-preview controls, app-shell buttons.
- **Page meta/action wrappers** — `DocsMetaItem` (coverage breakdown, commit hash, …), `DocsActionChip` (page actions), `DocsBadge` (skill/mode badges). `DocsMetaItem`'s `·` separator moved from an adjacent-sibling (`+`) to a general-sibling (`~`) selector and un-scoped, since `AppTooltip` renders a multi-root fragment (see #359).
- **Non-button elements** — `DocsSearch` result actions (9), skillz badges, release/commit anchors, home color swatch.
- **The Ask form's Send button** (native `type="submit"`) — converted via `Tooltip` **renderless** mode, binding `attrs` + the anchor `styles` onto the submit button so it keeps its `type` and native form submission. This relies on the `Tooltip.Activator` renderless anchor-styles fix (#648), merged and included here.

## Accessibility (preserved, not just moved)
`Tooltip.Activator` wires `aria-describedby` — a *description*, not a name. So every icon-only trigger that relied on `title` for its accessible name gained an explicit `aria-label`; state-conveying toggles keep a **reactive** `aria-label`; copy/status buttons use a **stable** name with only the tooltip text flipping to "Copied!". `Tooltip.Content` renders via the native `popover` API (top layer), so tooltips stack above dialogs/overlays.

## Deliberately left native (correct, not tooltips / other tranches)
- **Not tooltips:** heading-text `title`s (`DocsApi`, `DocsApiHover`, api pages, settings-section headers) and filename **data props** (`DocsCodeActions` & friends).
- **Correct as native:** truncation-mirror titles (home copy/install command inputs).
- **Other tranches:** genesis `GnActionButton` (versioned package + changeset), `Popover.Activator` triggers (activator-on-activator), the palette-browse swatch grid (hundreds of `Tooltip.Root` instances), the playground editor chrome, and docs teaching examples.

## Verification
- `vue-tsc` + eslint clean on changed files.
- Independent code-review pass (a11y names, submit/disabled handling, scoped-CSS, template balance, double-fire) — clean.
- Browser-verified across app bars, the search overlay, the settings dialog, the meta row (separators + coverage tooltip), and the renderless Send button (tooltip positions against the submit button; accessible name + submit preserved). Zero console errors.