### PR TITLE
docs: stop presenting @vuetify/paper as a consumed package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ import { createRegistry } from '#v0/composables'
 ## Packages
 
 - **`@vuetify/v0`** (`packages/0/`): Headless components and composables
-- **`@vuetify/paper`** (`packages/paper/`): Styling primitives depending on v0
+- **`@vuetify/paper`** (`packages/paper/`): Styling primitives depending on v0 — **not published (dormant)**
 
 ## Apps
 
@@ -112,7 +112,7 @@ The `.changeset/*.md` body renders verbatim into the changelog and GitHub releas
 - **Body (optional)** — add one when the title can't answer those questions itself: a behavior delta, a performance change worth quantifying (state the magnitude), a breaking/migration step, or new public options or escape hatches. Length is earned by impact, not padded to a target.
 - **Never the mechanism** — internal composables touched, private fields, refactors mirrored from a sibling go in the PR description and commit body, never the changelog.
 
-- **Substrate** (`@vuetify/v0` + `@vuetify/paper`) is a `fixed` group: one shared version, one aggregate `v<version>` GitHub release.
+- **Substrate** — `@vuetify/v0` is the sole published substrate, versioned and released on its own `v<version>` GitHub release. `@vuetify/paper` is `private`/dormant and no longer part of the changesets `fixed` group.
 - **Design systems** (`@paper/*`, e.g. `@paper/genesis`) version and release independently, each on its own `name@version` release. Note `@paper/genesis` depends on `@vuetify/v0`, so a substrate **major** bump (e.g. `1.x` → `2.0.0`) leaves genesis's `^` range and changesets will also bump + republish genesis. That is expected — review it in the "Version Packages" PR before merging.
 
 ### Exiting beta / cutting a stable release

--- a/apps/docs/src/data/tips.ts
+++ b/apps/docs/src/data/tips.ts
@@ -79,11 +79,6 @@ export const tips: Tip[] = [
     link: { to: '/introduction/why-vuetify0', text: 'Why v0?' },
   },
   {
-    id: 'paper-companion',
-    body: '`@vuetify/paper` adds styling primitives on top of v0 without taking away the headless escape hatch. Use them together when you want opinions, independently when you want control.',
-    link: { to: '/guide/fundamentals/plugins', text: 'Plugins guide' },
-  },
-  {
     id: 'logger-adapters',
     body: '`useLogger` ships with Pino and Consola adapters — wire your v0 logs into your existing observability stack in one line.',
     link: { to: '/composables/plugins/use-logger', text: 'useLogger' },

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -83,7 +83,7 @@ pnpm dev:docs
 │   │       ├── utilities/     # Helper functions
 │   │       └── types/         # TypeScript types
 │   ├── genesis/        # @paper/genesis - design system
-│   └── paper/          # @vuetify/paper - styling primitives
+│   └── paper/          # @vuetify/paper - styling primitives (dormant, not published)
 ├── apps/
 │   ├── docs/           # Documentation site
 │   └── playground/     # Browser-based code editor
@@ -151,7 +151,7 @@ The entire changeset body — everything after the frontmatter — is rendered v
 - **Body (optional)** — add one when the title can't carry the whole consumer-visible consequence: a behavior delta, a performance change worth quantifying (state the magnitude), a breaking change or migration step, or new public options / escape hatches. Length is earned by consumer impact — a genuinely rich behavior change may run to a paragraph; a routine, self-evident fix stays one line.
 - **Never the mechanism.** How you implemented it — internal composables touched, private fields, refactors mirrored from a sibling — belongs in the PR description and the commit body, not the changelog. A consumer reads release notes to decide whether to upgrade and whether they must act, nothing more.
 
-`@vuetify/v0` and `@vuetify/paper` version in lockstep — selecting `@vuetify/v0` carries `@vuetify/paper` automatically; the `@paper/*` design systems version separately. Docs-only, chore, refactor, or CI PRs don't need one. A bot comments on every PR to remind you.
+`@vuetify/v0` versions and publishes independently; `@vuetify/paper` is `private` and unpublished, so it takes no changeset. The `@paper/*` design systems version separately. Docs-only, chore, refactor, or CI PRs don't need one. A bot comments on every PR to remind you.
 
 The changeset is how your change reaches a release. On every push to `master`, automation gathers all pending `.changeset/*.md` files into a "Version Packages" PR that applies the version bumps and writes the changelog entries. When a maintainer merges that PR, the packages are built, published to npm, and the GitHub releases are created. A `packages/*` change merged without a changeset still ships in the code — but with no version bump and no changelog entry.
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -37,7 +37,6 @@ This is a **pnpm monorepo** containing:
 | Package | Description |
 |---------|-------------|
 | [`@vuetify/v0`](./packages/0) | Core headless components and composables |
-| [`@vuetify/paper`](./packages/paper) | Styling and layout primitives |
 | [`apps/docs`](./apps/docs) | Documentation site ([0.vuetifyjs.com](https://0.vuetifyjs.com)) |
 | [`apps/playground`](./apps/playground) | Interactive development environment |
 

--- a/skills/vuetify0/SKILL.md
+++ b/skills/vuetify0/SKILL.md
@@ -284,10 +284,9 @@ Sub-components talk to the root via `createContext`. Never prop-drill state betw
 ## Paper and Vuetify relationship
 
 - `@vuetify/v0` — headless (this skill)
-- `@vuetify/paper` — styling primitives that depend on v0
 - `vuetify` v4 — Material Design framework, integrates v0 via minor releases
 
-When the user asks to "style" a v0 component or build a design system, point them at `@vuetify/paper` or a Paper-based design system (e.g., Emerald, Helix). Keep v0 itself headless.
+When the user asks to "style" a v0 component or build a design system, point them at a Paper design system (e.g., Emerald, Helix) — that is how styling is layered on top of headless v0. Keep v0 itself headless.
 
 ## Vuetify MCP
 

--- a/skills/vuetify0/references/layer-decisions.md
+++ b/skills/vuetify0/references/layer-decisions.md
@@ -7,9 +7,7 @@ When to use composables, components, or both.
 ```
 Vuetify 4 (design system consumer)
     ↑
-Design Systems (Emerald, Helix, …)
-    ↑
-Paper (styling primitives)
+Design Systems (Emerald, Helix, …) — add styling on top of v0
     ↑
 v0 — components (WAI-ARIA wrappers)
 v0 — composables (state, logic, registries)


### PR DESCRIPTION
Companion to #671. With `@vuetify/paper` removed from the publish path (kept in-repo but not published), this scrubs the docs/skill references that told users to install or consume it, and fixes two now-false contributor lines.

## User-facing (were pointing at an unpublishable package)
- `apps/docs/src/data/tips.ts` — remove the `paper-companion` tip
- `packages/0/README.md` — remove the `@vuetify/paper` row (root README is a symlink → covered)
- `skills/vuetify0/SKILL.md` + `references/layer-decisions.md` — drop the `@vuetify/paper` layer; redirect styling guidance to the Paper design systems (Emerald/Helix)

## Contributor prose (were stale/false)
- `CLAUDE.md` — packages list annotated dormant; the "substrate is a `fixed` group" line corrected (v0 is the sole published substrate)
- `apps/docs/src/pages/introduction/contributing.md` — lockstep-versioning prose corrected

Deliberately silent on paper's longer-term fate (dormant, deferred to the second-DS evaluation). `AGENTS.md` also has a stale layer line but it's git-excluded (local-only), so it can't be fixed via PR — handled out of band.