### PR TITLE
docs(AppBanner): prevent banner text overflow on narrow viewports

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -16,7 +16,7 @@
   if (!notifications.has('rc-banner')) {
     notifications.register({
       id: 'rc-banner',
-      subject: 'Vuetify0 v1.0 releases July 22, 2026 — the stable release is almost here!',
+      subject: 'Vuetify0 v1.0 releases July 22, 2026',
       severity: 'warning',
       data: { type: 'banner' },
     })
@@ -51,10 +51,10 @@
     :as
     class="flex items-center justify-center h-[24px] fixed inset-x-0 top-0 px-3 text-xs gap-2 text-on-primary z-1 bg-glass-primary"
   >
-    <AppIcon icon="vuetify-0" :size="14" />
+    <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 
-    <div>
-      {{ banner?.subject }} <span class="hidden md:inline">See the <RouterLink class="underline underline-offset-2" to="/roadmap#release-candidate">roadmap</RouterLink> for details.</span>
+    <div class="min-w-0 truncate pe-6">
+      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is almost here!</span><span class="hidden md:inline"> See the <RouterLink class="underline underline-offset-2" to="/roadmap#release-candidate">roadmap</RouterLink> for details.</span>
     </div>
 
     <button


### PR DESCRIPTION
## Problem

The RC announcement banner text was too long on narrow (<400px) devices. The seeded subject (`Vuetify0 v1.0 releases July 22, 2026 — the stable release is almost here!`, ~72 chars at `text-xs` ≈ 430px wide) wrapped to two lines and got clipped by the fixed `h-[24px]` banner.

## Fix

Progressive-enhancement copy instead of one overflowing string:

- **Core subject** (`Vuetify0 v1.0 releases July 22, 2026`) always renders — fits 320px comfortably.
- Decorative tail (`— the stable release is almost here!`) gated behind `sm:inline`.
- Roadmap link stays gated behind `md:inline` (unchanged).
- `min-w-0 truncate` on the text + `pe-6` reserve + `shrink-0` on the icon act as a hard floor so nothing ever clips or slides under the close button, at any width.

## Verified in-browser

| Viewport | Result |
|----------|--------|
| 320px / 375px | Single line, core subject, no wrap/clip |
| ≥768px (md) | Full copy + roadmap link on one line (unchanged desktop experience) |