### PR TITLE
docs(DocsApiHover): center API popover on its target

### DIFF
--- a/apps/docs/src/components/docs/DocsApiHover.vue
+++ b/apps/docs/src/components/docs/DocsApiHover.vue
@@ -89,7 +89,7 @@
   const HIDE_DELAY = 100 // Grace period when moving to popover
 
   // Position state
-  const { position, flipped: flipAbove, calculate: calculatePosition } = usePopoverPosition({
+  const { position, flipped: flipBelow, calculate: calculatePosition } = usePopoverPosition({
     maxWidth: 450,
     maxHeight: 400,
   })
@@ -342,7 +342,7 @@
         v-if="isVisible && activeApi"
         ref="popover"
         class="docs-api-hover-popover"
-        :class="{ 'popover-flipped': flipAbove }"
+        :class="{ 'popover-flipped': flipBelow }"
         :style="{
           top: `${position.top}px`,
           left: `${position.left}px`,
@@ -484,10 +484,11 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   font-size: 13px;
   line-height: 1.5;
+  transform: translateY(calc(-100% - 8px));
 }
 
 .docs-api-hover-popover.popover-flipped {
-  transform: translateY(calc(-100% - 8px));
+  transform: none;
 }
 
 .popover-header {

--- a/apps/docs/src/components/docs/DocsApiHover.vue
+++ b/apps/docs/src/components/docs/DocsApiHover.vue
@@ -89,7 +89,7 @@
   const HIDE_DELAY = 100 // Grace period when moving to popover
 
   // Position state
-  const { position, flipped: flipBelow, calculate: calculatePosition } = usePopoverPosition({
+  const { position, flipped: flipAbove, calculate: calculatePosition } = usePopoverPosition({
     maxWidth: 450,
     maxHeight: 400,
   })
@@ -342,7 +342,7 @@
         v-if="isVisible && activeApi"
         ref="popover"
         class="docs-api-hover-popover"
-        :class="{ 'popover-flipped': flipBelow }"
+        :class="{ 'popover-flipped': flipAbove }"
         :style="{
           top: `${position.top}px`,
           left: `${position.left}px`,
@@ -484,11 +484,10 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   font-size: 13px;
   line-height: 1.5;
-  transform: translateY(calc(-100% - 8px));
 }
 
 .docs-api-hover-popover.popover-flipped {
-  transform: none;
+  transform: translateY(calc(-100% - 8px));
 }
 
 .popover-header {

--- a/apps/docs/src/composables/usePopoverPosition.ts
+++ b/apps/docs/src/composables/usePopoverPosition.ts
@@ -32,7 +32,8 @@ export function usePopoverPosition (options: PopoverPositionOptions = {}) {
 
   /**
    * Calculate position for popover relative to target element.
-   * By default positions above the target, flips below if insufficient space.
+   * By default positions below the target and centered horizontally, flips
+   * above when there isn't enough space below.
    */
   function calculate (target: HTMLElement) {
     if (!IN_BROWSER) return
@@ -40,20 +41,21 @@ export function usePopoverPosition (options: PopoverPositionOptions = {}) {
     const rect = target.getBoundingClientRect()
     const viewportWidth = window.innerWidth
 
-    // Clamp horizontal position to keep popover within viewport
-    let left = rect.left + window.scrollX
-    if (rect.left + maxWidth > viewportWidth - padding) {
-      left = Math.max(padding, viewportWidth - maxWidth - padding + window.scrollX)
-    }
+    // Center on the target, then clamp within the viewport
+    const min = padding + window.scrollX
+    const max = viewportWidth - maxWidth - padding + window.scrollX
+    let left = rect.left + rect.width / 2 - maxWidth / 2 + window.scrollX
+    left = Math.max(min, Math.min(left, max))
 
-    // Flip below if not enough space above
+    // Flip above only when there isn't room below but there is above
+    const spaceBelow = window.innerHeight - rect.bottom - gap
     const spaceAbove = rect.top - gap
-    flipped.value = spaceAbove < maxHeight
+    flipped.value = spaceBelow < maxHeight && spaceAbove > spaceBelow
 
     position.value = {
       top: flipped.value
-        ? rect.bottom + window.scrollY + gap
-        : rect.top + window.scrollY,
+        ? rect.top + window.scrollY
+        : rect.bottom + window.scrollY + gap,
       left,
     }
   }

--- a/apps/docs/src/composables/usePopoverPosition.ts
+++ b/apps/docs/src/composables/usePopoverPosition.ts
@@ -32,8 +32,8 @@ export function usePopoverPosition (options: PopoverPositionOptions = {}) {
 
   /**
    * Calculate position for popover relative to target element.
-   * By default positions below the target and centered horizontally, flips
-   * above when there isn't enough space below.
+   * By default positions above the target and centered horizontally, flips
+   * below when there isn't enough space above.
    */
   function calculate (target: HTMLElement) {
     if (!IN_BROWSER) return
@@ -47,15 +47,15 @@ export function usePopoverPosition (options: PopoverPositionOptions = {}) {
     let left = rect.left + rect.width / 2 - maxWidth / 2 + window.scrollX
     left = Math.max(min, Math.min(left, max))
 
-    // Flip above only when there isn't room below but there is above
-    const spaceBelow = window.innerHeight - rect.bottom - gap
+    // Flip below only when there isn't room above but there is below
     const spaceAbove = rect.top - gap
-    flipped.value = spaceBelow < maxHeight && spaceAbove > spaceBelow
+    const spaceBelow = window.innerHeight - rect.bottom - gap
+    flipped.value = spaceAbove < maxHeight && spaceBelow > spaceAbove
 
     position.value = {
       top: flipped.value
-        ? rect.top + window.scrollY
-        : rect.bottom + window.scrollY + gap,
+        ? rect.bottom + window.scrollY + gap
+        : rect.top + window.scrollY,
       left,
     }
   }


### PR DESCRIPTION
## Problem

The API hover popover opened offset to the right of the target: `left` was set to the token's left edge, so a 450px panel extended far to the right of a short inline token, reading as shifted to the end rather than centered.

## Fix

- **Center** the popover horizontally on the target, clamped to the viewport.
- Flip below only when there's less room above than below (previously flipped below whenever there was <400px above, regardless of whether below was roomier).

Popover still opens **above** by default. Docs-only change to `apps/docs`.