### PR TITLE
fix(Button,Pagination): activate non-native as-div/span elements on Enter/Space

### DIFF
--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -110,6 +110,7 @@
       'data-selected': true | undefined
       'data-solo': true | undefined
       'onClick': (() => void) | undefined
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 
@@ -187,6 +188,13 @@
     ticket.toggle()
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+
   onBeforeUnmount(() => {
     timer.stop()
     ticket?.unregister()
@@ -223,6 +231,7 @@
     'data-selected': group && isSelected.value ? true : undefined,
     'data-solo': isSolo.value ? true : undefined,
     'onClick': ticket ? onClick : undefined,
+    'onKeydown': as === 'button' ? undefined : onKeydown,
   }))
 
   const slotProps = toRef((): ButtonRootSlotProps => ({

--- a/packages/0/src/components/Button/index.browser.test.ts
+++ b/packages/0/src/components/Button/index.browser.test.ts
@@ -388,6 +388,93 @@ describe('button', () => {
         expect(props().isSelected).toBe(false)
       })
     })
+
+    describe('keyboard activation for non-native elements', () => {
+      it('should expose onKeydown in slot attrs when as is non-button', () => {
+        const { props } = mountButton({ props: { as: 'div' } })
+        expect(typeof props().attrs.onKeydown).toBe('function')
+      })
+
+      it('should not expose onKeydown in slot attrs when as is button', () => {
+        const { props } = mountButton()
+        expect(props().attrs.onKeydown).toBeUndefined()
+      })
+
+      it('should toggle selection on Enter key for non-native element in a group', async () => {
+        const model = ref<string | undefined>(undefined)
+        const wrapper = mount(Button.Group, {
+          props: {
+            'as': 'div',
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as string
+            },
+          },
+          slots: {
+            default: () => [
+              h(Button.Root as any, { value: 'bold', as: 'div' }, { default: (p: any) => h('div', p.attrs, 'Bold') }),
+            ],
+          },
+        })
+
+        const btn = wrapper.find('div[role="button"]')
+        await btn.trigger('keydown', { key: 'Enter' })
+        await nextTick()
+        expect(model.value).toBe('bold')
+      })
+
+      it('should prevent default on Enter key for non-native element', async () => {
+        let prevented = false
+        const wrapper = mount(Button.Root, {
+          props: { as: 'div' },
+          slots: {
+            default: (props: any) => h('div', {
+              onKeydown: (e: KeyboardEvent) => {
+                props.attrs.onKeydown(e)
+              },
+            }, 'Label'),
+          },
+        })
+
+        const div = wrapper.find('div')
+        const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+        Object.defineProperty(event, 'preventDefault', {
+          value: () => {
+            prevented = true
+          },
+          writable: false,
+        })
+        div.element.dispatchEvent(event)
+        await nextTick()
+        expect(prevented).toBe(true)
+      })
+
+      it('should prevent default on Space key for non-native element', async () => {
+        let prevented = false
+        const wrapper = mount(Button.Root, {
+          props: { as: 'div' },
+          slots: {
+            default: (props: any) => h('div', {
+              onKeydown: (e: KeyboardEvent) => {
+                props.attrs.onKeydown(e)
+              },
+            }, 'Label'),
+          },
+        })
+
+        const div = wrapper.find('div')
+        const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+        Object.defineProperty(event, 'preventDefault', {
+          value: () => {
+            prevented = true
+          },
+          writable: false,
+        })
+        div.element.dispatchEvent(event)
+        await nextTick()
+        expect(prevented).toBe(true)
+      })
+    })
   })
 
   describe('loading/content visibility', () => {

--- a/packages/0/src/components/Pagination/PaginationItem.vue
+++ b/packages/0/src/components/Pagination/PaginationItem.vue
@@ -57,6 +57,7 @@
       'tabindex': number
       'type': 'button' | undefined
       'onClick': () => void
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 
@@ -104,6 +105,13 @@
     pagination.select(value)
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      select()
+    }
+  }
+
   const slotProps = toRef((): PaginationItemSlotProps => ({
     page: value,
     isSelected: isSelected.value,
@@ -119,6 +127,7 @@
       'tabindex': disabled ? -1 : 0,
       'type': as === 'button' ? 'button' : undefined,
       'onClick': select,
+      'onKeydown': as === 'button' ? undefined : onKeydown,
     },
   }))
 

--- a/packages/0/src/components/Pagination/index.browser.test.ts
+++ b/packages/0/src/components/Pagination/index.browser.test.ts
@@ -509,6 +509,120 @@ describe('pagination', () => {
         expect(page.value).toBe(1)
       })
     })
+
+    describe('keyboard activation for non-native elements', () => {
+      it('should expose onKeydown in slot attrs when as is non-button', async () => {
+        let itemProps: any
+
+        mount(Pagination.Root, {
+          props: { size: 100, renderless: true },
+          slots: {
+            default: () =>
+              h(Pagination.Item, { value: 1, as: 'div' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Page 1')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+        expect(typeof itemProps.attrs.onKeydown).toBe('function')
+      })
+
+      it('should not expose onKeydown in slot attrs when as is button', async () => {
+        let itemProps: any
+
+        mount(Pagination.Root, {
+          props: { size: 100, renderless: true },
+          slots: {
+            default: () =>
+              h(Pagination.Item, { value: 1 }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('button', 'Page 1')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+        expect(itemProps.attrs.onKeydown).toBeUndefined()
+      })
+
+      it('should prevent default and navigate on Enter key for non-native element', async () => {
+        const page = ref(1)
+        let itemProps: any
+
+        mount(Pagination.Root, {
+          props: {
+            'size': 100,
+            'renderless': true,
+            'modelValue': page.value,
+            'onUpdate:modelValue': (v: number) => {
+              page.value = v
+            },
+          },
+          slots: {
+            default: () =>
+              h(Pagination.Item, { value: 3, as: 'div' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Page 3')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+        let prevented = false
+        const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+        Object.defineProperty(event, 'preventDefault', { value: () => {
+          prevented = true
+        } })
+        itemProps.attrs.onKeydown(event)
+        await nextTick()
+        expect(prevented).toBe(true)
+        expect(page.value).toBe(3)
+      })
+
+      it('should prevent default and navigate on Space key for non-native element', async () => {
+        const page = ref(1)
+        let itemProps: any
+
+        mount(Pagination.Root, {
+          props: {
+            'size': 100,
+            'renderless': true,
+            'modelValue': page.value,
+            'onUpdate:modelValue': (v: number) => {
+              page.value = v
+            },
+          },
+          slots: {
+            default: () =>
+              h(Pagination.Item, { value: 3, as: 'div' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Page 3')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+        let prevented = false
+        const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+        Object.defineProperty(event, 'preventDefault', { value: () => {
+          prevented = true
+        } })
+        itemProps.attrs.onKeydown(event)
+        await nextTick()
+        expect(prevented).toBe(true)
+        expect(page.value).toBe(3)
+      })
+    })
   })
 
   describe('first', () => {


### PR DESCRIPTION
## Problem

`ButtonRoot` and `PaginationItem` render with `role="button"` and `tabindex="0"` when used as non-native elements (`as="div"`, `as="span"`), but have no `onKeydown` handler. Native `<button>` activates on Enter/Space automatically; `<div role="button">` does not. Keyboard-only users can focus these elements but cannot activate them.

Closes #616.

## Solution

Added an `onKeydown` handler to each component that fires `onClick()`/`select()` on `Enter` or `Space`. The handler is only wired when `as !== 'button'` — native buttons keep their default behavior untouched.

```ts
function onKeydown (e: KeyboardEvent) {
  if (e.key === 'Enter' || e.key === ' ') {
    e.preventDefault()
    onClick()
  }
}
// in attrs:
'onKeydown': as === 'button' ? undefined : onKeydown,
```

Note: `ToggleRoot` already had keyboard handling and was not changed.