### PR TITLE
docs(Checkbox): nest HiddenInput under Root in Anatomy to match source

### DIFF
--- a/apps/docs/src/pages/components/forms/checkbox.md
+++ b/apps/docs/src/pages/components/forms/checkbox.md
@@ -43,9 +43,9 @@ A checkbox for boolean state or multi-selection groups with tri-state support.
 
     <Checkbox.Root>
       <Checkbox.Indicator />
-    </Checkbox.Root>
 
-    <Checkbox.HiddenInput />
+      <Checkbox.HiddenInput />
+    </Checkbox.Root>
   </Checkbox.Group>
 </template>
 ```


### PR DESCRIPTION
The Checkbox Anatomy block placed `<Checkbox.HiddenInput />` as a direct child of `Checkbox.Group`, a sibling of `Checkbox.Root`. In source, `HiddenInput` belongs to a single checkbox — `Checkbox.Root` auto-renders it when a `name` prop is set, and its `@example` nests it inside `Root`. The anatomy now reflects that structure.

Kept the sibling blank-line spacing convention (Indicator and HiddenInput are now adjacent same-level children of Root). Found via a docs-inventory scout pass.