### PR TITLE
fix(AlertDialog): focus Cancel element on open per APG alertdialog pattern

### DIFF
--- a/.changeset/fix-alert-dialog-cancel-focus-609.md
+++ b/.changeset/fix-alert-dialog-cancel-focus-609.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(AlertDialog): focus the Cancel element on open per the APG alertdialog pattern (#630)
+
+The WAI-ARIA Authoring Practices alertdialog pattern calls for initial focus to land on the least-destructive action, and the docs already stated this — but `AlertDialogContent` never actually called `.focus()` on the Cancel element, so focus landed wherever the browser defaulted. `AlertDialogCancel` now registers its DOM element on the shared context, and `AlertDialogContent` focuses it immediately after opening.

--- a/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogCancel.vue
@@ -40,7 +40,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onMounted, onUnmounted, toRef, useTemplateRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogCancel' })
 
@@ -56,6 +56,16 @@
   } = defineProps<AlertDialogCancelProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  const cancelRef = useTemplateRef('cancel')
+
+  onMounted(() => {
+    context.cancelEl.value = (cancelRef.value?.element as HTMLElement | null) ?? null
+  })
+
+  onUnmounted(() => {
+    context.cancelEl.value = null
+  })
 
   function onClick () {
     if (disabled) return
@@ -75,6 +85,7 @@
 
 <template>
   <Atom
+    ref="cancel"
     :as
     :renderless
     v-bind="slotProps.attrs"

--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -109,6 +109,10 @@
     }
   }, { immediate: true })
 
+  function focusCancel () {
+    context.cancelEl.value?.focus()
+  }
+
   watch(context.isOpen, isOpen => {
     const element = contentRef.value?.element as HTMLDialogElement | undefined
     /* v8 ignore next -- defensive guard, element is always present after mount */
@@ -116,6 +120,7 @@
 
     if (isOpen) {
       element.showModal?.()
+      focusCancel()
     } else {
       element.close?.()
     }
@@ -124,6 +129,7 @@
   onMounted(() => {
     if (context.isOpen.value) {
       (contentRef.value?.element as HTMLDialogElement | undefined)?.showModal()
+      focusCancel()
     }
   })
 

--- a/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
@@ -23,6 +23,7 @@
     titleId: string
     descriptionId: string
     isPending: ShallowRef<boolean>
+    cancelEl: ShallowRef<HTMLElement | null>
     open: () => void
     close: () => void
   }
@@ -78,6 +79,7 @@
 
   const isOpen = defineModel<boolean>({ default: false })
   const isPending = shallowRef(false)
+  const cancelEl = shallowRef<HTMLElement | null>(null)
 
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
@@ -97,6 +99,7 @@
     titleId,
     descriptionId,
     isPending,
+    cancelEl,
     open,
     close,
   })

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -476,14 +476,9 @@ describe('alertDialog', () => {
     })
 
     it('should focus the Cancel element when opened with modelValue=true from the start', async () => {
-      const focusMock = vi.fn()
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
 
-      HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
-        const cancel = this.querySelector('button[type="button"]') as HTMLElement | null
-        if (cancel) cancel.focus = focusMock
-      })
-
-      mountWithStack(AlertDialog.Root, {
+      const wrapper = mountWithStack(AlertDialog.Root, {
         props: { modelValue: true },
         attachTo: document.body,
         slots: {
@@ -494,20 +489,23 @@ describe('alertDialog', () => {
       })
 
       await nextTick()
-      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+
+      const cancel = wrapper.findComponent(AlertDialog.Cancel as any)
+      expect(focusSpy).toHaveBeenCalledWith()
+      expect(cancel.element.tagName).toBe('BUTTON')
+      wrapper.unmount()
     })
 
     it('should not throw when opened without a Cancel element', async () => {
-      expect(async () => {
-        const wrapper = mountWithStack(AlertDialog.Root, {
-          props: { modelValue: true },
-          slots: {
-            default: () => h(AlertDialog.Content, {}, () => 'No cancel here'),
-          },
-        })
-        await nextTick()
-        wrapper.unmount()
-      }).not.toThrow()
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { modelValue: true },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => 'No cancel here'),
+        },
+      })
+      await nextTick()
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+      wrapper.unmount()
     })
   })
 

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -444,6 +444,71 @@ describe('alertDialog', () => {
       expect(custom.element.parentElement?.tagName).not.toBe('DIALOG')
       expect(wrapper.findAll('[role="alertdialog"]')).toHaveLength(1)
     })
+
+    it('should focus the Cancel element when dialog opens', async () => {
+      const isOpen = ref(false)
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: {
+          'modelValue': isOpen.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            isOpen.value = v as boolean
+          },
+        },
+        attachTo: document.body,
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Cancel, {}, () => 'Cancel'),
+          ]),
+        },
+      })
+
+      await nextTick()
+
+      const cancel = wrapper.findComponent(AlertDialog.Cancel as any)
+      const focusSpy = vi.spyOn(cancel.element as HTMLElement, 'focus')
+
+      await wrapper.setProps({ modelValue: true })
+      await nextTick()
+
+      expect(focusSpy).toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('should focus the Cancel element when opened with modelValue=true from the start', async () => {
+      const focusMock = vi.fn()
+
+      HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+        const cancel = this.querySelector('button[type="button"]') as HTMLElement | null
+        if (cancel) cancel.focus = focusMock
+      })
+
+      mountWithStack(AlertDialog.Root, {
+        props: { modelValue: true },
+        attachTo: document.body,
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Cancel, {}, () => 'Cancel'),
+          ]),
+        },
+      })
+
+      await nextTick()
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+    })
+
+    it('should not throw when opened without a Cancel element', async () => {
+      expect(async () => {
+        const wrapper = mountWithStack(AlertDialog.Root, {
+          props: { modelValue: true },
+          slots: {
+            default: () => h(AlertDialog.Content, {}, () => 'No cancel here'),
+          },
+        })
+        await nextTick()
+        wrapper.unmount()
+      }).not.toThrow()
+    })
   })
 
   describe('title', () => {

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -356,6 +356,32 @@ describe('alertDialog', () => {
       expect(cancelEvent.defaultPrevented).toBe(true)
     })
 
+    it('should close and emit close on native close event', async () => {
+      const isOpen = ref(true)
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: {
+          'modelValue': isOpen.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            isOpen.value = v as boolean
+          },
+        },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => 'Content'),
+        },
+      })
+
+      await nextTick()
+
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      await content.trigger('close')
+
+      await nextTick()
+
+      expect(isOpen.value).toBe(false)
+      expect(content.emitted('close')).toBeTruthy()
+    })
+
     it('should close on escape when closeOnEscape=true', async () => {
       const isOpen = ref(true)
 
@@ -501,6 +527,22 @@ describe('alertDialog', () => {
         props: { modelValue: true },
         slots: {
           default: () => h(AlertDialog.Content, {}, () => 'No cancel here'),
+        },
+      })
+      await nextTick()
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('should not throw when Cancel is renderless (no element to focus)', async () => {
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { modelValue: true },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Cancel, { renderless: true }, {
+              default: () => h('span', 'Cancel'),
+            }),
+          ]),
         },
       })
       await nextTick()


### PR DESCRIPTION
## Problem

The AlertDialog docs state that initial focus should land on the Cancel button — the least-destructive action — per the WAI-ARIA Authoring Practices alertdialog pattern. However, `AlertDialogContent` never called `.focus()` on the Cancel element; focus landed wherever the browser defaulted.

Closes #609.

## Solution

1. **`AlertDialogRoot.vue`** — Added `cancelEl: ShallowRef<HTMLElement | null>` to `AlertDialogContext` so child components can share a reference to the Cancel button's DOM element.

2. **`AlertDialogCancel.vue`** — Added `ref="cancel"` on the `Atom` element, then used `onMounted`/`onUnmounted` to register/deregister the underlying DOM element in `context.cancelEl`.

3. **`AlertDialogContent.vue`** — Added `focusCancel()` (`context.cancelEl.value?.focus()`) and called it immediately after `showModal()` in both the `watch` handler and `onMounted`.