### PR TITLE
docs: reference rc.9 and v1.0.0 release dates

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -16,7 +16,7 @@
   if (!notifications.has('rc-banner')) {
     notifications.register({
       id: 'rc-banner',
-      subject: 'Vuetify0 is now a release candidate!',
+      subject: 'Vuetify0 v1.0 releases July 22, 2026 — the stable release is almost here!',
       severity: 'warning',
       data: { type: 'banner' },
     })

--- a/apps/docs/src/pages/guide/tooling/vuetify-cli.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-cli.md
@@ -264,22 +264,22 @@ Print the release notes for a Vuetify package without leaving the terminal:
 pnpm dlx @vuetify/cli release-notes v0
 
 # A specific version
-pnpm dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+pnpm dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
 ```
 
 ```bash npm
 npx @vuetify/cli release-notes v0
-npx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+npx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
 ```
 
 ```bash yarn
 yarn dlx @vuetify/cli release-notes v0
-yarn dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+yarn dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
 ```
 
 ```bash bun
 bunx @vuetify/cli release-notes v0
-bunx @vuetify/cli release-notes v0 --version 1.0.0-rc.8
+bunx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
 ```
 
 :::

--- a/apps/docs/src/pages/introduction/why-vuetify0.md
+++ b/apps/docs/src/pages/introduction/why-vuetify0.md
@@ -242,7 +242,7 @@ Vuetify0 is already being merged into Vuetify's next major release. The first PR
 
 ### Road to v1
 
-**Alpha → Beta → Release Candidate → v1.0 (Q3 2026)** — [see the full roadmap](/roadmap).
+**Alpha → Beta → Release Candidate → v1.0 (July 22, 2026)** — [see the full roadmap](/roadmap).
 
 What comes after v1: **Vuetify Paper** — a styled layer built on v0 that provides opinionated design system primitives. Emerald and Onyx are the first design systems. Build on v0 today; Paper gives you a head start on the styled layer when you're ready.
 

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -28,15 +28,15 @@ Track the development of @vuetify/v0. Milestones are organized by time horizon:
 
 **Now a release candidate.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
 
-Alpha opened on April 7, 2026 for feedback; beta hardened the APIs. The release candidate locks the v1 stable set — what remains is final validation, documentation, and bug fixes before v1.0.
+Alpha opened on April 7, 2026 for feedback; beta hardened the APIs. The release candidate locks the v1 stable set — what remains is final validation, documentation, and bug fixes. The final candidate, rc.9, lands July 21, 2026, with the stable v1.0.0 release the next day, July 22, 2026.
 
 ### Road to v1
 
 <DocsTimeline :milestones="[
   { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Opened for feedback, bug reports, and contributions. APIs mostly stable, may evolve.' },
   { id: 'beta', label: 'Beta', date: 'June 2, 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
-  { id: 'rc', label: 'RC', date: 'July 2, 2026', description: 'Release candidate for final testing and documentation. No new features.', active: true },
-  { id: 'v1', label: 'v1.0', date: 'Q3 2026', description: 'Milestone-driven. Ships when the milestones are met.' },
+  { id: 'rc', label: 'RC', date: 'July 2, 2026', description: 'Release candidate for final testing and documentation. No new features. The final candidate, rc.9, lands July 21, 2026.', active: true },
+  { id: 'v1', label: 'v1.0', date: 'July 22, 2026', description: 'Stable release. v0 1.0.0 ships July 22, 2026.' },
 ]" />
 
 ### What RC means

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -28,7 +28,7 @@
 
 Headless Vue 3 UI primitives and composables for building modern applications and design systems. `@vuetify/v0` is the foundation of the Vuetify ecosystem, offering lightweight, unstyled building blocks with full TypeScript support and accessibility features built-in.
 
-> **Note:** v0 is a release candidate — the v1 stable set is locked. Install with `npm i @vuetify/v0@rc`. Preview APIs may still see minor, documented changes before the stable release.
+> **Note:** v0 is a release candidate — the v1 stable set is locked. Install with `npm i @vuetify/v0@rc`. Preview APIs may still see minor, documented changes before the stable v1.0.0 release on July 22, 2026 (final candidate, rc.9, lands July 21).
 
 ## Repository Structure
 
@@ -301,7 +301,7 @@ pnpm validate
 
 ## Contributing
 
-Vuetify0 is a release candidate — open for final validation, bug reports, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap#release-candidate) for what's planned and how to get involved.
+Vuetify0 is a release candidate — open for final validation, bug reports, and contributions. The stable v1.0.0 release ships July 22, 2026 (final candidate, rc.9, on July 21). See the [Roadmap](https://0.vuetifyjs.com/roadmap#release-candidate) for what's planned and how to get involved.
 
 ## License
 


### PR DESCRIPTION
Updates docs and the v1.0.0 GitHub milestone to reference the scheduled release window:

- **rc.9** — final release candidate, **2026-07-21 (Tue)**
- **v1.0.0** — stable release, **2026-07-22 (Wed)**

## Changes
- `roadmap.md` — `DocsTimeline`: v1 date `Q3 2026` → `July 22, 2026`; rc entry + intro prose note the final rc.9 cut on July 21.
- `AppBanner.vue` — site banner now announces the July 22 stable release instead of the generic "now a release candidate".
- `why-vuetify0.md` — Road-to-v1 line `(Q3 2026)` → `(July 22, 2026)`.
- `README.md` (packages/0, root symlink) — @rc install note + contributing section reference the July 22 stable date.
- `guide/tooling/vuetify-cli.md` — example version `1.0.0-rc.8` → `1.0.0-rc.9`.

Also updated out-of-band (not in this diff): the **v1.0.0 GitHub milestone** description now reads "stable release scheduled 2026-07-22" with the rc.9/July-21 detail — this drives the "Now" block of the docs roadmap live via the GitHub milestones API.

All copy is future-tense/scheduled (today is 2026-07-16); nothing claims the stable release has shipped.

Not touched (flagged, out of scope): `constants/releases.ts` RELEASE_ALIASES (no rc/1.0.0 alias — renders raw, fine); `constants.md` example version string; `devkey.md` historical alpha framing.