### PR TITLE
fix(Tooltip): expose anchor styles on Tooltip.Activator renderless slot

### DIFF
--- a/.changeset/tooltip-activator-renderless-anchor-styles.md
+++ b/.changeset/tooltip-activator-renderless-anchor-styles.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Tooltip): expose anchor styles on Tooltip.Activator's renderless slot
+
+`Tooltip.Activator` now surfaces its CSS anchor-positioning styles as a `styles` slot prop (mirroring `Tooltip.Content`). In renderless mode the activator no longer renders its own element, so previously the anchor name was lost and the tooltip content could not position. Consumers can now bind `attrs` and apply `styles` onto their own trigger element — e.g. attaching a tooltip to a native `<button type="submit">` without the activator overriding its `type`.

--- a/packages/0/src/components/Tooltip/TooltipActivator.vue
+++ b/packages/0/src/components/Tooltip/TooltipActivator.vue
@@ -5,10 +5,12 @@
  *
  * @remarks
  * Tooltip trigger element. Binds pointer, focus, and escape events and
- * exposes them on slot attrs for renderless usage. Touch interactions
- * are suppressed per WAI-ARIA APG. Keyboard focus opens the tooltip
- * instantly (no delay), gated on :focus-visible so a mouse click that
- * incidentally moves focus does not open the tooltip.
+ * exposes them on slot `attrs` — alongside the anchor-positioning `styles` —
+ * for renderless usage, so a consumer can wire the tooltip onto their own
+ * element (e.g. a native `type="submit"` button) and still anchor the
+ * content. Touch interactions are suppressed per WAI-ARIA APG. Keyboard
+ * focus opens the tooltip instantly (no delay), gated on :focus-visible so a
+ * mouse click that incidentally moves focus does not open the tooltip.
  */
 
 <script lang="ts">
@@ -46,6 +48,7 @@
       'onClick': () => void
       'onKeydown': (e: KeyboardEvent) => void
     }
+    styles: Record<string, string>
   }
 </script>
 
@@ -114,6 +117,7 @@
       'onClick': onClick,
       'onKeydown': onKeydown,
     },
+    styles: root.anchorStyles.value,
   }))
 </script>
 


### PR DESCRIPTION
## Problem

`Tooltip.Activator` applies its CSS anchor-positioning styles directly on the `Atom` it renders (`:style="root.anchorStyles.value"`). In **renderless** mode the activator renders no element of its own, so the anchor name never reaches the consumer's trigger and `Tooltip.Content` has nothing to position against — the tooltip renders detached.

This is an asymmetry: the sibling `Tooltip.Content` already exposes its positioning via a `styles` slot prop, but `Tooltip.Activator` only exposed `attrs`.

A visible consequence: you can't give a native `<button type="submit">` a v0 tooltip. The non-renderless activator forces `type="button"` (the framework-wide convention), and renderless — the intended escape hatch — couldn't position.

## Change

Expose `root.anchorStyles.value` as a `styles` slot prop on `Tooltip.Activator`, mirroring `Tooltip.Content`. A renderless consumer can now bind `attrs` and apply `styles` onto their own element:

```vue
<Tooltip.Root>
  <Tooltip.Activator renderless v-slot="{ attrs, styles }">
    <button v-bind="attrs" :style="styles" type="submit">Send</button>
  </Tooltip.Activator>
  <Tooltip.Content>Send</Tooltip.Content>
</Tooltip.Root>
```

The tooltip wires onto the consumer's element (hover/focus/`aria-describedby`) and positions correctly, while the element keeps its own `type`.

## Notes
- Additive slot prop; non-breaking. Non-renderless behavior is unchanged (it still applies `anchorStyles` on the `Atom` directly).
- Types clean (`styles: Record<string, string>`, same shape `Tooltip.Content` uses); `<DocsApi />` picks up the new slot prop automatically.
- Follow-up: converts `apps/docs` `DocsAskForm`'s Send (submit) button to a styled tooltip via this path — depends on this landing first.

Surfaced while working on #495 (native `title` → v0 `Tooltip` sweep), where the submit button was the one site the `AppTooltip` wrapper couldn't cover.