### PR TITLE
chore(playground): single-source the Vuetify Play preset mapping

### DIFF
--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -123,8 +123,14 @@ export function isFileRecord (v: unknown): v is Record<string, string> {
 /**
  * Parse a Vuetify Play tuple format: [files, vueVersion, vuetifyVersion, appendJson, activeFile, ...]
  * Shared between decodePlaygroundHash and openPlayground.
+ *
+ * The tuple format is exclusive to Vuetify Play exports, so `preset` is always
+ * 'vuetify'. This is the single source of that mapping — both callers consume it
+ * rather than each deciding the preset themselves, which is how a v0/vuetify
+ * feature-sniff once drifted into openPlayground and mis-detected single-file
+ * Vuetify Play playgrounds as v0 (see #666).
  */
-export function parseVuetifyPlayTuple (parsed: unknown[]): { files: Record<string, string>, imports: Record<string, string>, active?: string, vue?: string } | null {
+export function parseVuetifyPlayTuple (parsed: unknown[]): { files: Record<string, string>, imports: Record<string, string>, active?: string, vue?: string, preset: 'vuetify' } | null {
   const [rawFiles, vueVer, , , rawActive] = parsed as [
     unknown, unknown, unknown, unknown, unknown,
   ]
@@ -199,6 +205,7 @@ export function parseVuetifyPlayTuple (parsed: unknown[]): { files: Record<strin
     imports,
     active,
     vue: isString(vueVer) ? vueVer : undefined,
+    preset: 'vuetify',
   }
 }
 
@@ -246,7 +253,7 @@ export async function decodePlaygroundHash (hash: string): Promise<PlaygroundHas
       const result = parseVuetifyPlayTuple(parsed)
       if (!result) return null
 
-      const settings: PlaygroundHashData['settings'] = { preset: 'vuetify' }
+      const settings: PlaygroundHashData['settings'] = { preset: result.preset }
       if (result.vue) settings.vue = result.vue
       const imports = Object.keys(result.imports).length > 0 ? result.imports : undefined
       return { files: result.files, active: result.active, imports, settings }

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -331,17 +331,11 @@ export function usePlaygroundFiles () {
       const result = parseVuetifyPlayTuple(parsed)
       if (!result) return
 
-      const { files, imports, active, vue } = result
+      const { files, imports, active, vue, preset } = result
 
-      // The tuple (array) format is exclusive to Vuetify Play exports — the v0
-      // playground's own saves use the object format handled by decodePlaygroundHash.
-      // Since only arrays reach this point, the preset is always vuetify, matching
-      // decodePlaygroundHash's Format 4 branch. The old feature-sniff
-      // ('vuetify' in imports || setup.ts) misfired on single-file Vuetify Play
-      // playgrounds (just App.vue, no stored import-map, no setup.ts): they fell
-      // back to 'default', so main.ts kept v0's createThemePlugin with no
-      // createVuetify() and every v-* component failed to resolve.
-      activePreset.value = 'vuetify'
+      // Preset comes from parseVuetifyPlayTuple (the single source of the
+      // tuple→preset mapping), shared with decodePlaygroundHash's Format 4 branch.
+      activePreset.value = preset
       activeAddons.value = []
       extraImports.value = Object.keys(imports).length > 0 ? imports : undefined
       aliasMap.value = new Map()


### PR DESCRIPTION
Follow-up hardening to #666 (already merged). That fix corrected the symptom; this removes the *shape* that allowed the regression.

## Why

The preset for an opened Vuetify Play playground was decided in **two** places from the same tuple:
- `decodePlaygroundHash` Format 4 (URL-hash path) — stayed correct
- `openPlayground` (Open-dialog path) — drifted to a `'vuetify' in imports || setup.ts` feature-sniff that mis-detected single-file playgrounds as v0, leaving v0's `main.ts` in place → `Failed to resolve component v-app`

Two independent decision sites for one fact is what let them diverge.

## Change

Fold the tuple→preset mapping into `parseVuetifyPlayTuple`'s return:

```ts
export function parseVuetifyPlayTuple (...): { …, preset: 'vuetify' } | null
```

Both callers now consume `result.preset` instead of each deciding for themselves. The tuple format is exclusive to Vuetify Play exports, so the value is a typed constant with a single home. A future "detect v0 vs vuetify" attempt has to edit the shared function and reconcile both entry points — it can't silently break one path while the other stays right.

No behavior change: both paths already resolved to `vuetify` post-#666. This locks that in structurally.

## Verification

- Pure type-level refactor; the annotated `preset: 'vuetify'` return type makes both consume sites type-checked.
- `pnpm typecheck` not run in the worktree (no `node_modules`); change is trivially type-sound — flag if CI disagrees.
- No package source touched (`chore`, not `fix`).