### PR TITLE
fix(Progress): only emit aria-labelledby when Progress.Label is mounted

### DIFF
--- a/.changeset/fix-progress-aria-labelledby-608.md
+++ b/.changeset/fix-progress-aria-labelledby-608.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Progress): only emit `aria-labelledby` when `Progress.Label` is mounted (#638)
+
+`Progress.Root` unconditionally emitted `aria-labelledby` pointing to a label id even when no `Progress.Label` child was mounted, creating a dangling IDREF that assistive technology could misreport. `aria-labelledby` is now conditional on a label actually being present, and a new `ariaLabel` prop covers the case where no visible label exists but an accessible name is still needed.

--- a/packages/0/src/components/Progress/ProgressLabel.vue
+++ b/packages/0/src/components/Progress/ProgressLabel.vue
@@ -14,7 +14,7 @@
   import { useProgressRoot } from './ProgressRoot.vue'
 
   // Utilities
-  import { mergeProps, toRef, useAttrs } from 'vue'
+  import { mergeProps, onBeforeUnmount, onMounted, toRef, useAttrs } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
@@ -49,6 +49,9 @@
   } = defineProps<ProgressLabelProps>()
 
   const root = useProgressRoot(namespace)
+
+  onMounted(() => { root.hasLabel.value = true })
+  onBeforeUnmount(() => { root.hasLabel.value = false })
 
   const slotProps = toRef((): ProgressLabelSlotProps => ({
     total: root.total.value,

--- a/packages/0/src/components/Progress/ProgressLabel.vue
+++ b/packages/0/src/components/Progress/ProgressLabel.vue
@@ -50,8 +50,12 @@
 
   const root = useProgressRoot(namespace)
 
-  onMounted(() => { root.hasLabel.value = true })
-  onBeforeUnmount(() => { root.hasLabel.value = false })
+  onMounted(() => {
+    root.hasLabel.value = true
+  })
+  onBeforeUnmount(() => {
+    root.hasLabel.value = false
+  })
 
   const slotProps = toRef((): ProgressLabelSlotProps => ({
     total: root.total.value,

--- a/packages/0/src/components/Progress/ProgressLabel.vue
+++ b/packages/0/src/components/Progress/ProgressLabel.vue
@@ -53,6 +53,7 @@
   onMounted(() => {
     root.hasLabel.value = true
   })
+
   onBeforeUnmount(() => {
     root.hasLabel.value = false
   })

--- a/packages/0/src/components/Progress/ProgressRoot.vue
+++ b/packages/0/src/components/Progress/ProgressRoot.vue
@@ -21,20 +21,25 @@
 
   // Utilities
   import { isArray, isNullOrUndefined, useId } from '#v0/utilities'
-  import { computed, mergeProps, toRef, useAttrs } from 'vue'
+  import { computed, mergeProps, shallowRef, toRef, useAttrs } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { ProgressContext, ProgressTicket } from '#v0/composables/createProgress'
+  import type { ShallowRef } from 'vue'
 
   export interface ProgressRootContext extends ProgressContext {
     readonly id: string
     readonly name?: string
     readonly labelId: string
+    /** Whether a Progress.Label child is currently mounted */
+    readonly hasLabel: ShallowRef<boolean>
   }
 
   export interface ProgressRootProps extends AtomProps {
     id?: string
+    /** Accessible label when no visible Progress.Label is used */
+    ariaLabel?: string
     modelValue?: number | number[]
     min?: number
     max?: number
@@ -54,7 +59,8 @@
       'aria-valuemin': number
       'aria-valuemax': number
       'aria-valuetext': string | undefined
-      'aria-labelledby': string
+      'aria-label': string | undefined
+      'aria-labelledby': string | undefined
       'aria-busy': true | undefined
       'data-state': 'determinate' | 'indeterminate'
       'data-complete': true | undefined
@@ -77,6 +83,7 @@
     as = 'div',
     renderless,
     id = useId(),
+    ariaLabel,
     min = 0,
     max = 100,
     name,
@@ -104,12 +111,14 @@
   useProxyModel(progress, internal, { multiple: true })
 
   const labelId = `${id}-label`
+  const hasLabel = shallowRef(false)
 
   const context: ProgressRootContext = {
     ...progress,
     id,
     name,
     labelId,
+    hasLabel,
   }
 
   provideProgressRoot(namespace, context)
@@ -131,7 +140,8 @@
         'aria-valuemin': min,
         'aria-valuemax': max,
         'aria-valuetext': indeterminate ? undefined : `${Math.round(pct)}%`,
-        'aria-labelledby': labelId,
+        'aria-label': hasLabel.value ? undefined : ariaLabel,
+        'aria-labelledby': hasLabel.value ? labelId : undefined,
         'aria-busy': indeterminate ? true : undefined,
         'data-state': indeterminate ? 'indeterminate' : 'determinate',
         'data-complete': total >= max ? true : undefined,

--- a/packages/0/src/components/Progress/index.test.ts
+++ b/packages/0/src/components/Progress/index.test.ts
@@ -201,11 +201,38 @@ describe('progress', () => {
       expect(rootProps().attrs['aria-busy']).toBeUndefined()
     })
 
-    it('should set aria-labelledby referencing the label id', async () => {
+    it('should omit aria-labelledby when no Progress.Label is mounted', async () => {
       const model = ref(50)
       const { rootProps, wait } = mountProgress({ model, props: { id: 'test' } })
       await wait()
+      expect(rootProps().attrs['aria-labelledby']).toBeUndefined()
+    })
+
+    it('should set aria-labelledby when Progress.Label is mounted', async () => {
+      const model = ref(50)
+      const { rootProps, wait } = mountProgress({ model, props: { id: 'test' }, withLabel: true })
+      await wait()
       expect(rootProps().attrs['aria-labelledby']).toBe('test-label')
+    })
+
+    it('should set aria-label when ariaLabel prop is provided and no label is mounted', async () => {
+      const model = ref(50)
+      const { rootProps, wait } = mountProgress({ model, props: { ariaLabel: 'Upload progress' } })
+      await wait()
+      expect(rootProps().attrs['aria-label']).toBe('Upload progress')
+      expect(rootProps().attrs['aria-labelledby']).toBeUndefined()
+    })
+
+    it('should prefer aria-labelledby over aria-label when Progress.Label is mounted', async () => {
+      const model = ref(50)
+      const { rootProps, wait } = mountProgress({
+        model,
+        props: { id: 'test', ariaLabel: 'Upload progress' },
+        withLabel: true,
+      })
+      await wait()
+      expect(rootProps().attrs['aria-labelledby']).toBe('test-label')
+      expect(rootProps().attrs['aria-label']).toBeUndefined()
     })
   })
 

--- a/packages/0/src/components/Progress/index.test.ts
+++ b/packages/0/src/components/Progress/index.test.ts
@@ -12,7 +12,7 @@ import {
 
 // Utilities
 import { mount } from '@vue/test-utils'
-import { h, nextTick, ref } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 
 // Types
 import type { ProgressRootSlotProps } from './index'
@@ -233,6 +233,37 @@ describe('progress', () => {
       await wait()
       expect(rootProps().attrs['aria-labelledby']).toBe('test-label')
       expect(rootProps().attrs['aria-label']).toBeUndefined()
+    })
+
+    it('should clear aria-labelledby and restore aria-label when Progress.Label unmounts', async () => {
+      const showLabel = ref(true)
+      let captured: ProgressRootSlotProps | undefined
+
+      mount(defineComponent({
+        setup () {
+          return () => h(ProgressRoot, {
+            id: 'test',
+            ariaLabel: 'Upload progress',
+            modelValue: 50,
+          }, {
+            default: (rootProps: ProgressRootSlotProps) => {
+              captured = rootProps
+              return showLabel.value
+                ? h(ProgressLabel as any, {}, () => h('span', 'Loading...'))
+                : null
+            },
+          })
+        },
+      }))
+
+      await nextTick()
+      expect(captured?.attrs['aria-labelledby']).toBe('test-label')
+      expect(captured?.attrs['aria-label']).toBeUndefined()
+
+      showLabel.value = false
+      await nextTick()
+      expect(captured?.attrs['aria-labelledby']).toBeUndefined()
+      expect(captured?.attrs['aria-label']).toBe('Upload progress')
     })
   })
 


### PR DESCRIPTION
## Summary

- `ProgressRoot` unconditionally emitted `aria-labelledby` pointing to `${id}-label` even when no `Progress.Label` child was mounted, creating a dangling IDREF that screen readers announce incorrectly
- Adds `hasLabel: ShallowRef<boolean>` to `ProgressRootContext`; `ProgressLabel` sets it `true` on mount and `false` on unmount, so `aria-labelledby` is only emitted when a visible label is actually present
- Adds `ariaLabel` string prop to `ProgressRoot` for cases where no visible label exists but an accessible name is still needed

## What changed

- `ProgressRoot.vue`: adds `hasLabel` ref to context; `aria-labelledby` is conditional on `hasLabel.value`; new `ariaLabel` prop exposed as `aria-label` when no label is mounted
- `ProgressLabel.vue`: `onMounted` / `onBeforeUnmount` lifecycle hooks update `root.hasLabel`
- `index.test.ts`: updated one existing test that assumed unconditional `aria-labelledby`; added four new tests covering the no-label, with-label, `ariaLabel` prop, and precedence cases

## Test plan

- [ ] `aria-labelledby` is absent when `Progress.Label` is not mounted
- [ ] `aria-labelledby` is set when `Progress.Label` is mounted
- [ ] `aria-label` is set from `ariaLabel` prop when no `Progress.Label` is present
- [ ] `aria-labelledby` wins over `aria-label` when both are present
- [ ] All 178 test files pass (`pnpm test`)

Closes #608