### PR TITLE
docs(home): add border-divider to colorless borders in HomeArchitecture

### DIFF
--- a/apps/docs/src/components/home/HomeArchitecture.vue
+++ b/apps/docs/src/components/home/HomeArchitecture.vue
@@ -212,7 +212,7 @@
       <!-- Code panel -->
       <div class="demo-code rounded-xl border overflow-hidden bg-surface flex flex-col h-[350px] md:h-[510px]">
         <Tabs.Root v-model="activeTab">
-          <div class="px-2 py-2 bg-surface-tint border-b flex items-center gap-2">
+          <div class="px-2 py-2 bg-surface-tint border-b border-divider flex items-center gap-2">
             <Tabs.List class="flex items-center gap-2" label="Code examples">
               <Tabs.Item v-slot="{ attrs }" renderless value="composable">
                 <button
@@ -285,7 +285,7 @@
           </div>
         </Selection.Root>
 
-        <div class="relative mt-8 pt-6 border-t">
+        <div class="relative mt-8 pt-6 border-t border-divider">
           <router-link
             class="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1"
             to="/components/providers/selection"


### PR DESCRIPTION
## Problem

On the home page, the "Composable Architecture" section (`HomeArchitecture.vue`) had two borders with no color token:

- The code panel's tab-bar header used `border-b` (no `border-divider`)
- The Live Preview panel's footer divider used `border-t` (no `border-divider`)

With presetWind4 there's no global default border color, so both fell back to `currentColor` instead of the divider color every other home component uses (`HomeSpecialSponsor`, `HomePrimarySponsor`, `HomeInstallCommand`, the `card-header`/`border-card` uno shortcuts).

## Fix

| Line | Before | After |
|------|--------|-------|
| 215 | `border-b` | `border-b border-divider` |
| 288 | `border-t` | `border-t border-divider` |

Line 215 is the one reported (tab header); line 288 is the same defect inside the Live Preview panel — fixed together since it's the identical missing token in the same component.