### PR TITLE
fix(Carousel): add onKeydown to Next/Previous for non-native element keyboard activation

### DIFF
--- a/.changeset/fix-carousel-next-prev-keydown.md
+++ b/.changeset/fix-carousel-next-prev-keydown.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Carousel): add `onKeydown` to `Next`/`Previous` for non-native element keyboard activation (#639)
+
+`Carousel.Next` and `Carousel.Previous` only exposed `onClick` in their `attrs` slot props. When rendered with `as="div"` (or any non-button element), browsers do not synthesize click events from Enter or Space, silently breaking keyboard navigation. Both now wire an `onKeydown` handler that calls the existing click logic on Enter/Space, matching the pattern already used by `CarouselIndicator`.

--- a/.changeset/fix-carousel-next-prev-keydown.md
+++ b/.changeset/fix-carousel-next-prev-keydown.md
@@ -4,4 +4,4 @@
 
 fix(Carousel): add `onKeydown` to `Next`/`Previous` for non-native element keyboard activation (#639)
 
-`Carousel.Next` and `Carousel.Previous` only exposed `onClick` in their `attrs` slot props. When rendered with `as="div"` (or any non-button element), browsers do not synthesize click events from Enter or Space, silently breaking keyboard navigation. Both now wire an `onKeydown` handler that calls the existing click logic on Enter/Space, matching the pattern already used by `CarouselIndicator`.
+`Carousel.Next` and `Carousel.Previous` only exposed `onClick` in their `attrs` slot props. When rendered with `as="div"` (or any non-button element), browsers do not synthesize click events from Enter or Space, silently breaking keyboard navigation. Both now wire an `onKeydown` handler that calls the existing click logic on Enter/Space when `as` is not `"button"` — same gate as `PaginationItem`, leaving native buttons to the browser's built-in activation.

--- a/packages/0/src/components/Carousel/CarouselNext.vue
+++ b/packages/0/src/components/Carousel/CarouselNext.vue
@@ -48,6 +48,7 @@
       'data-disabled': true | undefined
       'data-edge': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -90,6 +91,13 @@
     }
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+
   const slotProps = toRef((): CarouselNextSlotProps => ({
     isDisabled: isDisabled.value,
     isAtEdge: isAtEdge.value,
@@ -102,6 +110,7 @@
       'data-disabled': isDisabled.value || undefined,
       'data-edge': isAtEdge.value || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Carousel/CarouselNext.vue
+++ b/packages/0/src/components/Carousel/CarouselNext.vue
@@ -48,7 +48,7 @@
       'data-disabled': true | undefined
       'data-edge': true | undefined
       'onClick': () => void
-      'onKeydown': (e: KeyboardEvent) => void
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 </script>
@@ -110,7 +110,7 @@
       'data-disabled': isDisabled.value || undefined,
       'data-edge': isAtEdge.value || undefined,
       'onClick': onClick,
-      'onKeydown': onKeydown,
+      'onKeydown': as === 'button' ? undefined : onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Carousel/CarouselPrevious.vue
+++ b/packages/0/src/components/Carousel/CarouselPrevious.vue
@@ -48,6 +48,7 @@
       'data-disabled': true | undefined
       'data-edge': true | undefined
       'onClick': () => void
+      'onKeydown': (e: KeyboardEvent) => void
     }
   }
 </script>
@@ -86,6 +87,13 @@
     }
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+
   const slotProps = toRef((): CarouselPreviousSlotProps => ({
     isDisabled: isDisabled.value,
     isAtEdge: isAtEdge.value,
@@ -98,6 +106,7 @@
       'data-disabled': isDisabled.value || undefined,
       'data-edge': isAtEdge.value || undefined,
       'onClick': onClick,
+      'onKeydown': onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Carousel/CarouselPrevious.vue
+++ b/packages/0/src/components/Carousel/CarouselPrevious.vue
@@ -48,7 +48,7 @@
       'data-disabled': true | undefined
       'data-edge': true | undefined
       'onClick': () => void
-      'onKeydown': (e: KeyboardEvent) => void
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 </script>
@@ -106,7 +106,7 @@
       'data-disabled': isDisabled.value || undefined,
       'data-edge': isAtEdge.value || undefined,
       'onClick': onClick,
-      'onKeydown': onKeydown,
+      'onKeydown': as === 'button' ? undefined : onKeydown,
     },
   }))
 </script>

--- a/packages/0/src/components/Carousel/index.test.ts
+++ b/packages/0/src/components/Carousel/index.test.ts
@@ -892,6 +892,45 @@ describe('carousel', () => {
       expect(prevProps.attrs.type).toBeUndefined()
       expect(prevProps.attrs.disabled).toBeUndefined()
     })
+
+    it('should navigate with Enter / Space when rendered as non-button', async () => {
+      const selected = ref<string>('b')
+      let prevProps: any
+
+      mount(Carousel.Root, {
+        props: {
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Carousel.Item as any, { value: 'a' }, { default: () => h('div', 'A') }),
+            h(Carousel.Item as any, { value: 'b' }, { default: () => h('div', 'B') }),
+            h(Carousel.Previous as any, { as: 'div' }, {
+              default: (p: any) => {
+                prevProps = p
+                return h('div', 'Prev')
+              },
+            }),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      const enter = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+      prevProps.attrs.onKeydown(enter)
+      await nextTick()
+      expect(selected.value).toBe('a')
+
+      const space = new KeyboardEvent('keydown', { key: ' ', cancelable: true })
+      prevProps.attrs.onKeydown(space)
+      await nextTick()
+      expect(selected.value).toBe('a')
+      expect(enter.defaultPrevented).toBe(true)
+    })
   })
 
   describe('next button', () => {
@@ -1091,6 +1130,45 @@ describe('carousel', () => {
 
       expect(nextBtnProps.attrs.type).toBeUndefined()
       expect(nextBtnProps.attrs.disabled).toBeUndefined()
+    })
+
+    it('should navigate with Enter / Space when rendered as non-button', async () => {
+      const selected = ref<string>('a')
+      let nextBtnProps: any
+
+      mount(Carousel.Root, {
+        props: {
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Carousel.Item as any, { value: 'a' }, { default: () => h('div', 'A') }),
+            h(Carousel.Item as any, { value: 'b' }, { default: () => h('div', 'B') }),
+            h(Carousel.Next as any, { as: 'div' }, {
+              default: (p: any) => {
+                nextBtnProps = p
+                return h('div', 'Next')
+              },
+            }),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      const enter = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+      nextBtnProps.attrs.onKeydown(enter)
+      await nextTick()
+      expect(selected.value).toBe('b')
+
+      const space = new KeyboardEvent('keydown', { key: ' ', cancelable: true })
+      nextBtnProps.attrs.onKeydown(space)
+      await nextTick()
+      expect(selected.value).toBe('b')
+      expect(enter.defaultPrevented).toBe(true)
     })
   })
 

--- a/packages/0/src/components/Carousel/index.test.ts
+++ b/packages/0/src/components/Carousel/index.test.ts
@@ -744,6 +744,7 @@ describe('carousel', () => {
       expect(typeof prevProps.isAtEdge).toBe('boolean')
       expect(prevProps.attrs['aria-label']).toBeDefined()
       expect(prevProps.attrs.type).toBe('button')
+      expect(prevProps.attrs.onKeydown).toBeUndefined()
     })
 
     it('should be disabled at first slide in non-circular mode', async () => {
@@ -891,6 +892,7 @@ describe('carousel', () => {
 
       expect(prevProps.attrs.type).toBeUndefined()
       expect(prevProps.attrs.disabled).toBeUndefined()
+      expect(typeof prevProps.attrs.onKeydown).toBe('function')
     })
 
     it('should navigate with Enter / Space when rendered as non-button', async () => {
@@ -957,6 +959,7 @@ describe('carousel', () => {
       expect(typeof nextBtnProps.isAtEdge).toBe('boolean')
       expect(nextBtnProps.attrs['aria-label']).toBeDefined()
       expect(nextBtnProps.attrs.type).toBe('button')
+      expect(nextBtnProps.attrs.onKeydown).toBeUndefined()
     })
 
     it('should be disabled at last slide in non-circular mode', async () => {
@@ -1130,6 +1133,7 @@ describe('carousel', () => {
 
       expect(nextBtnProps.attrs.type).toBeUndefined()
       expect(nextBtnProps.attrs.disabled).toBeUndefined()
+      expect(typeof nextBtnProps.attrs.onKeydown).toBe('function')
     })
 
     it('should navigate with Enter / Space when rendered as non-button', async () => {


### PR DESCRIPTION
## Summary

- `Carousel.Next` and `Carousel.Previous` only exposed `onClick` in their `attrs` slot props. When rendered with `as='div'` (or any non-button element), browsers do not synthesize `click` events from Enter or Space keypresses, silently breaking keyboard navigation for users who rely on keyboards or AT
- Adds `onKeydown` handlers to both components that call the existing `onClick` logic when Enter or Space is pressed — the same pattern already used by `CarouselIndicator`
- The `onKeydown` type is added to `CarouselNextSlotProps.attrs` and `CarouselPreviousSlotProps.attrs` so TypeScript consumers know it's available

## What changed

- `CarouselNext.vue`: new `onKeydown` function calling `onClick()` on Enter/Space; exposed in `slotProps.attrs`; type added to `CarouselNextSlotProps`
- `CarouselPrevious.vue`: same changes symmetrically
- `index.test.ts`: two new tests — one for each component — mounting with `as='div'` and asserting Enter/Space trigger slide navigation

## Test plan

- [ ] `Carousel.Next` rendered as `div`: Enter key advances to next slide
- [ ] `Carousel.Previous` rendered as `div`: Enter key moves to previous slide
- [ ] Space key also triggers navigation (and `defaultPrevented`)
- [ ] All 100 Carousel tests pass