### PR TITLE
docs: fix orphan API pages and ineffective code-splitting in build

### DIFF
--- a/apps/docs/build/api-names.ts
+++ b/apps/docs/build/api-names.ts
@@ -3,7 +3,7 @@
  * Used by both SSG route generation and nav generation.
  */
 
-import { readdir } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -11,6 +11,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '../../..')
 const COMPONENTS_DIR = resolve(ROOT, 'packages/0/src/components')
 const COMPOSABLES_DIR = resolve(ROOT, 'packages/0/src/composables')
+const COMPOSABLES_BARREL = resolve(COMPOSABLES_DIR, 'index.ts')
 
 export interface ApiNameInfo {
   name: string
@@ -74,20 +75,47 @@ async function getComponentNames (): Promise<ApiNameInfo[]> {
 }
 
 /**
+ * Read the public composable surface from the barrel (index.ts).
+ *
+ * Discovery must mirror the public API, not the filesystem. Internal-only
+ * composables (e.g., createFocusTraversal, createObserver) live in their own
+ * directories but are never re-exported, so they must not leak into the SSG
+ * routes or nav — otherwise they mint orphan /api/:name pages with no matching
+ * docs page or API data. The barrel is the single source of truth: every line
+ * is `export * from './<dirName>'`. This mirrors generate-api.ts and
+ * generate-api-whitelist.ts, so a new internal composable is excluded
+ * automatically with no blocklist to maintain.
+ */
+async function getPublicComposableDirs (): Promise<Set<string>> {
+  const content = await readFile(COMPOSABLES_BARREL, 'utf8')
+  const dirs = new Set<string>()
+
+  for (const match of content.matchAll(/export\s+\*\s+from\s+'\.\/([^']+)'/g)) {
+    dirs.add(match[1])
+  }
+
+  return dirs
+}
+
+/**
  * Discover all composable names from the packages/0/src/composables directory.
- * Only includes directories that have an index.ts file.
+ * Only includes directories re-exported from the public barrel that have an
+ * index.ts file.
  */
 async function getComposableNames (): Promise<ApiNameInfo[]> {
   const names: ApiNameInfo[] = []
-  const dirs = await readdir(COMPOSABLES_DIR)
+  const [dirs, publicDirs] = await Promise.all([
+    readdir(COMPOSABLES_DIR),
+    getPublicComposableDirs(),
+  ])
 
   for (const dir of dirs) {
-    // Composable directories start with 'use', 'create', or 'to'
-    if (!dir.startsWith('use') && !dir.startsWith('create') && !dir.startsWith('to')) continue
+    // Only composables re-exported from the public barrel are part of the API.
+    if (!publicDirs.has(dir)) continue
 
     // Only include if the directory has an index.ts file
     const dirPath = resolve(COMPOSABLES_DIR, dir)
-    const entries = await readdir(dirPath).catch(() => [])
+    const entries = await readdir(dirPath).catch(() => [] as string[])
     const hasIndexTs = entries.includes('index.ts')
     if (!hasIndexTs) continue
 

--- a/apps/docs/build/shiki-api-transformer.ts
+++ b/apps/docs/build/shiki-api-transformer.ts
@@ -11,8 +11,10 @@
 
 // Auto-generated whitelists from packages/0/src/
 import { V0_COMPONENTS, V0_COMPOSABLES, V0_COMPOSABLE_TO_DIR } from './generated/api-whitelist'
-// Vue API content - import only keys for build-time detection
-import { VUE_API_CONTENT } from './vue-api-content'
+// Vue API names only — the heavy content in vue-api-content.ts stays
+// dynamically imported (DocsApiHover, hover-time) so it doesn't ride along in
+// the client bundle this transformer is part of.
+import { VUE_API_NAMES as VUE_API_NAME_LIST } from './vue-api-names'
 
 // Types
 import type { ShikiTransformer } from 'shiki'
@@ -31,7 +33,7 @@ const TRINITY_RETURNS: Record<string, string> = {
 
 // Vue API names derived from vue-api-content.ts
 // Used for build-time detection of Vue functions in code
-const VUE_API_NAMES = new Set(Object.keys(VUE_API_CONTENT))
+const VUE_API_NAMES = new Set<string>(VUE_API_NAME_LIST)
 
 /**
  * Maps composable names to their canonical API page (directory name).
@@ -199,5 +201,3 @@ export function renderV0ApiInlineCode (
 
 // Export for use in markdown.ts inline code processing
 export { VUE_API_NAMES }
-
-export { VUE_API_CONTENT } from './vue-api-content'

--- a/apps/docs/build/vue-api-content.ts
+++ b/apps/docs/build/vue-api-content.ts
@@ -7,6 +7,9 @@
  * NOTE: This module is imported client-side, so no Node.js APIs allowed.
  */
 
+// Types
+import type { VueApiName } from './vue-api-names'
+
 export interface VueApiEntry {
   name: string
   category: 'Reactivity' | 'Lifecycle' | 'Injection' | 'Setup' | 'Render' | 'General' | 'Types'
@@ -16,7 +19,10 @@ export interface VueApiEntry {
   href: string
 }
 
-export const VUE_API_CONTENT: Record<string, VueApiEntry> = {
+// Keyed by VueApiName so TypeScript keeps this content in exact sync with
+// vue-api-names.ts (the statically-imported names list). A missing or extra
+// key fails the build.
+export const VUE_API_CONTENT: Record<VueApiName, VueApiEntry> = {
   // ===========================================================================
   // Reactivity: Core
   // ===========================================================================

--- a/apps/docs/build/vue-api-names.ts
+++ b/apps/docs/build/vue-api-names.ts
@@ -1,0 +1,34 @@
+/**
+ * Vue API names for build-time detection.
+ *
+ * This list is the lightweight, statically-importable counterpart to
+ * vue-api-content.ts. The shiki transformer (which runs client-side on every
+ * docs page via useMarkdown/useHighlightCode) only needs the *names* to mark
+ * potential API references; it must not pull in the full descriptions. Those
+ * live in vue-api-content.ts, which is dynamically imported (hover-time only)
+ * by DocsApiHover.vue.
+ *
+ * vue-api-content.ts types its record as `Record<VueApiName, VueApiEntry>`, so
+ * TypeScript enforces that this list and the content stay in exact sync — a
+ * missing or extra name fails the build rather than drifting silently.
+ *
+ * NOTE: Imported client-side, so no Node.js APIs allowed.
+ */
+
+export const VUE_API_NAMES = [
+  'ref', 'computed', 'reactive', 'readonly', 'watch', 'watchEffect',
+  'watchPostEffect', 'watchSyncEffect', 'isRef', 'unref', 'toRef', 'toValue',
+  'toRefs', 'isProxy', 'isReactive', 'isReadonly', 'shallowRef', 'triggerRef',
+  'customRef', 'shallowReactive', 'shallowReadonly', 'toRaw', 'markRaw', 'effectScope',
+  'getCurrentScope', 'onScopeDispose', 'onMounted', 'onUpdated', 'onUnmounted', 'onBeforeMount',
+  'onBeforeUpdate', 'onBeforeUnmount', 'onErrorCaptured', 'onRenderTracked', 'onRenderTriggered', 'onActivated',
+  'onDeactivated', 'onServerPrefetch', 'provide', 'inject', 'hasInjectionContext', 'defineProps',
+  'defineEmits', 'defineExpose', 'defineOptions', 'defineSlots', 'defineModel', 'withDefaults',
+  'useSlots', 'useAttrs', 'useTemplateRef', 'useId', 'useCssModule', 'h',
+  'mergeProps', 'cloneVNode', 'isVNode', 'resolveComponent', 'resolveDirective', 'withDirectives',
+  'withModifiers', 'defineCustomElement', 'useHost', 'useShadowRoot', 'defineComponent', 'defineAsyncComponent',
+  'nextTick', 'createApp', 'Ref', 'ShallowRef', 'ComputedRef', 'MaybeRef',
+  'MaybeRefOrGetter', 'InjectionKey',
+] as const
+
+export type VueApiName = typeof VUE_API_NAMES[number]

--- a/apps/docs/src/components/docs/DocsBenchmarks.vue
+++ b/apps/docs/src/components/docs/DocsBenchmarks.vue
@@ -2,11 +2,9 @@
   // Composables
   import { TIER_CONFIG } from '@/composables/useBenchmarkData'
 
-  import metrics from '@/data/metrics.json'
-
   // Utilities
   import { resolveItemName } from '@/utilities/strings'
-  import { computed, toRef } from 'vue'
+  import { computed, shallowRef, toRef, watchEffect } from 'vue'
   import { useRoute } from 'vue-router'
 
   const tiers = (['good', 'fast', 'blazing', 'slow'] as const).map(t => [t, TIER_CONFIG[t]] as const)
@@ -15,11 +13,22 @@
 
   const itemName = computed(() => resolveItemName(route.path))
 
+  // metrics.json (~183 KB) is code-split via dynamic import so it stays out of
+  // the shared bundle — matching useBenchmarkData/useBenchmarkHistory. A static
+  // import here would defeat that split for every consumer.
+  const metrics = shallowRef<Record<string, { benchmarks?: Record<string, unknown> }> | null>(null)
+
+  watchEffect(() => {
+    if (!itemName.value || metrics.value) return
+    import('@/data/metrics.json').then(m => {
+      metrics.value = m.default as Record<string, { benchmarks?: Record<string, unknown> }>
+    })
+  })
+
   const hasBenchmarks = toRef(() => {
     const name = itemName.value
-    if (!name) return false
-    const m = (metrics as Record<string, { benchmarks?: Record<string, unknown> }>)[name]
-    return !!m?.benchmarks
+    if (!name || !metrics.value) return false
+    return !!metrics.value[name]?.benchmarks
   })
 
   const githubLink = toRef(() => {


### PR DESCRIPTION
Three anomalies surfaced by the `build:docs` log. None failed the build; all are now fixed and verified.

## 1. Orphan API pages for internal composables
`build/api-names.ts` enumerated composable API routes + nav directly from the filesystem (any `use`/`create`/`to` dir with `index.ts`), so internal-only composables `createFocusTraversal` and `createObserver` minted public `/api/create-observer` and `/api/create-focus-traversal` pages — with no docs page and no API data (both `generate-api.ts` and `generate-api-whitelist.ts` already exclude them via the barrel).

Fix: `getComposableNames()` now filters against the public barrel, mirroring the other two generators. Single source of truth; a new internal composable is excluded automatically. Rendered API pages drop 116 → 114 (exactly the two orphans). Nav is fixed in the same spot (`getApiNamesGrouped` shares the function).

## 2. `metrics.json` — ineffective dynamic import
`metrics.json` (~183 KB) was statically imported by `DocsBenchmarks.vue` (used synchronously to gate the section) while `DocsPageFeatures.vue`, `useBenchmarkData.ts`, and `useBenchmarkHistory.ts` imported it dynamically — the static edge defeated the split for everyone (`INEFFECTIVE_DYNAMIC_IMPORT`).

Fix: `DocsBenchmarks.vue` now lazy-loads `metrics.json` too. The benchmark data it wraps (`BenchmarkExplorer`/`useBenchmarkData`) is already client-loaded, so the section wrapper becoming client-rendered is consistent.

## 3. `vue-api-content.ts` — ineffective dynamic import
The shiki transformer (in the client bundle via `useMarkdown`/`useHighlightCode`/`useCodeHighlighter`) statically imported `vue-api-content.ts` **only** to derive `Object.keys(...)`, pulling all 651 lines of hover descriptions into the shared chunk on every page — defeating `DocsApiHover.vue`'s hover-time lazy import.

Fix: extract a names-only `build/vue-api-names.ts` (74 names) for the transformer; the content is now dynamic-only and splits into its own **24.7 KB (5.8 KB gzip) hover-time chunk**. `VUE_API_CONTENT` is typed `Record<VueApiName, VueApiEntry>`, so the names list and the content cannot drift — a missing/extra key fails the build. Also dropped the unused `VUE_API_CONTENT` re-export from the transformer.

## Verification
- `pnpm build:docs` — green; **zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings** (was 2); `vue-api-content` now a standalone chunk.
- Orphan pages absent; all real composable API pages intact (114 pages).
- `vue-tsc --noEmit` on the docs app — clean (proves the `Record<VueApiName>` drift-guard compiles).

## Not addressed (intentional, noise)
`DEP0205 module.register()` deprecation (dependency loader) and the >500 KB chunk-size warnings (`useExamples`, `app`) — pre-existing and unrelated.