### PR TITLE
chore(release): assert prereleases never land on the latest dist-tag

### DIFF
--- a/scripts/verify-published.js
+++ b/scripts/verify-published.js
@@ -1,8 +1,14 @@
-// Verify each just-published package@version is actually visible on npm.
+// Verify each just-published package@version is actually visible on npm, and
+// that no prerelease publish leaked onto the `latest` dist-tag.
 // Driven by the changesets/action `publishedPackages` output. Retries to ride
 // out npm propagation lag and fails the release loud on a partial publish (the
 // failure mode where one substrate package landed and the other did not).
 import { execFileSync } from 'node:child_process'
+
+// A semver prerelease always carries a hyphen (1.0.0-rc.8); a stable never does.
+function isPrerelease (version) {
+  return version.includes('-')
+}
 
 const published = JSON.parse(process.env.PUBLISHED_PACKAGES || '[]')
 
@@ -33,11 +39,37 @@ for (const { name, version } of published) {
     }
   }
 
-  if (found) {
-    console.log(`confirmed ${name}@${version}`)
-  } else {
+  if (!found) {
     console.error(`::error::${name}@${version} is missing from npm — the publish did not complete.`)
     failed = true
+    continue
+  }
+
+  console.log(`confirmed ${name}@${version}`)
+
+  // Dist-tag guard: while a prerelease cycle is in flight, `latest` must stay on
+  // the last stable — changesets publishes prereleases under the pre-tag and
+  // never touches `latest`. A prerelease sitting on `latest` means a publish
+  // escaped the pre-tag path (a manual/off-cycle publish), so plain
+  // `npm install <pkg>` silently hands users a release candidate. This caught
+  // nothing when 1.0.0-rc.6 leaked onto `latest`; it will now.
+  if (isPrerelease(version)) {
+    let latest
+    try {
+      latest = execFileSync('npm', ['view', name, 'dist-tags.latest'], { encoding: 'utf8' }).trim()
+    } catch {
+      // A failed read is an npm/infra hiccup, not a tag defect — the
+      // visibility guard above already confirmed the publish. Warn, don't fail.
+      console.log(`::warning::could not read dist-tags.latest for ${name}; skipping dist-tag guard`)
+      continue
+    }
+
+    if (isPrerelease(latest)) {
+      console.error(`::error::${name} 'latest' points at prerelease ${latest} — a prerelease escaped the pre-tag path. Retag with: npm dist-tag add <pkg>@<last-stable> latest`)
+      failed = true
+    } else {
+      console.log(`dist-tag ok for ${name}: latest → ${latest} (stable), prerelease ${version} correctly off latest`)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`1.0.0-rc.6` sat on the `latest` dist-tag for `@vuetify/v0` and `@vuetify/paper` for ~12 days (Jul 2 → noticed Jul 20). Plain `npm install @vuetify/v0` silently served a release candidate, and it was stale — `rc.7`/`rc.8` had shipped since.

Root cause: changesets in pre-mode publishes prereleases under the pre-tag (`rc`) and never touches `latest`, so during a prerelease cycle `latest` should stay frozen on the last stable (`0.2.1`). `rc.6` reaching `latest` means one publish escaped the pre-tag path (a manual/off-cycle publish). The `Verify published` step only checked version *visibility* — it had zero dist-tag validation — so nothing went red.

## Change

`scripts/verify-published.js`: for any just-published **prerelease** version, assert the package's `latest` dist-tag is not itself a prerelease. Fails the release step loud if it is, with the retag command in the error.

- Stable publishes (`1.0.0`, no hyphen) skip the guard entirely — the Jul 22 stable cut is unaffected.
- A failed `npm view` read warns instead of failing (infra hiccup ≠ tag defect; visibility already confirmed above).
- Reports every offender before exiting non-zero, consistent with the existing partial-publish handling.

## Verified

- Syntax check passes.
- Simulated a prerelease publish while `latest` is a prerelease → exits 1 with the retag hint.
- Simulated a stable publish → guard skipped, exit 0.

## Heads-up

`latest` is currently deliberately parked on `1.0.0-rc.8` (retagged manually to kill the rc.6 staleness for the 2-day gap to stable). This guard does **not** run outside a publish, so it won't flag that state on its own. But if an `rc.9` is published *before* cutting `1.0.0` stable, the guard will correctly go red — because `latest` shouldn't be a prerelease. Expected: the Jul 22 stable cut moves `latest → 1.0.0` and the question is moot.