### PR TITLE
docs(AppBanner): flip to 'v1.0 is here' + persist dismissal

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
   // Framework
-  import { IN_BROWSER, Atom, useNotifications } from '@vuetify/v0'
+  import { IN_BROWSER, Atom, useNotifications, useStorage } from '@vuetify/v0'
 
   // Utilities
-  import { onScopeDispose, shallowRef, toRef, watchEffect } from 'vue'
+  import { onScopeDispose, toRef, watchEffect } from 'vue'
 
   // Types
   import type { AtomProps } from '@vuetify/v0'
@@ -11,11 +11,15 @@
   const { as = 'header' } = defineProps<AtomProps>()
 
   const notifications = useNotifications()
+  const storage = useStorage()
 
-  // Seed banner notification (repla
-  if (!notifications.has('rc-banner')) {
+  // Bump BANNER_ID whenever the banner content changes — a new id re-shows the
+  // banner even for readers who dismissed the previous one.
+  const BANNER_ID = 'v1.0-live'
+
+  if (!notifications.has(BANNER_ID)) {
     notifications.register({
-      id: 'rc-banner',
+      id: BANNER_ID,
       subject: 'Vuetify0 v1.0 is here',
       severity: 'warning',
       data: { type: 'banner' },
@@ -26,11 +30,13 @@
     return notifications.values().find(n => n.data?.type === 'banner')
   })
 
-  const dismissed = shallowRef(false)
-  const visible = toRef(() => banner.value && !dismissed.value)
+  // Persist dismissal keyed to the banner id, so a dismissed banner stays closed
+  // across reloads until BANNER_ID changes.
+  const dismissedId = storage.get<string>('docs-banner-dismissed', '')
+  const visible = toRef(() => banner.value && dismissedId.value !== BANNER_ID)
 
   function onDismiss () {
-    dismissed.value = true
+    storage.set('docs-banner-dismissed', BANNER_ID)
   }
 
   // Sync banner height to CSS variable so AppBar, AppNav, and layouts can adapt

--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -16,7 +16,7 @@
   if (!notifications.has('rc-banner')) {
     notifications.register({
       id: 'rc-banner',
-      subject: 'Vuetify0 v1.0 releases July 22, 2026',
+      subject: 'Vuetify0 v1.0 is here',
       severity: 'warning',
       data: { type: 'banner' },
     })
@@ -54,7 +54,7 @@
     <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 
     <div class="min-w-0 truncate pe-6">
-      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is almost here!</span><span class="hidden md:inline"> See the <RouterLink class="underline underline-offset-2" to="/roadmap#release-candidate">roadmap</RouterLink> for details.</span>
+      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <RouterLink class="underline underline-offset-2" to="/releases">release notes</RouterLink>.</span>
     </div>
 
     <button


### PR DESCRIPTION
Two changes to the docs launch banner now that 1.0 shipped.

## 1. Launch copy
- `subject`: `Vuetify0 v1.0 releases July 22, 2026` → **`Vuetify0 v1.0 is here`**
- inline: `— the stable release is almost here!` → **`— the stable release is live!`**
- link: `roadmap#release-candidate` → **`/releases`** (repoint to the announcement blog when published)

## 2. Persisted dismissal (keyed to a versioned id)
- Dismissal now persists via v0 `useStorage` (localStorage, SSR-safe) under `docs-banner-dismissed`, storing the dismissed `BANNER_ID`.
- The banner stays closed across reloads **while the id is unchanged**. Bumping `BANNER_ID` (do this whenever the banner content changes) re-shows it even for readers who dismissed the prior one.
- Notification id is now the content-versioned `'v1.0-live'` instead of the static `'rc-banner'`.

Uses v0's `useStorage` (not hand-rolled localStorage). `severity`/dismiss-button/height-sync behavior unchanged.