### PR TITLE
docs(paper): design-system and kit authoring contract

### DIFF
--- a/DESIGN_SYSTEMS.md
+++ b/DESIGN_SYSTEMS.md
@@ -1,24 +1,23 @@
-# Building on Paper — Design Systems & Kits
+# Paper — Design Systems & Kits
 
-The contract for every package in the `@paper/*` family. Per-package specifics live in
-that package's `SPEC.md` (see [Per-package SPEC.md](#per-package-specmd)); this document
-defines what is common, what is required, and what is forbidden — so patterns are decided
-once, not rediscovered per component.
+**Paper** is the family of design systems and kits built on `@vuetify/v0`, published
+under the `@paper/*` scope. Each package stands on its own — v0 is the only substrate.
+
+This document is the family contract. Per-package specifics live in that package's
+`SPEC.md` (see [Per-package SPEC.md](#per-package-specmd)); this document defines what
+is common, what is required, and what is forbidden — so patterns are decided once, not
+rediscovered per component.
 
 Rulings 1–3 below are **decided**; sections 4–5 are **PROPOSED** and open for review.
 
 The stack:
 
 ```
-@vuetify/v0      headless logic — compound components, composables, theme engine
-                 (incl. V0StyleSheetThemeAdapter, the adapter base)
-@vuetify/paper   styling primitives — useColor, useTheme, useContrast
-@paper/*         design systems and kits (the classes below)
+@vuetify/v0      the substrate — compound components, composables, utilities,
+                 and the theme engine (incl. V0StyleSheetThemeAdapter)
+@paper/*         design systems and kits (the classes below), each standalone on v0
 vuetify          orchestration + defaults (Material ships here)
 ```
-
-`@paper/*` names the family, not a dependency: a kit may depend on `@vuetify/v0`
-alone (Genesis does today).
 
 ## Two classes
 
@@ -46,8 +45,8 @@ customer's file. This is why the token pipeline must be reproducible end to end.
 
 Tokens are TypeScript objects (`theme.ts`), published as CSS custom properties at
 runtime by a stylesheet adapter extending **v0's theme engine**
-(`V0StyleSheetThemeAdapter`, imported from `@vuetify/v0`, constructed with the design
-system's prefix). Two consumption paths, both required:
+(`V0StyleSheetThemeAdapter`, constructed with the design system's prefix). Two
+consumption paths, both required:
 
 - **Zero-config**: the build prebakes the default theme to `dist/theme.css`. A newcomer
   installs, imports one CSS file, and components render correctly — no plugin.
@@ -60,8 +59,7 @@ path is wired. Design values live in tokens; literals appear **only** as `var()`
 fallbacks or in `theme.ts`.
 
 Kits skip all of this: consume `--v0-*` variables with literal fallbacks, exactly as
-`@paper/genesis` documents in its SPEC.md. (Paper's own composables — `useColor`,
-`useTheme`, `useContrast` — also operate on the `--v0-*` namespace today.)
+`@paper/genesis` documents in its SPEC.md.
 
 ### 2. Composition
 
@@ -71,7 +69,8 @@ Kits skip all of this: consume `--v0-*` variables with literal fallbacks, exactl
 - **Purely presentational components** (cards, badges, dividers) render semantic
   elements or v0's `Atom`; there is no behavioral primitive to compose and none should
   be invented.
-- In neither case is `V0Paper` the component base.
+- Styling logic comes from v0's utilities (`apca`, `foreground`, `hexToRgb`, …) and the
+  package's own tokens — there is no intermediate styling-primitives package.
 - Never compose native HTML form controls.
 
 ### 3. Styling
@@ -92,10 +91,11 @@ The config layer is mechanical and must be **generated, not authored** — scaff
 packages start from the canonical shape rather than copying a sibling:
 
 - `package.json`: two-tier exports (`development` condition → `src/index.ts`,
-  `publishConfig` dist-only), `workspace:^` internal ranges, `vue >=3.5.0` peer
-  (components use reactive props destructure), `catalog:` dev deps.
-- `tsconfig.json`: extends `@vue/tsconfig/tsconfig.dom.json`; `#<name>`/`#paper`/`#v0`
-  path aliases; `lib` includes `esnext`; no `baseUrl`.
+  `publishConfig` dist-only), `@vuetify/v0` as the sole internal dependency
+  (`workspace:^`), `vue >=3.5.0` peer (components use reactive props destructure),
+  `catalog:` dev deps.
+- `tsconfig.json`: extends `@vue/tsconfig/tsconfig.dom.json`; `#<name>` and `#v0` path
+  aliases; `lib` includes `esnext`; no `baseUrl`.
 - `tsdown.config.mts`: `unplugin-vue/rolldown`, `dts: { vue: true }`, the deferred
   `__DEV__: 'process.env.NODE_ENV !== \'production\''` expression (never baked at
   build time), `exports: { devExports: 'development' }`.

--- a/DESIGN_SYSTEMS.md
+++ b/DESIGN_SYSTEMS.md
@@ -70,7 +70,12 @@ Kits skip all of this: consume `--v0-*` variables with literal fallbacks, exactl
   elements or v0's `Atom`; there is no behavioral primitive to compose and none should
   be invented.
 - Styling logic comes from v0's utilities (`apca`, `foreground`, `hexToRgb`, …) and the
-  package's own tokens — there is no intermediate styling-primitives package.
+  package's own tokens; no published `@paper/*` package routes styling through an
+  intermediate styling-primitives layer. (`@vuetify/paper` is removed from the
+  version/publish path and kept dormant in-repo. Whether v0's utilities fully cover the
+  color/contrast math a design system needs — and so whether Paper's primitives are still
+  required — is to be evaluated against the second design system, Onyx: decision deferred,
+  not made.)
 - Never compose native HTML form controls.
 
 ### 3. Styling

--- a/packages/paper/DESIGN_SYSTEMS.md
+++ b/packages/paper/DESIGN_SYSTEMS.md
@@ -1,0 +1,114 @@
+# Building on Paper — Design Systems & Kits
+
+The contract for every package built on the Paper layer. Per-package specifics live in
+that package's `SPEC.md` (see [Per-package SPEC.md](#per-package-specmd)); this document
+defines what is common, what is required, and what is forbidden — so patterns are decided
+once, not rediscovered per component.
+
+The stack:
+
+```
+@vuetify/v0      headless logic — compound components, composables, theme engine
+@vuetify/paper   styling primitives — useColor, useTheme, useContrast, adapter bases
+@paper/*         packages built on Paper (both classes below)
+vuetify          orchestration + defaults (Material ships here)
+```
+
+## Two classes
+
+The `@paper/*` scope hosts two deliberately different kinds of package. Identify the
+class first — a kit missing a token pipeline is correct, not incomplete; a design
+system missing one is broken.
+
+| | **Design system** | **Kit** |
+|---|---|---|
+| Intent | Encompass everything — a complete visual framework | Purpose-scoped component set |
+| Exemplars | Material, Emerald, Onyx | Genesis (docs), Helix (docs platform) |
+| Token namespace | Owns one (`--emerald-*`) | **None** — consumes `--v0-*` |
+| Theme plugin / adapter | Required (`theme.ts`, `adapter.ts`, `plugin.ts`) | **Forbidden** |
+| Stylesheet artifact | `dist/theme.css` (prebaked default theme) | None — inherits the page's theme |
+| Component coverage | Full, spec-driven | Only what the purpose needs |
+| Visual language | Its own | Blends with whatever theme is active |
+
+"Custom design system via bring-your-own Figma" is a **delivery mode** of the design
+system class, not a third class: same contract, same pipeline, tokens sourced from the
+customer's file. This is why the token pipeline must be reproducible end to end.
+
+## Rulings
+
+### 1. Tokens and the zero-config on-ramp (design systems)
+
+Tokens are TypeScript objects (`theme.ts`), published as CSS custom properties at
+runtime by a stylesheet adapter extending v0's theme system. Two consumption paths, both
+required:
+
+- **Zero-config**: the build prebakes the default theme to `dist/theme.css`. A newcomer
+  installs, imports one CSS file, and components render correctly — no plugin.
+- **Full**: `app.use(create<Name>Plugin())` for theming, dark mode, runtime switching,
+  CSP nonces.
+
+Component styles reference tokens with literal fallbacks — `var(--emerald-primary,
+#26C26D)` — so components degrade to the default look rather than breaking when neither
+path is wired. Design values live in tokens; literals appear **only** as `var()`
+fallbacks or in `theme.ts`.
+
+Kits skip all of this: consume `--v0-*` variables with literal fallbacks, exactly as
+`@paper/genesis` documents in its SPEC.md.
+
+### 2. Composition
+
+Components compose **v0 compound primitives directly** — `Button.Root`, `Dialog.Root`,
+`Tabs.Root`, and friends own behavior, accessibility, and state. Paper contributes
+through its **composables** (`useColor`, `useTheme`, `useContrast`, …) and **adapter
+base classes**, not as a component base: `V0Paper` is not the foundation for design
+system or kit components. Never compose native HTML form controls.
+
+### 3. Styling
+
+- **Never `<style scoped>`.** Scoped rules silently fail on multi-root compound
+  children (the `data-v` attribute never lands on the primitive's root — this bit
+  Genesis in [#359](https://github.com/vuetifyjs/0/issues/359)). One rule, zero
+  judgment calls.
+- Isolation comes from the class prefix: every class is namespaced by package
+  (`emerald-button`, `genesis-docs-example`).
+- State styling hooks are data attributes (`data-variant`, `data-size`,
+  `data-disabled`), not JS-computed class lists.
+- No utility classes in package source.
+
+### 4. Package skeleton (PROPOSED)
+
+The config layer is mechanical and must be **generated, not authored** — scaffolded new
+packages start from the canonical shape rather than copying a sibling:
+
+- `package.json`: two-tier exports (`development` condition → `src/index.ts`,
+  `publishConfig` dist-only), `workspace:^` internal ranges, `vue >=3.5.0` peer
+  (components use reactive props destructure), `catalog:` dev deps.
+- `tsconfig.json`: extends `@vue/tsconfig/tsconfig.dom.json`; `#<name>`/`#paper`/`#v0`
+  path aliases; `lib` includes `esnext`; no `baseUrl`.
+- `tsdown.config.mts`: `unplugin-vue/rolldown`, `dts: { vue: true }`, the deferred
+  `__DEV__: 'process.env.NODE_ENV !== \'production\''` expression (never baked at
+  build time), `exports: { devExports: 'development' }`.
+
+### 5. Component maturity bar (PROPOSED)
+
+A design system component ships only when:
+
+- every variant and size in its spec exists (no "1 of 4 variants");
+- interactive states are styled: hover, `:focus-visible`, disabled, loading where
+  applicable;
+- dark-mode tokens resolve wherever the design system defines a dark theme;
+- its tokens are **wired** — a token defined in `theme.ts` but unused by any component,
+  or a component hardcoding a value a token exists for, fails review.
+
+Kits gate only on their purpose's spec.
+
+## Per-package SPEC.md
+
+Every `@paper/*` package carries a `SPEC.md` declaring:
+
+1. its **class** (design system or kit) and purpose;
+2. its **token source** (e.g. the canonical Figma file key) — design systems only;
+3. its component inventory and any intentional deviations from this contract, with
+   reasons.
+
+`packages/genesis/SPEC.md` is the exemplar for kits.

--- a/packages/paper/DESIGN_SYSTEMS.md
+++ b/packages/paper/DESIGN_SYSTEMS.md
@@ -1,18 +1,24 @@
 # Building on Paper — Design Systems & Kits
 
-The contract for every package built on the Paper layer. Per-package specifics live in
+The contract for every package in the `@paper/*` family. Per-package specifics live in
 that package's `SPEC.md` (see [Per-package SPEC.md](#per-package-specmd)); this document
 defines what is common, what is required, and what is forbidden — so patterns are decided
 once, not rediscovered per component.
+
+Rulings 1–3 below are **decided**; sections 4–5 are **PROPOSED** and open for review.
 
 The stack:
 
 ```
 @vuetify/v0      headless logic — compound components, composables, theme engine
-@vuetify/paper   styling primitives — useColor, useTheme, useContrast, adapter bases
-@paper/*         packages built on Paper (both classes below)
+                 (incl. V0StyleSheetThemeAdapter, the adapter base)
+@vuetify/paper   styling primitives — useColor, useTheme, useContrast
+@paper/*         design systems and kits (the classes below)
 vuetify          orchestration + defaults (Material ships here)
 ```
+
+`@paper/*` names the family, not a dependency: a kit may depend on `@vuetify/v0`
+alone (Genesis does today).
 
 ## Two classes
 
@@ -23,7 +29,7 @@ system missing one is broken.
 | | **Design system** | **Kit** |
 |---|---|---|
 | Intent | Encompass everything — a complete visual framework | Purpose-scoped component set |
-| Exemplars | Material, Emerald, Onyx | Genesis (docs), Helix (docs platform) |
+| Exemplars | Material, Emerald, Onyx | Genesis (docs) |
 | Token namespace | Owns one (`--emerald-*`) | **None** — consumes `--v0-*` |
 | Theme plugin / adapter | Required (`theme.ts`, `adapter.ts`, `plugin.ts`) | **Forbidden** |
 | Stylesheet artifact | `dist/theme.css` (prebaked default theme) | None — inherits the page's theme |
@@ -39,8 +45,9 @@ customer's file. This is why the token pipeline must be reproducible end to end.
 ### 1. Tokens and the zero-config on-ramp (design systems)
 
 Tokens are TypeScript objects (`theme.ts`), published as CSS custom properties at
-runtime by a stylesheet adapter extending v0's theme system. Two consumption paths, both
-required:
+runtime by a stylesheet adapter extending **v0's theme engine**
+(`V0StyleSheetThemeAdapter`, imported from `@vuetify/v0`, constructed with the design
+system's prefix). Two consumption paths, both required:
 
 - **Zero-config**: the build prebakes the default theme to `dist/theme.css`. A newcomer
   installs, imports one CSS file, and components render correctly — no plugin.
@@ -53,15 +60,19 @@ path is wired. Design values live in tokens; literals appear **only** as `var()`
 fallbacks or in `theme.ts`.
 
 Kits skip all of this: consume `--v0-*` variables with literal fallbacks, exactly as
-`@paper/genesis` documents in its SPEC.md.
+`@paper/genesis` documents in its SPEC.md. (Paper's own composables — `useColor`,
+`useTheme`, `useContrast` — also operate on the `--v0-*` namespace today.)
 
 ### 2. Composition
 
-Components compose **v0 compound primitives directly** — `Button.Root`, `Dialog.Root`,
-`Tabs.Root`, and friends own behavior, accessibility, and state. Paper contributes
-through its **composables** (`useColor`, `useTheme`, `useContrast`, …) and **adapter
-base classes**, not as a component base: `V0Paper` is not the foundation for design
-system or kit components. Never compose native HTML form controls.
+- **Behavioral components** compose **v0 compound primitives directly** —
+  `Button.Root`, `Dialog.Root`, `Tabs.Root`, and friends own behavior, accessibility,
+  and state.
+- **Purely presentational components** (cards, badges, dividers) render semantic
+  elements or v0's `Atom`; there is no behavioral primitive to compose and none should
+  be invented.
+- In neither case is `V0Paper` the component base.
+- Never compose native HTML form controls.
 
 ### 3. Styling
 
@@ -88,6 +99,8 @@ packages start from the canonical shape rather than copying a sibling:
 - `tsdown.config.mts`: `unplugin-vue/rolldown`, `dts: { vue: true }`, the deferred
   `__DEV__: 'process.env.NODE_ENV !== \'production\''` expression (never baked at
   build time), `exports: { devExports: 'development' }`.
+- **Design systems additionally**: `src/theme.ts`, `src/adapter.ts`, `src/plugin.ts`,
+  and the build step that prebakes `dist/theme.css` from the default theme (ruling 1).
 
 ### 5. Component maturity bar (PROPOSED)
 
@@ -111,4 +124,6 @@ Every `@paper/*` package carries a `SPEC.md` declaring:
 3. its component inventory and any intentional deviations from this contract, with
    reasons.
 
-`packages/genesis/SPEC.md` is the exemplar for kits.
+`packages/genesis/SPEC.md` is the exemplar of the kit *shape*. Genesis itself predates
+this contract (most of its components still use `<style scoped>`, and its SPEC declares
+no class); its alignment is tracked separately and does not weaken the rulings above.


### PR DESCRIPTION
Establishes the family contract for Paper — the design systems and kits published under `@paper/*`, each standalone on `@vuetify/v0` (v0 is the sole substrate; `@vuetify/paper` is **removed from the version/publish path and kept dormant in-repo** — its fate deferred until the second design system, Onyx, proves whether its primitives are needed; decision deferred, not made).

- Two classes: design systems (rich — Material, Emerald, Onyx) vs kits (purpose-scoped — Genesis)
- Custom-via-Figma = a delivery mode of the design-system class
- Ruling 1: TS tokens → v0 theme-engine adapter → runtime vars, plus prebaked dist/theme.css + var() fallbacks (zero-config on-ramp)
- Ruling 2: behavioral components compose v0 compound primitives; presentational render semantic elements/Atom; V0Paper is not a base
- Ruling 3: never scoped styles; prefixed classes; data-attribute state hooks
- Sections 4 (generated skeleton) and 5 (component maturity bar) are PROPOSED for review
- Doc lives at repo root; per-package SPEC.md declares class, token source, inventory

Follow-ups (separate PRs): revisit `@vuetify/paper` after the second design system (whether v0 utilities fully cover the color/contrast math is to be evaluated then), align Genesis (unscoped sweep + SPEC class field), realign #167 components to ruling 2.