### PR TITLE
docs: fix composable Reactivity/Options table drift (4 pages)

### DIFF
--- a/apps/docs/src/pages/composables/forms/create-number-field.md
+++ b/apps/docs/src/pages/composables/forms/create-number-field.md
@@ -96,7 +96,7 @@ flowchart TD
 | `ceil()` | `() => void` | -- | Set to maximum |
 | `formatValue(v)` | `(value: number) => string` | -- | Format a number |
 | `parse(text)` | `(text: string) => number \| null` | -- | Parse text to number |
-| `commit()` | `() => void` | -- | Snap and optionally clamp |
+| `commit(next?)` | `(next?: number \| null) => void` | -- | Snap and optionally clamp |
 
 ## Examples
 

--- a/apps/docs/src/pages/composables/forms/create-rating.md
+++ b/apps/docs/src/pages/composables/forms/create-rating.md
@@ -98,7 +98,7 @@ flowchart TD
 | `value` | `WritableComputedRef<number>` | Yes | Current rating, clamped 0–size |
 | `size` | `number` | Getter | Total items |
 | `half` | `boolean` | Getter | Half-step enabled |
-| `items` | `ComputedRef<RatingItem[]>` | Yes | Items with `full`/`half`/`empty` state |
+| `items` | `ComputedRef<RatingItemDescriptor[]>` | Yes | Items with `full`/`half`/`empty` state |
 | `isFirst` | `Readonly<Ref<boolean>>` | Yes | Value is 0 |
 | `isLast` | `Readonly<Ref<boolean>>` | Yes | Value equals size |
 | `select(v)` | `(value: number) => void` | — | Set rating |

--- a/apps/docs/src/pages/composables/selection/create-nested.md
+++ b/apps/docs/src/pages/composables/selection/create-nested.md
@@ -174,7 +174,6 @@ const picker = createNested({ selection: 'leaf' })
 | `parents` | <AppSuccessIcon /> | ShallowReactive Map |
 | `openedIds` | <AppSuccessIcon /> | ShallowReactive Set |
 | `openedItems` | <AppSuccessIcon /> | Computed from openedIds |
-| `rootIds` | <AppSuccessIcon /> | ShallowReactive Set — IDs of all top-level (parentless) nodes |
 | `roots` | <AppSuccessIcon /> | Computed, root nodes |
 | `leaves` | <AppSuccessIcon /> | Computed, leaf nodes |
 | `ticket.isOpen` | <AppSuccessIcon /> | Ref via toRef() |

--- a/apps/docs/src/pages/composables/semantic/create-overflow.md
+++ b/apps/docs/src/pages/composables/semantic/create-overflow.md
@@ -91,6 +91,14 @@ flowchart LR
   capacity --> isOverflowing
 ```
 
+## Options
+
+| Option | Type | Default | Notes |
+| - | - | - | - |
+| `gap` | `MaybeRefOrGetter<number>` | `0` | Gap between items in pixels |
+| `reserved` | `MaybeRefOrGetter<number>` | `0` | Reserved space in pixels (nav buttons, ellipsis, etc.) |
+| `itemWidth` | `MaybeRefOrGetter<number>` | — | Uniform item width; enables uniform mode |
+
 ## Reactivity
 
 | Property/Method | Reactive | Notes |
@@ -100,9 +108,6 @@ flowchart LR
 | `capacity` | <AppSuccessIcon /> | Computed from width and measurements |
 | `total` | <AppSuccessIcon /> | Computed, sum of all item widths |
 | `isOverflowing` | <AppSuccessIcon /> | Computed from total vs available width |
-| `gap` | <AppSuccessIcon /> | Accepts MaybeRefOrGetter |
-| `reserved` | <AppSuccessIcon /> | Accepts MaybeRefOrGetter |
-| `itemWidth` | <AppSuccessIcon /> | Accepts MaybeRefOrGetter (uniform mode) |
 
 ## Examples
 


### PR DESCRIPTION
Four composable pages documented Reactivity/return-value rows that contradict source:

1. **createOverflow** — the Reactivity (return-value) table listed `gap`, `reserved`, `itemWidth` as returned reactive properties, but those are constructor **options** (`OverflowOptions`), never on the returned `OverflowContext` (`{ container, width, capacity, total, isOverflowing, measure, reset }`). Moved them into a new Options section.
2. **createNested** — Reactivity listed `rootIds`, but the returned context exposes only the derived `roots` computed; `rootIds` is an internal `shallowReactive` Set and isn't returned. Row removed.
3. **createRating** — `items` type cited `RatingItem[]`, a type that doesn't exist; source is `ComputedRef<RatingItemDescriptor[]>`. Corrected.
4. **createNumberField** — `commit()` was typed `() => void`, but source is `commit(next?: number | null)`. Documented the optional argument.

Each is a separate atomic commit. Found via a docs-inventory scout pass.