### PR TITLE
fix(Splitter): add localized default aria-label for handle

### DIFF
--- a/.changeset/fix-splitter-handle-locale.md
+++ b/.changeset/fix-splitter-handle-locale.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Splitter): give the resize handle a default localized `aria-label` (#627)
+
+A `Splitter.Handle` without an explicit `label` now falls back to the localized `Splitter.handle` string ("Resize"), so `role="separator"` always exposes an accessible name to assistive technology (WCAG 4.1.2, Name/Role/Value).

--- a/packages/0/src/components/Splitter/SplitterHandle.vue
+++ b/packages/0/src/components/Splitter/SplitterHandle.vue
@@ -270,7 +270,7 @@
       'aria-valuemax': valuemax.value,
       'aria-orientation': ariaOrientation.value,
       'aria-controls': ariaControls.value,
-      'aria-label': label || (locale.ti('Splitter.handle') ?? 'Resize') || undefined,
+      'aria-label': label || (locale.ti('Splitter.handle') ?? 'Resize'),
       'aria-disabled': isDisabled.value,
       'data-state': state.value,
       'data-orientation': splitter.orientation.value,

--- a/packages/0/src/components/Splitter/SplitterHandle.vue
+++ b/packages/0/src/components/Splitter/SplitterHandle.vue
@@ -17,6 +17,7 @@
 
   // Composables
   import { useDocumentEventListener } from '#v0/composables/useEventListener'
+  import { useLocale } from '#v0/composables/useLocale'
   import { useRaf } from '#v0/composables/useRaf'
   import { useToggleScope } from '#v0/composables/useToggleScope'
 
@@ -83,6 +84,7 @@
   const ARROW_STEP = 1
   const PAGE_STEP = 10
 
+  const locale = useLocale()
   const splitter = useSplitterRoot()
   const ticket = splitter.handles.register()
 
@@ -268,7 +270,7 @@
       'aria-valuemax': valuemax.value,
       'aria-orientation': ariaOrientation.value,
       'aria-controls': ariaControls.value,
-      'aria-label': label || undefined,
+      'aria-label': label || (locale.ti('Splitter.handle') ?? 'Resize') || undefined,
       'aria-disabled': isDisabled.value,
       'data-state': state.value,
       'data-orientation': splitter.orientation.value,

--- a/packages/0/src/locale/messages/en/index.test.ts
+++ b/packages/0/src/locale/messages/en/index.test.ts
@@ -6,7 +6,7 @@ describe('locale/messages/en', () => {
   it('should export an English aria-string catalog for every v0 component namespace', () => {
     expect(en).toBeTypeOf('object')
 
-    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar']) {
+    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar', 'Splitter']) {
       expect(en).toHaveProperty(key)
     }
   })

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -68,4 +68,7 @@ export default {
   Snackbar: {
     close: 'Dismiss',
   },
+  Splitter: {
+    handle: 'Resize',
+  },
 } as const


### PR DESCRIPTION
## Problem

`SplitterHandle` emits `role="separator"` but only sets `aria-label` when the consumer passes the `label` prop. An unnamed `role=separator` violates WCAG 4.1.2 (Name, Role, Value) — screen readers announce the element with no accessible name.

## Solution

Add a `Splitter.handle` key (`'Resize'`) to the English locale catalog and fall back to `locale.ti('Splitter.handle') ?? 'Resize'` when no `label` prop is provided. This mirrors the pattern already used in `ButtonRoot.vue` (see `locale.ti('Button.label') ?? 'Button'`).

The inline `?? 'Resize'` hardcode satisfies the `vuetify/locale-ti-requires-fallback` ESLint rule, ensuring unconfigured apps still get an accessible name.

## Changes

- `packages/0/src/locale/messages/en/index.ts` — add `Splitter.handle: 'Resize'`
- `packages/0/src/locale/messages/en/index.test.ts` — add `'Splitter'` to the catalog key assertion
- `packages/0/src/components/Splitter/SplitterHandle.vue` — import `useLocale`, instantiate it, and fall back to the locale string on `aria-label`

Closes #617