### PR TITLE
chore(playground): treat opened Vuetify Play tuples as the vuetify preset

### DIFF
--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -330,10 +330,15 @@ export function usePlaygroundFiles () {
 
       const { files, imports, active, vue } = result
 
-      // Detect preset: vuetify template has 'vuetify' in the import map and setup.ts;
-      // v0 template uses @vuetify/v0 with createThemePlugin in main.ts
-      const isVuetifyPreset = 'vuetify' in imports || !!files['src/vuetify.ts'] || !!files['src/setup.ts']
-      activePreset.value = isVuetifyPreset ? 'vuetify' : 'default'
+      // The tuple (array) format is exclusive to Vuetify Play exports — the v0
+      // playground's own saves use the object format handled by decodePlaygroundHash.
+      // Since only arrays reach this point, the preset is always vuetify, matching
+      // decodePlaygroundHash's Format 4 branch. The old feature-sniff
+      // ('vuetify' in imports || setup.ts) misfired on single-file Vuetify Play
+      // playgrounds (just App.vue, no stored import-map, no setup.ts): they fell
+      // back to 'default', so main.ts kept v0's createThemePlugin with no
+      // createVuetify() and every v-* component failed to resolve.
+      activePreset.value = 'vuetify'
       activeAddons.value = []
       extraImports.value = Object.keys(imports).length > 0 ? imports : undefined
       aliasMap.value = new Map()


### PR DESCRIPTION
## Problem

Opening a saved playground from v0play's **Open** dialog yields `Failed to resolve component v-app`. The underlying system files never switched to Vuetify: `main.ts` kept v0's `createThemePlugin` and never called `createVuetify()`, so every `v-*` component was unresolved.

## Root cause

`PlaygroundOpenDialog` fetches Vuetify Play playgrounds from `/one/playgrounds` and hands the content to `openPlayground`, which decided the preset with a feature-sniff:

```ts
const isVuetifyPreset = 'vuetify' in imports || !!files['src/vuetify.ts'] || !!files['src/setup.ts']
```

Modern single-file Vuetify Play playgrounds carry **only** `App.vue` — no stored import-map, no `setup.ts`. The sniff returned false, so the preset fell back to `default` (v0), `createMainTs` emitted the v0 `main.ts`, and `<v-app>` failed to resolve.

## Fix

`openPlayground` already early-returns on non-array content, and the tuple (array) format is exclusive to Vuetify Play exports — v0's own saves use the object format handled by `decodePlaygroundHash`. So the preset is unconditionally `vuetify` here, matching `decodePlaygroundHash`'s Format 4 branch. Dropped the fragile heuristic.

## Verification

- Reproduced against a live single-file Vuetify Play playground (`App.vue` with `<v-app>`, no `setup.ts`/import-map) — the exact shape that mis-detected.
- No sibling copy of the heuristic elsewhere in the playground source.
- One-line behavioral change; no package source touched (hence `chore`, not `fix`).