### PR TITLE
fix(Snackbar): add urgent prop to switch live-region role to alert (#615)

### DIFF
--- a/.changeset/fix-snackbar-urgent-role.md
+++ b/.changeset/fix-snackbar-urgent-role.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Snackbar): add an `urgent` prop that switches the live region to `role="alert"` (#624)
+
+Informational snackbars keep `role="status"` (a polite live region); setting `urgent` switches to `role="alert"` (assertive) so critical notifications interrupt assistive technology instead of waiting for it to go idle (WCAG 4.1.3, Status Messages).

--- a/packages/0/src/components/Snackbar/SnackbarRoot.vue
+++ b/packages/0/src/components/Snackbar/SnackbarRoot.vue
@@ -40,6 +40,8 @@
     namespace?: string
     /** Unique identifier. Auto-generated if not provided. */
     id?: ID
+    /** When true, sets role="alert" for urgent messages; otherwise role="status". */
+    urgent?: boolean
   }
 
   export interface SnackbarRootSlotProps {
@@ -61,7 +63,7 @@
     default: (props: SnackbarRootSlotProps) => any
   }>()
 
-  const { as = 'div', namespace = 'v0:notifications', id = useId(), renderless } = defineProps<SnackbarRootProps>()
+  const { as = 'div', namespace = 'v0:notifications', id = useId(), renderless, urgent } = defineProps<SnackbarRootProps>()
 
   const queue = useSnackbarQueueContext(namespace, null)
 
@@ -78,7 +80,7 @@
   const slotProps = toRef((): SnackbarRootSlotProps => ({
     id,
     attrs: {
-      role: 'status',
+      role: urgent ? 'alert' : 'status',
     },
   }))
 </script>


### PR DESCRIPTION
## Summary

- Adds an `urgent` boolean prop to `SnackbarRoot` that switches the ARIA live-region `role` from `'status'` to `'alert'` when set to `true`
- Previously `role` was hardcoded to `'status'`, making it impossible to signal urgency to assistive technologies at the component level
- Addresses WCAG 4.1.3 (Status Messages): urgent notifications now use `role="alert"` (assertive live region) while informational ones keep `role="status"` (polite live region)

## Changed file

`packages/0/src/components/Snackbar/SnackbarRoot.vue`

- `SnackbarRootProps` — new optional `urgent?: boolean` prop (JSDoc included)
- `defineProps` destructure — `urgent` added
- `slotProps` computed — `role: urgent ? 'alert' : 'status'`

## Test plan

- [ ] Render `<SnackbarRoot>` without `urgent` — verify rendered element has `role="status"`
- [ ] Render `<SnackbarRoot urgent>` — verify rendered element has `role="alert"`
- [ ] Run existing Snackbar unit tests to confirm no regressions
- [ ] Smoke-test with a screen reader: urgent snackbar should interrupt; non-urgent should wait for idle