### PR TITLE
fix(Carousel): pause autoplay on keyboard focus (WCAG 2.2.2)

### DIFF
--- a/.changeset/fix-carousel-focus-pause.md
+++ b/.changeset/fix-carousel-focus-pause.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Carousel): pause autoplay while keyboard focus is inside the carousel (#625)
+
+Moving focus into the carousel now pauses auto-rotation and moving focus out resumes it, mirroring the existing pointer/touch behavior and satisfying WCAG 2.2.2 (Pause, Stop, Hide).

--- a/packages/0/src/components/Carousel/CarouselViewport.vue
+++ b/packages/0/src/components/Carousel/CarouselViewport.vue
@@ -248,6 +248,9 @@
 
     useEventListener(el, 'touchstart', () => carousel.pause(), { passive: true })
     useEventListener(el, 'touchend', () => carousel.resume(), { passive: true })
+
+    useEventListener(el, 'focusin', () => carousel.pause())
+    useEventListener(el, 'focusout', () => carousel.resume())
   }
 
   watch(() => carousel.selectedIndex.value, index => {


### PR DESCRIPTION
## Summary

- Adds `focusin` and `focusout` event listeners to `CarouselViewport` so that autoplay pauses when keyboard focus enters the carousel and resumes when focus leaves
- Mirrors the existing pointer/touch pause-on-interaction pattern already present in the component
- Satisfies WCAG 2.2.2 (Pause, Stop, Hide): moving keyboard focus into an auto-rotating carousel must stop the rotation

## Changes

**`packages/0/src/components/Carousel/CarouselViewport.vue`**
- Added `useEventListener(el, 'focusin', () => carousel.pause())` after the existing `touchend` listener
- Added `useEventListener(el, 'focusout', () => carousel.resume())` immediately after

Both listeners are registered inside the existing `if (IN_BROWSER)` block alongside the other interaction listeners. No `{ passive: true }` flag is needed because `focusin`/`focusout` cannot be cancelled.

## Test plan

- [ ] Start a carousel with autoplay enabled
- [ ] Tab into the carousel — autoplay should pause
- [ ] Tab out of the carousel — autoplay should resume
- [ ] Verify mouse and touch pause behavior is unchanged