### PR TITLE
docs(Select): remove Custom Positioning recipe for unsupported props

### DIFF
--- a/apps/docs/src/pages/components/forms/select.md
+++ b/apps/docs/src/pages/components/forms/select.md
@@ -202,18 +202,6 @@ Select supports pre-selected values via `v-model` or `:model-value`. The `Select
 </template>
 ```
 
-### Custom Positioning
-
-Control dropdown placement with CSS anchor positioning props on Content:
-
-```vue
-<template>
-  <Select.Content position-area="top" position-try="flip-block">
-    <!-- Dropdown appears above the activator -->
-  </Select.Content>
-</template>
-```
-
 ### Data Attributes
 
 Style interactive states without slot props:


### PR DESCRIPTION
The Select "Custom Positioning" recipe showed `<Select.Content position-area="top" position-try="flip-block">`, but `Select.Content` doesn't support those props:

- `SelectContentProps extends AtomProps` declares only `namespace` and `eager` (`SelectContent.vue:31-36`).
- `SelectRoot` creates `usePopover({ id })` with no positioning options (`SelectRoot.vue:158`), so the content style is locked to `position-area: bottom`.
- `position-area`/`position-try` are real props on `Popover.Content` (`PopoverContent.vue:20-22`), not `Select.Content` — on Select they land as inert attributes and change nothing.

The recipe documented a capability Select doesn't have, so it's removed. (Adding real positioning passthrough to Select would be a separate feature.) Found via a docs-inventory scout pass.