### PR TITLE
chore(playground): patch @vue/repl to dispose stale monaco dep models (fixes listener leak)

### DIFF
--- a/patches/@vue__repl@4.7.1.patch
+++ b/patches/@vue__repl@4.7.1.patch
@@ -1,8 +1,20 @@
 diff --git a/dist/monaco-editor.js b/dist/monaco-editor.js
-index 0000000000000000000000000000000000000000..0000000000000000000000000000000000000001 100644
+index 32187d073bfa62031a526f4e20a21ee8ac14c857..06df068c8e78db8e521008e63849e324ed078ba5 100644
 --- a/dist/monaco-editor.js
 +++ b/dist/monaco-editor.js
-@@ -190204,7 +190204,6 @@
+@@ -178523,6 +178523,11 @@ class WorkerHost {
+ let disposeVue;
+ async function reloadLanguageTools(store) {
+   disposeVue?.();
++  for (const model of editor.getModels()) {
++    if (model.uri.toString().startsWith("file:///node_modules")) {
++      model.dispose();
++    }
++  }
+   let dependencies = {
+     ...store.dependencyVersion
+   };
+@@ -190204,7 +190209,6 @@ const _sfc_main$1 = /* @__PURE__ */ defineComponent({
              editorInstance.setModel(model);
              if (file.editorViewState) {
                editorInstance.restoreViewState(file.editorViewState);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,7 @@ overrides:
 
 patchedDependencies:
   '@vue/repl@4.7.1':
-    hash: 22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe
+    hash: fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33
     path: patches/@vue__repl@4.7.1.patch
   vite-ssg@28.3.0:
     hash: 2c7dbea92b654ad6e2bb1700bb4d07589f96f5bcf32f5ecac4eaf58ccd7ac95c
@@ -363,7 +363,7 @@ importers:
         version: link:../../packages/genesis
       '@vue/repl':
         specifier: 'catalog:'
-        version: 4.7.1(patch_hash=22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe)
+        version: 4.7.1(patch_hash=fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33)
       '@vuetify/auth':
         specifier: 'catalog:'
         version: 0.1.8(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
@@ -505,7 +505,7 @@ importers:
         version: mdi-js-es@7.4.47
       '@vue/repl':
         specifier: 'catalog:'
-        version: 4.7.1(patch_hash=22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe)
+        version: 4.7.1(patch_hash=fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33)
       '@vuetify/auth':
         specifier: 'catalog:'
         version: 0.1.8(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
@@ -10305,7 +10305,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.6.0-beta.15
 
-  '@vue/repl@4.7.1(patch_hash=22a1e92d68b942412d71072ca179a113ff51e2ff6598767c7c954ceb4e277cbe)': {}
+  '@vue/repl@4.7.1(patch_hash=fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33)': {}
 
   '@vue/runtime-core@3.5.39':
     dependencies:


### PR DESCRIPTION
## Description

The playground's Monaco editor accumulates monaco `TextModel`s and never releases them, producing the escalating console noise:

```
[001] potential listener LEAK detected, having 200 listeners already ...
Uncaught Error: [001] potential listener LEAK detected, having 300 ... (then 400, 500)
```

### Root cause

`@vue/repl`'s `initMonaco` cleanup loop disposes stale **source-file** models but deliberately **skips `file:///node_modules/*`** (the dependency `.d.ts` models that back IntelliSense, created by the worker's `onFetchCdnFile`). `getOrCreateModel` reuses by URI, so re-fetching the *same* dep is fine — but every time the **dependency set changes** (File → Open a playground with different imports, switching Vue/TS version, switching preset), new `node_modules` URIs are created and the old ones linger for the life of the page. Each holds a listener on monaco's singleton `LanguageService._onDidChange` (hardcoded `leakWarningThreshold: 200`), so the count climbs 200 → 300 → 400 → 500 and the monaco error handler re-throws. Confirmed **not** dev-gated — it ships in prod, and the accumulation is a genuine memory leak.

### Fix

Patch `reloadLanguageTools` to dispose stale `file:///node_modules/*` models before the freshly-created worker repopulates the current dependency set. `reloadLanguageTools` already tears down and rebuilds the worker + language providers on every run, so type models re-resolve anyway — this just bounds `node_modules` models to the active deps instead of letting them accumulate.

One hunk added to the existing `patches/@vue__repl@4.7.1.patch` (via `pnpm patch`); no app-source change.

### Verification

Drove the running playground through the initial load + four Vue-version switches (five dependency reloads total). With the stock bundle this churn escalated to the 500-listener warning; with the patch there are **zero `listener LEAK` warnings**, every recompile reports "successfully compiled", and the disposal loop runs without error.

### Upstream

`@vue/repl` here is the stock Vue package (`github.com/vuejs/repl`), not ours — this is a local pnpm patch as a stopgap; an upstream issue should be filed so the patch can eventually be dropped. Maintenance note: it's a context-anchored patch on a minified bundle, so re-verify on `@vue/repl` bumps (we already carry three such hunks).
