### PR TITLE
chore(tests): eliminate benign framework warnings from v0 test output

### DIFF
--- a/packages/0/src/components/Atom/index.browser.test.ts
+++ b/packages/0/src/components/Atom/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Atom } from './index'
@@ -12,6 +12,19 @@ import type { Component } from 'vue'
 
 describe('atom', () => {
   describe('rendering modes', () => {
+    // VTU compiles the string-literal slots below at runtime; Vue's compiler
+    // emits a benign "[@vue/compiler-core] decodeEntities … ignored in
+    // non-browser builds" notice on each compile. Capture and assert it so it
+    // does not leak to stderr (testing.md zero-warnings policy).
+    let warn: ReturnType<typeof vi.spyOn>
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
     it('should render as div by default', () => {
       const wrapper = mount(Atom, {
         slots: {
@@ -53,6 +66,17 @@ describe('atom', () => {
   })
 
   describe('renderless mode', () => {
+    // String-literal slots below are compiled at runtime by VTU, triggering
+    // Vue's benign decodeEntities compiler notice. Capture and assert it.
+    let warn: ReturnType<typeof vi.spyOn>
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
     it('should render slot content directly when renderless=true', () => {
       const wrapper = mount(Atom, {
         props: {
@@ -99,6 +123,10 @@ describe('atom', () => {
 
   describe('self-closing tags', () => {
     it('should render self-closing img tag without children', () => {
+      // VTU compiles the string slot at runtime; Vue emits a benign
+      // decodeEntities compiler notice. Capture and assert it.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const wrapper = mount(Atom, {
         props: {
           as: 'img',
@@ -117,6 +145,7 @@ describe('atom', () => {
       expect(img.attributes('src')).toBe('test.jpg')
       expect(img.attributes('alt')).toBe('Test')
       expect(wrapper.text()).toBe('')
+      expect(warn).toHaveBeenCalled()
     })
 
     it('should render self-closing input tag', () => {
@@ -289,6 +318,10 @@ describe('atom', () => {
     })
 
     it('should not expose element ref in renderless mode', () => {
+      // VTU compiles the string slot at runtime; Vue emits a benign
+      // decodeEntities compiler notice. Capture and assert it.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const wrapper = mount(Atom, {
         props: {
           renderless: true,
@@ -300,10 +333,22 @@ describe('atom', () => {
 
       const exposed = wrapper.vm as any
       expect(exposed.element).toBeNull()
+      expect(warn).toHaveBeenCalled()
     })
   })
 
   describe('complex element types', () => {
+    // String-literal slots below are compiled at runtime by VTU, triggering
+    // Vue's benign decodeEntities compiler notice. Capture and assert it.
+    let warn: ReturnType<typeof vi.spyOn>
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
     it('should render section element', () => {
       const wrapper = mount(Atom, {
         props: {
@@ -383,6 +428,10 @@ describe('atom', () => {
     })
 
     it('should handle multiple root elements in slot', () => {
+      // VTU compiles the string slot at runtime; Vue emits a benign
+      // decodeEntities compiler notice. Capture and assert it.
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const wrapper = mount(Atom, {
         props: {
           as: 'div',
@@ -393,6 +442,7 @@ describe('atom', () => {
       })
 
       expect(wrapper.findAll('span').length).toBe(2)
+      expect(warn).toHaveBeenCalled()
     })
 
     it('should handle nested Atom components', () => {

--- a/packages/0/src/components/Avatar/index.browser.test.ts
+++ b/packages/0/src/components/Avatar/index.browser.test.ts
@@ -396,9 +396,13 @@ describe('avatar', () => {
     })
 
     describe('renderless mode', () => {
-      it('should support renderless mode with slot props', () => {
-        // Suppress Vue warning about runtime directive on non-element root
-        // This is expected when using v-show with renderless components
+      it('should support renderless mode with slot props', async () => {
+        // A renderless AvatarImage applies its mandated v-show (PHILOSOPHY
+        // §10.11) to a renderless Atom, whose root is the slot rather than an
+        // element, so Vue emits a benign runtime-directive warning — on mount
+        // and again on the async re-render when the image load settles. Drive
+        // that settle inside the spy's scope so the warning is captured here
+        // instead of leaking to stderr after the test body exits.
         using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         let slotProps: any
@@ -415,9 +419,19 @@ describe('avatar', () => {
           },
         })
 
+        const image = wrapper.findComponent(Avatar.Image as any)
+        await image.trigger('error')
+        await nextTick()
+
         expect(slotProps).toBeDefined()
         expect(wrapper.find('.custom-img').exists()).toBe(true)
         expect(warnSpy).toHaveBeenCalled()
+
+        // Unmount inside the spy's scope so the re-render triggered by the
+        // image's native async load/error settling can't fire the warning
+        // during global teardown, after the spy has been restored.
+        wrapper.unmount()
+        await nextTick()
       })
     })
   })

--- a/packages/0/src/components/Combobox/index.browser.test.ts
+++ b/packages/0/src/components/Combobox/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Adapters
 import { ClientComboboxAdapter } from '#v0/composables/createCombobox/adapters/client'
@@ -1587,6 +1587,20 @@ describe('combobox', () => {
   })
 
   describe('renderless', () => {
+    // Renderless sub-components apply their directive (Combobox.Item's mandated
+    // v-show — PHILOSOPHY §10.11) to a renderless Atom, whose root is the slot
+    // rather than an element, so Vue warns about a runtime directive on a
+    // non-element root. The warning is benign and expected here; capture and
+    // assert it rather than letting it leak to stderr (testing.md).
+    let warn: ReturnType<typeof vi.spyOn>
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
     async function createRenderless (options: {
       'modelValue'?: unknown
       'onUpdate:modelValue'?: (v: unknown) => void

--- a/packages/0/vitest.browser.config.ts
+++ b/packages/0/vitest.browser.config.ts
@@ -25,6 +25,12 @@ export default defineConfig({
     '__DEV__': JSON.stringify(process.env.NODE_ENV !== 'production'),
     '__VITE_LOGGER_ENABLED__': JSON.stringify(process.env.VITE_LOGGER_ENABLED ?? false),
     '__VERSION__': '"0.0.1"',
+    // Vue esm-bundler feature flags. The dev/docs/playground apps inject these;
+    // the browser test project must too, or every app creation logs a
+    // "feature flags not explicitly defined" warning. Matches apps/docs.
+    '__VUE_OPTIONS_API__': 'true',
+    '__VUE_PROD_DEVTOOLS__': 'false',
+    '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': 'false',
     // Node-flavored deps (e.g. @testing-library/vue) read process.env at
     // import time; give them an empty object since the browser has none.
     'process.env': '{}',

--- a/packages/0/vitest.config.ts
+++ b/packages/0/vitest.config.ts
@@ -34,6 +34,11 @@ export default defineConfig({
     __DEV__: 'process.env.NODE_ENV !== \'production\'',
     __VITE_LOGGER_ENABLED__: 'process.env.VITE_LOGGER_ENABLED',
     __VERSION__: '"0.0.1"',
+    // Vue esm-bundler feature flags — silence the "not explicitly defined"
+    // warning on app creation. Matches apps/docs and the browser config.
+    __VUE_OPTIONS_API__: 'true',
+    __VUE_PROD_DEVTOOLS__: 'false',
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
   },
   test: {
     name: 'v0:unit',


### PR DESCRIPTION
## Summary

`pnpm test:run` emitted **99 non-actionable framework warnings** that buried real signal and violated the `testing.md` zero-stderr policy. This clears all of them — **178 files / 6439 tests pass with zero stderr warnings** — without touching any component source.

| Warning | Count | Cause | Fix |
|---|---|---|---|
| `Feature flags __VUE_OPTIONS_API__ … not explicitly defined` | 32 | The browser + unit vitest projects never injected the Vue esm-bundler flags that dev/docs/playground apps do | Define `__VUE_OPTIONS_API__` / `__VUE_PROD_DEVTOOLS__` / `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` in both configs |
| `Runtime directive used on component with non-element root` | 53 | Vue warns when a `v-show` component — **mandated by PHILOSOPHY §10.11** — is mounted `renderless` (the Atom root is the slot, not an element) | Capture + assert per `testing.md` "expected warnings" pattern in the leaking Combobox (block-level spy) and Avatar tests |
| `[@vue/compiler-core] decodeEntities … ignored in non-browser builds` | 14 | Emitted when VTU compiles the string-literal slots in `Atom/index.browser.test.ts` at runtime | Same capture + assert pattern |

## Notes

- **No component source changed.** The obvious "fix" (swap `v-show` for `:style="{ display }"`) is explicitly forbidden by PHILOSOPHY §10.11 — `v-show` is canonical for registry-driven visibility, load-state preservation, and virtualization. Warnings are handled at the test layer instead.
- The **renderless `AvatarImage`** warning fires on the *async* image-load settle, so per-test `using` spies couldn't catch it reliably. That one test now drives the settle inside the spy's scope and unmounts before teardown, so the warning is captured deterministically (verified stable across repeated runs).
- Approach chosen per maintainer direction: **capture + assert**, not a blanket console filter.

## Verification

- `pnpm test:run` — 178 files / 6439 pass, 3 skipped, **0** `[Vue warn]` / `[v0 warn]` / `[v0:context]` in stderr
- `pnpm typecheck` — clean