### PR TITLE
chore(paper): remove @vuetify/paper from the publish path

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "vuetifyjs/0" }],
   "commit": false,
-  "fixed": [["@vuetify/v0", "@vuetify/paper"]],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "master",

--- a/.changeset/security-guard-sweep-qgbm.md
+++ b/.changeset/security-guard-sweep-qgbm.md
@@ -1,6 +1,5 @@
 ---
 "@vuetify/v0": patch
-"@vuetify/paper": patch
 ---
 
 fix(security): apply prototype-pollution and CSS-injection guards flagged in the security review
@@ -8,6 +7,4 @@ fix(security): apply prototype-pollution and CSS-injection guards flagged in the
 - `useFeatures` adapters (LaunchDarkly / Flagsmith / PostHog) now skip `UNSAFE_KEYS` (`__proto__` / `constructor` / `prototype`) flag names when building the flags object, matching the guard already used by `mergeDeep`, `usePermissions`, and `createTokens`
 - `useLocale` `restore()` validates the persisted value with `isString` / `isNumber` guards before applying it instead of blind-casting `saved as ID`, completing the persist/restore sweep (`useTheme` and `useRtl` now use the same guards)
 - `ThemeAdapter`'s `UNSAFE_CSS` denylist is hardened against declaration injection: it now also rejects `;`, `\` (CSS escape evasion), and the URL-loading functions `src()` / `image()` / `image-set()` / `cross-fade()`
-- `@vuetify/paper` `useTheme` sanitizes color keys and values before writing them into the injected `<style>` element, mirroring the hardened v0 `ThemeAdapter` `SAFE_IDENT` / `UNSAFE_CSS` guards
-- `@vuetify/paper` `createTheme` now merges `options.themes` into the defaults — previously they were passed as `structuredClone`'s options bag and silently dropped, so a custom `current` theme threw at first render
 - `V0Error` filters `UNSAFE_KEYS` when copying caller-supplied error details onto the instance

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vuetify/paper",
   "version": "1.0.0-rc.9",
+  "private": true,
   "description": "Vuetify Paper",
   "license": "MIT",
   "types": "./dist/index.d.mts",


### PR DESCRIPTION
Removes `@vuetify/paper` from the release/publish path for the 1.0 line. The package **stays in the repo** and remains buildable — this only stops it from publishing to npm and versioning in lockstep with v0.

## Why
Per the 2026-07-21 decision: v0 is the sole substrate; `@vuetify/paper` is kept **dormant** and its fate deferred until the second design system (Onyx) proves whether its primitives are needed. Publishing `@vuetify/paper@1.0.0` would commit a public semver API to a package whose design isn't settled — this keeps it out of npm with zero deprecation debt.

## Changes
- `packages/paper/package.json` — `"private": true` (changeset publish skips it; `dev`/`docs` still consume it via `workspace:*`)
- `.changeset/config.json` — drop it from the `fixed` group (`"fixed": []`)
- `.changeset/security-guard-sweep-qgbm.md` — strip the `@vuetify/paper` entry + its 2 paper bullets; the `@vuetify/v0` patch and its 4 bullets are retained

## Not in scope (separate PRs)
- Install-facing doc references (README/tips/skill)
- Stale contributor prose (AGENTS.md, CLAUDE.md fixed-group line)
- `scripts/github-release.js` no-ops when paper is unpublished (keys off the published-version map); only stale comments remain