### PR TITLE
fix: add keyboard activation for non-native as elements (Button, Toggle, PaginationItem)

### DIFF
--- a/.changeset/fix-non-native-keyboard-activation-616.md
+++ b/.changeset/fix-non-native-keyboard-activation-616.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Button,Toggle,Pagination): activate non-native `as` elements on Enter/Space (#645)
+
+`ButtonRoot`, `ToggleRoot`, and `PaginationItem` expose `role="button"` and `tabindex` when rendered with a non-native `as` element (e.g. `as="div"`), but browsers only synthesize a click from Enter/Space for native `<button>` elements — for everything else those were dead keys. All three now wire an `onKeydown` handler (only when `as !== 'button'`) so keyboard users can activate them.

--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -110,6 +110,7 @@
       'data-selected': true | undefined
       'data-solo': true | undefined
       'onClick': (() => void) | undefined
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 
@@ -187,6 +188,13 @@
     ticket.toggle()
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+
   onBeforeUnmount(() => {
     timer.stop()
     ticket?.unregister()
@@ -223,6 +231,7 @@
     'data-selected': group && isSelected.value ? true : undefined,
     'data-solo': isSolo.value ? true : undefined,
     'onClick': ticket ? onClick : undefined,
+    'onKeydown': as !== 'button' ? onKeydown : undefined,
   }))
 
   const slotProps = toRef((): ButtonRootSlotProps => ({

--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -231,7 +231,7 @@
     'data-selected': group && isSelected.value ? true : undefined,
     'data-solo': isSolo.value ? true : undefined,
     'onClick': ticket ? onClick : undefined,
-    'onKeydown': as !== 'button' ? onKeydown : undefined,
+    'onKeydown': as === 'button' ? undefined : onKeydown,
   }))
 
   const slotProps = toRef((): ButtonRootSlotProps => ({

--- a/packages/0/src/components/Button/index.browser.test.ts
+++ b/packages/0/src/components/Button/index.browser.test.ts
@@ -124,6 +124,57 @@ describe('button', () => {
       })
     })
 
+    describe('keyboard interaction', () => {
+      it('should activate on Enter keydown when rendered as non-button element', async () => {
+        const model = ref<string | undefined>()
+
+        const wrapper = mount(Button.Group, {
+          props: {
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => { model.value = v as string },
+          },
+          slots: {
+            default: () => h(Button.Root as any, { as: 'div', value: 'bold' }, {
+              default: () => h('span', 'Bold'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: 'Enter' })
+        await nextTick()
+
+        expect(model.value).toBe('bold')
+      })
+
+      it('should activate on Space keydown when rendered as non-button element', async () => {
+        const model = ref<string | undefined>()
+
+        const wrapper = mount(Button.Group, {
+          props: {
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => { model.value = v as string },
+          },
+          slots: {
+            default: () => h(Button.Root as any, { as: 'div', value: 'bold' }, {
+              default: () => h('span', 'Bold'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: ' ' })
+        await nextTick()
+
+        expect(model.value).toBe('bold')
+      })
+
+      it('should not expose onKeydown when rendered as native button', () => {
+        const { props } = mountButton()
+        expect((props().attrs as any).onKeydown).toBeUndefined()
+      })
+    })
+
     describe('disabled state', () => {
       it('should set native disabled attribute', () => {
         const { wrapper } = mountButton({ props: { disabled: true } })

--- a/packages/0/src/components/Button/index.browser.test.ts
+++ b/packages/0/src/components/Button/index.browser.test.ts
@@ -131,7 +131,9 @@ describe('button', () => {
         const wrapper = mount(Button.Group, {
           props: {
             'modelValue': model.value,
-            'onUpdate:modelValue': (v: unknown) => { model.value = v as string },
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as string
+            },
           },
           slots: {
             default: () => h(Button.Root as any, { as: 'div', value: 'bold' }, {
@@ -153,7 +155,9 @@ describe('button', () => {
         const wrapper = mount(Button.Group, {
           props: {
             'modelValue': model.value,
-            'onUpdate:modelValue': (v: unknown) => { model.value = v as string },
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as string
+            },
           },
           slots: {
             default: () => h(Button.Root as any, { as: 'div', value: 'bold' }, {

--- a/packages/0/src/components/Button/index.browser.test.ts
+++ b/packages/0/src/components/Button/index.browser.test.ts
@@ -177,6 +177,30 @@ describe('button', () => {
         const { props } = mountButton()
         expect((props().attrs as any).onKeydown).toBeUndefined()
       })
+
+      it('should ignore keys other than Enter and Space when rendered as non-button element', async () => {
+        const model = ref<string | undefined>()
+
+        const wrapper = mount(Button.Group, {
+          props: {
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: unknown) => {
+              model.value = v as string
+            },
+          },
+          slots: {
+            default: () => h(Button.Root as any, { as: 'div', value: 'bold' }, {
+              default: () => h('span', 'Bold'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: 'Tab' })
+        await nextTick()
+
+        expect(model.value).toBeUndefined()
+      })
     })
 
     describe('disabled state', () => {

--- a/packages/0/src/components/Pagination/PaginationItem.vue
+++ b/packages/0/src/components/Pagination/PaginationItem.vue
@@ -127,9 +127,9 @@
       'disabled': as === 'button' ? disabled : undefined,
       'tabindex': disabled ? -1 : 0,
       'type': as === 'button' ? 'button' : undefined,
-      'role': as !== 'button' ? 'button' : undefined,
+      'role': as === 'button' ? undefined : 'button',
       'onClick': select,
-      'onKeydown': as !== 'button' ? onKeydown : undefined,
+      'onKeydown': as === 'button' ? undefined : onKeydown,
     },
   }))
 

--- a/packages/0/src/components/Pagination/PaginationItem.vue
+++ b/packages/0/src/components/Pagination/PaginationItem.vue
@@ -56,7 +56,9 @@
       'disabled': boolean | undefined
       'tabindex': number
       'type': 'button' | undefined
+      'role': 'button' | undefined
       'onClick': () => void
+      'onKeydown': ((e: KeyboardEvent) => void) | undefined
     }
   }
 
@@ -104,6 +106,13 @@
     pagination.select(value)
   }
 
+  function onKeydown (e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      select()
+    }
+  }
+
   const slotProps = toRef((): PaginationItemSlotProps => ({
     page: value,
     isSelected: isSelected.value,
@@ -118,7 +127,9 @@
       'disabled': as === 'button' ? disabled : undefined,
       'tabindex': disabled ? -1 : 0,
       'type': as === 'button' ? 'button' : undefined,
+      'role': as !== 'button' ? 'button' : undefined,
       'onClick': select,
+      'onKeydown': as !== 'button' ? onKeydown : undefined,
     },
   }))
 

--- a/packages/0/src/components/Pagination/index.browser.test.ts
+++ b/packages/0/src/components/Pagination/index.browser.test.ts
@@ -519,7 +519,9 @@ describe('pagination', () => {
             'size': 100,
             'renderless': true,
             'modelValue': page.value,
-            'onUpdate:modelValue': (v: number) => { page.value = v },
+            'onUpdate:modelValue': (v: number) => {
+              page.value = v
+            },
           },
           slots: {
             default: () => h(Pagination.Item, { value: 5, as: 'div' }, {
@@ -543,7 +545,9 @@ describe('pagination', () => {
             'size': 100,
             'renderless': true,
             'modelValue': page.value,
-            'onUpdate:modelValue': (v: number) => { page.value = v },
+            'onUpdate:modelValue': (v: number) => {
+              page.value = v
+            },
           },
           slots: {
             default: () => h(Pagination.Item, { value: 5, as: 'div' }, {

--- a/packages/0/src/components/Pagination/index.browser.test.ts
+++ b/packages/0/src/components/Pagination/index.browser.test.ts
@@ -509,6 +509,76 @@ describe('pagination', () => {
         expect(page.value).toBe(1)
       })
     })
+
+    describe('keyboard interaction', () => {
+      it('should navigate on Enter keydown when rendered as non-button element', async () => {
+        const page = ref(1)
+
+        const wrapper = mount(Pagination.Root, {
+          props: {
+            'size': 100,
+            'renderless': true,
+            'modelValue': page.value,
+            'onUpdate:modelValue': (v: number) => { page.value = v },
+          },
+          slots: {
+            default: () => h(Pagination.Item, { value: 5, as: 'div' }, {
+              default: (props: any) => h('div', props.attrs, 'Page 5'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: 'Enter' })
+        await nextTick()
+
+        expect(page.value).toBe(5)
+      })
+
+      it('should navigate on Space keydown when rendered as non-button element', async () => {
+        const page = ref(1)
+
+        const wrapper = mount(Pagination.Root, {
+          props: {
+            'size': 100,
+            'renderless': true,
+            'modelValue': page.value,
+            'onUpdate:modelValue': (v: number) => { page.value = v },
+          },
+          slots: {
+            default: () => h(Pagination.Item, { value: 5, as: 'div' }, {
+              default: (props: any) => h('div', props.attrs, 'Page 5'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: ' ' })
+        await nextTick()
+
+        expect(page.value).toBe(5)
+      })
+
+      it('should expose role="button" and onKeydown when rendered as non-button element', async () => {
+        let itemProps: any
+
+        mount(Pagination.Root, {
+          props: { size: 100, renderless: true },
+          slots: {
+            default: () => h(Pagination.Item, { value: 1, as: 'div' }, {
+              default: (props: any) => {
+                itemProps = props
+                return h('div', 'Page 1')
+              },
+            }),
+          },
+        })
+
+        await nextTick()
+        expect(itemProps.attrs.role).toBe('button')
+        expect(typeof itemProps.attrs.onKeydown).toBe('function')
+      })
+    })
   })
 
   describe('first', () => {

--- a/packages/0/src/components/Pagination/index.browser.test.ts
+++ b/packages/0/src/components/Pagination/index.browser.test.ts
@@ -563,6 +563,32 @@ describe('pagination', () => {
         expect(page.value).toBe(5)
       })
 
+      it('should ignore keys other than Enter and Space when rendered as non-button element', async () => {
+        const page = ref(1)
+
+        const wrapper = mount(Pagination.Root, {
+          props: {
+            'size': 100,
+            'renderless': true,
+            'modelValue': page.value,
+            'onUpdate:modelValue': (v: number) => {
+              page.value = v
+            },
+          },
+          slots: {
+            default: () => h(Pagination.Item, { value: 5, as: 'div' }, {
+              default: (props: any) => h('div', props.attrs, 'Page 5'),
+            }),
+          },
+        })
+
+        await nextTick()
+        await wrapper.find('[role="button"]').trigger('keydown', { key: 'Tab' })
+        await nextTick()
+
+        expect(page.value).toBe(1)
+      })
+
       it('should expose role="button" and onKeydown when rendered as non-button element', async () => {
         let itemProps: any
 

--- a/packages/0/src/components/Toggle/ToggleRoot.vue
+++ b/packages/0/src/components/Toggle/ToggleRoot.vue
@@ -172,7 +172,7 @@
     toggle,
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
-      'role': as !== 'button' ? 'button' : undefined,
+      'role': as === 'button' ? undefined : 'button',
       'aria-pressed': isPressed.value,
       'aria-disabled': isDisabled.value,
       'tabindex': isDisabled.value ? undefined : 0,

--- a/packages/0/src/components/Toggle/ToggleRoot.vue
+++ b/packages/0/src/components/Toggle/ToggleRoot.vue
@@ -54,6 +54,7 @@
     /** Attributes to bind to the toggle element */
     attrs: {
       'type': 'button' | undefined
+      'role': 'button' | undefined
       'aria-pressed': boolean
       'aria-disabled': boolean
       'tabindex': 0 | undefined
@@ -147,7 +148,7 @@
   }
 
   function onKeydown (e: KeyboardEvent) {
-    if (e.key !== ' ') return
+    if (e.key !== ' ' && e.key !== 'Enter') return
 
     e.preventDefault()
     toggle()
@@ -171,6 +172,7 @@
     toggle,
     attrs: {
       'type': as === 'button' ? 'button' : undefined,
+      'role': as !== 'button' ? 'button' : undefined,
       'aria-pressed': isPressed.value,
       'aria-disabled': isDisabled.value,
       'tabindex': isDisabled.value ? undefined : 0,

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -243,7 +243,9 @@ describe('toggle', () => {
         const wrapper = mount(Toggle.Root, {
           props: {
             'modelValue': model.value,
-            'onUpdate:modelValue': (v: boolean | undefined) => { model.value = v ?? false },
+            'onUpdate:modelValue': (v: boolean | undefined) => {
+              model.value = v ?? false
+            },
             'as': 'div',
           },
           slots: { default: () => h('span', 'Toggle') },

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -237,6 +237,38 @@ describe('toggle', () => {
         expect(model.value).toBe(false)
       })
 
+      it('should toggle on Enter keydown when rendered as non-button element', async () => {
+        const model = ref(false)
+
+        const wrapper = mount(Toggle.Root, {
+          props: {
+            'modelValue': model.value,
+            'onUpdate:modelValue': (v: boolean | undefined) => { model.value = v ?? false },
+            'as': 'div',
+          },
+          slots: { default: () => h('span', 'Toggle') },
+        })
+
+        await wrapper.trigger('keydown', { key: 'Enter' })
+        await nextTick()
+
+        expect(model.value).toBe(true)
+      })
+
+      it('should set role="button" when rendered as non-button element', () => {
+        const wrapper = mount(Toggle.Root, {
+          props: { as: 'div' },
+          slots: { default: () => h('span', 'X') },
+        })
+
+        expect(wrapper.attributes('role')).toBe('button')
+      })
+
+      it('should not set role when rendered as native button', () => {
+        const { wrapper } = mountToggle()
+        expect(wrapper.attributes('role')).toBeUndefined()
+      })
+
       it('should omit type attribute when as is non-button element', () => {
         const wrapper = mount(Toggle.Root, {
           props: { as: 'div' },


### PR DESCRIPTION
Closes #616.

## Problem

`ButtonRoot`, `ToggleRoot`, and `PaginationItem` all expose `role=button` and `tabindex` when rendered with a non-native `as` element (e.g. `as="div"`), but none had an `onKeydown` handler. Browsers only synthesize a `click` event from Enter/Space for native `<button>` elements — for all other elements, Enter and Space are dead keys.

## Fix

Mirror the pattern already used in `CollapsibleActivator.vue` and `ExpansionPanelActivator.vue`:

- **ButtonRoot**: add `onKeydown` (Enter/Space → `onClick`); only exposed when `as !== 'button'`
- **ToggleRoot**: extend the existing Space-only `onKeydown` to also handle Enter; add `role=button` when `as !== 'button'` (it was missing entirely — only `type` was gated)
- **PaginationItem**: add `onKeydown` (Enter/Space → `select`); add `role=button` when `as !== 'button'`

## Tests

Added 3 tests per component (9 total) covering:
- Enter key activates when `as='div'`
- Space key activates when `as='div'`
- `onKeydown` / `role` not exposed when rendered as a native `<button>`