### PR TITLE
chore(tests): silence remaining stderr warnings in v0:unit test output

### DIFF
--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -290,6 +290,8 @@ describe('createNested', () => {
     })
 
     it('should not infinite loop in getDescendants when children form a cycle', { timeout: 1000 }, () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const nested = createNested()
 
       nested.register({ id: 'a', value: 'A' })
@@ -303,9 +305,12 @@ describe('createNested', () => {
 
       // Should terminate, returning each descendant at most once.
       expect(descendants.length).toBeLessThanOrEqual(2)
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
     })
 
     it('should not stack-overflow in visibleItems when children form a cycle of opened nodes', { timeout: 1000 }, () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       const nested = createNested()
 
       nested.register({ id: 'a', value: 'A' })
@@ -321,6 +326,7 @@ describe('createNested', () => {
 
       // Should terminate with each item at most once
       expect(items.length).toBeLessThanOrEqual(2)
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Circular'))
     })
 
     it('should not infinite loop in open() reveal when parents form a cycle', { timeout: 1000 }, () => {

--- a/packages/0/src/composables/useStack/index.ssr.test.ts
+++ b/packages/0/src/composables/useStack/index.ssr.test.ts
@@ -26,7 +26,9 @@ describe('useStack SSR', () => {
 
   it('should not share registered tickets across calls in SSR', () => {
     const first = useStack()
-    first.register()
+    // Explicit id: useId() warns when called outside a component during SSR,
+    // and this test only cares about ticket isolation, not id generation.
+    first.register({ id: 'v0:ssr-stack' })
 
     const second = useStack()
 

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -762,8 +762,6 @@ describe('createTheme', () => {
         })
 
         expect(theme!.selectedId.value).toBe('light')
-
-        app.unmount()
       })
     })
   })


### PR DESCRIPTION
## Summary

Follow-up to #660 (which cleaned the `v0:browser` project). The `v0:unit` (happy-dom) project still leaked **three** warnings to stderr, against the `testing.md` zero-warnings policy. This clears them — **178 files / 6439 tests pass with zero stderr warnings**.

| Warning | Test | Cause | Fix |
|---|---|---|---|
| `[v0:logger warn] Circular child reference detected` | `createNested` getDescendants-cycle & visibleItems-cycle | Expected cycle-detection warning, but these two tests never captured it (their sibling cycle tests do) | Added the same `using vi.spyOn(console, 'warn')` + `expect(spy).toHaveBeenCalledWith(…'Circular')` pattern |
| `[Vue warn]: Cannot unmount an app that is not mounted` | `useTheme` "should ignore non-id persisted values" | Test called `app.unmount()` on an app it never mounted (it uses `runWithContext`, no `.mount()`) | Removed the spurious `app.unmount()` — matches the sibling `app1` test |
| `[v0 warn] useId() called outside component context during SSR` | `useStack` SSR ticket-isolation | `register()` with no id calls `useId()`, which warns under SSR | Passed an explicit `id` (what the warning advises); the test only checks ticket isolation, not id generation |

## Notes

- Two are genuine **expected v0 warnings** now captured+asserted per the "expected warnings" pattern; one (`useTheme`) was a real **test bug** (unmount without mount) fixed at the source rather than suppressed.
- No component/composable source changed — test-only.

## Verification

- `pnpm test:run` — 178 files / 6439 pass, 3 skipped, **0** `[Vue warn]` / `[v0 warn]` / `[v0:context]` / `[@vue]` in stderr (full-suite grep)
- `pnpm typecheck` — clean