### PR TITLE
chore(playground): seed repl tsconfig so sandbox main.ts type-checks

### DIFF
--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -6,7 +6,7 @@ import { decodePlaygroundHash, encodePlaygroundHash, parseVuetifyPlayTuple } fro
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
-import { createMainTs, UNO_CONFIG_TS } from '@/data/playground-defaults'
+import { createMainTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, UNO_CONFIG_TS } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
 
 // Utilities
@@ -115,11 +115,13 @@ export function usePlaygroundFiles () {
           'src/main.ts': createMainTs(theme_),
           'src/uno.config.ts': UNO_CONFIG_TS,
           'src/App.vue': DEFAULT_APP,
+          'tsconfig.json': REPL_TSCONFIG,
         },
         'src/main.ts',
       )
       store.files['src/main.ts']!.hidden = true
       store.files['src/uno.config.ts']!.hidden = true
+      store.files['tsconfig.json']!.hidden = true
       store.setActive('src/App.vue')
     }
 
@@ -159,6 +161,7 @@ export function usePlaygroundFiles () {
       {
         'src/main.ts': createMainTs(theme_, mergedMainOptions()),
         'src/uno.config.ts': UNO_CONFIG_TS,
+        'tsconfig.json': REPL_TSCONFIG,
         ...files,
         ...aliases,
       },
@@ -166,6 +169,7 @@ export function usePlaygroundFiles () {
     )
     store.files['src/main.ts']!.hidden = true
     store.files['src/uno.config.ts']!.hidden = true
+    store.files['tsconfig.json']!.hidden = true
     for (const key of Object.keys(aliases)) {
       if (store.files[key]) store.files[key]!.hidden = true
     }
@@ -180,9 +184,11 @@ export function usePlaygroundFiles () {
     const aliases = new Set(aliasMap.value.values())
     const files: Record<string, string> = {}
     for (const [path, file] of Object.entries(store.files)) {
-      if (!aliases.has(path)) {
-        files[path] = file.code
-      }
+      // Skip aliases and repl builtins (tsconfig.json / import-map.json) — the
+      // builtins are re-seeded on load, so baking them into the share hash only
+      // bloats the URL.
+      if (aliases.has(path) || REPL_BUILTIN_FILES.includes(path as typeof REPL_BUILTIN_FILES[number])) continue
+      files[path] = file.code
     }
     if (Object.keys(files).length === 0) return
     const active = store.activeFile?.filename
@@ -244,12 +250,14 @@ export function usePlaygroundFiles () {
       {
         'src/main.ts': createMainTs(theme_, preset.mainOptions),
         'src/uno.config.ts': UNO_CONFIG_TS,
+        'tsconfig.json': REPL_TSCONFIG,
         ...preset.files,
       },
       'src/main.ts', // must be main.ts so the sandbox runs it (installs plugins)
     )
     store.files['src/main.ts']!.hidden = true
     store.files['src/uno.config.ts']!.hidden = true
+    store.files['tsconfig.json']!.hidden = true
     store.setActive('src/App.vue')
 
     rebuildImportMap()

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -9,6 +9,32 @@ export const REPL_BUILTIN_FILES = ['import-map.json', 'tsconfig.json'] as const
 /** Infrastructure files revealed by the file tree's "Toggle config files" button */
 export const CONFIG_FILE_IDS = new Set(['src/main.ts', 'src/uno.config.ts', 'import-map.json'])
 
+// ── REPL tsconfig ──────────────────────────────────────────────────────────
+//
+// @vue/repl auto-injects a default tsconfig once during store init, but only
+// if none exists. Every store.setFiles() call rebuilds the file map from
+// scratch and drops it, and the injection is a one-time `if` — not a watcher —
+// so it never comes back. With no tsconfig, store.getTsConfig() throws and the
+// Monaco worker falls back to empty compilerOptions: no `allowImportingTsExtensions`
+// (the sandbox `import './uno.config.ts'` reports TS5097) and no `dom` lib
+// (`document` reports TS2584). Seeding this alongside the other builtins keeps
+// the worker's type environment correct.
+export const REPL_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    allowJs: true,
+    checkJs: true,
+    jsx: 'Preserve',
+    target: 'ESNext',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+    allowImportingTsExtensions: true,
+    lib: ['ESNext', 'DOM', 'DOM.Iterable'],
+  },
+  vueCompilerOptions: {
+    target: 3.5,
+  },
+}, undefined, 2)
+
 // ── Template files (matching Vuetify Play's v0 template) ────────────────
 
 export interface MainOptions {


### PR DESCRIPTION
## Problem

The playground's generated sandbox `main.ts` (v0 preset) shows two false-positive TypeScript diagnostics in the in-browser editor:

- **TS5097** — `An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled` on `import './uno.config.ts'`
- **TS2584** — `Cannot find name 'document'. … change the 'lib' compiler option to include 'dom'` on the `document.*` calls in the generated setup

Both are always present in the v0 `main.ts` template (`createMainTs`).

## Root cause

`@vue/repl` injects its default `tsconfig.json` **once** during store `init()`, guarded by a plain `if (!files.value[tsconfigFile])` — not a watcher. Every `store.setFiles()` call rebuilds the file map from scratch (`Object.create(null)`) and only keeps the files passed in. The playground's three `setFiles` calls in `usePlaygroundFiles` never include `tsconfig.json`, so after the first `setFiles` there is **no tsconfig at all**.

`store.getTsConfig()` then throws (`JSON.parse(undefined.code)`) and falls back to `{}`. The Monaco/Volar worker runs with empty `compilerOptions`:
- no `allowImportingTsExtensions` → TS5097
- no `dom` lib → TS2584

(This same degraded env is why `src/data/presets.ts` carries a `// @ts-expect-error - strictNullChecks not enabled in REPL tsconfig`.)

The infrastructure already *reserves* `tsconfig.json` as a repl builtin (`REPL_BUILTIN_FILES`, `INFRASTRUCTURE_FILES`, PROTECTED in the file tree) — it was simply never seeded into the live store; `tsconfigTemplate` was only wired into the export/download path.

## Fix

- Add a `REPL_TSCONFIG` constant (`allowImportingTsExtensions: true`, `lib: [ESNext, DOM, DOM.Iterable]`, bundler resolution).
- Seed `'tsconfig.json': REPL_TSCONFIG` (hidden, like `uno.config.ts`) in all three `store.setFiles()` call sites.
- Exclude repl builtins from the share-hash serialization so the static config doesn't bloat every shared URL (builtins are re-seeded on load).

The store's `watch(() => files.value[tsconfigFile]?.code, … reloadLanguageTools)` picks up the seeded config, so the Monaco worker gets the correct `compilerOptions`. It stays hidden and out of the file tree (`rebuildFileTree` already skips `REPL_BUILTIN_FILES` and hidden files).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` → 0 errors (after building `packages/0`; the earlier TS6305 wall was just the unbuilt project reference).
- ESLint clean on both files.
