### PR TITLE
docs: fix invalid compound sub-components in Tabs and Combobox

### DIFF
--- a/apps/docs/src/pages/components/disclosure/tabs.md
+++ b/apps/docs/src/pages/components/disclosure/tabs.md
@@ -98,9 +98,9 @@ Set `enroll` to auto-select the first registered tab. Useful when tabs are rende
 <template>
   <Tabs.Root enroll>
     <!-- First tab to register is automatically selected -->
-    <Tabs.Tab v-for="tab in dynamicTabs" :key="tab.id" :value="tab.id">
+    <Tabs.Item v-for="tab in dynamicTabs" :key="tab.id" :value="tab.id">
       {{ tab.label }}
-    </Tabs.Tab>
+    </Tabs.Item>
   </Tabs.Root>
 </template>
 ```

--- a/apps/docs/src/pages/components/forms/combobox.md
+++ b/apps/docs/src/pages/components/forms/combobox.md
@@ -57,8 +57,6 @@ The Combobox component follows the same compound pattern as Select, but replaces
 
       <Combobox.Empty />
     </Combobox.Content>
-
-    <Combobox.HiddenInput />
   </Combobox.Root>
 </template>
 ```


### PR DESCRIPTION
Two hand-written code snippets referenced compound sub-components that don't exist on the public export:

1. **Tabs** — the Auto-Enrollment example used `<Tabs.Tab>`, but the `Tabs` compound exports only `Root, List, Item, Panel` (`Tabs/index.ts`). The page's own Anatomy already uses `<Tabs.Item>`. → `Tabs.Item`.
2. **Combobox** — the Anatomy rendered `<Combobox.HiddenInput />`, but `HiddenInput` is not a member of the `Combobox` compound export; `ComboboxHiddenInput.vue` is rendered internally by `ComboboxRoot` when `name` is set and isn't consumer-facing. → line removed.

Each is a separate atomic commit. Found via a docs-inventory scout pass.