### PR TITLE
docs: fix palette explorer export and frame the palettes page

### DIFF
--- a/apps/docs/src/components/docs/DocsPaletteBrowse.vue
+++ b/apps/docs/src/components/docs/DocsPaletteBrowse.vue
@@ -29,6 +29,8 @@
     ant: { label: 'Ant Design', data: ant as Record<string, Record<string, string>>, namespace: 'ant' },
   }
 
+  const ROLES = ['primary', 'secondary', 'accent', 'error', 'info', 'success', 'warning']
+
   const selected = shallowRef('tailwind')
   const clicks = ref(new Map<string, string>())
   const { copied, copy } = useClipboard()
@@ -76,23 +78,33 @@
   }
 
   function onExport () {
-    const p = palette.value
-    const ns = p.namespace
+    const ns = palette.value.namespace
     const name = selected.value
+
+    const lines: string[] = []
+
+    if (clicks.value.size > 0) {
+      // Map each clicked swatch to a theme role, in click order
+      let i = 0
+      for (const [path] of clicks.value) {
+        const role = ROLES[i] ?? `color${i + 1}`
+        lines.push(`          ${role}: '{palette.${ns}.${path}}',`)
+        i++
+      }
+    } else {
+      // No clicks: seed primary/secondary from real hues in this palette so the config resolves
+      const shade = columns.value[Math.floor(columns.value.length / 2)]
+      for (const [index, [hue, collection]] of rows.value.slice(0, 2).entries()) {
+        const key = shade && collection[shade] ? shade : Object.keys(collection)[0]!
+        lines.push(`          ${ROLES[index]}: '{palette.${ns}.${hue}.${key}}',`)
+      }
+    }
+
     let code = `import { ${name} } from '@vuetify/v0/palettes/${name}'\n\n`
     code += `app.use(\n  createThemePlugin({\n    palette: { ${ns}: ${name} },\n`
     code += `    themes: {\n      light: {\n        colors: {\n`
-
-    if (clicks.value.size > 0) {
-      for (const [path] of clicks.value) {
-        code += `          // '{palette.${ns}.${path}}',\n`
-      }
-    } else {
-      code += `          // primary: '{palette.${ns}.blue.500}',\n`
-      code += `          // secondary: '{palette.${ns}.slate.600}',\n`
-    }
-
-    code += `        }\n      }\n    }\n  })\n)`
+    code += `${lines.join('\n')}\n`
+    code += `        },\n      },\n    },\n  })\n)`
     copy(code)
   }
 </script>
@@ -139,6 +151,11 @@
           </Select.Item>
         </Select.Content>
       </Select.Root>
+    </div>
+
+    <!-- Hint -->
+    <div class="text-xs op-60">
+      Click a swatch to copy its token path and add it to the config. Then use <span class="font-medium">Copy Config</span> for a ready-to-paste theme.
     </div>
 
     <!-- Swatch grid — fixed height container, uniform cell sizes -->

--- a/apps/docs/src/components/docs/DocsPaletteBrowse.vue
+++ b/apps/docs/src/components/docs/DocsPaletteBrowse.vue
@@ -24,7 +24,7 @@
     tailwind: { label: 'Tailwind', data: tailwind as Record<string, Record<string, string>>, namespace: 'tw' },
     md1: { label: 'MD1', data: md1 as Record<string, Record<string, string>>, namespace: 'md1' },
     md2: { label: 'MD2', data: md2 as Record<string, Record<string, string>>, namespace: 'md2' },
-    material: { label: 'Material', data: material as Record<string, Record<string, string>>, namespace: 'md' },
+    material: { label: 'Material 3', data: material as Record<string, Record<string, string>>, namespace: 'md' },
     radix: { label: 'Radix', data: radix as Record<string, Record<string, string>>, namespace: 'radix' },
     ant: { label: 'Ant Design', data: ant as Record<string, Record<string, string>>, namespace: 'ant' },
   }
@@ -67,6 +67,18 @@
   // This swaps axes so groups become columns and tones become rows
   const transposed = computed(() => columns.value.length > rows.value.length * 2)
 
+  // Clicked swatches mapped to theme roles, in click order — drives the summary chips and the export
+  const selection = computed(() =>
+    [...clicks.value].map(([path, hex], index) => ({
+      path,
+      hex,
+      role: ROLES[index] ?? `color${index + 1}`,
+    })),
+  )
+
+  // Fast path -> role lookup so each swatch can show whether it is picked
+  const picked = computed(() => new Map(selection.value.map(entry => [entry.path, entry.role])))
+
   watch(selected, () => {
     clicks.value.clear()
   })
@@ -77,19 +89,24 @@
     clicks.value.set(path, hex)
   }
 
+  function onRemove (path: string) {
+    clicks.value.delete(path)
+  }
+
+  function onClear () {
+    clicks.value.clear()
+  }
+
   function onExport () {
     const ns = palette.value.namespace
     const name = selected.value
 
     const lines: string[] = []
 
-    if (clicks.value.size > 0) {
-      // Map each clicked swatch to a theme role, in click order
-      let i = 0
-      for (const [path] of clicks.value) {
-        const role = ROLES[i] ?? `color${i + 1}`
+    if (selection.value.length > 0) {
+      // Each clicked swatch is already mapped to a role
+      for (const { path, role } of selection.value) {
         lines.push(`          ${role}: '{palette.${ns}.${path}}',`)
-        i++
       }
     } else {
       // No clicks: seed primary/secondary from real hues in this palette so the config resolves
@@ -189,9 +206,12 @@
             v-for="([hue, collection]) in rows"
             :key="hue"
             class="h-7 cursor-pointer border-0 transition-opacity"
-            :class="collection[tone] ? 'hover:opacity-80' : 'opacity-0 pointer-events-none'"
+            :class="[
+              collection[tone] ? 'hover:opacity-80' : 'opacity-0 pointer-events-none',
+              picked.has(`${hue}.${tone}`) && 'outline outline-2 -outline-offset-2 outline-on-surface',
+            ]"
             :style="collection[tone] ? { backgroundColor: collection[tone] } : {}"
-            :title="collection[tone] ? `${hue}.${tone} · ${collection[tone]}` : ''"
+            :title="collection[tone] ? `${hue}.${tone} · ${collection[tone]}${picked.has(`${hue}.${tone}`) ? ` · ${picked.get(`${hue}.${tone}`)}` : ''}` : ''"
             @click="collection[tone] && onSwatch(hue, tone, collection[tone]!)"
           />
         </template>
@@ -228,13 +248,37 @@
             v-for="col in columns"
             :key="col"
             class="h-7 cursor-pointer border-0 transition-opacity"
-            :class="collection[col] ? 'hover:opacity-80' : 'opacity-0 pointer-events-none'"
+            :class="[
+              collection[col] ? 'hover:opacity-80' : 'opacity-0 pointer-events-none',
+              picked.has(`${hue}.${col}`) && 'outline outline-2 -outline-offset-2 outline-on-surface',
+            ]"
             :style="collection[col] ? { backgroundColor: collection[col] } : {}"
-            :title="collection[col] ? `${hue}.${col} · ${collection[col]}` : ''"
+            :title="collection[col] ? `${hue}.${col} · ${collection[col]}${picked.has(`${hue}.${col}`) ? ` · ${picked.get(`${hue}.${col}`)}` : ''}` : ''"
             @click="collection[col] && onSwatch(hue, col, collection[col]!)"
           />
         </template>
       </div>
+    </div>
+
+    <!-- Selection summary — which swatches are picked and the role each maps to -->
+    <div v-if="selection.length > 0" class="flex flex-wrap items-center gap-2">
+      <div
+        v-for="item in selection"
+        :key="item.path"
+        class="inline-flex items-center gap-1.5 h-7 pl-1.5 pr-0.5 text-xs border border-divider rounded-full"
+      >
+        <span class="w-3 h-3 rounded-full border border-divider" :style="{ backgroundColor: item.hex }" />
+        <span class="font-medium">{{ item.role }}</span>
+        <span class="op-50 font-mono">{{ item.path }}</span>
+        <AppCloseButton :label="`Remove ${item.role}`" size="sm" @click="onRemove(item.path)" />
+      </div>
+
+      <button
+        class="text-xs op-60 hover:op-100 underline underline-offset-2 cursor-pointer bg-transparent border-0"
+        @click="onClear"
+      >
+        Clear
+      </button>
     </div>
 
     <!-- Export button with inline copied indicator -->

--- a/apps/docs/src/pages/guide/features/palettes.md
+++ b/apps/docs/src/pages/guide/features/palettes.md
@@ -24,6 +24,12 @@ v0 ships pre-built color data from popular design systems and generator adapters
 
 <DocsPageFeatures :frontmatter />
 
+Palettes come in two forms. **Static palettes** are raw color data — a map of hues to shades — that you namespace under the `palette` option and reference from your themes. **Generator adapters** take a single seed color and hand back a ready-made `{ palette, themes }` pair by wrapping a third-party color algorithm.
+
+Colors are wired up with token references: the `'{palette.tw.blue.500}'` string in the examples below points at a value in the `palette` map instead of hardcoding a hex, so one palette can back many theme roles. See [Theming](/guide/features/theming) for how references resolve.
+
+Use the explorer to browse the static palettes. Click any swatch to copy its token path, then **Copy Config** for a ready-to-paste `createThemePlugin` setup seeded with the swatches you clicked. Palettes with far more shades than hues, like Material, render with their axes flipped so the grid stays readable.
+
 <DocsPaletteExplorer />
 
 ## Static Palettes


### PR DESCRIPTION
## Problem

The `/guide/features/palettes` page rated poorly for being confusing. Root causes, all in the interactive explorer at the top of the page:

1. **Copy Config emitted dead code.** `onExport` produced a `colors` block where every line was commented out — pasting it gave a theme with no colors (silent no-op). The click path was worse: bare token strings with no role key, invalid once uncommented.
2. **No visible selection state.** Clicking swatches quietly accumulated into the export, but nothing on screen showed what you'd picked, which role each mapped to, or how to reset — so idle exploring silently polluted the output.
3. **"Material" meant two things** — the explorer's static entry vs the Material *generator* section lower down.
4. **Static-vs-generator and the `{palette.…}` token syntax were never framed** before the widget.

## Changes

**Export**
- `onExport` now emits real, uncommented config. Clicked swatches map to theme roles (`primary`, `secondary`, …) in click order; the no-click default seeds `primary`/`secondary` from hues that actually exist in the selected palette (the old default hardcoded `blue.500`/`slate.600`, absent outside Tailwind).

**Selection state**
- Summary chip row below the grid: each pick shows its swatch color, mapped role, and token path, with a per-chip remove and a Clear button.
- Selected swatches get an inset outline so the grid and the export stay in sync.

**Framing**
- Prose above the explorer: static vs generator forms, the token-reference syntax with a link to Theming, and a note that shade-heavy palettes (Material) render transposed.
- In-widget hint explaining click-to-copy → Copy Config.
- Static Material entry relabeled **Material 3** to disambiguate from the generator section.

## Verification

- Export code-gen validated in isolation — no-click and multi-click branches both produce valid, resolvable config.
- `vue-tsc` on `apps/docs`: 0 errors. ESLint clean. `AppCloseButton` confirmed auto-registered.
- **Not driven in a live browser** — the docs dev server won't boot in this worktree (a build plugin's `fs.watch` hits `ENOSPC` on WSL, unrelated to this change). The interactive additions are straightforward reactive-Map bindings, but a click-through before merge is still worth doing.