### PR TITLE
fix dangling aria idrefs

### DIFF
--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -48,8 +48,8 @@
       'id': string
       'role': 'alertdialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -162,8 +162,8 @@
       'id': context.id,
       'role': 'alertdialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.hasTitle.value ? context.titleId : undefined,
+      'aria-describedby': context.hasDescription.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogDescription' })
 
@@ -48,6 +48,14 @@
   } = defineProps<AlertDialogDescriptionProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasDescription.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasDescription.value = false
+  })
 
   const slotProps = toRef((): AlertDialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
@@ -22,6 +22,8 @@
     id: string
     titleId: string
     descriptionId: string
+    hasTitle: ShallowRef<boolean>
+    hasDescription: ShallowRef<boolean>
     isPending: ShallowRef<boolean>
     open: () => void
     close: () => void
@@ -81,6 +83,8 @@
 
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
+  const hasTitle = shallowRef(false)
+  const hasDescription = shallowRef(false)
 
   function open () {
     isOpen.value = true
@@ -96,6 +100,8 @@
     id,
     titleId,
     descriptionId,
+    hasTitle,
+    hasDescription,
     isPending,
     open,
     close,

--- a/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogTitle' })
 
@@ -48,6 +48,14 @@
   } = defineProps<AlertDialogTitleProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasTitle.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasTitle.value = false
+  })
 
   const slotProps = toRef((): AlertDialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -242,7 +242,7 @@ describe('alertDialog', () => {
       expect(content.attributes('aria-modal')).toBe('true')
     })
 
-    it('should have aria-labelledby pointing to title', () => {
+    it('should have aria-labelledby pointing to title', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -252,11 +252,12 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-labelledby')).toBe('test-alert-title')
     })
 
-    it('should have aria-describedby pointing to description', () => {
+    it('should have aria-describedby pointing to description', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -266,8 +267,22 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-describedby')).toBe('test-alert-description')
+    })
+
+    it('should omit title and description references when targets are missing', () => {
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'no-title-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => 'Content'),
+        },
+      })
+
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
     })
 
     it('should call showModal when opened', async () => {

--- a/packages/0/src/components/Dialog/DialogContent.vue
+++ b/packages/0/src/components/Dialog/DialogContent.vue
@@ -47,8 +47,8 @@
       'id': string
       'role': 'dialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -156,8 +156,8 @@
       'id': context.id,
       'role': 'dialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.hasTitle.value ? context.titleId : undefined,
+      'aria-describedby': context.hasDescription.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/Dialog/DialogDescription.vue
+++ b/packages/0/src/components/Dialog/DialogDescription.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogDescription' })
 
@@ -48,6 +48,14 @@
   } = defineProps<DialogDescriptionProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasDescription.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasDescription.value = false
+  })
 
   const slotProps = toRef((): DialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/DialogRoot.vue
+++ b/packages/0/src/components/Dialog/DialogRoot.vue
@@ -21,6 +21,8 @@
     id: string
     titleId: string
     descriptionId: string
+    hasTitle: ShallowRef<boolean>
+    hasDescription: ShallowRef<boolean>
     open: () => void
     close: () => void
   }
@@ -52,7 +54,7 @@
 
   // Utilities
   import { useId } from '#v0/utilities'
-  import { toRef } from 'vue'
+  import { shallowRef, toRef } from 'vue'
 
   defineOptions({ name: 'DialogRoot' })
 
@@ -75,6 +77,8 @@
   const id = _id ?? useId()
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
+  const hasTitle = shallowRef(false)
+  const hasDescription = shallowRef(false)
 
   function open () {
     isOpen.value = true
@@ -89,6 +93,8 @@
     id,
     titleId,
     descriptionId,
+    hasTitle,
+    hasDescription,
     open,
     close,
   })

--- a/packages/0/src/components/Dialog/DialogTitle.vue
+++ b/packages/0/src/components/Dialog/DialogTitle.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogTitle' })
 
@@ -48,6 +48,14 @@
   } = defineProps<DialogTitleProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasTitle.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasTitle.value = false
+  })
 
   const slotProps = toRef((): DialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/index.browser.test.ts
+++ b/packages/0/src/components/Dialog/index.browser.test.ts
@@ -395,7 +395,7 @@ describe('dialog', () => {
         expect(content.attributes('aria-modal')).toBe('true')
       })
 
-      it('should have aria-labelledby pointing to title', () => {
+      it('should have aria-labelledby pointing to title', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -405,11 +405,12 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-labelledby')).toBe('test-dialog-title')
       })
 
-      it('should have aria-describedby pointing to description', () => {
+      it('should have aria-describedby pointing to description', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -419,6 +420,7 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-describedby')).toBe('test-dialog-description')
       })
@@ -989,7 +991,7 @@ describe('dialog', () => {
       expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
     })
 
-    it('should handle missing title and description', () => {
+    it('should omit title and description references when targets are missing', () => {
       const wrapper = mountWithStack(Dialog.Root, {
         props: { id: 'no-title-dialog' },
         slots: {
@@ -998,9 +1000,8 @@ describe('dialog', () => {
       })
 
       const content = wrapper.findComponent(Dialog.Content as any)
-      // Should still have aria attributes pointing to potentially missing elements
-      expect(content.attributes('aria-labelledby')).toBe('no-title-dialog-title')
-      expect(content.attributes('aria-describedby')).toBe('no-title-dialog-description')
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
     })
 
     it('should handle dialog without trigger (controlled)', async () => {

--- a/packages/0/src/components/Progress/ProgressLabel.vue
+++ b/packages/0/src/components/Progress/ProgressLabel.vue
@@ -14,7 +14,7 @@
   import { useProgressRoot } from './ProgressRoot.vue'
 
   // Utilities
-  import { mergeProps, toRef, useAttrs } from 'vue'
+  import { mergeProps, onBeforeUnmount, onMounted, toRef, useAttrs } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
@@ -49,6 +49,14 @@
   } = defineProps<ProgressLabelProps>()
 
   const root = useProgressRoot(namespace)
+
+  onMounted(() => {
+    root.hasLabel.value = true
+  })
+
+  onBeforeUnmount(() => {
+    root.hasLabel.value = false
+  })
 
   const slotProps = toRef((): ProgressLabelSlotProps => ({
     total: root.total.value,

--- a/packages/0/src/components/Progress/ProgressRoot.vue
+++ b/packages/0/src/components/Progress/ProgressRoot.vue
@@ -21,16 +21,18 @@
 
   // Utilities
   import { isArray, isNullOrUndefined, useId } from '#v0/utilities'
-  import { computed, mergeProps, toRef, useAttrs } from 'vue'
+  import { computed, mergeProps, shallowRef, toRef, useAttrs } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { ProgressContext, ProgressTicket } from '#v0/composables/createProgress'
+  import type { ShallowRef } from 'vue'
 
   export interface ProgressRootContext extends ProgressContext {
     readonly id: string
     readonly name?: string
     readonly labelId: string
+    readonly hasLabel: ShallowRef<boolean>
   }
 
   export interface ProgressRootProps extends AtomProps {
@@ -54,7 +56,7 @@
       'aria-valuemin': number
       'aria-valuemax': number
       'aria-valuetext': string | undefined
-      'aria-labelledby': string
+      'aria-labelledby': string | undefined
       'aria-busy': true | undefined
       'data-state': 'determinate' | 'indeterminate'
       'data-complete': true | undefined
@@ -104,12 +106,14 @@
   useProxyModel(progress, internal, { multiple: true })
 
   const labelId = `${id}-label`
+  const hasLabel = shallowRef(false)
 
   const context: ProgressRootContext = {
     ...progress,
     id,
     name,
     labelId,
+    hasLabel,
   }
 
   provideProgressRoot(namespace, context)
@@ -131,7 +135,7 @@
         'aria-valuemin': min,
         'aria-valuemax': max,
         'aria-valuetext': indeterminate ? undefined : `${Math.round(pct)}%`,
-        'aria-labelledby': labelId,
+        'aria-labelledby': hasLabel.value ? labelId : undefined,
         'aria-busy': indeterminate ? true : undefined,
         'data-state': indeterminate ? 'indeterminate' : 'determinate',
         'data-complete': total >= max ? true : undefined,

--- a/packages/0/src/components/Progress/index.test.ts
+++ b/packages/0/src/components/Progress/index.test.ts
@@ -203,9 +203,16 @@ describe('progress', () => {
 
     it('should set aria-labelledby referencing the label id', async () => {
       const model = ref(50)
-      const { rootProps, wait } = mountProgress({ model, props: { id: 'test' } })
+      const { rootProps, wait } = mountProgress({ model, props: { id: 'test' }, withLabel: true })
       await wait()
       expect(rootProps().attrs['aria-labelledby']).toBe('test-label')
+    })
+
+    it('should omit aria-labelledby when label is missing', async () => {
+      const model = ref(50)
+      const { rootProps, wait } = mountProgress({ model, props: { id: 'test' } })
+      await wait()
+      expect(rootProps().attrs['aria-labelledby']).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes #608.

Dialog, AlertDialog, and Progress now only emit ARIA IDREF attributes after the referenced optional subcomponent is mounted. That prevents aria-labelledby and aria-describedby from pointing at elements that do not exist when title, description, or label components are omitted.

## Changes

- Track mounted Dialog and AlertDialog title/description components in root context.
- Track mounted Progress label components in root context.
- Omit aria-labelledby / aria-describedby when the referenced target is missing.
- Add regression coverage for both present and missing target branches.

## Validation

- pnpm vitest run packages/0/src/components/Dialog/index.browser.test.ts packages/0/src/components/AlertDialog/index.browser.test.ts packages/0/src/components/Progress/index.test.ts
- pnpm --filter=./packages/0 typecheck

Note: local Node is v25.6.1, so pnpm reports the repo engine warning for Node >=26, but the focused checks passed.