### PR TITLE
chore(playground): floor the Vue version picker at 3.5.0 (v0 peer requirement)

### DIFF
--- a/apps/playground/src/composables/usePlaygroundSettings.ts
+++ b/apps/playground/src/composables/usePlaygroundSettings.ts
@@ -25,7 +25,9 @@ export function usePlaygroundSettings () {
     fetching.value = true
     try {
       const [vue, v0] = await Promise.all([
-        fetchNpmVersions('vue', '3.2.0', false),
+        // Floor at 3.5.0: @vuetify/v0 requires vue >=3.5.0 (uses useId), and
+        // Vuetify 4 needs 3.5+ too — offering older Vue breaks both presets.
+        fetchNpmVersions('vue', '3.5.0', false),
         fetchNpmVersions('@vuetify/v0', '0.1.0', true),
       ])
       vueVersions.value = vue


### PR DESCRIPTION
## Description

The Vue version picker offered releases incompatible with the playground. Selecting Vue < 3.5 broke both presets with:

```
The requested module 'vue' does not provide an export named 'useId'
```

### Root cause

`usePlaygroundSettings.fetchVersions()` fetched Vue versions with a floor of `3.2.0`. But `@vuetify/v0` declares `peerDependencies.vue: ">=3.5.0"` (it imports `useId`, added in Vue 3.5), and the Vuetify 4 preset needs 3.5+ as well. So the picker listed 3.2–3.4, and choosing one produced a `useId` import error and a dead sandbox.

### Fix

Raise the fetch floor to `3.5.0`, so only versions compatible with both presets are offered. One-line change.

## Verification

Reasoned against `packages/0/package.json` (`peerDependencies.vue: ">=3.5.0"`). ⚠️ Live browser re-verification pending — the Playwright MCP disconnected mid-session; I'll confirm the picker lists only >=3.5.0 and the sandbox stays healthy once it reconnects.

## Not in scope

A shared playground/tuple that pins an older Vue in its saved settings would still bypass the picker — separate, rarer path; left for a follow-up if it comes up.
