### PR TITLE
fix(Dialog,AlertDialog): omit aria-labelledby/describedby when title/description absent

### DIFF
--- a/.changeset/fix-dialog-dangling-aria-idrefs-608.md
+++ b/.changeset/fix-dialog-dangling-aria-idrefs-608.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Dialog,AlertDialog): omit `aria-labelledby`/`aria-describedby` when title/description are absent (#631)
+
+`DialogContent` and `AlertDialogContent` unconditionally emitted `aria-labelledby`/`aria-describedby` pointing at ids even when no `Title`/`Description` sub-component was rendered, producing a dangling IDREF — invalid per the ARIA spec and liable to make screen readers announce empty text or skip the dialog's accessible name. Both attributes are now gated on the referenced sub-component actually being mounted.

--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -48,8 +48,8 @@
       'id': string
       'role': 'alertdialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -168,8 +168,8 @@
       'id': context.id,
       'role': 'alertdialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.titlePresent.value ? context.titleId : undefined,
+      'aria-describedby': context.descriptionPresent.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onMounted, onUnmounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogDescription' })
 
@@ -48,6 +48,13 @@
   } = defineProps<AlertDialogDescriptionProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.descriptionPresent.value = true
+  })
+  onUnmounted(() => {
+    context.descriptionPresent.value = false
+  })
 
   const slotProps = toRef((): AlertDialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
@@ -22,6 +22,8 @@
     id: string
     titleId: string
     descriptionId: string
+    titlePresent: ShallowRef<boolean>
+    descriptionPresent: ShallowRef<boolean>
     isPending: ShallowRef<boolean>
     cancelEl: ShallowRef<HTMLElement | null>
     open: () => void
@@ -79,6 +81,8 @@
 
   const isOpen = defineModel<boolean>({ default: false })
   const isPending = shallowRef(false)
+  const titlePresent = shallowRef(false)
+  const descriptionPresent = shallowRef(false)
   const cancelEl = shallowRef<HTMLElement | null>(null)
 
   const titleId = `${id}-title`
@@ -98,6 +102,8 @@
     id,
     titleId,
     descriptionId,
+    titlePresent,
+    descriptionPresent,
     isPending,
     cancelEl,
     open,

--- a/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onMounted, onUnmounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogTitle' })
 
@@ -48,6 +48,13 @@
   } = defineProps<AlertDialogTitleProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.titlePresent.value = true
+  })
+  onUnmounted(() => {
+    context.titlePresent.value = false
+  })
 
   const slotProps = toRef((): AlertDialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -287,7 +287,7 @@ describe('alertDialog', () => {
       expect(content.attributes('aria-modal')).toBe('true')
     })
 
-    it('should have aria-labelledby pointing to title', () => {
+    it('should have aria-labelledby pointing to title', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -297,11 +297,12 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-labelledby')).toBe('test-alert-title')
     })
 
-    it('should have aria-describedby pointing to description', () => {
+    it('should have aria-describedby pointing to description', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -311,8 +312,63 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-describedby')).toBe('test-alert-description')
+    })
+
+    it('should omit aria-labelledby when no title is rendered', async () => {
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'test-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => 'No title'),
+        },
+      })
+
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+    })
+
+    it('should remove aria-labelledby when title is dynamically removed', async () => {
+      const showTitle = ref(true)
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'test-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            showTitle.value ? h(AlertDialog.Title, {}, () => 'Title') : null,
+          ]),
+        },
+      })
+
+      await nextTick()
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      expect(content.attributes('aria-labelledby')).toBe('test-alert-title')
+
+      showTitle.value = false
+      await nextTick()
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+    })
+
+    it('should remove aria-describedby when description is dynamically removed', async () => {
+      const showDesc = ref(true)
+
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'test-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            showDesc.value ? h(AlertDialog.Description, {}, () => 'Description') : null,
+          ]),
+        },
+      })
+
+      await nextTick()
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      expect(content.attributes('aria-describedby')).toBe('test-alert-description')
+
+      showDesc.value = false
+      await nextTick()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
     })
 
     it('should call showModal when opened', async () => {

--- a/packages/0/src/components/Dialog/DialogContent.vue
+++ b/packages/0/src/components/Dialog/DialogContent.vue
@@ -47,8 +47,8 @@
       'id': string
       'role': 'dialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -156,8 +156,8 @@
       'id': context.id,
       'role': 'dialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.titlePresent.value ? context.titleId : undefined,
+      'aria-describedby': context.descriptionPresent.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/Dialog/DialogDescription.vue
+++ b/packages/0/src/components/Dialog/DialogDescription.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onMounted, onUnmounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogDescription' })
 
@@ -48,6 +48,13 @@
   } = defineProps<DialogDescriptionProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.descriptionPresent.value = true
+  })
+  onUnmounted(() => {
+    context.descriptionPresent.value = false
+  })
 
   const slotProps = toRef((): DialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/DialogRoot.vue
+++ b/packages/0/src/components/Dialog/DialogRoot.vue
@@ -21,6 +21,8 @@
     id: string
     titleId: string
     descriptionId: string
+    titlePresent: ShallowRef<boolean>
+    descriptionPresent: ShallowRef<boolean>
     open: () => void
     close: () => void
   }
@@ -52,7 +54,7 @@
 
   // Utilities
   import { useId } from '#v0/utilities'
-  import { toRef } from 'vue'
+  import { shallowRef, toRef } from 'vue'
 
   defineOptions({ name: 'DialogRoot' })
 
@@ -75,6 +77,8 @@
   const id = _id ?? useId()
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
+  const titlePresent = shallowRef(false)
+  const descriptionPresent = shallowRef(false)
 
   function open () {
     isOpen.value = true
@@ -89,6 +93,8 @@
     id,
     titleId,
     descriptionId,
+    titlePresent,
+    descriptionPresent,
     open,
     close,
   })

--- a/packages/0/src/components/Dialog/DialogTitle.vue
+++ b/packages/0/src/components/Dialog/DialogTitle.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onMounted, onUnmounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogTitle' })
 
@@ -48,6 +48,13 @@
   } = defineProps<DialogTitleProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.titlePresent.value = true
+  })
+  onUnmounted(() => {
+    context.titlePresent.value = false
+  })
 
   const slotProps = toRef((): DialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/index.browser.test.ts
+++ b/packages/0/src/components/Dialog/index.browser.test.ts
@@ -478,7 +478,7 @@ describe('dialog', () => {
         expect(content.attributes('aria-modal')).toBe('true')
       })
 
-      it('should have aria-labelledby pointing to title', () => {
+      it('should have aria-labelledby pointing to title', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -488,11 +488,12 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-labelledby')).toBe('test-dialog-title')
       })
 
-      it('should have aria-describedby pointing to description', () => {
+      it('should have aria-describedby pointing to description', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -502,8 +503,51 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-describedby')).toBe('test-dialog-description')
+      })
+
+      it('should remove aria-labelledby when title is dynamically removed', async () => {
+        const showTitle = ref(true)
+
+        const wrapper = mountWithStack(Dialog.Root, {
+          props: { id: 'test-dialog' },
+          slots: {
+            default: () => h(Dialog.Content, {}, () => [
+              showTitle.value ? h(Dialog.Title, {}, () => 'Title') : null,
+            ]),
+          },
+        })
+
+        await nextTick()
+        const content = wrapper.findComponent(Dialog.Content as any)
+        expect(content.attributes('aria-labelledby')).toBe('test-dialog-title')
+
+        showTitle.value = false
+        await nextTick()
+        expect(content.attributes('aria-labelledby')).toBeUndefined()
+      })
+
+      it('should remove aria-describedby when description is dynamically removed', async () => {
+        const showDesc = ref(true)
+
+        const wrapper = mountWithStack(Dialog.Root, {
+          props: { id: 'test-dialog' },
+          slots: {
+            default: () => h(Dialog.Content, {}, () => [
+              showDesc.value ? h(Dialog.Description, {}, () => 'Description') : null,
+            ]),
+          },
+        })
+
+        await nextTick()
+        const content = wrapper.findComponent(Dialog.Content as any)
+        expect(content.attributes('aria-describedby')).toBe('test-dialog-description')
+
+        showDesc.value = false
+        await nextTick()
+        expect(content.attributes('aria-describedby')).toBeUndefined()
       })
     })
 
@@ -1143,7 +1187,7 @@ describe('dialog', () => {
       expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
     })
 
-    it('should handle missing title and description', () => {
+    it('should omit aria-labelledby and aria-describedby when title and description are absent', () => {
       const wrapper = mountWithStack(Dialog.Root, {
         props: { id: 'no-title-dialog' },
         slots: {
@@ -1152,9 +1196,8 @@ describe('dialog', () => {
       })
 
       const content = wrapper.findComponent(Dialog.Content as any)
-      // Should still have aria attributes pointing to potentially missing elements
-      expect(content.attributes('aria-labelledby')).toBe('no-title-dialog-title')
-      expect(content.attributes('aria-describedby')).toBe('no-title-dialog-description')
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
     })
 
     it('should handle dialog without trigger (controlled)', async () => {


### PR DESCRIPTION
## Problem

`DialogContent` and `AlertDialogContent` unconditionally emit `aria-labelledby={titleId}` and `aria-describedby={descriptionId}` even when `DialogTitle` / `DialogDescription` are not rendered. If the referenced element doesn't exist in the DOM, the IDREF is dangling — invalid per the ARIA spec. Screen readers may announce empty text or skip the dialog's accessible name.

Closes #608.

## Solution

Presence-track `Title` and `Description` sub-components using `ShallowRef<boolean>` in the root context, set/unset via `onMounted`/`onUnmounted`. Content components then gate the ARIA attributes on whether the sub-component is actually present:

```ts
'aria-labelledby': context.titlePresent.value ? context.titleId : undefined,
'aria-describedby': context.descriptionPresent.value ? context.descriptionId : undefined,
```

Files changed: `DialogRoot.vue`, `DialogTitle.vue`, `DialogDescription.vue`, `DialogContent.vue`, `AlertDialogRoot.vue`, `AlertDialogTitle.vue`, `AlertDialogDescription.vue`, `AlertDialogContent.vue`.