### PR TITLE
test(Collapsible): add keyboard toggle tests for non-native activator elements

### DIFF
--- a/.changeset/test-collapsible-non-native-keyboard-toggle.md
+++ b/.changeset/test-collapsible-non-native-keyboard-toggle.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+test(Collapsible): cover keyboard toggle for non-native activator elements (#641)
+
+`CollapsibleActivator` already handles Enter/Space and sets `role="button"` for non-native `as` elements, but no test asserted that a non-native activator actually toggles the collapsible on Enter/Space. Adds two tests covering that gap.

--- a/packages/0/src/components/Collapsible/index.browser.test.ts
+++ b/packages/0/src/components/Collapsible/index.browser.test.ts
@@ -263,6 +263,26 @@ describe('collapsible', () => {
 
       expect(content().hasAttribute('hidden')).toBe(false)
     })
+
+    it('should toggle on Enter when rendered as a div', async () => {
+      const { wrapper, content, wait } = mountCollapsible({ activatorAs: 'div' })
+      await wait()
+
+      await wrapper.get('[role="button"]').trigger('keydown', { key: 'Enter' })
+      await wait()
+
+      expect(content().hasAttribute('hidden')).toBe(false)
+    })
+
+    it('should toggle on Space when rendered as a div', async () => {
+      const { wrapper, content, wait } = mountCollapsible({ activatorAs: 'div' })
+      await wait()
+
+      await wrapper.get('[role="button"]').trigger('keydown', { key: ' ' })
+      await wait()
+
+      expect(content().hasAttribute('hidden')).toBe(false)
+    })
   })
 
   describe('cue', () => {


### PR DESCRIPTION
## Summary

- `CollapsibleActivator` correctly handles Enter/Space in `onKeydown` and sets `role='button'` for non-native elements, but every existing keyboard test uses the default `as='button'` element
- The `non-button activator` describe block already covers `role='button'`/tag/no-type-attribute and a click-based toggle, but nothing verified that a non-native activator actually toggles on Enter/Space
- Adds two tests mounting with `activatorAs: 'div'`: Enter opens, Space opens

## What changed

- `index.browser.test.ts`: two new tests in the existing `non-button activator` block, matching the style already used by the `open via keyboard` block — a real `keydown` DOM event via `@vue/test-utils`, not a captured render-prop handler

## Rebase note

Rebased onto master's post-#655 test layout: `index.test.ts` was consolidated into `index.browser.test.ts` as part of the 1.0 component-spine promotion, and the test style moved from capturing render-prop handlers to triggering real DOM events. Rewrote both new tests in that style rather than reintroducing the old pattern — the `role='button'` coverage I originally added is no longer needed since it already exists on master (`should expose role=button and no native type when rendered as a div`).

## Test plan

- [x] Enter key with `activatorAs: 'div'` toggles collapsible open
- [x] Space key with `activatorAs: 'div'` toggles collapsible open
- [x] All 23 Collapsible tests pass (`pnpm test:run --project v0:browser`)