### PR TITLE
docs: fix release calendar back button icon

### DIFF
--- a/apps/docs/src/plugins/icons.ts
+++ b/apps/docs/src/plugins/icons.ts
@@ -158,6 +158,7 @@ export const [useIconContext, provideIconContext, context] = createTokensContext
     'right': mdiChevronRight,
     'chevron-up': mdiChevronUp,
     'chevron-down': mdiChevronDown,
+    'chevron-left': mdiChevronLeft,
     'chevron-right': mdiChevronRight,
     'up': '{chevron-up}',
     'down': '{chevron-down}',


### PR DESCRIPTION
## Problem

The "Previous release" (back) button in the docs release calendar (`DocsReleaseCalendar.vue`) rendered blank — no icon.

## Cause

The button uses `<AppIcon icon="chevron-left" />`, but `chevron-left` was never registered in the docs icon plugin (`apps/docs/src/plugins/icons.ts`). Only `left` was aliased to `mdiChevronLeft`. Its siblings — `chevron-right`, `chevron-up`, `chevron-down` — were all registered, so the "Next release" button worked while the back button resolved to nothing.

## Fix

Register `'chevron-left': mdiChevronLeft` alongside its siblings. `mdiChevronLeft` was already imported. Chose adding the token over switching the button to the existing `left` alias, to stay consistent with the surrounding `chevron-*` naming.