### PR TITLE
chore(playground): pin repl TypeScript to 5.9.3 so editor libs load

### DIFF
--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -6,7 +6,7 @@ import { decodePlaygroundHash, encodePlaygroundHash, parseVuetifyPlayTuple } fro
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
-import { createMainTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, UNO_CONFIG_TS } from '@/data/playground-defaults'
+import { createMainTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
 
 // Utilities
@@ -33,6 +33,9 @@ export function usePlaygroundFiles () {
   const store = useStore({
     builtinImportMap,
     vueVersion,
+    // Pin the worker's TypeScript so it doesn't float to typescript@latest (TS 7
+    // native port), which breaks lib .d.ts loading — see REPL_TYPESCRIPT_VERSION.
+    typescriptVersion: shallowRef(REPL_TYPESCRIPT_VERSION),
     showOutput: shallowRef(false),
   })
 

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -9,16 +9,29 @@ export const REPL_BUILTIN_FILES = ['import-map.json', 'tsconfig.json'] as const
 /** Infrastructure files revealed by the file tree's "Toggle config files" button */
 export const CONFIG_FILE_IDS = new Set(['src/main.ts', 'src/uno.config.ts', 'import-map.json'])
 
+// ── REPL TypeScript version ─────────────────────────────────────────────────
+//
+// @vue/repl's Monaco worker fetches TypeScript's lib .d.ts files (lib.dom.d.ts,
+// lib.esnext.d.ts, …) from the `typescript@<version>` package on the CDN. Left
+// unpinned, the store defaults to `typescript@latest`, which now resolves to the
+// 7.0.x native/Go port — a package layout the bundled Volar tools can't read, so
+// the worker loads NO libs at all and every global (document, window, console,
+// even Array.map/Promise/Symbol) reports "Cannot find name". Pinning to the last
+// 5.x keeps the worker's type environment intact until @vue/repl supports TS 7.
+export const REPL_TYPESCRIPT_VERSION = '5.9.3'
+
 // ── REPL tsconfig ──────────────────────────────────────────────────────────
 //
 // @vue/repl auto-injects a default tsconfig once during store init, but only
 // if none exists. Every store.setFiles() call rebuilds the file map from
 // scratch and drops it, and the injection is a one-time `if` — not a watcher —
 // so it never comes back. With no tsconfig, store.getTsConfig() throws and the
-// Monaco worker falls back to empty compilerOptions: no `allowImportingTsExtensions`
-// (the sandbox `import './uno.config.ts'` reports TS5097) and no `dom` lib
-// (`document` reports TS2584). Seeding this alongside the other builtins keeps
-// the worker's type environment correct.
+// Monaco worker falls back to empty compilerOptions — notably no
+// `allowImportingTsExtensions`, so the sandbox `import './uno.config.ts'`
+// reports TS5097. Seeding this alongside the other builtins keeps the worker's
+// compiler options stable across setFiles() calls. (DOM/ESNext globals like
+// `document` are provided by the worker's lib .d.ts files, not this `lib`
+// array — see REPL_TYPESCRIPT_VERSION for why those must stay on TS 5.x.)
 export const REPL_TSCONFIG = JSON.stringify({
   compilerOptions: {
     allowJs: true,


### PR DESCRIPTION
## Problem

The v0 playground editor reports `Cannot find name 'document'` (TS2584) — and in fact fails on *every* global. The prior fix (#662) seeded a `lib: ['ESNext','DOM','DOM.Iterable']` tsconfig, but the error persisted.

## Root cause

The `@vue/repl` store never pinned `typescriptVersion`, so it defaults to `latest`. That tag now resolves to **TypeScript 7.0.2** (the native/Go port), whose npm package layout the bundled Volar worker can't read. Result: the Monaco worker loads **no** lib `.d.ts` files at all, so `document`, `window`, `console` — and even `Array.map`, `Promise`, `Symbol` — all report "Cannot find name". `document` is just the global users happen to hover.

The tsconfig `lib` array from #662 has **no effect** on this — DOM types come from the worker's fetched lib files, not the tsconfig.

## Fix

Pin the store to `typescript@5.9.3` (last 5.x) via a documented `REPL_TYPESCRIPT_VERSION` constant. Also corrected the now-inaccurate REPL_TSCONFIG comment (its real job is seeding `allowImportingTsExtensions` for the `uno.config.ts` import / TS5097).

## Verification

Drove the running playground and read Monaco's actual diagnostics on a probe mixing ES + DOM globals (`arr.map`, `'x'.padStart`, `Promise`, `Symbol`, `document`, `window`):

| `typescriptVersion` | resolves to | editor errors |
|---|---|---|
| `latest` | 7.0.2 | **8** (all globals) |
| `5.6.3` | 5.6.3 | 0 |
| `5.9.3` (shipped) | 5.9.3 | 0 |

Confirmed with the exact shipped tsconfig (explicit `lib`) + the 5.9.3 pin: **0 diagnostics**.

## Follow-up

Revisit the pin once `@vue/repl` ships Volar tooling compatible with TypeScript 7.
