### PR TITLE
docs: normalize component and composable page surface

### DIFF
--- a/apps/docs/src/pages/components/disclosure/dialog.md
+++ b/apps/docs/src/pages/components/disclosure/dialog.md
@@ -88,6 +88,36 @@ The `blocking` prop disables scrim-based dismissal entirely — the dialog can o
 </template>
 ```
 
+## Accessibility
+
+Dialog renders its panel through the native `<dialog>` element opened with `showModal()`, so focus trapping, backdrop rendering, inerting of the page behind it, and Escape-to-close all come from the browser.
+
+### ARIA Attributes
+
+| Attribute | Value | Element |
+|-----------|-------|---------|
+| `aria-haspopup` | `dialog` | Activator |
+| `aria-expanded` | `true` / `false` | Activator |
+| `role` | `dialog` | Content |
+| `aria-modal` | `true` | Content |
+| `aria-labelledby` | Title element ID | Content |
+| `aria-describedby` | Description element ID | Content |
+| `aria-label` | Localized "Close" string | Close |
+
+`Dialog.Title` and `Dialog.Description` generate the IDs referenced by `aria-labelledby` and `aria-describedby`. Render them inside `Dialog.Content` so the dialog has an accessible name and description.
+
+### Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift + Tab` | Cycles focus through focusable controls inside Content (trapped by `showModal()`) |
+| `Escape` | Closes the dialog (native `cancel` event) |
+| `Enter` / `Space` | Activates the focused control |
+
+### Focus management
+
+`showModal()` moves focus into the dialog on open, and the browser traps `Tab` within it while it stays open. `Dialog.Activator` renders a `<button>` by default — carrying `aria-haspopup="dialog"` and `aria-expanded` — and opens the dialog on click.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/disclosure/expansion-panel.md
+++ b/apps/docs/src/pages/components/disclosure/expansion-panel.md
@@ -24,7 +24,7 @@ A component for creating accordion-style expansion panels with proper ARIA suppo
 
 ## Usage
 
-The ExpansionPanel component provides a wrapper and item pattern for managing expansion state in accordion-style interfaces. It uses the `createSelection` composable internally and provides full v-model support with automatic state synchronization.
+Group a set of panels into an accordion where opening one can collapse the others. Bind `v-model` to track which panel is open — or, in `multiple` mode, which panels.
 
 ::: gn-example
 /components/expansion-panel/basic
@@ -73,6 +73,32 @@ Reach for single-open mode when answers are long and you want the reader focused
 | `FaqAccordion.vue` | Renders the ExpansionPanel compound — Group, Header, Activator, animated Cue, and Content |
 | `faq-accordion.vue` | Wires the composable to the accordion and adds the status line and collapse control |
 :::
+
+## Accessibility
+
+ExpansionPanel follows the [WAI-ARIA Accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/). `ExpansionPanel.Header` renders a heading (`<h3>` by default) that wraps the `ExpansionPanel.Activator` button, so screen-reader users can move between panels by heading.
+
+### ARIA Attributes
+
+| Attribute | Value | Element |
+|-----------|-------|---------|
+| `role` | `button` (only when Activator is not a native `<button>`) | Activator |
+| `aria-expanded` | `true` / `false` | Activator |
+| `aria-controls` | Content region ID | Activator |
+| `aria-disabled` | `true` / `false` | Activator |
+| `role` | `region` | Content |
+| `aria-labelledby` | Activator ID | Content |
+| `hidden` | Present when collapsed | Content |
+| `aria-hidden` | `true` | Cue |
+
+The Activator and Content IDs are paired: `aria-controls` on the Activator points at the Content, and `aria-labelledby` on the Content points back at the Activator. The Cue chevron is decorative and hidden from assistive technology.
+
+### Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Toggles the focused panel |
+| `Space` | Toggles the focused panel |
 
 ## FAQ
 

--- a/apps/docs/src/pages/components/disclosure/popover.md
+++ b/apps/docs/src/pages/components/disclosure/popover.md
@@ -85,6 +85,28 @@ Use `position-try` to specify fallback positions when the preferred position doe
 </template>
 ```
 
+## Accessibility
+
+Popover uses the native Popover API — the `popover` attribute on the content plus `popovertarget` on the trigger — so opening, closing, light-dismiss (clicking outside), and Escape-to-close are all handled by the browser. Placement uses CSS Anchor Positioning.
+
+### ARIA Attributes
+
+| Attribute | Value | Element |
+|-----------|-------|---------|
+| `popovertarget` | Content popover ID | Activator |
+| `aria-expanded` | `true` / `false` | Activator |
+| `aria-controls` | Content popover ID | Activator |
+| `popover` | `auto` | Content |
+
+`Popover.Activator` renders a `<button>` by default and toggles the popover through the native `popovertarget` attribute. `Popover.Content` is unstyled and carries no semantic `role` of its own — assign one that matches what the popover contains (for example `menu`, `listbox`, or `tooltip`).
+
+### Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| `Enter` / `Space` | Toggles the popover (native button activating `popovertarget`) |
+| `Escape` | Closes the popover (native `popover="auto"` light-dismiss) |
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/disclosure/tabs.md
+++ b/apps/docs/src/pages/components/disclosure/tabs.md
@@ -25,7 +25,7 @@ A component for creating accessible tabbed interfaces with proper ARIA support a
 
 ## Usage
 
-The Tabs component provides a compound pattern for building accessible tab interfaces. It uses the `createStep` composable internally for navigation and provides full v-model support with automatic state synchronization.
+Organize content into panels that share the same space, showing one at a time. Bind `v-model` to track the active tab and switch panels declaratively.
 
 ::: gn-example
 /components/tabs/basic

--- a/apps/docs/src/pages/components/disclosure/treeview.md
+++ b/apps/docs/src/pages/components/disclosure/treeview.md
@@ -25,7 +25,7 @@ A compound component for building accessible hierarchical tree interfaces with e
 
 ## Usage
 
-The Treeview component provides a compound pattern for building accessible tree structures. It uses the `createNested` composable internally for hierarchical state management — tracking parent-child relationships, open/close state, and cascade selection.
+Display hierarchical data as an expandable, selectable tree. Nodes open and close, selection cascades through parents and children, and `v-model` tracks the selected nodes.
 
 ::: gn-example
 /components/treeview/basic
@@ -226,6 +226,47 @@ The `--v0-treeview-depth` CSS variable is set on each Item, enabling indentation
   padding-left: calc(var(--v0-treeview-depth) * 1rem);
 }
 ```
+
+## Accessibility
+
+Treeview implements the [WAI-ARIA Tree View pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/). `Treeview.List` establishes roving tabindex, so only one node is in the Tab order at a time and the arrow keys move focus between nodes. The Activator and Checkbox are `tabindex="-1"` and are reached through the tree rather than the page's Tab sequence.
+
+### ARIA Attributes
+
+| Attribute | Value | Element |
+|-----------|-------|---------|
+| `role` | `tree` | List |
+| `aria-multiselectable` | `true` / `false` | List |
+| `aria-label` | Provided `label` | List |
+| `role` | `group` | Group |
+| `role` | `treeitem` | Item |
+| `aria-expanded` | `true` / `false` (only when the node has children) | Item |
+| `aria-selected` | `true` / `false` | Item |
+| `aria-disabled` | `true` / `false` | Item |
+| `aria-level` | Depth (1-based) | Item |
+| `aria-posinset` | Position among siblings | Item |
+| `aria-setsize` | Sibling count | Item |
+| `aria-current` | `true` when active | Item |
+| `role` | `checkbox` | Checkbox, SelectAll |
+| `aria-checked` | `true` / `false` / `mixed` | Checkbox, SelectAll |
+| `aria-hidden` | `true` | Cue, Indicator |
+
+### Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| `ArrowUp` | Moves focus to the previous visible node |
+| `ArrowDown` | Moves focus to the next visible node |
+| `ArrowRight` | Expands a collapsed node, or moves focus to its first child |
+| `ArrowLeft` | Collapses an expanded node, or moves focus to its parent |
+| `Home` | Moves focus to the first node |
+| `End` | Moves focus to the last visible node |
+| `Enter` | Toggles expansion (when expandable) and activates the node |
+| `Space` | Toggles selection of the focused node |
+| `*` | Expands all sibling nodes at the current level |
+| `Tab` | Moves focus to focusable controls inside a row, then out to the next node |
+
+In RTL, the `ArrowRight` and `ArrowLeft` directions are swapped. `Treeview.SelectAll` toggles the whole tree with `Enter` or `Space`.
 
 ## FAQ
 

--- a/apps/docs/src/pages/components/forms/number-field.md
+++ b/apps/docs/src/pages/components/forms/number-field.md
@@ -1,10 +1,10 @@
 ---
 title: NumberField - Numeric Input with Formatting
 meta:
-  - name: description
-    content: Headless numeric input with increment/decrement controls, locale-aware formatting, drag-to-scrub, and WAI-ARIA spinbutton compliance.
-  - name: keywords
-    content: number field, number input, stepper, spinbutton, increment, decrement, scrub, currency, vuetify, headless
+- name: description
+  content: Headless numeric input with increment/decrement controls, locale-aware formatting, drag-to-scrub, and WAI-ARIA spinbutton compliance.
+- name: keywords
+  content: number field, number input, stepper, spinbutton, increment, decrement, scrub, currency, vuetify, headless
 features:
   category: Component
   label: 'C: NumberField'

--- a/apps/docs/src/pages/components/forms/rating.md
+++ b/apps/docs/src/pages/components/forms/rating.md
@@ -1,10 +1,10 @@
 ---
 title: Rating - Accessible Star Rating Controls
 meta:
-  - name: description
-    content: Headless rating component with hover preview, half-star support, keyboard navigation, and full ARIA compliance for Vue 3.
-  - name: keywords
-    content: rating, stars, review, score, form control, accessible, ARIA, Vue 3, headless
+- name: description
+  content: Headless rating component with hover preview, half-star support, keyboard navigation, and full ARIA compliance for Vue 3.
+- name: keywords
+  content: rating, stars, review, score, form control, accessible, ARIA, Vue 3, headless
 features:
   category: Component
   label: 'C: Rating'

--- a/apps/docs/src/pages/components/forms/select.md
+++ b/apps/docs/src/pages/components/forms/select.md
@@ -132,7 +132,7 @@ Use `mandatory` to prevent deselecting the last item, or `mandatory="force"` to 
 </template>
 ```
 
-### Understanding `id` vs `value`
+### Understanding id vs value
 
 Each `Select.Item` has two key props:
 

--- a/apps/docs/src/pages/components/index.md
+++ b/apps/docs/src/pages/components/index.md
@@ -1,10 +1,10 @@
 ---
 title: Vuetify0 Components - Headless Vue 3 UI Primitives
 meta:
-  - name: description
-    content: Headless Vue 3 UI components with full accessibility. Selection, pagination, expansion panels, popovers, and more. Unstyled and fully customizable.
-  - name: keywords
-    content: components, headless ui, Vue 3, accessible, customizable, selection, pagination, expansion panel, popover
+- name: description
+  content: Headless Vue 3 UI components with full accessibility. Selection, pagination, expansion panels, popovers, and more. Unstyled and fully customizable.
+- name: keywords
+  content: components, headless ui, Vue 3, accessible, customizable, selection, pagination, expansion panel, popover
 features:
   level: 1
 related:

--- a/apps/docs/src/pages/components/primitives/aspect-ratio.md
+++ b/apps/docs/src/pages/components/primitives/aspect-ratio.md
@@ -1,10 +1,10 @@
 ---
 title: AspectRatio - Reserve Layout Space for Vue 3
 meta:
-  - name: description
-    content: Headless Vue 3 primitive that reserves a fixed width-to-height ratio using CSS aspect-ratio. Prevents Cumulative Layout Shift for media, iframes, and responsive containers.
-  - name: keywords
-    content: aspect ratio, aspectRatio, CLS, cumulative layout shift, responsive, Vue 3, headless, primitive, iframe wrapper
+- name: description
+  content: Headless Vue 3 primitive that reserves a fixed width-to-height ratio using CSS aspect-ratio. Prevents Cumulative Layout Shift for media, iframes, and responsive containers.
+- name: keywords
+  content: aspect ratio, aspectRatio, CLS, cumulative layout shift, responsive, Vue 3, headless, primitive, iframe wrapper
 features:
   category: Component
   label: 'C: AspectRatio'

--- a/apps/docs/src/pages/components/providers/group.md
+++ b/apps/docs/src/pages/components/providers/group.md
@@ -85,6 +85,15 @@ The slot props `isAllSelected`, `isNoneSelected`, and `isMixed` reflect the aggr
 </template>
 ```
 
+## Accessibility
+
+Group is a headless **state provider**, not a complete interactive widget. It manages multi-selection with tri-state support and exposes that state on each slot's `attrs`; it ships pointer activation (a click handler) but no keyboard navigation or focus management.
+
+- `Group.Root` exposes `aria-multiselectable="true"`.
+- `Group.Item` exposes `role="checkbox"`, `aria-checked` (`true`, `false`, or `"mixed"` for the indeterminate state), and `aria-disabled`, plus `data-selected`, `data-disabled`, and `data-mixed` for styling.
+
+This is checkbox-group selection state. For a fully accessible checkbox with a native hidden input, label association, and Space activation, use [Checkbox](/components/forms/checkbox), which composes the same group logic. When you bind `attrs` to your own element, you are responsible for supplying keyboard handlers and any roles the pattern requires beyond what Group emits.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/providers/locale.md
+++ b/apps/docs/src/pages/components/providers/locale.md
@@ -121,6 +121,12 @@ When `renderless` is set, the component does not render a wrapper element. Inste
 </template>
 ```
 
+## Accessibility
+
+Locale sets the `lang` attribute on its wrapper element — or exposes it via `attrs` in renderless mode — to match the scoped locale. This is a genuine accessibility affordance: assistive technology reads `lang` to select the correct pronunciation and voice, satisfying [WCAG 3.1.2 Language of Parts](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts). It also sets a `data-locale` attribute for styling and selection.
+
+Beyond `lang`, Locale is a headless context provider — it adds no roles, keyboard behavior, or interactive elements. In renderless mode you are responsible for binding `attrs` (which includes `lang`) to your own element, so the language information reaches the accessibility tree.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/providers/scrim.md
+++ b/apps/docs/src/pages/components/providers/scrim.md
@@ -132,6 +132,12 @@ The default transition is `fade`. Customize with the `transition` prop:
 </style>
 ```
 
+## Accessibility
+
+Scrim renders each backdrop layer with `aria-hidden="true"`, so assistive technology skips it entirely — the scrim is decorative and must never hold focusable or interactive content. Its only behavior is click-to-dismiss (suppressed when the topmost overlay is `blocking`), which is a pointer convenience, not the accessible dismissal path.
+
+The accessible dismissal contract — Escape-to-close, focus trapping, and focus return — belongs to the overlay the scrim sits behind, not to the scrim itself. Pair Scrim with [Dialog](/components/disclosure/dialog), which owns `role="dialog"`, focus management, and keyboard handling; the scrim only paints the backdrop.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/providers/selection.md
+++ b/apps/docs/src/pages/components/providers/selection.md
@@ -1,10 +1,10 @@
 ---
 title: Selection - Headless Selection State for Vue 3
 meta:
-  - name: description
-    content: Manage selection state in Vue 3 collections. Build checkboxes, radio groups, and listboxes with full v-model support, mandatory selection, and item enrollment.
-  - name: keywords
-    content: selection, checkbox, radio group, listbox, Vue 3, headless, v-model, state management
+- name: description
+  content: Manage selection state in Vue 3 collections. Build checkboxes, radio groups, and listboxes with full v-model support, mandatory selection, and item enrollment.
+- name: keywords
+  content: selection, checkbox, radio group, listbox, Vue 3, headless, v-model, state management
 features:
   category: Component
   label: 'C: Selection'
@@ -25,7 +25,7 @@ A headless component for managing selection state in collections with support fo
 
 ## Usage
 
-The Selection component provides a wrapper and item pattern for managing selection state in collections. It uses the `createSelection` composable internally and provides full v-model support with automatic state synchronization.
+The Selection component provides a wrapper and item pattern for managing selection state in collections. It supports both single and multi-selection with full v-model support and automatic state synchronization.
 
 ::: gn-example
 /components/selection/basic
@@ -44,6 +44,15 @@ The Selection component provides a wrapper and item pattern for managing selecti
   </Selection.Root>
 </template>
 ```
+
+## Accessibility
+
+Selection is a headless **state provider**, not a complete interactive widget. It tracks which items are selected and exposes that state on each slot's `attrs`; it ships pointer activation (a click handler) but no `role`, keyboard navigation, or focus management.
+
+- `Selection.Root` exposes `aria-multiselectable`, reflecting the `multiple` prop — `true` in multi-select mode, `false` otherwise.
+- `Selection.Item` exposes `aria-selected` and `aria-disabled`, plus `data-selected` and `data-disabled` for styling.
+
+For fully accessible widgets built on this selection state, reach for the specialized providers and form components that compose it — [Single](/components/providers/single) and [Group](/components/providers/group), or [Radio](/components/forms/radio) and [Checkbox](/components/forms/checkbox), which add native inputs, label association, and keyboard handling. When you bind `attrs` to your own element, you are responsible for supplying the appropriate `role` and keyboard handlers for the pattern you are building.
 
 ## FAQ
 

--- a/apps/docs/src/pages/components/providers/step.md
+++ b/apps/docs/src/pages/components/providers/step.md
@@ -85,6 +85,15 @@ Disabled items are automatically skipped by `next`, `prev`, and `step`. Use this
 </template>
 ```
 
+## Accessibility
+
+Step is a headless **state provider**, not a complete interactive widget. It tracks the active item and exposes sequential navigation methods (`first`, `last`, `next`, `prev`, `step`) plus per-item state on each slot's `attrs`; it ships pointer activation (a click handler) but no `role`, keyboard navigation, or focus management.
+
+- `Step.Root` exposes `aria-multiselectable="false"` — single-selection.
+- `Step.Item` exposes `aria-selected` and `aria-disabled`, plus `data-selected` and `data-disabled` for styling.
+
+This is single-selection navigation state. For a fully accessible tabbed stepper — `role="tablist"` / `role="tab"`, arrow-key navigation, and roving `tabindex` — use [Tabs](/components/disclosure/tabs), which composes the same step logic. When you bind `attrs` to your own element, you are responsible for wiring the navigation methods to keyboard handlers and supplying the roles the pattern requires.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/providers/theme.md
+++ b/apps/docs/src/pages/components/providers/theme.md
@@ -127,6 +127,12 @@ The default slot exposes `theme` (the active ID), `isDark` (boolean), and `attrs
 </template>
 ```
 
+## Accessibility
+
+Theme is a headless **context provider**. It scopes theme state to a subtree and writes a `data-theme` attribute on its wrapper element for CSS variable targeting; it adds no ARIA attributes, roles, or keyboard behavior, and it introduces no interactive elements of its own.
+
+Theme selection is a visual concern, not a semantic one — a scoped theme changes token values, not the accessibility tree. Ensure the color choices in every theme you expose meet [WCAG contrast requirements](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum); the component does not enforce contrast for you.
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/semantic/avatar.md
+++ b/apps/docs/src/pages/components/semantic/avatar.md
@@ -143,6 +143,26 @@ The data lives in a separate module so the component stays focused on compositio
 
 :::
 
+## Accessibility
+
+Avatar is presentational — it renders an image with a text or icon fallback and ships no interactive roles or keyboard behavior. Its accessibility surface is about naming the image and announcing group truncation:
+
+- `Avatar.Image` renders an `<img>` with `role="img"` and forwards the `alt` prop as its accessible name. Pass `alt` with a meaningful description (for example the person's name) for identifying avatars; pass `alt=""` for purely decorative avatars so screen readers skip them.
+- `Avatar.Fallback` renders the initials or icon shown when no image loads. Use readable initials so identity is still conveyed when the image is unavailable.
+- `Avatar.Group` renders `role="group"` and accepts a `label` (mapped to `aria-label`), `ariaLabelledby`, and `ariaDescribedby` so the collection has an accessible name.
+- `Avatar.Indicator` (the `+N` overflow chip) renders `aria-live="polite"` and a localized `aria-label` (`"+N more"`, via the `Avatar.indicatorLabel` key) so the hidden count is announced when it changes.
+- Avatars hidden by `Avatar.Group` truncation are marked `aria-hidden`, removing them from the accessibility tree while the group reports the remainder through the indicator.
+
+For custom markup, use `renderless` mode and bind the `attrs` slot prop to preserve these attributes:
+
+```vue
+<template>
+  <Avatar.Image v-slot="{ attrs }" src="/avatar.jpg" alt="Jane Doe" renderless>
+    <img v-bind="attrs">
+  </Avatar.Image>
+</template>
+```
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/components/semantic/breadcrumbs.md
+++ b/apps/docs/src/pages/components/semantic/breadcrumbs.md
@@ -27,7 +27,7 @@ A headless component for creating responsive breadcrumb navigation with proper A
 
 ## Usage
 
-The Breadcrumbs component provides a compound component pattern for building navigation trails. It uses `createBreadcrumbs`, `createGroup`, and `createOverflow` internally.
+Breadcrumbs renders a navigation trail that shows where the current page sits in a hierarchy. When the trail is wider than its container, the middle crumbs automatically collapse behind an ellipsis so the first crumb and the current page stay visible.
 
 ::: gn-example
 /components/breadcrumbs/basic
@@ -254,6 +254,28 @@ app.mount('#app')
 ```
 
 The `label` prop takes priority over locale messages, so you can still override individual instances when needed.
+
+## Accessibility
+
+The Breadcrumbs component renders semantic navigation markup and manages ARIA attributes automatically:
+
+- `Breadcrumbs.Root` renders a `<nav>` landmark whose `aria-label` defaults to `"Breadcrumbs"` (override with the `label` prop or the `Breadcrumbs.label` locale key). When you change the element with `as`, it applies `role="navigation"` instead so the landmark is preserved.
+- `Breadcrumbs.List` renders an ordered list with `role="list"` to expose the trail as a list to screen readers.
+- `Breadcrumbs.Page` marks the current item with `aria-current="page"` so it is announced as the current location. Omitting `href` on the last crumb renders it as a Page automatically.
+- `Breadcrumbs.Link` renders a native `<a>`, so crumbs are focusable and activated with the keyboard like any link — no custom key handling is added.
+- `Breadcrumbs.Divider` and `Breadcrumbs.Ellipsis` render `aria-hidden="true"`, keeping the visual separators and the collapsed-items indicator out of the accessibility tree.
+
+For custom implementations, use `renderless` mode and bind the `attrs` slot prop to preserve the landmark role and label:
+
+```vue
+<template>
+  <Breadcrumbs.Root v-slot="{ attrs }" renderless>
+    <nav v-bind="attrs">
+      <!-- Custom breadcrumb trail -->
+    </nav>
+  </Breadcrumbs.Root>
+</template>
+```
 
 ## FAQ
 

--- a/apps/docs/src/pages/components/semantic/pagination.md
+++ b/apps/docs/src/pages/components/semantic/pagination.md
@@ -24,7 +24,7 @@ A headless component for creating page navigation with proper ARIA support.
 
 ## Usage
 
-The Pagination component provides a compound component pattern for building page navigation interfaces. It uses the `createPagination` and `createOverflow` composable internally.
+The Pagination component provides a compound component pattern for building page navigation interfaces. It adjusts how many page buttons it shows to fit the available width, collapsing the overflow behind ellipses.
 
 The two core props are `size` (total item count) and `items-per-page` (items per page, default `10`). Together they determine the page count:
 

--- a/apps/docs/src/pages/composables/data/create-data-table.md
+++ b/apps/docs/src/pages/composables/data/create-data-table.md
@@ -203,6 +203,28 @@ const virtual = createVirtual(table.items, { itemHeight: 40 })
 > table.register({ id, value })
 > ```
 
+## Architecture
+
+`createDataTable` composes independent primitives rather than extending a selection chain. Rows live in a non-reactive `createRegistry` surfaced reactively through `useProxyRegistry`, while columns live in a second, reactive registry. Sort state rides `createGroup`'s tri-state (selected = ascending, mixed = descending, unselected = none), `useLocale` supplies the collation locale, and the `DataTableAdapter` runs the filter → sort → paginate pipeline — the client adapter in memory, the server and virtual adapters against a fetcher.
+
+```mermaid "createDataTable Architecture"
+flowchart TD
+  Rows["createRegistry (rows)"]
+  Proxy["useProxyRegistry"]
+  Columns["createRegistry (columns)"]
+  Group["createGroup"]
+  Locale["useLocale"]
+  Adapter["DataTableAdapter (Client / Server / Virtual)"]
+  CDT["createDataTable"]:::primary
+
+  Rows --> Proxy
+  Proxy --> CDT
+  Columns --> CDT
+  Group --> CDT
+  Locale --> CDT
+  Adapter --> CDT
+```
+
 ## Reactivity
 
 | Property / Method | Reactive | Notes |

--- a/apps/docs/src/pages/composables/forms/create-combobox.md
+++ b/apps/docs/src/pages/composables/forms/create-combobox.md
@@ -1,10 +1,10 @@
 ---
 title: createCombobox - Orchestrator Composable for Combobox Components
 meta:
-  - name: description
-    content: Orchestrator composable that coordinates selection, popover, virtual focus, and adapter-based filtering for building combobox and autocomplete components.
-  - name: keywords
-    content: createCombobox, combobox, autocomplete, composable, filtering, virtual focus, Vue 3, headless
+- name: description
+  content: Orchestrator composable that coordinates selection, popover, virtual focus, and adapter-based filtering for building combobox and autocomplete components.
+- name: keywords
+  content: createCombobox, combobox, autocomplete, composable, filtering, virtual focus, Vue 3, headless
 features:
   category: Composable
   label: 'E: createCombobox'

--- a/apps/docs/src/pages/composables/forms/create-input.md
+++ b/apps/docs/src/pages/composables/forms/create-input.md
@@ -1,10 +1,10 @@
 ---
 title: createInput - Shared Form Field Primitive
 meta:
-  - name: description
-    content: Generic form field primitive with validation, field state tracking, ARIA IDs, and form registration for Vue 3 headless components.
-  - name: keywords
-    content: createInput, input, form, validation, field state, composable, Vue 3, headless
+- name: description
+  content: Generic form field primitive with validation, field state tracking, ARIA IDs, and form registration for Vue 3 headless components.
+- name: keywords
+  content: createInput, input, form, validation, field state, composable, Vue 3, headless
 features:
   category: Composable
   label: 'E: createInput'

--- a/apps/docs/src/pages/composables/forms/create-number-field.md
+++ b/apps/docs/src/pages/composables/forms/create-number-field.md
@@ -1,10 +1,10 @@
 ---
 title: createNumberField - Numeric Input Composable
 meta:
-  - name: description
-    content: Composable for numeric input state with Intl.NumberFormat, step snapping, and field validation for Vue 3.
-  - name: keywords
-    content: createNumberField, number input, composable, formatting, stepping, Vue 3, headless
+- name: description
+  content: Composable for numeric input state with Intl.NumberFormat, step snapping, and field validation for Vue 3.
+- name: keywords
+  content: createNumberField, number input, composable, formatting, stepping, Vue 3, headless
 features:
   category: Composable
   label: 'E: createNumberField'

--- a/apps/docs/src/pages/composables/forms/create-numeric.md
+++ b/apps/docs/src/pages/composables/forms/create-numeric.md
@@ -1,10 +1,10 @@
 ---
 title: createNumeric - Pure Numeric Math Primitive
 meta:
-  - name: description
-    content: Pure numeric math for bounded values. Snap, step, clamp, percentage conversion, and circular wrapping with floating-point precision handling.
-  - name: keywords
-    content: createNumeric, numeric, math, clamp, snap, step, composable, Vue 3, headless
+- name: description
+  content: Pure numeric math for bounded values. Snap, step, clamp, percentage conversion, and circular wrapping with floating-point precision handling.
+- name: keywords
+  content: createNumeric, numeric, math, clamp, snap, step, composable, Vue 3, headless
 features:
   category: Composable
   label: 'E: createNumeric'

--- a/apps/docs/src/pages/composables/forms/create-rating.md
+++ b/apps/docs/src/pages/composables/forms/create-rating.md
@@ -1,10 +1,10 @@
 ---
 title: createRating - Bounded Rating Value Management
 meta:
-  - name: description
-    content: Headless composable for discrete star ratings with half-step support, value clamping, and computed item states for Vue 3.
-  - name: keywords
-    content: rating, stars, review, score, composable, bounded, Vue 3, headless
+- name: description
+  content: Headless composable for discrete star ratings with half-step support, value clamping, and computed item states for Vue 3.
+- name: keywords
+  content: rating, stars, review, score, composable, bounded, Vue 3, headless
 features:
   category: Composable
   label: 'E: createRating'
@@ -69,6 +69,26 @@ provideProductRating()
 // In child component
 const rating = useProductRating()
 rating.select(4)
+```
+
+## Architecture
+
+`createRating` is standalone — it does not build on the registry or selection chain. The current rating is a single `clamp`-bounded number and the item descriptors are derived with `range`, so there is no per-item ticket overhead. Optional dependency injection is layered on by `createRatingContext`, which wraps the context in `createTrinity`.
+
+```mermaid "createRating Architecture"
+flowchart TD
+  Options["RatingOptions"]
+  clamp["clamp"]
+  range["range"]
+  CR["createRating"]:::primary
+  Context["RatingContext"]
+  Trinity["createRatingContext + createTrinity"]
+
+  Options --> CR
+  clamp --> CR
+  range --> CR
+  CR --> Context
+  Context --> Trinity
 ```
 
 ## Reactivity

--- a/apps/docs/src/pages/composables/forms/create-slider.md
+++ b/apps/docs/src/pages/composables/forms/create-slider.md
@@ -51,6 +51,24 @@ slider2.set(0, 30)         // values: [30, 75]
 slider2.set(1, 60)         // values: [30, 60]
 ```
 
+## Architecture
+
+`createSlider` extends `createModel` — which itself extends `createRegistry` — so each thumb is a model ticket holding a `shallowRef<number>`, and `values` is derived from the ordered tickets rather than a standalone ref. It composes `createNumeric` for the pure value math: step snapping, min/max clamping, and value ↔ percentage conversion.
+
+```mermaid "createSlider Architecture"
+flowchart TD
+  Registry["createRegistry"]
+  Model["createModel"]
+  Numeric["createNumeric"]
+  CS["createSlider"]:::primary
+  Context["SliderContext"]
+
+  Registry --> Model
+  Model --> CS
+  Numeric --> CS
+  CS --> Context
+```
+
 ## Reactivity
 
 Slider state is **always reactive**. Values and derived properties update automatically.

--- a/apps/docs/src/pages/composables/index.md
+++ b/apps/docs/src/pages/composables/index.md
@@ -1,10 +1,10 @@
 ---
 title: Vuetify0 Composables - Vue 3 Headless Primitives
 meta:
-  - name: description
-    content: Type-safe Vue 3 composables for headless UI. Selection, forms, theming, tokens, and state management primitives for building custom design systems.
-  - name: keywords
-    content: composables, Vue 3, headless ui, primitives, selection, forms, theming, state management, TypeScript
+- name: description
+  content: Type-safe Vue 3 composables for headless UI. Selection, forms, theming, tokens, and state management primitives for building custom design systems.
+- name: keywords
+  content: composables, Vue 3, headless ui, primitives, selection, forms, theming, state management, TypeScript
 features:
   level: 1
 related:
@@ -181,7 +181,7 @@ registry.on('unregister:ticket', ticket => {
 
 Composable names signal how they're used:
 
-### `create*` — Factory Functions
+### create* — Factory Functions
 
 Factory functions construct a new instance of stateful logic. They return an object you can provide, pass around, or destructure.
 
@@ -191,7 +191,7 @@ Factory functions construct a new instance of stateful logic. They return an obj
 | State factories | `createSelection`, `createRegistry` | Creating isolated state instances |
 | Feature factories | `createDataTable`, `createForm` | Composing multiple primitives into a feature |
 
-### `use*` — Composables
+### use* — Composables
 
 Composables consume existing context or wrap browser APIs. They're called inside `setup()` and return reactive state.
 

--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -333,6 +333,24 @@ app.use(
 > }
 > ```
 
+## Architecture
+
+`useDate` is a thin plugin around a required `DateAdapter` — there is no default, so `createDatePlugin` must be installed with an explicit adapter. It resolves the active locale (from `useLocale` when present, otherwise its own option) and pushes it plus the derived `firstDayOfWeek` onto the adapter; all date math is delegated. `V0DateAdapter` is the bundled Temporal-backed implementation, but any `DateAdapter` subclass can back a different library.
+
+```mermaid "useDate Architecture"
+flowchart TD
+  Locale["useLocale"]
+  UD["useDate"]:::primary
+  Adapter["DateAdapter"]
+  V0["V0DateAdapter (Temporal)"]
+  Custom["Custom adapter (date-fns, dayjs, …)"]
+
+  Locale --> UD
+  UD --> Adapter
+  Adapter --> V0
+  Adapter --> Custom
+```
+
 ## Reactivity
 
 The date context provides minimal reactivity, with the adapter being a static instance.

--- a/apps/docs/src/pages/composables/plugins/use-rtl.md
+++ b/apps/docs/src/pages/composables/plugins/use-rtl.md
@@ -109,6 +109,24 @@ abstract class RtlAdapter {
 }
 ```
 
+## Architecture
+
+`useRtl` is a standalone plugin built with `createPluginContext`; its entire state is one reactive boolean (`isRtl`). Applying that direction to the DOM is delegated to an `RtlAdapter` — the default `V0RtlAdapter` writes the `dir` attribute onto the target element (`document.documentElement` unless overridden). It is independent of `useLocale`; Vuetify wires the two together through its own adapter.
+
+```mermaid "useRtl Architecture"
+flowchart TD
+  Plugin["createPluginContext"]
+  UR["useRtl"]:::primary
+  Adapter["RtlAdapter"]
+  V0["V0RtlAdapter"]
+  DOM["dir attribute on target"]
+
+  Plugin --> UR
+  UR --> Adapter
+  Adapter --> V0
+  V0 --> DOM
+```
+
 ## Reactivity
 
 | Property | Type | Description |

--- a/apps/docs/src/pages/composables/plugins/use-theme.md
+++ b/apps/docs/src/pages/composables/plugins/use-theme.md
@@ -1,5 +1,5 @@
 ---
-title: useTheme Composable
+title: useTheme - Theme Management for Vue 3
 meta:
 - name: description
   content: A composable for theme management that registers multiple themes, switches

--- a/apps/docs/src/pages/composables/registration/create-timeline.md
+++ b/apps/docs/src/pages/composables/registration/create-timeline.md
@@ -25,7 +25,7 @@ Bounded undo/redo history built on `createRegistry` with a configurable size lim
 
 The `createTimeline` composable extends `createRegistry` to provide undo/redo functionality with a bounded history. When the timeline reaches its size limit, older items are moved to an overflow buffer, allowing you to undo back to them while maintaining a fixed active timeline size.
 
-```ts
+```ts collapse
 import { createTimeline } from '@vuetify/v0'
 
 const timeline = createTimeline({ size: 10 })

--- a/apps/docs/src/pages/composables/registration/create-tokens.md
+++ b/apps/docs/src/pages/composables/registration/create-tokens.md
@@ -189,9 +189,9 @@ Even though cycles fail safe, design your token hierarchy as a directed acyclic 
 
 ```mermaid "Valid Token Graph"
 flowchart TD
-    primary["primary: #3b82f6"] --> info["info: {primary}"]
-    primary --> link["link: {primary}"]
-    info --> infoBorder["info-border: {info}"]
+    primary["color.primary: #3b82f6"] --> info["color.info: {color.primary}"]
+    primary --> link["color.link: {color.primary}"]
+    info --> infoBorder["color.info-border: {color.info}"]
 ```
 
 ??? Can I use refs or computed values as tokens?

--- a/apps/docs/src/pages/composables/selection/create-model.md
+++ b/apps/docs/src/pages/composables/selection/create-model.md
@@ -27,7 +27,7 @@ Reactive value store that wraps a ref with two-way selection binding.
 
 `createModel` stores a reactive value. Register a ref and `useProxyModel` keeps it synced — the same idea as `defineModel` but built on the registry pattern.
 
-```ts
+```ts collapse
 import { shallowRef } from 'vue'
 import { createModel, useProxyModel } from '@vuetify/v0'
 

--- a/apps/docs/src/pages/composables/selection/create-selection.md
+++ b/apps/docs/src/pages/composables/selection/create-selection.md
@@ -27,7 +27,7 @@ A composable for managing the selection of items in a collection with automatic 
 
 `createSelection` extends `createModel` with selection-specific concepts: `mandatory` enforcement, `multiple` selection mode, auto-enrollment, and ticket self-methods (`select()`, `unselect()`, `toggle()`). It is reactive and provides helper properties for working with selected IDs, values, and items.
 
-```ts
+```ts collapse
 import { createSelection } from '@vuetify/v0'
 
 const selection = createSelection()

--- a/apps/docs/src/pages/composables/transformers/to-highlight.md
+++ b/apps/docs/src/pages/composables/transformers/to-highlight.md
@@ -1,10 +1,10 @@
 ---
 title: toHighlight - Text Search Highlighting for Vue 3
 meta:
-  - name: description
-    content: Pure Vue 3 transformer that splits text into matched and unmatched chunks given a query string or pre-computed match ranges. No DOM, no state, no reactivity — just a HighlightChunk array. Wrap in computed() for reactive recomputation.
-  - name: keywords
-    content: highlight, text search, mark, query, search terms, Vue 3, headless, transformer, filter, autocomplete, MatchRange
+- name: description
+  content: Pure Vue 3 transformer that splits text into matched and unmatched chunks given a query string or pre-computed match ranges. No DOM, no state, no reactivity — just a HighlightChunk array. Wrap in computed() for reactive recomputation.
+- name: keywords
+  content: highlight, text search, mark, query, search terms, Vue 3, headless, transformer, filter, autocomplete, MatchRange
 features:
   category: Transformer
   label: 'E: toHighlight'


### PR DESCRIPTION
Surface-consistency pass over the component and composable docs pages, plus fill-ins for confirmed-missing sections. Derived from a docs audit whose findings were re-verified against source before acting.

## Mechanical
- **useTheme** — title moved to `Name - Description` form
- **Headers** — stripped inline-code backticks from headers in `select.md` and the composables index (`### create*`, `### use*`)
- **Usage fences** — added `collapse` to composable Usage `ts` fences (`create-timeline`, `create-model`, `create-selection`)
- **Frontmatter** — moved `meta` list items to column 0 across 12 pages (includes both `index.md` pages the original audit missed)
- **create-tokens** — normalized the Architecture mermaid to dot-notation token ids so it matches the Usage sample

## Content (source-verified)
- **Accessibility** sections added to 12 components (dialog, expansion-panel, popover, treeview, group, locale, scrim, selection, step, theme, avatar, breadcrumbs) — ARIA roles/attributes and keyboard behavior read from each component's source; headless providers get honest "state only, a11y belongs to the consumer" sections rather than invented tables
- **Architecture** diagrams added to 5 composables (create-data-table, create-rating, create-slider, use-date, use-rtl) — each mermaid reflects the actual composition/adapter graph in source
- **Usage openers** — rewrote 6 component openers to be user-facing and drop internal composable names (expansion-panel, tabs, treeview, selection, breadcrumbs, pagination); `overflow.md` intentionally left as the correct model

## Deliberately excluded
- Meta-description length: the audit's "~20 pages, worst ~310/~374 chars" was inaccurate (actual ~67 pages outside 150–160; worst cases were ~172/~234). Not batched here — it's editorial, not mechanical.

Canonical section order preserved on every page. `pnpm build:docs` passes.