### PR TITLE
chore: exit changesets pre mode for 1.0.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@vuetify-private/docs": "1.0.0-beta.2",


### PR DESCRIPTION
Step 1 of the 1.0.0 cut.

Runs `changeset pre exit` — flips `.changeset/pre.json` to `mode: exit` so we leave the `rc` prerelease channel. The accumulated rc changesets stay in place and will consolidate into the **1.0.0** changelog.

## After this merges
The changesets action opens/updates a **"Version Packages"** PR that produces clean `1.0.0` (dropping the `-rc.x`). That PR is the publish gate — merging *it* is what runs the build + publishes to npm via OIDC and mints the GitHub release.

- `@vuetify/paper` is `private` and out of the `fixed` group, so it will **not** publish.
- Verify on the VP PR: version = `1.0.0`, paper absent, changelog aggregates the rc series.