### PR TITLE
docs: rewrite composable intros to be user-facing

### DIFF
--- a/apps/docs/src/pages/composables/registration/create-timeline.md
+++ b/apps/docs/src/pages/composables/registration/create-timeline.md
@@ -17,7 +17,7 @@ related:
 
 # createTimeline
 
-Bounded undo/redo history built on `createRegistry` with a configurable size limit.
+Bounded undo/redo history with a configurable size limit; older entries overflow into a buffer you can still undo back into.
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/pages/composables/selection/create-nested.md
+++ b/apps/docs/src/pages/composables/selection/create-nested.md
@@ -18,7 +18,7 @@ related:
 
 # createNested
 
-Hierarchical tree management built on `createGroup`, with parent-child relationships, open/close state, and pluggable traversal strategies.
+Manage hierarchical tree structures with parent-child relationships, open/close state, and pluggable traversal strategies.
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/pages/composables/selection/create-single.md
+++ b/apps/docs/src/pages/composables/selection/create-single.md
@@ -18,7 +18,7 @@ related:
 
 # createSingle
 
-Extends `createSelection` to enforce single-item selection, automatically clearing the previous selection.
+Enforce single-item selection in a collection — selecting one item automatically clears the previous.
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/pages/composables/selection/create-step.md
+++ b/apps/docs/src/pages/composables/selection/create-step.md
@@ -17,7 +17,7 @@ related:
 
 # createStep
 
-Extends `createSingle` with bounded or circular navigation. Built for wizards, multi-step forms, and onboarding flows.
+Navigate a collection one step at a time with bounded or circular movement. Built for wizards, multi-step forms, and onboarding flows.
 
 <DocsPageFeatures :frontmatter />
 

--- a/apps/docs/src/pages/composables/semantic/create-breadcrumbs.md
+++ b/apps/docs/src/pages/composables/semantic/create-breadcrumbs.md
@@ -18,7 +18,7 @@ related:
 
 # createBreadcrumbs
 
-A composable that extends `createSingle` for breadcrumb navigation with automatic path truncation.
+Manage a breadcrumb trail with automatic path truncation — selecting an earlier crumb drops everything after it.
 
 <DocsPageFeatures :frontmatter />
 


### PR DESCRIPTION
Per the docs authoring rule (`.claude/rules/docs.md` Page Intro: intros must be user-facing and never name internal composables), five composable page intros were describing themselves in terms of their parent primitive:

- `create-single` — "Extends `createSelection`…"
- `create-step` — "Extends `createSingle`…"
- `create-nested` — "…built on `createGroup`…"
- `create-timeline` — "…built on `createRegistry`…"
- `create-breadcrumbs` — "…extends `createSingle`…"

Rewrites each intro to describe what the composable does for the consumer. The parent hierarchy is unchanged and still shown in each page's Architecture diagram. Found via a docs-inventory scout pass.