### PR TITLE
chore(playground): bind Select value to item id so "Latest" version resolves

### DIFF
--- a/apps/playground/src/components/app/AppSelect.vue
+++ b/apps/playground/src/components/app/AppSelect.vue
@@ -51,7 +51,7 @@
         :key="item.id"
         v-slot="{ isSelected }"
         class="item"
-        :value="item.label"
+        :value="item.id"
       >
         <span>{{ item.label }}</span>
 


### PR DESCRIPTION
## Description

Selecting **"Latest"** in the playground's Vue or `@vuetify/v0` version picker broke the preview: the CDN request became `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@Latest/...` (capital-L) and 404'd, so the sandbox failed to compile.

### Root cause

`AppSelect.vue` bound `Select.Item :value="item.label"`, but everything around it keys off `item.id`:
- `AppSelect`'s own `selectedLabel` getter matches `item.id === model.value`
- `PlaygroundSettingsVersions`' `set()` maps `value === 'latest' ? null : String(value)`

v0's `Select` v-model carries ticket **values** (`SelectRoot.vue`: *"Carries ticket values"*), so the model held the **label**. For concrete versions `label === id` (e.g. `'3.5.13'`), so it worked. Only the `Latest` entry diverged — label `'Latest'` vs id `'latest'` — so selecting it set `vueVersion`/`v0Version` to the literal `'Latest'`, producing `@…@Latest` → 404.

### Fix

Bind `:value="item.id"` so the model carries the id the surrounding code (and the `'latest' → null` mapping) expects. One-line change; the only `AppSelect` consumer is the version picker, which already treats the model as the id.

## Verification

Root cause confirmed against the installed v0 `Select` source (model carries ticket `value`). ⚠️ Live browser re-verification is pending — the Playwright MCP disconnected mid-session; I'll drive the picker (select "Latest" for both Vue and `@vuetify/v0`, confirm the sandbox compiles and the CDN URL resolves) as soon as it reconnects.
