### PR TITLE
chore(ci): path-filter deploy workflows and cancel superseded runs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,6 +2,25 @@ name: Docs Deploy
 on:
   push:
     branches: [master]
+    # Single paths list with `!` negations — GitHub does not allow both
+    # `paths` and `paths-ignore` on the same event. Order matters: a negation
+    # after a positive match wins, so a test-only src commit is excluded.
+    paths:
+      - 'apps/docs/**'
+      - 'packages/0/src/**'
+      - 'packages/0/package.json'
+      - 'packages/genesis/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/docs-deploy.yml'
+      - '!packages/0/src/**/*.test.ts'
+      - '!packages/0/src/**/*.bench.ts'
+      - '!packages/0/src/**/*.browser.test.ts'
+      - '!packages/0/src/**/*.ssr.test.ts'
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/.github/workflows/playground-deploy.yml
+++ b/.github/workflows/playground-deploy.yml
@@ -2,6 +2,24 @@ name: Playground Deploy
 on:
   push:
     branches: [master]
+    # Single paths list with `!` negations — GitHub does not allow both
+    # `paths` and `paths-ignore` on the same event. Playground bundles only
+    # @vuetify/v0 (no genesis, no paper), so those packages are omitted.
+    paths:
+      - 'apps/playground/**'
+      - 'packages/0/src/**'
+      - 'packages/0/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/playground-deploy.yml'
+      - '!packages/0/src/**/*.test.ts'
+      - '!packages/0/src/**/*.bench.ts'
+      - '!packages/0/src/**/*.browser.test.ts'
+      - '!packages/0/src/**/*.ssr.test.ts'
+
+concurrency:
+  group: playground-deploy
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Both deploy workflows fired on **every** master push with no path filters and no concurrency control. This adds:

- **Path filters** so a deploy only runs when files it actually consumes change.
- **`concurrency: cancel-in-progress`** so a push storm cancels superseded runs instead of queueing redundant redeploys.

## Filters

Single `paths` list with `!` negations — GitHub does **not** allow both `paths` and `paths-ignore` on the same event; order matters (a negation after a positive match wins), so test-only src commits are excluded.

**Docs** — `apps/docs/**`, `packages/0/src/**`, `packages/0/package.json`, `packages/genesis/**`, lockfile/workspace, own workflow.
**Playground** — `apps/playground/**`, `packages/0/src/**`, `packages/0/package.json`, lockfile/workspace, own workflow.

Both exclude `*.test.ts` / `*.bench.ts` / `*.browser.test.ts` / `*.ssr.test.ts` under `packages/0/src/**`.

### Dependency-graph corrections vs. the original brief

Verified against the actual workspace at implement time:

- **`packages/genesis/**` added to docs** — docs bundles `@paper/genesis` (`GnPeek`, `GnActionButton`, `GnDotGrid`, …); a genesis-only change would otherwise silently miss a docs redeploy.
- **`packages/paper/**` dropped from both** — paper is dissolved (2026-07-20) and imported by neither app's bundle graph (docs declares it but never imports it; genesis depends only on `@vuetify/v0`; playground depends only on `@vuetify/v0`).
- **Playground omits genesis/paper** — it bundles only `@vuetify/v0`.

## Verification after merge

- Push a docs-only commit -> playground workflow **skipped**, docs runs.
- Push a `packages/0/src` runtime commit -> **both** run.
- Push a test-only `packages/0/src/**/*.test.ts` commit -> **both skipped**.
- During a rapid push sequence -> intermediate runs show **cancelled**.

Coolify note: cancel-in-progress may race with a mid-flight `coolify-action` deploy; the next SHA heals it. Watch the first few cancelled runs.