### PR TITLE
add default splitter handle label

### DIFF
--- a/packages/0/src/components/Splitter/SplitterHandle.vue
+++ b/packages/0/src/components/Splitter/SplitterHandle.vue
@@ -17,6 +17,7 @@
 
   // Composables
   import { useDocumentEventListener } from '#v0/composables/useEventListener'
+  import { useLocale } from '#v0/composables/useLocale'
   import { useRaf } from '#v0/composables/useRaf'
   import { useToggleScope } from '#v0/composables/useToggleScope'
 
@@ -84,6 +85,7 @@
   const PAGE_STEP = 10
 
   const splitter = useSplitterRoot()
+  const locale = useLocale()
   const ticket = splitter.handles.register()
 
   onBeforeUnmount(() => {
@@ -268,7 +270,7 @@
       'aria-valuemax': valuemax.value,
       'aria-orientation': ariaOrientation.value,
       'aria-controls': ariaControls.value,
-      'aria-label': label || undefined,
+      'aria-label': label || locale.ti('Splitter.handle') || 'Resize panels',
       'aria-disabled': isDisabled.value,
       'data-state': state.value,
       'data-orientation': splitter.orientation.value,

--- a/packages/0/src/components/Splitter/index.browser.test.ts
+++ b/packages/0/src/components/Splitter/index.browser.test.ts
@@ -565,6 +565,14 @@ describe('splitter', () => {
         expect(handle.attributes('aria-label')).toBe('Resize panels')
       })
 
+      it('should set a default aria-label when label prop is omitted', async () => {
+        const wrapper = twoPanel()
+        await nextTick()
+
+        const handle = wrapper.findComponent(SplitterHandle as any)
+        expect(handle.attributes('aria-label')).toBe('Resize panels')
+      })
+
       it('should set aria-disabled when disabled', async () => {
         const wrapper = twoPanel({ disabled: true })
         await nextTick()

--- a/packages/0/src/locale/messages/en/index.test.ts
+++ b/packages/0/src/locale/messages/en/index.test.ts
@@ -6,7 +6,7 @@ describe('locale/messages/en', () => {
   it('should export an English aria-string catalog for every v0 component namespace', () => {
     expect(en).toBeTypeOf('object')
 
-    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar']) {
+    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar', 'Splitter']) {
       expect(en).toHaveProperty(key)
     }
   })
@@ -23,5 +23,6 @@ describe('locale/messages/en', () => {
     expect(en.Dialog.close).toBeTypeOf('string')
     expect(en.Pagination.next).toBeTypeOf('string')
     expect(en.Snackbar.close).toBeTypeOf('string')
+    expect(en.Splitter.handle).toBeTypeOf('string')
   })
 })

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -68,4 +68,7 @@ export default {
   Snackbar: {
     close: 'Dismiss',
   },
+  Splitter: {
+    handle: 'Resize panels',
+  },
 } as const


### PR DESCRIPTION
## Summary

Fixes #617.

Splitter handles now get a default accessible name when consumers do not pass the `label` prop. The explicit prop still wins, while the fallback uses the locale catalog with a built-in English fallback.

## Changes

- Add `Splitter.handle` to the English locale messages.
- Use `locale.ti('Splitter.handle')` for the default Splitter handle `aria-label`.
- Keep custom `label` prop behavior unchanged.
- Add regression coverage for default and custom labels.

## Validation

- pnpm vitest run packages/0/src/components/Splitter/index.browser.test.ts packages/0/src/locale/messages/en/index.test.ts
- pnpm --filter=./packages/0 typecheck

Note: local Node is v25.6.1, so pnpm reports the repo engine warning for Node >=26, but the focused checks passed.