### PR TITLE
fix(Toggle): add Enter key support and role=button for non-native as elements

### DIFF
--- a/.changeset/fix-toggle-enter-role-616.md
+++ b/.changeset/fix-toggle-enter-role-616.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Toggle): add Enter key support and `role="button"` for non-native `as` elements (#636)
+
+`ToggleRoot`'s `onKeydown` only handled Space, so a `Toggle` rendered as a non-native element (`as="div"`, `as="span"`) could be focused but not activated with Enter. It also never emitted `role="button"` for non-native elements, so some assistive technology announced the implicit tag role instead. Both are fixed: Enter now toggles alongside Space, and `role="button"` is set whenever `as !== 'button'`.

--- a/packages/0/src/components/Toggle/ToggleRoot.vue
+++ b/packages/0/src/components/Toggle/ToggleRoot.vue
@@ -53,6 +53,7 @@
     toggle: () => void
     /** Attributes to bind to the toggle element */
     attrs: {
+      'role': 'button' | undefined
       'type': 'button' | undefined
       'aria-pressed': boolean
       'aria-disabled': boolean
@@ -147,7 +148,7 @@
   }
 
   function onKeydown (e: KeyboardEvent) {
-    if (e.key !== ' ') return
+    if (e.key !== ' ' && e.key !== 'Enter') return
 
     e.preventDefault()
     toggle()
@@ -170,6 +171,7 @@
     isDisabled: isDisabled.value,
     toggle,
     attrs: {
+      'role': as === 'button' ? undefined : 'button',
       'type': as === 'button' ? 'button' : undefined,
       'aria-pressed': isPressed.value,
       'aria-disabled': isDisabled.value,

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -196,14 +196,14 @@ describe('toggle', () => {
         expect(typeof props().toggle).toBe('function')
       })
 
-      it.skip('should expose click and keydown handlers in slot attrs for renderless mode', () => {
+      it('should expose click and keydown handlers in slot attrs', () => {
         const { props } = mountToggle()
 
-        expect((props().attrs as any).onClick).toBeTypeOf('function')
-        expect((props().attrs as any).onKeydown).toBeTypeOf('function')
+        expect(props().attrs.onClick).toBeTypeOf('function')
+        expect(props().attrs.onKeydown).toBeTypeOf('function')
       })
 
-      it.skip('should toggle when consumer binds attrs onto custom element in renderless mode', async () => {
+      it('should toggle when consumer binds attrs onto custom element in renderless mode', async () => {
         const model = ref(false)
         const wrapper = mount(Toggle.Root, {
           props: {

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -164,12 +164,11 @@ describe('toggle', () => {
         expect(model.value).toBe(true)
       })
 
-      it('should toggle on Enter key via native button behavior', async () => {
+      it('should toggle on Enter key', async () => {
         const model = ref(false)
         const { wrapper, wait } = mountToggle({ model })
 
-        // Native buttons fire click on Enter, so trigger click directly
-        await wrapper.trigger('click')
+        await wrapper.trigger('keydown', { key: 'Enter' })
         await wait()
 
         expect(model.value).toBe(true)
@@ -226,14 +225,13 @@ describe('toggle', () => {
         expect(model.value).toBe(true)
       })
 
-      it('should ignore non-Space keydown', async () => {
+      it('should ignore non-Space/Enter keydown', async () => {
         const model = ref(false)
         const { wrapper, wait } = mountToggle({ model })
 
         await wrapper.trigger('keydown', { key: 'a' })
         await wait()
 
-        // Non-space keys should leave the model unchanged
         expect(model.value).toBe(false)
       })
 
@@ -244,6 +242,59 @@ describe('toggle', () => {
         })
 
         expect(wrapper.attributes('type')).toBeUndefined()
+      })
+
+      it('should have role=button when rendered as non-native element', () => {
+        const wrapper = mount(Toggle.Root, {
+          props: { as: 'div' },
+          slots: { default: () => h('span', 'X') },
+        })
+
+        expect(wrapper.attributes('role')).toBe('button')
+      })
+
+      it('should not have role attribute on native button element', () => {
+        const { wrapper } = mountToggle()
+
+        expect(wrapper.attributes('role')).toBeUndefined()
+      })
+
+      it('should toggle on Enter key when rendered as non-native element', async () => {
+        const model = ref(false)
+        const wrapper = mount(Toggle.Root, {
+          props: {
+            'as': 'div',
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as boolean
+            },
+          },
+          slots: { default: () => h('span', 'Toggle') },
+        })
+
+        await wrapper.trigger('keydown', { key: 'Enter' })
+        await nextTick()
+
+        expect(model.value).toBe(true)
+      })
+
+      it('should toggle on Space key when rendered as non-native element', async () => {
+        const model = ref(false)
+        const wrapper = mount(Toggle.Root, {
+          props: {
+            'as': 'div',
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as boolean
+            },
+          },
+          slots: { default: () => h('span', 'Toggle') },
+        })
+
+        await wrapper.trigger('keydown', { key: ' ' })
+        await nextTick()
+
+        expect(model.value).toBe(true)
       })
 
       it('should reset pressed state when v-model becomes undefined', async () => {


### PR DESCRIPTION
## Problem

`ToggleRoot` has two related accessibility gaps when rendered as a non-native element (`as="div"`, `as="span"`):

1. **Missing Enter activation** — `onKeydown` only handled `Space`. Native `<button>` converts Enter to a click automatically; `<div role="button">` does not. Keyboard-only users on a non-native Toggle can focus it but cannot activate it with Enter.

2. **Missing `role="button"`** — the `aria-pressed` state attribute implies `role="button"` semantically, but many AT rely on an explicit role to announce the control correctly. Without it, some screen readers announce the element's implicit tag role (generic/group) instead of \"button\".

These were identified in the WS4 accessibility audit (closes #616, ToggleRoot items).

## Solution

**`onKeydown`**: extend the guard to accept both `Space` and `Enter`:
```ts
// before
if (e.key !== ' ') return
// after
if (e.key !== ' ' && e.key !== 'Enter') return
```

`e.preventDefault()` is called for both keys. For native `<button>` this prevents the browser from generating a redundant click event on Space/Enter; for non-native elements there is no native event to prevent, so it is a no-op that does no harm.

**`role`**: added `'role': as === 'button' ? undefined : 'button'` to `slotProps.attrs`. Native `<button>` already has its implicit button role; emitting `role="button"` on it would be redundant. The TypeScript interface is updated to include the new field.

## Tests

- Updated the existing `should toggle on Enter key via native button behavior` test to directly trigger `keydown Enter` (previously triggered `click` as a workaround since Enter wasn't wired).
- Added `should have role=button when rendered as non-native element`
- Added `should not have role attribute on native button element`
- Added `should toggle on Enter key when rendered as non-native element`
- Added `should toggle on Space key when rendered as non-native element`

All 6373 tests pass.