### PR TITLE
docs: fix API drift in composable docs (createRating, createOtp, useDelay)

### DIFF
--- a/apps/docs/src/pages/composables/forms/create-otp.md
+++ b/apps/docs/src/pages/composables/forms/create-otp.md
@@ -130,7 +130,7 @@ Exactly once on the false → true edge of `isComplete` — when the value first
 
 ??? What happens during async verification?
 
-While an async `onComplete` is pending, every mutation helper (`write`, `distribute`, `fill`, `clear`) is a no-op — the field is effectively locked until the promise settles, so the user can't race the verifier. On rejection, the value clears and `input.errors` surfaces `v0.otp.rejected`; on the next successful mutation the rejection clears automatically.
+While an async `onComplete` is pending, every mutation helper (`write`, `distribute`, `fill`, `clear`) is a no-op — the field is effectively locked until the promise settles, so the user can't race the verifier. On rejection, the value clears and `input.errors` surfaces an `Invalid code` message; on the next successful mutation the rejection clears automatically.
 
 ??? Where does focus management live?
 

--- a/apps/docs/src/pages/composables/forms/create-rating.md
+++ b/apps/docs/src/pages/composables/forms/create-rating.md
@@ -61,7 +61,7 @@ Use `createRatingContext` to share a rating instance across a component tree:
 import { createRatingContext } from '@vuetify/v0'
 
 export const [useProductRating, provideProductRating, productRating] =
-  createRatingContext({ namespace: 'my:rating', max: 5 })
+  createRatingContext({ namespace: 'my:rating', size: 5 })
 
 // In parent component
 provideProductRating()

--- a/apps/docs/src/pages/composables/system/use-delay.md
+++ b/apps/docs/src/pages/composables/system/use-delay.md
@@ -110,7 +110,7 @@ import { shallowRef } from 'vue'
 
 const fast = shallowRef(false)
 
-const delay = useDelay({
+const delay = useDelay(undefined, {
   openDelay: () => fast.value ? 0 : 500,
   closeDelay: 200,
 })
@@ -121,7 +121,7 @@ const delay = useDelay({
 Pass `minDelay` to `start()` to enforce a floor on the resolved delay. Useful for transient feedback like toasts where the close delay must not be shorter than the time the content has been visible.
 
 ```ts
-const delay = useDelay({ closeDelay: 200 })
+const delay = useDelay(undefined, { closeDelay: 200 })
 
 await delay.start(true)
 // User dismisses immediately — still hold for 500ms total
@@ -143,7 +143,7 @@ delay.start(false) // previous promise resolves false, new close delay begins
 Pause preserves the remaining delay; resume continues from where pause left off. Useful for hover-driven UI where the user briefly interacts with the panel itself and you don't want the auto-close timer to keep counting.
 
 ```ts
-const delay = useDelay({ closeDelay: 1000 })
+const delay = useDelay(undefined, { closeDelay: 1000 })
 
 delay.start(false)
 
@@ -160,7 +160,7 @@ The pending timer clears on scope disposal — no manual cleanup needed.
 
 ```ts
 // Timer automatically clears when component unmounts
-const delay = useDelay({ openDelay: 300 })
+const delay = useDelay(undefined, { openDelay: 300 })
 ```
 
 ## FAQ


### PR DESCRIPTION
Three independent API documentation errors where a docs example or claim contradicted source, found in an api-scope scout pass:

1. **createRating** — the Context/DI example passed `max: 5`, which is not a `RatingOptions` field; the item-count option is `size` (default 5). `max` was silently ignored. → `size: 5`.
2. **createOtp** — the async-completion section claimed `input.errors` surfaces `v0.otp.rejected`; source (`createOtp/index.ts:285`) sets `['Invalid code']` and that key exists nowhere. → `Invalid code`.
3. **useDelay** — four Recipes snippets passed the options object as the first argument, but the signature is `useDelay(callback?, options = {})`, so `openDelay`/`closeDelay` were silently dropped. → options passed as the second arg.

Each is a separate atomic commit. Found via a docs-inventory scout pass.