### PR TITLE
fix(Group,Selection,Single,Step): add missing ARIA role alongside aria-selected

### DIFF
--- a/.changeset/provider-items-aria-contract-613.md
+++ b/.changeset/provider-items-aria-contract-613.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Group,Selection,Single,Step): complete the provider Item ARIA contract (#613)
+
+`aria-selected` is only valid on roles like `option` and `tab`, so the state the provider Items emitted was ignored by assistive technology. SelectionItem and SingleItem now emit `role="option"`, StepItem emits `role="tab"`, and all four Item families (including GroupItem's existing `role="checkbox"`) ship `tabindex` plus Enter/Space (Space for checkbox) keyboard activation so the bound element is operable without consumer completion.

--- a/packages/0/src/components/Group/GroupItem.vue
+++ b/packages/0/src/components/Group/GroupItem.vue
@@ -55,12 +55,14 @@
     /** Attributes to bind to the item element */
     attrs: {
       'role': 'checkbox'
+      'tabindex': 0 | -1
       'aria-checked': boolean | 'mixed'
       'aria-disabled': boolean
       'data-selected': true | undefined
       'data-disabled': true | undefined
       'data-mixed': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -99,6 +101,14 @@
     ticket.toggle()
   }
 
+  // role=checkbox implies an interactive element, so keyboard users need
+  // parity with click — Space toggles per the WAI-ARIA APG checkbox pattern.
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key !== ' ') return
+    e.preventDefault()
+    onClick()
+  }
+
   onBeforeUnmount(() => {
     group.unregister(ticket.id)
   })
@@ -117,12 +127,14 @@
     unmix: ticket.unmix,
     attrs: {
       'role': 'checkbox',
+      'tabindex': toValue(isDisabled) ? -1 : 0,
       'aria-checked': toValue(ticket.isMixed) ? 'mixed' : toValue(ticket.isSelected),
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
       'data-mixed': toValue(ticket.isMixed) || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Group/index.browser.test.ts
+++ b/packages/0/src/components/Group/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Group } from './index'
@@ -952,6 +952,102 @@ describe('group', () => {
         await nextTick()
 
         expect(itemProps.attrs['data-mixed']).toBe(true)
+      })
+    })
+
+    describe('tabindex', () => {
+      it('should set tabindex="0" for enabled item', async () => {
+        let itemProps: any
+
+        mount(Group.Root, {
+          slots: {
+            default: () =>
+              h(Group.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(0)
+      })
+
+      it('should set tabindex="-1" for disabled item', async () => {
+        let itemProps: any
+
+        mount(Group.Root, {
+          slots: {
+            default: () =>
+              h(Group.Item as any, { value: 'item-1', disabled: true }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(-1)
+      })
+    })
+
+    describe('keyboard activation', () => {
+      it('should toggle selection on Space and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Group.Root, {
+          slots: {
+            default: () =>
+              h(Group.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: ' ', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should not activate on unrelated keys', async () => {
+        let itemProps: any
+
+        mount(Group.Root, {
+          slots: {
+            default: () =>
+              h(Group.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'Enter', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).not.toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(false)
       })
     })
   })

--- a/packages/0/src/components/Selection/SelectionItem.vue
+++ b/packages/0/src/components/Selection/SelectionItem.vue
@@ -45,11 +45,14 @@
     toggle: () => void
     /** Attributes to bind to the item element */
     attrs: {
+      'role': 'option'
+      'tabindex': 0 | -1
       'aria-selected': boolean
       'aria-disabled': boolean
       'data-selected': true | undefined
       'data-disabled': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -87,6 +90,14 @@
     ticket.toggle()
   }
 
+  // aria-selected implies an interactive element, so keyboard users need
+  // parity with click — Enter/Space toggle per the WAI-ARIA APG.
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    e.preventDefault()
+    onClick()
+  }
+
   onBeforeUnmount(() => {
     selection.unregister(ticket.id)
   })
@@ -101,11 +112,14 @@
     unselect: ticket.unselect,
     toggle: ticket.toggle,
     attrs: {
+      'role': 'option',
+      'tabindex': toValue(isDisabled) ? -1 : 0,
       'aria-selected': toValue(ticket.isSelected),
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Selection/index.browser.test.ts
+++ b/packages/0/src/components/Selection/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Selection } from './index'
@@ -582,6 +582,149 @@ describe('selection', () => {
         await nextTick()
 
         expect(itemProps.attrs['data-disabled']).toBe(true)
+      })
+    })
+
+    describe('role and tabindex', () => {
+      it('should expose role="option" in attrs', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.role).toBe('option')
+      })
+
+      it('should set tabindex="0" for enabled item', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(0)
+      })
+
+      it('should set tabindex="-1" for disabled item', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1', disabled: true }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(-1)
+      })
+    })
+
+    describe('keyboard activation', () => {
+      it('should toggle selection on Enter and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'Enter', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should toggle selection on Space and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: ' ', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should not activate on unrelated keys', async () => {
+        let itemProps: any
+
+        mount(Selection.Root, {
+          slots: {
+            default: () =>
+              h(Selection.Item as any, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'ArrowDown', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).not.toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(false)
       })
     })
   })

--- a/packages/0/src/components/Single/SingleItem.vue
+++ b/packages/0/src/components/Single/SingleItem.vue
@@ -45,11 +45,14 @@
     toggle: () => void
     /** Attributes to bind to the item element */
     attrs: {
+      'role': 'option'
+      'tabindex': 0 | -1
       'aria-selected': boolean
       'aria-disabled': boolean
       'data-selected': true | undefined
       'data-disabled': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -87,6 +90,14 @@
     ticket.toggle()
   }
 
+  // aria-selected implies an interactive element, so keyboard users need
+  // parity with click — Enter/Space toggle per the WAI-ARIA APG.
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    e.preventDefault()
+    onClick()
+  }
+
   onBeforeUnmount(() => {
     single.unregister(ticket.id)
   })
@@ -101,11 +112,14 @@
     unselect: ticket.unselect,
     toggle: ticket.toggle,
     attrs: {
+      'role': 'option',
+      'tabindex': toValue(isDisabled) ? -1 : 0,
       'aria-selected': toValue(ticket.isSelected),
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Single/index.browser.test.ts
+++ b/packages/0/src/components/Single/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Single } from './index'
@@ -459,6 +459,149 @@ describe('single', () => {
         await nextTick()
 
         expect(itemProps.attrs['data-disabled']).toBe(true)
+      })
+    })
+
+    describe('role and tabindex', () => {
+      it('should expose role="option" in attrs', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.role).toBe('option')
+      })
+
+      it('should set tabindex="0" for enabled item', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(0)
+      })
+
+      it('should set tabindex="-1" for disabled item', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1', disabled: true }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(-1)
+      })
+    })
+
+    describe('keyboard activation', () => {
+      it('should toggle selection on Enter and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'Enter', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should toggle selection on Space and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: ' ', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should not activate on unrelated keys', async () => {
+        let itemProps: any
+
+        mount(Single.Root, {
+          slots: {
+            default: () =>
+              h(Single.Item, { value: 'item-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'ArrowDown', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).not.toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(false)
       })
     })
   })

--- a/packages/0/src/components/Step/StepItem.vue
+++ b/packages/0/src/components/Step/StepItem.vue
@@ -45,11 +45,14 @@
     toggle: () => void
     /** Attributes to bind to the item element */
     attrs: {
+      'role': 'tab'
+      'tabindex': 0 | -1
       'aria-selected': boolean
       'aria-disabled': boolean
       'data-selected': true | undefined
       'data-disabled': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -87,6 +90,14 @@
     ticket.toggle()
   }
 
+  // aria-selected implies an interactive element, so keyboard users need
+  // parity with click — Enter/Space activate per the WAI-ARIA APG.
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    e.preventDefault()
+    onClick()
+  }
+
   onBeforeUnmount(() => {
     step.unregister(ticket.id)
   })
@@ -101,11 +112,14 @@
     unselect: ticket.unselect,
     toggle: ticket.toggle,
     attrs: {
+      'role': 'tab',
+      'tabindex': toValue(isDisabled) ? -1 : 0,
       'aria-selected': toValue(ticket.isSelected),
       'aria-disabled': toValue(isDisabled),
       'data-selected': toValue(ticket.isSelected) || undefined,
       'data-disabled': toValue(isDisabled) || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Step/index.browser.test.ts
+++ b/packages/0/src/components/Step/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Step } from './index'
@@ -684,6 +684,149 @@ describe('step', () => {
         await nextTick()
 
         expect(itemProps.attrs['data-disabled']).toBe(true)
+      })
+    })
+
+    describe('role and tabindex', () => {
+      it('should expose role="tab" in attrs', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.role).toBe('tab')
+      })
+
+      it('should set tabindex="0" for enabled item', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(0)
+      })
+
+      it('should set tabindex="-1" for disabled item', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1', disabled: true }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.attrs.tabindex).toBe(-1)
+      })
+    })
+
+    describe('keyboard activation', () => {
+      it('should activate on Enter and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'Enter', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should activate on Space and call preventDefault', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        expect(itemProps.isSelected).toBe(false)
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: ' ', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(true)
+      })
+
+      it('should not activate on unrelated keys', async () => {
+        let itemProps: any
+
+        mount(Step.Root, {
+          slots: {
+            default: () =>
+              h(Step.Item as any, { value: 'step-1' }, {
+                default: (props: any) => {
+                  itemProps = props
+                  return h('div', 'Item')
+                },
+              }),
+          },
+        })
+
+        await nextTick()
+
+        const preventDefault = vi.fn()
+        itemProps.attrs.onKeydown({ key: 'ArrowDown', preventDefault })
+        await nextTick()
+
+        expect(preventDefault).not.toHaveBeenCalled()
+        expect(itemProps.isSelected).toBe(false)
       })
     })
   })


### PR DESCRIPTION
## Description

From the #543 WS4 audit (#613): the provider Item components emitted `aria-selected` with no ARIA role. Per the ARIA spec, `aria-selected` is only valid on roles like `option`, `tab`, `row`, `gridcell`, and `treeitem` — without one, assistive technology ignores the state entirely. All four Item families also bound `onClick` with no `tabindex`/`onKeydown`, so keyboard users could not operate them unless the consumer supplied the missing half.

This completes the contract where the role is knowable (option (a) from the issue):

- **SelectionItem / SingleItem** — now emit `role="option"`, making the existing `aria-selected` valid, plus `tabindex` and Enter/Space activation.
- **StepItem** — now emits `role="tab"`, plus `tabindex` and Enter/Space activation.
- **GroupItem** — role was already correct (`checkbox` + `aria-checked`); adds the missing `tabindex` and Space activation per the APG checkbox pattern.

Keyboard activation routes through the same guarded `onClick` handler, so disabled items stay inert and `tabindex` is `-1` while disabled. All changes are additive to the slot-prop `attrs` contract; existing tests pass unchanged (115 tests across the four families).

Closes #613

## Checklist

- [x] Lint passes on changed files
- [x] `vue-tsc` typecheck passes
- [x] Browser tests for Group/Selection/Single/Step pass (115/115)
- [x] Changeset added