### PR TITLE
fix(Treeview): emit aria-current on active item for AT navigation

### DIFF
--- a/.changeset/fix-treeview-aria-current.md
+++ b/.changeset/fix-treeview-aria-current.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Treeview): expose the active node to assistive technology via `aria-current` (#626)
+
+Navigation trees without checkbox selection now convey the current node — the active `treeitem` emits `aria-current="true"` alongside the existing `aria-selected`, so screen readers can announce the focused node.

--- a/packages/0/src/components/Treeview/TreeviewItem.vue
+++ b/packages/0/src/components/Treeview/TreeviewItem.vue
@@ -102,6 +102,7 @@
       'aria-expanded': hasContent.value ? toValue(ticket.isOpen) : undefined,
       'aria-level': toValue(ticket.depth) + 1,
       'aria-posinset': ticket.position(),
+      'aria-current': toValue(ticket.isActive) ? ('true' as const) : undefined,
       'aria-selected': toValue(ticket.isSelected),
       'aria-setsize': ticket.siblings().length,
       'data-active': toValue(ticket.isActive) || undefined,

--- a/packages/0/src/components/Treeview/TreeviewItem.vue
+++ b/packages/0/src/components/Treeview/TreeviewItem.vue
@@ -102,7 +102,7 @@
       'aria-expanded': hasContent.value ? toValue(ticket.isOpen) : undefined,
       'aria-level': toValue(ticket.depth) + 1,
       'aria-posinset': ticket.position(),
-      'aria-current': toValue(ticket.isActive) ? ('true' as const) : undefined,
+      'aria-current': toValue(ticket.isActive) ? 'true' : undefined,
       'aria-selected': toValue(ticket.isSelected),
       'aria-setsize': ticket.siblings().length,
       'data-active': toValue(ticket.isActive) || undefined,

--- a/packages/0/src/components/Treeview/types.ts
+++ b/packages/0/src/components/Treeview/types.ts
@@ -199,6 +199,7 @@ export interface TreeviewItemSlotProps<V = unknown> {
     'aria-expanded': boolean | undefined
     'aria-level': number
     'aria-posinset': number
+    'aria-current': 'true' | undefined
     'aria-selected': boolean
     'aria-setsize': number
     'data-active': true | undefined


### PR DESCRIPTION
## Summary

- Active `treeitem` nodes were tracked only via `data-active`, which is not exposed to the accessibility tree
- Screen readers have no way to announce the currently focused/active node in navigation trees that do not use checkbox selection
- Adds `aria-current="true"` to the `treeitem` role element whenever `ticket.isActive` is true, alongside the existing `aria-selected`

## Details

`aria-current` is the correct ARIA attribute for expressing "this is the current item" on navigation-style widgets. Per [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#aria-current), setting `aria-current="true"` on a `treeitem` conveys the active/current-location state to assistive technology without conflicting with `aria-selected` (which expresses multi-selection state used by checkbox trees).

The one-line change is in `TreeviewItem.vue`'s `attrs` computed object:

```diff
+ 'aria-current': toValue(ticket.isActive) ? ('true' as const) : undefined,
  'aria-selected': toValue(ticket.isSelected),
```

`ticket.isActive` was already present in scope (it is also used for `data-active`), so no additional composable wiring is needed.

## Test plan

- [ ] Open a Treeview without `Treeview.Checkbox` and activate a node via click or keyboard
- [ ] Inspect the DOM: the active `li[role="treeitem"]` should have `aria-current="true"`; inactive nodes should have no `aria-current` attribute
- [ ] Verify with a screen reader (NVDA/JAWS/VoiceOver) that the reader announces the active node distinctly
- [ ] Confirm checkbox-selection trees are unaffected: `aria-selected` continues to work as before

Closes #611