### PR TITLE
docs(roadmap): add v1.1-v1.5 release calendar with graduation waves

### DIFF
--- a/apps/docs/src/components.d.ts
+++ b/apps/docs/src/components.d.ts
@@ -159,6 +159,7 @@ declare module 'vue' {
     DocsProgressBar: typeof import('./components/docs/DocsProgressBar.vue')['default']
     DocsQuestion: typeof import('./components/docs/DocsQuestion.vue')['default']
     DocsRelated: typeof import('./components/docs/DocsRelated.vue')['default']
+    DocsReleaseCalendar: typeof import('./components/docs/DocsReleaseCalendar.vue')['default']
     DocsReleases: typeof import('./components/docs/DocsReleases.vue')['default']
     DocsRoadmap: typeof import('./components/docs/DocsRoadmap.vue')['default']
     DocsSearch: typeof import('./components/docs/DocsSearch.vue')['default']

--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
   // Framework
-  import { createSingle } from '@vuetify/v0'
+  import { Collapsible, createStep } from '@vuetify/v0'
 
   // Constants
   import { MATURITY_LEVELS as levels } from '@/constants/maturity'
   import { type FeatureType, type ResolvedRelease, releases } from '@/constants/roadmap-buckets'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { shallowRef, toRef } from 'vue'
   import { RouterLink } from 'vue-router'
 
   const items = releases()
+  const count = items.length
 
   const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
@@ -101,12 +102,15 @@
     return `color-mix(in srgb, ${color} ${pct}%, transparent)`
   }
 
-  const single = createSingle({ mandatory: 'force' })
-  single.onboard(items.map(release => ({ id: release.title, value: release.title })))
-  single.select(items[0].title)
+  const step = createStep({ mandatory: 'force' })
+  step.onboard(items.map(release => ({ id: release.title, value: release.title })))
+  step.select(items[0].title)
 
-  const selectedTitle = toRef(() => single.selectedValue.value)
+  const selectedTitle = toRef(() => step.selectedValue.value)
+  const selectedIndex = toRef(() => step.selectedIndex.value)
   const selected = toRef(() => items.find(release => release.title === selectedTitle.value))
+
+  const calendarOpen = shallowRef(false)
 
   function longDate (iso: string): string {
     const at = parts(iso)
@@ -131,72 +135,36 @@
       </span>
     </div>
 
-    <!-- Month cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
-      <div v-for="month in months" :key="month.key" class="border border-divider rounded-xl bg-surface p-3">
-        <div class="flex items-baseline justify-between mb-2 px-0.5">
-          <span class="text-sm font-semibold tracking-tight">{{ month.month }}</span>
-          <span class="text-[11px] font-mono text-on-surface-variant/50">{{ month.year }}</span>
-        </div>
-
-        <div class="grid grid-cols-7 gap-0.5">
-          <div
-            v-for="(weekday, w) in WEEKDAYS"
-            :key="`w-${w}`"
-            class="h-5 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
-          >
-            {{ weekday }}
-          </div>
-
-          <template v-for="(cell, index) in month.cells">
-            <!-- Release day -->
-            <button
-              v-if="cell.release"
-              :key="`r-${index}`"
-              :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
-              :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
-              class="group relative h-8 flex flex-col items-center justify-center rounded-md overflow-hidden cursor-pointer transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
-              :style="{
-                background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
-                boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
-              }"
-              type="button"
-              @click="single.select(cell.release.title)"
-            >
-              <span class="text-xs font-mono font-bold leading-none tabular-nums">{{ cell.day }}</span>
-              <span class="text-[10px] font-mono leading-none mt-0.5" :style="{ color: accent(cell.release) }">{{ shortTitle(cell.release.title) }}</span>
-
-              <!-- Payload split: arriving | graduating -->
-              <span class="absolute inset-x-0 bottom-0 h-1 flex">
-                <span class="h-full" :style="{ width: `${newPct(cell.release)}%`, background: ARRIVING.color }" />
-                <span class="h-full flex-1" :style="{ background: GRADUATING.color }" />
-              </span>
-            </button>
-
-            <!-- Non-release day -->
-            <div
-              v-else
-              :key="`d-${index}`"
-              class="h-8 grid place-items-center text-[11px] font-mono tabular-nums"
-              :class="cell.adjacent ? 'text-on-surface-variant/25' : cell.weekend ? 'text-on-surface-variant/45' : 'text-on-surface-variant/70'"
-            >
-              {{ cell.day }}
-            </div>
-          </template>
-        </div>
-      </div>
-    </div>
-
-    <!-- Selected release detail -->
+    <!-- Selected release detail (always visible; step through releases) -->
     <div
       v-if="selected"
       aria-live="polite"
-      class="mt-5 rounded-xl bg-surface border border-divider p-4"
+      class="rounded-xl bg-surface border border-divider p-4"
       :style="{ borderInlineStartWidth: '4px', borderInlineStartColor: accent(selected) }"
     >
-      <div class="flex items-baseline gap-3 flex-wrap">
+      <div class="flex items-center gap-2 flex-wrap">
+        <button
+          aria-label="Previous release"
+          class="grid place-items-center w-7 h-7 rounded-md hover:bg-surface-tint disabled:opacity-30 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors"
+          :disabled="selectedIndex === 0"
+          type="button"
+          @click="step.prev()"
+        >
+          <AppIcon icon="chevron-left" :size="18" />
+        </button>
+
         <h3 class="text-lg font-mono font-bold">{{ selected.title }}</h3>
         <span class="text-sm text-on-surface-variant">{{ longDate(selected.date) }}</span>
+
+        <button
+          aria-label="Next release"
+          class="grid place-items-center w-7 h-7 rounded-md hover:bg-surface-tint disabled:opacity-30 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors"
+          :disabled="selectedIndex === count - 1"
+          type="button"
+          @click="step.next()"
+        >
+          <AppIcon icon="chevron-right" :size="18" />
+        </button>
 
         <span class="ms-auto inline-flex items-center gap-3 text-xs">
           <span v-if="selected.features.length > 0" class="inline-flex items-center gap-1" :style="{ color: ARRIVING.color }">
@@ -253,6 +221,71 @@
         </p>
       </div>
     </div>
+
+    <!-- Full calendar, collapsed by default -->
+    <Collapsible.Root v-model="calendarOpen" class="mt-3">
+      <Collapsible.Activator class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary rounded-lg hover:bg-surface-tint transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+        <AppIcon :icon="calendarOpen ? 'chevron-up' : 'chevron-down'" :size="16" />
+        {{ calendarOpen ? 'Hide calendar' : 'Show calendar' }}
+      </Collapsible.Activator>
+
+      <Collapsible.Content>
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-3">
+          <div v-for="month in months" :key="month.key" class="border border-divider rounded-xl bg-surface p-3">
+            <div class="flex items-baseline justify-between mb-2 px-0.5">
+              <span class="text-sm font-semibold tracking-tight">{{ month.month }}</span>
+              <span class="text-[11px] font-mono text-on-surface-variant/50">{{ month.year }}</span>
+            </div>
+
+            <div class="grid grid-cols-7 gap-0.5">
+              <div
+                v-for="(weekday, w) in WEEKDAYS"
+                :key="`w-${w}`"
+                class="h-5 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
+              >
+                {{ weekday }}
+              </div>
+
+              <template v-for="(cell, index) in month.cells">
+                <!-- Release day -->
+                <button
+                  v-if="cell.release"
+                  :key="`r-${index}`"
+                  :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
+                  :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
+                  class="group relative h-8 flex flex-col items-center justify-center rounded-md overflow-hidden cursor-pointer transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
+                  :style="{
+                    background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
+                    boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
+                  }"
+                  type="button"
+                  @click="step.select(cell.release.title)"
+                >
+                  <span class="text-xs font-mono font-bold leading-none tabular-nums">{{ cell.day }}</span>
+                  <span class="text-[10px] font-mono leading-none mt-0.5" :style="{ color: accent(cell.release) }">{{ shortTitle(cell.release.title) }}</span>
+
+                  <!-- Payload split: arriving | graduating -->
+                  <span class="absolute inset-x-0 bottom-0 h-1 flex">
+                    <span class="h-full" :style="{ width: `${newPct(cell.release)}%`, background: ARRIVING.color }" />
+                    <span class="h-full flex-1" :style="{ background: GRADUATING.color }" />
+                  </span>
+                </button>
+
+                <!-- Non-release day -->
+                <div
+                  v-else
+                  :key="`d-${index}`"
+                  class="h-8 grid place-items-center text-[11px] font-mono tabular-nums"
+                  :class="cell.adjacent ? 'text-on-surface-variant/25' : cell.weekend ? 'text-on-surface-variant/45' : 'text-on-surface-variant/70'"
+                >
+                  {{ cell.day }}
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
 
     <!-- Disclaimer -->
     <p class="mt-6 text-sm opacity-60 text-center">

--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -1,87 +1,250 @@
 <script setup lang="ts">
+  // Framework
+  import { createSingle } from '@vuetify/v0'
+
   // Constants
   import { MATURITY_LEVELS as levels } from '@/constants/maturity'
-  import { type FeatureType, releases } from '@/constants/roadmap-buckets'
+  import { type FeatureType, type ResolvedRelease, releases } from '@/constants/roadmap-buckets'
 
   // Utilities
+  import { toRef } from 'vue'
   import { RouterLink } from 'vue-router'
 
   const items = releases()
 
-  const stableColor = levels.stable.color
+  const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+  // Destination tiers on the maturity ladder — the two moves a release makes.
+  const ARRIVING = { color: levels.preview.color, icon: 'arrow-up-circle', label: 'Arriving (reaches preview)' }
+  const GRADUATING = { color: levels.stable.color, icon: 'shield-check', label: 'Graduating to stable' }
 
   const typeIcon: Record<FeatureType, string> = {
     composable: 'code',
     component: 'puzzle',
     utility: 'typescript',
   }
+
+  interface DateParts { year: number, month: number, day: number }
+
+  // Parse ISO locally (never `new Date(iso)` — that parses as UTC and can slip a day).
+  function parts (iso: string): DateParts {
+    const [year, month, day] = iso.split('-').map(Number)
+    return { year, month: month - 1, day }
+  }
+
+  const dated = items.map(release => ({ release, at: parts(release.date) }))
+  const byDay = new Map(dated.map(({ release, at }) => [`${at.year}-${at.month}-${at.day}`, release]))
+
+  interface Cell { day: number | null, weekend: boolean, release?: ResolvedRelease }
+  interface MonthGrid { key: string, month: string, year: number, cells: Cell[] }
+
+  // Render every month from the first release to the last, inclusive.
+  const start = dated[0].at
+  const end = dated.at(-1)!.at
+
+  const months: MonthGrid[] = []
+  for (let year = start.year, month = start.month; year < end.year || (year === end.year && month <= end.month);) {
+    const firstDow = new Date(year, month, 1).getDay()
+    const total = new Date(year, month + 1, 0).getDate()
+
+    const cells: Cell[] = Array.from({ length: firstDow }, (_, i) => ({ day: null, weekend: i % 7 === 0 || i % 7 === 6 }))
+    for (let day = 1; day <= total; day++) {
+      const column = (firstDow + day - 1) % 7
+      cells.push({ day, weekend: column === 0 || column === 6, release: byDay.get(`${year}-${month}-${day}`) })
+    }
+
+    months.push({
+      key: `${year}-${month}`,
+      month: new Date(year, month, 1).toLocaleDateString('en-US', { month: 'long' }),
+      year,
+      cells,
+    })
+
+    month += 1
+    if (month > 11) {
+      month = 0
+      year += 1
+    }
+  }
+
+  function shortTitle (title: string): string {
+    return title.replace(/^v/, '').replace(/\.0$/, '')
+  }
+
+  // Each marker is tinted by whichever move dominates the release. The split bar
+  // carries the exact composition, so the tint may overclaim on a near-even
+  // release — no planned release is close to even today (the nearest is ~15/85),
+  // so a neutral-tint fallback would be dead code. Revisit if that changes.
+  function accent (release: ResolvedRelease): string {
+    return release.features.length >= release.stabilizing.length ? ARRIVING.color : GRADUATING.color
+  }
+
+  function newPct (release: ResolvedRelease): number {
+    const total = release.features.length + release.stabilizing.length
+    return total === 0 ? 100 : Math.round((release.features.length / total) * 100)
+  }
+
+  function tint (color: string, pct: number): string {
+    return `color-mix(in srgb, ${color} ${pct}%, transparent)`
+  }
+
+  const single = createSingle({ mandatory: 'force' })
+  single.onboard(items.map(release => ({ id: release.title, value: release.title })))
+  single.select(items[0].title)
+
+  const selectedTitle = toRef(() => single.selectedValue.value)
+  const selected = toRef(() => items.find(release => release.title === selectedTitle.value))
+
+  function longDate (iso: string): string {
+    const at = parts(iso)
+    return new Date(at.year, at.month, at.day).toLocaleDateString('en-US', {
+      weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+    })
+  }
 </script>
 
 <template>
   <div class="my-6">
-    <div class="relative ps-5 border-s-2 border-divider ms-3 space-y-8">
-      <section
-        v-for="release in items"
-        :key="release.title"
-        class="relative"
-      >
-        <!-- Timeline dot -->
-        <div class="absolute -start-[calc(0.5rem+1px)] top-1.5 w-4 h-4 rounded-full border-2 border-primary bg-background" />
+    <!-- Legend -->
+    <div class="flex items-center justify-end gap-4 mb-3 text-xs text-on-surface-variant">
+      <span class="inline-flex items-center gap-1.5">
+        <span class="w-2.5 h-2.5 rounded-full" :style="{ background: ARRIVING.color }" />
+        {{ ARRIVING.label }}
+      </span>
 
-        <!-- Release header -->
-        <div class="flex items-baseline gap-3 flex-wrap ms-4">
-          <h3 class="text-lg font-semibold">{{ release.title }}</h3>
-          <span class="text-sm text-on-surface-variant">{{ release.date }}</span>
-        </div>
+      <span class="inline-flex items-center gap-1.5">
+        <span class="w-2.5 h-2.5 rounded-full" :style="{ background: GRADUATING.color }" />
+        {{ GRADUATING.label }}
+      </span>
+    </div>
 
-        <!-- Tracks -->
-        <div class="ms-4 mt-3 space-y-4">
-          <!-- Net-new features -->
-          <div v-if="release.features.length > 0">
-            <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">New in this release</div>
-
-            <div class="flex flex-wrap gap-2">
-              <component
-                :is="feature.level === 'draft' ? 'span' : RouterLink"
-                v-for="feature in release.features"
-                :key="feature.id"
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline"
-                :class="feature.level === 'draft' ? 'cursor-default' : 'hover:bg-surface-tint transition-colors'"
-                :style="{ borderColor: levels[feature.level].color, color: levels[feature.level].color }"
-                :to="feature.level !== 'draft' ? feature.path : undefined"
-              >
-                <AppIcon :icon="typeIcon[feature.type]" :size="12" />
-                {{ feature.name }}
-              </component>
-            </div>
+    <!-- One unified calendar object, four months across -->
+    <div class="border border-divider rounded-xl bg-surface overflow-hidden">
+      <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-divider">
+        <div v-for="month in months" :key="month.key" class="p-3">
+          <div class="flex items-baseline justify-between mb-2 px-0.5">
+            <span class="text-sm font-semibold tracking-tight">{{ month.month }}</span>
+            <span class="text-[11px] font-mono text-on-surface-variant/50">{{ month.year }}</span>
           </div>
 
-          <!-- Graduating to stable -->
-          <div v-if="release.stabilizing.length > 0">
-            <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">
-              Graduating to stable
-              <span class="opacity-70">({{ release.stabilizing.length }})</span>
+          <div class="grid grid-cols-7 gap-0.5">
+            <div
+              v-for="(weekday, w) in WEEKDAYS"
+              :key="`w-${w}`"
+              class="h-6 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
+            >
+              {{ weekday }}
             </div>
 
-            <div class="flex flex-wrap gap-2">
-              <RouterLink
-                v-for="feature in release.stabilizing"
-                :key="feature.id"
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline hover:bg-surface-tint transition-colors"
-                :style="{ borderColor: stableColor, color: stableColor }"
-                :to="feature.path"
+            <template v-for="(cell, index) in month.cells">
+              <!-- Release day -->
+              <button
+                v-if="cell.release"
+                :key="`r-${index}`"
+                :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
+                :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
+                class="group relative h-9 flex flex-col items-center justify-center rounded-md overflow-hidden transition-all duration-150 hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
+                :style="{
+                  background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
+                  boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
+                }"
+                type="button"
+                @click="single.select(cell.release.title)"
               >
-                <AppIcon :icon="typeIcon[feature.type]" :size="12" />
-                {{ feature.name }}
-              </RouterLink>
-            </div>
+                <span class="text-xs font-mono font-bold leading-none tabular-nums">{{ cell.day }}</span>
+                <span class="text-[10px] font-mono leading-none mt-0.5" :style="{ color: accent(cell.release) }">{{ shortTitle(cell.release.title) }}</span>
+
+                <!-- Payload split: arriving | graduating -->
+                <span class="absolute inset-x-0 bottom-0 h-1 flex">
+                  <span class="h-full" :style="{ width: `${newPct(cell.release)}%`, background: ARRIVING.color }" />
+                  <span class="h-full flex-1" :style="{ background: GRADUATING.color }" />
+                </span>
+              </button>
+
+              <!-- Non-release day -->
+              <div
+                v-else
+                :key="`d-${index}`"
+                class="h-9 grid place-items-center text-[11px] font-mono tabular-nums"
+                :class="cell.day === null ? '' : cell.weekend ? 'text-on-surface-variant/20' : 'text-on-surface-variant/45'"
+              >
+                {{ cell.day }}
+              </div>
+            </template>
           </div>
         </div>
-      </section>
+      </div>
+    </div>
+
+    <!-- Selected release detail -->
+    <div
+      v-if="selected"
+      aria-live="polite"
+      class="mt-5 rounded-xl bg-surface border border-divider p-4"
+      :style="{ borderInlineStartWidth: '4px', borderInlineStartColor: accent(selected) }"
+    >
+      <div class="flex items-baseline gap-3 flex-wrap">
+        <h3 class="text-lg font-mono font-bold">{{ selected.title }}</h3>
+        <span class="text-sm text-on-surface-variant">{{ longDate(selected.date) }}</span>
+
+        <span class="ms-auto inline-flex items-center gap-3 text-xs">
+          <span v-if="selected.features.length > 0" class="inline-flex items-center gap-1" :style="{ color: ARRIVING.color }">
+            <AppIcon :icon="ARRIVING.icon" :size="13" /> {{ selected.features.length }} arriving
+          </span>
+
+          <span v-if="selected.stabilizing.length > 0" class="inline-flex items-center gap-1" :style="{ color: GRADUATING.color }">
+            <AppIcon :icon="GRADUATING.icon" :size="13" /> {{ selected.stabilizing.length }} graduating
+          </span>
+        </span>
+      </div>
+
+      <div class="mt-4 space-y-4">
+        <!-- Net-new features -->
+        <div v-if="selected.features.length > 0">
+          <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">New in this release</div>
+
+          <div class="flex flex-wrap gap-2">
+            <component
+              :is="feature.level === 'draft' ? 'span' : RouterLink"
+              v-for="feature in selected.features"
+              :key="feature.id"
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline"
+              :class="feature.level === 'draft' ? 'cursor-default' : 'hover:bg-surface-tint transition-colors'"
+              :style="{ borderColor: levels[feature.level].color, color: levels[feature.level].color }"
+              :to="feature.level !== 'draft' ? feature.path : undefined"
+            >
+              <AppIcon :icon="typeIcon[feature.type]" :size="12" />
+              {{ feature.name }}
+            </component>
+          </div>
+        </div>
+
+        <!-- Graduating to stable -->
+        <div v-if="selected.stabilizing.length > 0">
+          <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">Graduating to stable</div>
+
+          <div class="flex flex-wrap gap-2">
+            <RouterLink
+              v-for="feature in selected.stabilizing"
+              :key="feature.id"
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline hover:bg-surface-tint transition-colors"
+              :style="{ borderColor: GRADUATING.color, color: GRADUATING.color }"
+              :to="feature.path"
+            >
+              <AppIcon :icon="typeIcon[feature.type]" :size="12" />
+              {{ feature.name }}
+            </RouterLink>
+          </div>
+        </div>
+
+        <p v-if="selected.stabilizing.length === 0" class="text-sm text-on-surface-variant">
+          No stable graduations this release — the two-minor clock resets at v1.0, so the first stable wave lands in v1.2.0.
+        </p>
+      </div>
     </div>
 
     <!-- Disclaimer -->
-    <p class="mt-8 text-sm opacity-60 text-center">
+    <p class="mt-6 text-sm opacity-60 text-center">
       Expected dates and graduations are strategic targets, not commitments — they may shift with community feedback and technical requirements.
     </p>
   </div>

--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -35,8 +35,12 @@
   const dated = items.map(release => ({ release, at: parts(release.date) }))
   const byDay = new Map(dated.map(({ release, at }) => [`${at.year}-${at.month}-${at.day}`, release]))
 
-  interface Cell { day: number | null, weekend: boolean, release?: ResolvedRelease }
+  interface Cell { day: number, adjacent: boolean, weekend: boolean, release?: ResolvedRelease }
   interface MonthGrid { key: string, month: string, year: number, cells: Cell[] }
+
+  // Every grid is a fixed 6-week block (42 cells) so all month cards share one
+  // height. Leading/trailing slots are filled with adjacent-month days, dimmed.
+  const WEEKS = 6
 
   // Render every month from the first release to the last, inclusive.
   const start = dated[0].at
@@ -46,12 +50,21 @@
   for (let year = start.year, month = start.month; year < end.year || (year === end.year && month <= end.month);) {
     const firstDow = new Date(year, month, 1).getDay()
     const total = new Date(year, month + 1, 0).getDate()
+    const prevTotal = new Date(year, month, 0).getDate()
 
-    const cells: Cell[] = Array.from({ length: firstDow }, (_, i) => ({ day: null, weekend: i % 7 === 0 || i % 7 === 6 }))
-    for (let day = 1; day <= total; day++) {
-      const column = (firstDow + day - 1) % 7
-      cells.push({ day, weekend: column === 0 || column === 6, release: byDay.get(`${year}-${month}-${day}`) })
+    const cells: Cell[] = []
+
+    function push (day: number, adjacent: boolean, release?: ResolvedRelease): void {
+      const column = cells.length % 7
+      cells.push({ day, adjacent, weekend: column === 0 || column === 6, release })
     }
+
+    // Leading days from the previous month.
+    for (let i = firstDow - 1; i >= 0; i--) push(prevTotal - i, true)
+    // This month.
+    for (let day = 1; day <= total; day++) push(day, false, byDay.get(`${year}-${month}-${day}`))
+    // Trailing days from the next month, to a fixed 6-week grid.
+    for (let day = 1; cells.length < WEEKS * 7; day++) push(day, true)
 
     months.push({
       key: `${year}-${month}`,
@@ -130,7 +143,7 @@
           <div
             v-for="(weekday, w) in WEEKDAYS"
             :key="`w-${w}`"
-            class="h-6 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
+            class="h-5 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
           >
             {{ weekday }}
           </div>
@@ -142,7 +155,7 @@
               :key="`r-${index}`"
               :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
               :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
-              class="group relative h-9 flex flex-col items-center justify-center rounded-md overflow-hidden cursor-pointer transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
+              class="group relative h-8 flex flex-col items-center justify-center rounded-md overflow-hidden cursor-pointer transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
               :style="{
                 background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
                 boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
@@ -164,8 +177,8 @@
             <div
               v-else
               :key="`d-${index}`"
-              class="h-9 grid place-items-center text-[11px] font-mono tabular-nums"
-              :class="cell.day === null ? '' : cell.weekend ? 'text-on-surface-variant/20' : 'text-on-surface-variant/45'"
+              class="h-8 grid place-items-center text-[11px] font-mono tabular-nums"
+              :class="cell.adjacent ? 'text-on-surface-variant/25' : cell.weekend ? 'text-on-surface-variant/45' : 'text-on-surface-variant/70'"
             >
               {{ cell.day }}
             </div>

--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -118,60 +118,58 @@
       </span>
     </div>
 
-    <!-- One unified calendar object, four months across -->
-    <div class="border border-divider rounded-xl bg-surface overflow-hidden">
-      <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-divider">
-        <div v-for="month in months" :key="month.key" class="p-3">
-          <div class="flex items-baseline justify-between mb-2 px-0.5">
-            <span class="text-sm font-semibold tracking-tight">{{ month.month }}</span>
-            <span class="text-[11px] font-mono text-on-surface-variant/50">{{ month.year }}</span>
+    <!-- Month cards -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+      <div v-for="month in months" :key="month.key" class="border border-divider rounded-xl bg-surface p-3">
+        <div class="flex items-baseline justify-between mb-2 px-0.5">
+          <span class="text-sm font-semibold tracking-tight">{{ month.month }}</span>
+          <span class="text-[11px] font-mono text-on-surface-variant/50">{{ month.year }}</span>
+        </div>
+
+        <div class="grid grid-cols-7 gap-0.5">
+          <div
+            v-for="(weekday, w) in WEEKDAYS"
+            :key="`w-${w}`"
+            class="h-6 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
+          >
+            {{ weekday }}
           </div>
 
-          <div class="grid grid-cols-7 gap-0.5">
-            <div
-              v-for="(weekday, w) in WEEKDAYS"
-              :key="`w-${w}`"
-              class="h-6 grid place-items-center text-[10px] font-medium text-on-surface-variant/40"
+          <template v-for="(cell, index) in month.cells">
+            <!-- Release day -->
+            <button
+              v-if="cell.release"
+              :key="`r-${index}`"
+              :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
+              :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
+              class="group relative h-9 flex flex-col items-center justify-center rounded-md overflow-hidden cursor-pointer transition duration-150 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
+              :style="{
+                background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
+                boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
+              }"
+              type="button"
+              @click="single.select(cell.release.title)"
             >
-              {{ weekday }}
+              <span class="text-xs font-mono font-bold leading-none tabular-nums">{{ cell.day }}</span>
+              <span class="text-[10px] font-mono leading-none mt-0.5" :style="{ color: accent(cell.release) }">{{ shortTitle(cell.release.title) }}</span>
+
+              <!-- Payload split: arriving | graduating -->
+              <span class="absolute inset-x-0 bottom-0 h-1 flex">
+                <span class="h-full" :style="{ width: `${newPct(cell.release)}%`, background: ARRIVING.color }" />
+                <span class="h-full flex-1" :style="{ background: GRADUATING.color }" />
+              </span>
+            </button>
+
+            <!-- Non-release day -->
+            <div
+              v-else
+              :key="`d-${index}`"
+              class="h-9 grid place-items-center text-[11px] font-mono tabular-nums"
+              :class="cell.day === null ? '' : cell.weekend ? 'text-on-surface-variant/20' : 'text-on-surface-variant/45'"
+            >
+              {{ cell.day }}
             </div>
-
-            <template v-for="(cell, index) in month.cells">
-              <!-- Release day -->
-              <button
-                v-if="cell.release"
-                :key="`r-${index}`"
-                :aria-current="selectedTitle === cell.release.title ? 'true' : undefined"
-                :aria-label="`${cell.release.title}, ${longDate(cell.release.date)}: ${cell.release.features.length} arriving, ${cell.release.stabilizing.length} graduating to stable`"
-                class="group relative h-9 flex flex-col items-center justify-center rounded-md overflow-hidden transition-all duration-150 hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
-                :style="{
-                  background: tint(accent(cell.release), selectedTitle === cell.release.title ? 26 : 12),
-                  boxShadow: `inset 0 0 0 ${selectedTitle === cell.release.title ? 2 : 1}px ${tint(accent(cell.release), selectedTitle === cell.release.title ? 100 : 45)}`,
-                }"
-                type="button"
-                @click="single.select(cell.release.title)"
-              >
-                <span class="text-xs font-mono font-bold leading-none tabular-nums">{{ cell.day }}</span>
-                <span class="text-[10px] font-mono leading-none mt-0.5" :style="{ color: accent(cell.release) }">{{ shortTitle(cell.release.title) }}</span>
-
-                <!-- Payload split: arriving | graduating -->
-                <span class="absolute inset-x-0 bottom-0 h-1 flex">
-                  <span class="h-full" :style="{ width: `${newPct(cell.release)}%`, background: ARRIVING.color }" />
-                  <span class="h-full flex-1" :style="{ background: GRADUATING.color }" />
-                </span>
-              </button>
-
-              <!-- Non-release day -->
-              <div
-                v-else
-                :key="`d-${index}`"
-                class="h-9 grid place-items-center text-[11px] font-mono tabular-nums"
-                :class="cell.day === null ? '' : cell.weekend ? 'text-on-surface-variant/20' : 'text-on-surface-variant/45'"
-              >
-                {{ cell.day }}
-              </div>
-            </template>
-          </div>
+          </template>
         </div>
       </div>
     </div>

--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+  // Constants
+  import { MATURITY_LEVELS as levels } from '@/constants/maturity'
+  import { type FeatureType, releases } from '@/constants/roadmap-buckets'
+
+  // Utilities
+  import { RouterLink } from 'vue-router'
+
+  const items = releases()
+
+  const stableColor = levels.stable.color
+
+  const typeIcon: Record<FeatureType, string> = {
+    composable: 'code',
+    component: 'puzzle',
+    utility: 'typescript',
+  }
+</script>
+
+<template>
+  <div class="my-6">
+    <div class="relative ps-5 border-s-2 border-divider ms-3 space-y-8">
+      <section
+        v-for="release in items"
+        :key="release.title"
+        class="relative"
+      >
+        <!-- Timeline dot -->
+        <div class="absolute -start-[calc(0.5rem+1px)] top-1.5 w-4 h-4 rounded-full border-2 border-primary bg-background" />
+
+        <!-- Release header -->
+        <div class="flex items-baseline gap-3 flex-wrap ms-4">
+          <h3 class="text-lg font-semibold">{{ release.title }}</h3>
+          <span class="text-sm text-on-surface-variant">{{ release.date }}</span>
+        </div>
+
+        <!-- Tracks -->
+        <div class="ms-4 mt-3 space-y-4">
+          <!-- Net-new features -->
+          <div v-if="release.features.length > 0">
+            <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">New in this release</div>
+
+            <div class="flex flex-wrap gap-2">
+              <component
+                :is="feature.level === 'draft' ? 'span' : RouterLink"
+                v-for="feature in release.features"
+                :key="feature.id"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline"
+                :class="feature.level === 'draft' ? 'cursor-default' : 'hover:bg-surface-tint transition-colors'"
+                :style="{ borderColor: levels[feature.level].color, color: levels[feature.level].color }"
+                :to="feature.level !== 'draft' ? feature.path : undefined"
+              >
+                <AppIcon :icon="typeIcon[feature.type]" :size="12" />
+                {{ feature.name }}
+              </component>
+            </div>
+          </div>
+
+          <!-- Graduating to stable -->
+          <div v-if="release.stabilizing.length > 0">
+            <div class="text-xs font-semibold uppercase tracking-wide opacity-60 mb-2">
+              Graduating to stable
+              <span class="opacity-70">({{ release.stabilizing.length }})</span>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <RouterLink
+                v-for="feature in release.stabilizing"
+                :key="feature.id"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border no-underline hover:bg-surface-tint transition-colors"
+                :style="{ borderColor: stableColor, color: stableColor }"
+                :to="feature.path"
+              >
+                <AppIcon :icon="typeIcon[feature.type]" :size="12" />
+                {{ feature.name }}
+              </RouterLink>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Disclaimer -->
+    <p class="mt-8 text-sm opacity-60 text-center">
+      Expected dates and graduations are strategic targets, not commitments — they may shift with community feedback and technical requirements.
+    </p>
+  </div>
+</template>

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -21,7 +21,7 @@ export interface ResolvedFeature {
  * expect to graduate to stable as of that release.
  */
 export interface ReleaseBucket {
-  /** Expected release date, as a display string (e.g. "September 4, 2026"). */
+  /** Expected release date, ISO `YYYY-MM-DD` (parsed locally for the calendar grid). */
   date: string
   /** Net-new features landing in this release (draft → preview). */
   features: string[]
@@ -43,12 +43,12 @@ export interface ReleaseBucket {
  */
 export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
   'v1.1.0': {
-    date: 'September 4, 2026',
+    date: '2026-09-04',
     features: ['DataTable', 'DataGrid', 'Alert'],
     stabilizing: [],
   },
   'v1.2.0': {
-    date: 'September 25, 2026',
+    date: '2026-09-25',
     features: ['Tour'],
     stabilizing: [
       'createValidation', 'createForm', 'createInput', 'usePopover', 'usePresence',
@@ -58,7 +58,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.3.0': {
-    date: 'October 22, 2026',
+    date: '2026-10-22',
     features: ['Virtualizer', 'Kanban', 'Otp'],
     stabilizing: [
       'useClickOutside', 'useEventListener', 'useHotkey', 'useMediaQuery', 'useToggleScope',
@@ -67,7 +67,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.4.0': {
-    date: 'November 13, 2026',
+    date: '2026-11-13',
     features: ['TimePicker'],
     stabilizing: [
       'createSlider', 'createNumeric', 'createNumberField', 'createProgress', 'createRating',
@@ -77,7 +77,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.5.0': {
-    date: 'December 11, 2026',
+    date: '2026-12-11',
     features: ['DatePicker', 'DateRangePicker'],
     stabilizing: [
       'Dialog', 'Popover', 'Tabs', 'AlertDialog', 'Collapsible', 'ExpansionPanel',

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -42,6 +42,19 @@ export interface ReleaseBucket {
  * under the calendar.
  */
 export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
+  'v1.0.0': {
+    date: '2026-07-22',
+    features: [],
+    // The v1 stable set locked at launch — the 16 composables promoted to stable.
+    // (The 17 stable utilities are also locked here; omitted from the calendar as
+    // low-signal chips that all resolve to the same utilities page.)
+    stabilizing: [
+      'createContext', 'createPlugin', 'createTrinity', 'createRegistry', 'createModel',
+      'createSelection', 'createSingle', 'createStep', 'createGroup', 'createNested',
+      'useBreakpoints', 'useStorage', 'useTheme', 'useIntersectionObserver',
+      'useMutationObserver', 'useResizeObserver',
+    ],
+  },
   'v1.1.0': {
     date: '2026-09-04',
     features: ['DataTable', 'DataGrid', 'Alert'],

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -56,12 +56,12 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.1.0': {
-    date: '2026-09-04',
+    date: '2026-08-25',
     features: ['DataTable', 'DataGrid', 'Alert'],
     stabilizing: [],
   },
   'v1.2.0': {
-    date: '2026-09-25',
+    date: '2026-09-22',
     features: ['Tour'],
     stabilizing: [
       'createValidation', 'createForm', 'createInput', 'usePopover', 'usePresence',
@@ -71,7 +71,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.3.0': {
-    date: '2026-10-22',
+    date: '2026-10-20',
     features: ['Virtualizer', 'Kanban', 'Otp'],
     stabilizing: [
       'useClickOutside', 'useEventListener', 'useHotkey', 'useMediaQuery', 'useToggleScope',
@@ -80,7 +80,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.4.0': {
-    date: '2026-11-13',
+    date: '2026-11-17',
     features: ['TimePicker'],
     stabilizing: [
       'createSlider', 'createNumeric', 'createNumberField', 'createProgress', 'createRating',
@@ -90,7 +90,7 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.5.0': {
-    date: '2026-12-11',
+    date: '2026-12-15',
     features: ['DatePicker', 'DateRangePicker'],
     stabilizing: [
       'Dialog', 'Popover', 'Tabs', 'AlertDialog', 'Collapsible', 'ExpansionPanel',

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -16,17 +16,82 @@ export interface ResolvedFeature {
 }
 
 /**
- * Roadmap bucket membership, keyed by GitHub milestone title. Values are
- * `maturity.json` keys. This overlay is the single place to move a feature
- * between milestones — `maturity.json` stays the stability source of truth and
- * is never edited for planning. Unknown ids are surfaced by `auditBuckets()`.
+ * A planned release: the date we expect to ship it, the net-new features
+ * arriving in it (draft → preview), and the existing preview features we
+ * expect to graduate to stable as of that release.
  */
-export const ROADMAP_BUCKETS: Record<string, string[]> = {
-  'v1.1.0': ['DataTable', 'DataGrid', 'Alert'],
-  'v1.2.0': ['Tour'],
-  'v1.3.0': ['Virtualizer', 'Kanban', 'Otp'],
-  'v1.4.0': ['TimePicker'],
-  'v1.5.0': ['DatePicker', 'DateRangePicker'],
+export interface ReleaseBucket {
+  /** Expected release date, as a display string (e.g. "September 4, 2026"). */
+  date: string
+  /** Net-new features landing in this release (draft → preview). */
+  features: string[]
+  /** Existing preview features graduating to stable in this release. */
+  stabilizing?: string[]
+}
+
+/**
+ * Roadmap bucket membership, keyed by GitHub milestone title. `features` and
+ * `stabilizing` values are `maturity.json` keys. This overlay is the single
+ * place to move a feature between milestones — `maturity.json` stays the
+ * stability source of truth and is never edited for planning. Unknown ids are
+ * surfaced by `auditBuckets()`.
+ *
+ * Dates are the published expected minor-release targets; the date a feature is
+ * expected to reach stable falls out of the release it is listed under. Both
+ * are strategic targets, not hard commitments — see the disclaimer rendered
+ * under the calendar.
+ */
+export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
+  'v1.1.0': {
+    date: 'September 4, 2026',
+    features: ['DataTable', 'DataGrid', 'Alert'],
+    stabilizing: [],
+  },
+  'v1.2.0': {
+    date: 'September 25, 2026',
+    features: ['Tour'],
+    stabilizing: [
+      'createValidation', 'createForm', 'createInput', 'usePopover', 'usePresence',
+      'useRovingFocus', 'useVirtualFocus', 'createFilter', 'createPagination', 'useRtl',
+      'useLocale', 'useStack',
+      'Single', 'Step', 'Selection', 'Group', 'Theme', 'Locale', 'Scrim',
+    ],
+  },
+  'v1.3.0': {
+    date: 'October 22, 2026',
+    features: ['Virtualizer', 'Kanban', 'Otp'],
+    stabilizing: [
+      'useClickOutside', 'useEventListener', 'useHotkey', 'useMediaQuery', 'useToggleScope',
+      'useRaf', 'useTimer', 'useProxyModel', 'useProxyRegistry', 'toArray', 'toElement',
+      'toReactive', 'useDelay', 'useHydration',
+    ],
+  },
+  'v1.4.0': {
+    date: 'November 13, 2026',
+    features: ['TimePicker'],
+    stabilizing: [
+      'createSlider', 'createNumeric', 'createNumberField', 'createProgress', 'createRating',
+      'createBreadcrumbs', 'createOverflow',
+      'Slider', 'NumberField', 'Radio', 'Checkbox', 'Switch', 'Rating', 'Progress',
+      'Form', 'Input',
+    ],
+  },
+  'v1.5.0': {
+    date: 'December 11, 2026',
+    features: ['DatePicker', 'DateRangePicker'],
+    stabilizing: [
+      'Dialog', 'Popover', 'Tabs', 'AlertDialog', 'Collapsible', 'ExpansionPanel',
+      'Treeview', 'Avatar', 'Pagination', 'Splitter', 'Select',
+    ],
+  },
+}
+
+/** A release with its bucket ids resolved to maturity-backed features. */
+export interface ResolvedRelease {
+  title: string
+  date: string
+  features: ResolvedFeature[]
+  stabilizing: ResolvedFeature[]
 }
 
 function kebab (name: string): string {
@@ -71,9 +136,8 @@ for (const [name, entry] of Object.entries(data.utilities)) {
   })
 }
 
-/** Resolve a milestone title's bucket into its maturity-backed features. */
-export function featuresFor (title: string): ResolvedFeature[] {
-  const ids = ROADMAP_BUCKETS[title]
+/** Resolve a list of bucket ids into their maturity-backed features. */
+function resolve (ids: string[] | undefined): ResolvedFeature[] {
   if (!ids) return []
 
   const result: ResolvedFeature[] = []
@@ -84,11 +148,31 @@ export function featuresFor (title: string): ResolvedFeature[] {
   return result
 }
 
+/** Resolve a milestone title's net-new features. */
+export function featuresFor (title: string): ResolvedFeature[] {
+  return resolve(ROADMAP_BUCKETS[title]?.features)
+}
+
+/** Resolve a milestone title's stabilizing (preview → stable) features. */
+export function stabilizingFor (title: string): ResolvedFeature[] {
+  return resolve(ROADMAP_BUCKETS[title]?.stabilizing)
+}
+
+/** Ordered, fully resolved releases for the release-calendar view. */
+export function releases (): ResolvedRelease[] {
+  return Object.entries(ROADMAP_BUCKETS).map(([title, bucket]) => ({
+    title,
+    date: bucket.date,
+    features: resolve(bucket.features),
+    stabilizing: resolve(bucket.stabilizing),
+  }))
+}
+
 /** Bucket ids that no longer resolve against maturity.json (typos, renames). */
 export function auditBuckets (): string[] {
   const unknown: string[] = []
-  for (const [title, ids] of Object.entries(ROADMAP_BUCKETS)) {
-    for (const id of ids) {
+  for (const [title, bucket] of Object.entries(ROADMAP_BUCKETS)) {
+    for (const id of [...bucket.features, ...(bucket.stabilizing ?? [])]) {
       if (!index.has(id)) unknown.push(`${title}:${id}`)
     }
   }

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -24,6 +24,12 @@ Track the development of @vuetify/v0. Milestones are organized by time horizon:
 
 <DocsRoadmap />
 
+## Release Calendar
+
+Expected dates for the v1.1–v1.5 minor releases, the net-new features landing in each, and the existing preview features on track to graduate to stable as of that release.
+
+<DocsReleaseCalendar />
+
 ## Release Candidate
 
 **Now a release candidate.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.


### PR DESCRIPTION
Publishes the expected v1.1-v1.5 minor release dates on the roadmap page, each showing its net-new features **and** the existing preview features on track to graduate to stable as of that release.

## What

- **`roadmap-buckets.ts`** - bucket values extended from `string[]` to `{ date, features, stabilizing? }`. Adds `stabilizingFor(title)` and `releases()`; `featuresFor`/`auditBuckets` signatures unchanged so `DocsRoadmap` + the roadmap store are unaffected.
- **`DocsReleaseCalendar.vue`** - new presentational component: a dated vertical timeline, each release rendering a "New in this release" chip group and a "Graduating to stable" chip group. Reads the constant directly (no GitHub fetch, SSG-deterministic). Chip styling mirrors `DocsRoadmap`.
- **`roadmap.md`** - new `## Release Calendar` section under `<DocsRoadmap />`.

## Dates

| Release | Date | New | -> Stable |
|---|---|---|---|
| v1.1.0 | Sep 4, 2026 | DataTable, DataGrid, Alert | - |
| v1.2.0 | Sep 25, 2026 | Tour | 19 (foundations + providers) |
| v1.3.0 | Oct 22, 2026 | Virtualizer, Kanban, Otp | 14 (system/reactivity) |
| v1.4.0 | Nov 13, 2026 | TimePicker | 16 (forms) |
| v1.5.0 | Dec 11, 2026 | DatePicker, DateRangePicker | 11 (disclosure/semantic) |

Dates are strategic targets (v1.3 pinned to Vue Fes Japan Oct 24), rendered with a "not commitments" disclaimer.

## Verification

- All 70 bucket ids resolve against `maturity.json` (`auditBuckets()` empty).
- `vue-tsc` clean on changed files (0 real errors once `@vuetify/v0` types are built).
- ESLint clean.