### PR TITLE
docs(DiscoveryContent): fix last-step tour popover scaling from bottom-right

### DIFF
--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -76,12 +76,16 @@
     // The last step has no activator, so no element carries the anchor-name.
     // position-area: center silently no-ops without a resolvable anchor and the
     // inset collapses the box to the top-left corner, so center on the viewport.
+    // Center via inset + margin auto rather than translate(-50%, -50%): the enter
+    // animation scales through the `scale` property, and a positioning translate
+    // shares its transform-origin, pinning the scale's fixed point to the box's
+    // own center - which sits at the visual bottom-right, so the box grew from
+    // there instead of its center. No transform here leaves scale about center.
     if (currentPlacement === 'center') {
       return {
         position: 'fixed' as const,
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
+        inset: '0',
+        margin: 'auto',
         width: 'max-content',
         height: 'max-content',
         maxWidth: `min(20rem, calc(100vw - ${offset * 2}px))`,


### PR DESCRIPTION
The final step of a skillz tour is center-placed and previously centered itself with `top/left: 50%` + `transform: translate(-50%, -50%)`.

The popover's enter animation scales via the standalone `scale` property (`.discovery-content`, `0.92 → 1`), which shares the positioning translate's `transform-origin`. That pinned the scale's fixed point to the box's own geometric center — visually the bottom-right corner of the centered box — so the popover appeared to grow from the bottom-right instead of its center.

Center via `inset: 0` + `margin: auto` instead, leaving `transform` unused so `scale` animates about the true center. Only the center placement used the self-centering translate; anchor-positioned steps were already correct.