### PR TITLE
feat(docs): replace native title= attributes with Tooltip component (#495)

### DIFF
--- a/apps/docs/src/components/app/AppAccount.vue
+++ b/apps/docs/src/components/app/AppAccount.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { Avatar, Dialog } from '@vuetify/v0'
+  import { Avatar, Dialog, Tooltip } from '@vuetify/v0'
 
   // Components
   import { Discovery } from '@/components/discovery'
@@ -31,37 +31,51 @@
 </script>
 
 <template>
-  <button
-    v-if="!auth.isAuthenticated"
-    aria-label="Sign in"
-    class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer border-0"
-    title="Sign in"
-    type="button"
-    @click="auth.dialog = true"
-  >
-    <AppIcon icon="account" />
-  </button>
+  <Tooltip.Root v-if="!auth.isAuthenticated" :close-delay="100" :open-delay="500">
+    <Tooltip.Activator
+      aria-label="Sign in"
+      class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer border-0"
+      type="button"
+      @click="auth.dialog = true"
+    >
+      <AppIcon icon="account" />
+    </Tooltip.Activator>
+
+    <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+      Sign in
+    </Tooltip.Content>
+  </Tooltip.Root>
 
   <Discovery.Activator v-else class="inline-flex rounded-full" step="settings">
-    <button
-      aria-label="Account settings"
-      class="inline-flex items-center justify-center rounded-full cursor-pointer border-0 bg-transparent p-0 hover:ring-2 hover:ring-primary/50 transition-all"
-      title="Account settings"
-      type="button"
-      @click="settings.toggle"
-    >
-      <Avatar.Root class="size-6 rounded-full overflow-hidden">
-        <Avatar.Image
-          alt="User avatar"
-          class="size-6 rounded-full object-cover"
-          :src="auth.user?.picture"
-        />
+    <Tooltip.Root :close-delay="100" :open-delay="500">
+      <Tooltip.Activator renderless>
+        <template #default="{ attrs: tooltipAttrs }">
+          <button
+            v-bind="tooltipAttrs"
+            aria-label="Account settings"
+            class="inline-flex items-center justify-center rounded-full cursor-pointer border-0 bg-transparent p-0 hover:ring-2 hover:ring-primary/50 transition-all"
+            type="button"
+            @click="settings.toggle"
+          >
+            <Avatar.Root class="size-6 rounded-full overflow-hidden">
+              <Avatar.Image
+                alt="User avatar"
+                class="size-6 rounded-full object-cover"
+                :src="auth.user?.picture"
+              />
 
-        <Avatar.Fallback class="size-6 rounded-full bg-primary text-on-primary flex items-center justify-center text-xs font-medium">
-          {{ initial }}
-        </Avatar.Fallback>
-      </Avatar.Root>
-    </button>
+              <Avatar.Fallback class="size-6 rounded-full bg-primary text-on-primary flex items-center justify-center text-xs font-medium">
+                {{ initial }}
+              </Avatar.Fallback>
+            </Avatar.Root>
+          </button>
+        </template>
+      </Tooltip.Activator>
+
+      <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+        Account settings
+      </Tooltip.Content>
+    </Tooltip.Root>
   </Discovery.Activator>
 
   <Dialog.Root v-model="auth.dialog">

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -91,7 +91,6 @@
         <button
           aria-label="Search (Ctrl+K)"
           :class="['inline-flex items-center gap-1.5 rounded-full md:border md:border-divider md:pl-1.5 md:pr-1.5 md:py-1.5 hover:border-primary/50 transition-colors', settings.showBgGlass.value ? 'md:bg-glass-surface' : 'md:bg-surface']"
-          title="Search (Ctrl+K)"
           type="button"
           @click="search.focus()"
         >
@@ -117,7 +116,6 @@
         href="https://discord.gg/vuetify"
         rel="noopener noreferrer"
         target="_blank"
-        title="Discord Community"
       >
         <AppIcon class="!opacity-100" icon="discord" />
       </a>
@@ -129,7 +127,6 @@
         href="https://github.com/vuetifyjs/0"
         rel="noopener noreferrer"
         target="_blank"
-        title="GitHub Repository"
       >
         <AppIcon class="!opacity-100" icon="github" />
       </a>

--- a/apps/docs/src/components/app/AppSettings.vue
+++ b/apps/docs/src/components/app/AppSettings.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  // Framework
+  import { Tooltip } from '@vuetify/v0'
+
   // Composables
   import { useSettings } from '@/composables/useSettings'
 
@@ -13,15 +16,20 @@
 </script>
 
 <template>
-  <button
-    aria-label="Open settings"
-    class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
-    title="Settings"
-    type="button"
-    @click="settings.toggle"
-    @focus="preload"
-    @mouseenter="preload"
-  >
-    <AppIcon icon="cog" />
-  </button>
+  <Tooltip.Root :close-delay="100" :open-delay="500">
+    <Tooltip.Activator
+      aria-label="Open settings"
+      class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
+      type="button"
+      @click="settings.toggle"
+      @focus="preload"
+      @mouseenter="preload"
+    >
+      <AppIcon icon="cog" />
+    </Tooltip.Activator>
+
+    <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+      Settings
+    </Tooltip.Content>
+  </Tooltip.Root>
 </template>

--- a/apps/docs/src/components/app/AppSkillFilter.vue
+++ b/apps/docs/src/components/app/AppSkillFilter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { Popover } from '@vuetify/v0'
+  import { Popover, Tooltip } from '@vuetify/v0'
 
   // Composables
   import { useLevelFilterContext } from '@/composables/useLevelFilter'
@@ -20,20 +20,30 @@
 
 <template>
   <Popover.Root v-model="isOpen" class="hidden md:block">
-    <Popover.Activator
-      aria-label="Filter by skill level"
-      class="relative bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
-      title="Filter by skill level"
-    >
-      <AppIcon icon="tune" />
+    <Tooltip.Root :close-delay="100" :open-delay="500">
+      <Tooltip.Activator renderless>
+        <template #default="{ attrs: tooltipAttrs }">
+          <Popover.Activator
+            v-bind="tooltipAttrs"
+            aria-label="Filter by skill level"
+            class="relative bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
+          >
+            <AppIcon icon="tune" />
 
-      <span
-        v-if="levelFilter.selectedLevels.size > 0"
-        class="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-on-primary rounded-full flex items-center justify-center"
-      >
-        {{ levelFilter.selectedLevels.size }}
-      </span>
-    </Popover.Activator>
+            <span
+              v-if="levelFilter.selectedLevels.size > 0"
+              class="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-on-primary rounded-full flex items-center justify-center"
+            >
+              {{ levelFilter.selectedLevels.size }}
+            </span>
+          </Popover.Activator>
+        </template>
+      </Tooltip.Activator>
+
+      <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+        Filter by skill level
+      </Tooltip.Content>
+    </Tooltip.Root>
 
     <Popover.Content class="p-2 rounded-lg bg-surface border border-divider shadow-lg min-w-[160px] !mt-1" position-area="bottom span-left">
       <!-- Header -->

--- a/apps/docs/src/components/docs/DocsExample.vue
+++ b/apps/docs/src/components/docs/DocsExample.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { createOverflow, isUndefined, Select, Splitter, Tabs, useBreakpoints, useElementSize } from '@vuetify/v0'
+  import { createOverflow, isUndefined, Select, Splitter, Tabs, Tooltip, useBreakpoints, useElementSize } from '@vuetify/v0'
 
   // Context
   import DocsSkeleton from './DocsSkeleton.vue'
@@ -336,14 +336,19 @@
         </span>
 
         <div class="ml-auto flex items-center gap-1">
-          <button
-            class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-            title="Reset example"
-            type="button"
-            @click="onReset"
-          >
-            <AppIcon icon="restart" :size="16" />
-          </button>
+          <Tooltip.Root :close-delay="100" :open-delay="500">
+            <Tooltip.Activator
+              class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
+              type="button"
+              @click="onReset"
+            >
+              <AppIcon icon="restart" :size="16" />
+            </Tooltip.Activator>
+
+            <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+              Reset example
+            </Tooltip.Content>
+          </Tooltip.Root>
         </div>
       </div>
 
@@ -455,41 +460,61 @@
           </span>
 
           <div class="ml-auto flex items-center gap-1">
-            <button
-              class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Reset example"
-              type="button"
-              @click="onReset"
-            >
-              <AppIcon icon="restart" :size="16" />
-            </button>
+            <Tooltip.Root :close-delay="100" :open-delay="500">
+              <Tooltip.Activator
+                class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
+                type="button"
+                @click="onReset"
+              >
+                <AppIcon icon="restart" :size="16" />
+              </Tooltip.Activator>
 
-            <button
-              class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Open in Playground"
-              type="button"
-              @click="openAllInPlayground"
-            >
-              <AppIcon icon="vuetify-play" :size="16" />
-            </button>
+              <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+                Reset example
+              </Tooltip.Content>
+            </Tooltip.Root>
 
-            <button
-              class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              title="Open in Bin"
-              type="button"
-              @click="openAllInBin"
-            >
-              <AppIcon icon="vuetify-bin" :size="16" />
-            </button>
+            <Tooltip.Root :close-delay="100" :open-delay="500">
+              <Tooltip.Activator
+                class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
+                type="button"
+                @click="openAllInPlayground"
+              >
+                <AppIcon icon="vuetify-play" :size="16" />
+              </Tooltip.Activator>
 
-            <button
-              class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
-              :title="combinedView ? 'Split files' : 'Combine files'"
-              type="button"
-              @click="combinedView = !combinedView"
-            >
-              <AppIcon :icon="combinedView ? 'split' : 'combine'" :size="16" />
-            </button>
+              <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+                Open in Playground
+              </Tooltip.Content>
+            </Tooltip.Root>
+
+            <Tooltip.Root :close-delay="100" :open-delay="500">
+              <Tooltip.Activator
+                class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
+                type="button"
+                @click="openAllInBin"
+              >
+                <AppIcon icon="vuetify-bin" :size="16" />
+              </Tooltip.Activator>
+
+              <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+                Open in Bin
+              </Tooltip.Content>
+            </Tooltip.Root>
+
+            <Tooltip.Root :close-delay="100" :open-delay="500">
+              <Tooltip.Activator
+                class="size-[30px] rounded text-on-surface-variant hover:bg-surface-variant transition-colors inline-flex items-center justify-center"
+                type="button"
+                @click="combinedView = !combinedView"
+              >
+                <AppIcon :icon="combinedView ? 'split' : 'combine'" :size="16" />
+              </Tooltip.Activator>
+
+              <Tooltip.Content class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg">
+                {{ combinedView ? 'Split files' : 'Combine files' }}
+              </Tooltip.Content>
+            </Tooltip.Root>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Continues the #495 migration by replacing native `title=` HTML attributes in `apps/docs` with the `Tooltip.Root / Tooltip.Activator / Tooltip.Content` compound component, following the same patterns already applied to `apps/playground` in #637.

- **DocsExample.vue** — 5 icon-only buttons (Reset example ×2, Open in Playground, Open in Bin, Combine/Split files) converted; `Tooltip` added to imports
- **AppSettings.vue** — Settings button replaced with `Tooltip.Activator` (which renders as `<button>` by default); `Tooltip` added to imports
- **AppAccount.vue** — Sign-in button wrapped in `Tooltip.Root`; Account settings button (inside `Discovery.Activator`) uses the renderless `Tooltip.Activator` pattern to spread hover/focus/`aria-describedby` attrs onto the native button; `Tooltip` added to imports
- **AppSkillFilter.vue** — `Popover.Activator` (inside `Popover.Root`) wrapped via renderless `Tooltip.Activator`; `Tooltip` added to imports
- **AppBar.vue** — Search, Discord, and GitHub elements already had `aria-label`; redundant `title=` attributes removed

## Tooltip.Content styling
All new `Tooltip.Content` elements use `class="px-2.5 py-1.5 rounded border border-divider text-xs bg-surface text-on-surface shadow-lg"`, matching the pattern established in `DocsMaturity.vue`.

## Not included
Dynamic `title=` bindings in `DocsCodeActions.vue`, `DocsAskPanel.vue`, `DocsSearch.vue`, `AppSettingsSheet.vue`, and others — those have more complex patterns (dynamic text, third-party `GnActionButton`) and will be addressed in follow-up PRs.

Closes part of #495