### PR TITLE
chore(playground): load MDI webfont in the Vuetify preset so icons render

### DIFF
--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -81,11 +81,17 @@ export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?
       // this preamble, vuetify-utilities ends up declared before vuetify-components
       // and components beat helpers in the cascade.
       `document.head.insertAdjacentHTML('afterbegin', '<style>@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;</style>')`,
-      `const link = document.createElement('link')`,
-      `link.rel = 'stylesheet'`,
-      `link.setAttribute('data-preset-css', 'vuetify')`,
-      `link.href = 'https://cdn.jsdelivr.net/npm/vuetify@latest/dist/vuetify-labs.css'`,
-      `document.head.appendChild(link)`,
+      // Vuetify's CSS plus the MDI webfont — its default icon set, which
+      // vuetify-labs.css doesn't bundle, so without it every mdi-* icon renders
+      // as tofu. Add further icon-set stylesheets here as list entries.
+      `for (const href of [`,
+      `  'https://cdn.jsdelivr.net/npm/vuetify@latest/dist/vuetify-labs.css',`,
+      `  'https://cdn.jsdelivr.net/npm/@mdi/font@7.x/css/materialdesignicons.min.css',`,
+      `]) {`,
+      `  const link = Object.assign(document.createElement('link'), { rel: 'stylesheet', href })`,
+      `  link.dataset.presetCss = 'vuetify'`,
+      `  document.head.appendChild(link)`,
+      `}`,
     )
     extraPlugins.push(`app.use(createVuetify())`)
   }


### PR DESCRIPTION
## Description

Vuetify's default icon set is the MDI **webfont** (class-based `mdi-*`), which `vuetify-labs.css` does not bundle. The playground's built-in **Vuetify preset** only injected the Vuetify stylesheet into the preview sandbox, so every icon (`icon="mdi-github"`, app-bar nav icon, etc.) fell back to `content: none` and rendered as tofu / nothing.

Fix: load the `@mdi/font` stylesheet alongside `vuetify-labs.css` in the generated `main.ts`. Also collapses the per-stylesheet `createElement` boilerplate into a single href-list loop, which is the natural seam for adding further icon sets later.

## Repro (before)

1. Playground -> Settings -> Presets -> **Vuetify** -> Apply
2. Icons in the template (`mdi-github`, app-bar nav icon, ...) render as empty boxes.

Shared Vuetify Play links were unaffected only because they carry their own `setup.ts` that loads the font.

## Verification

Drove the running playground and inspected the preview iframe: `.mdi-github::before` now resolves to `font-family: "Material Design Icons"` with the real glyph (24px), and the `@mdi/font` stylesheet is present in the preview `<head>`.

## Follow-up (not in this PR)

Making icon sets a first-class, configurable feature of the playground (a Settings "Icons" section over `createVuetify({ icons })`) - deliberately deferred.
