### PR TITLE
chore(ci): install Playwright browser in metrics-regen

### DIFF
--- a/.github/workflows/metrics-regen.yml
+++ b/.github/workflows/metrics-regen.yml
@@ -62,6 +62,14 @@ jobs:
             echo "Regenerating — missing: ${MISSING:-<none; manual dispatch>}"
           fi
 
+      # `pnpm metrics` runs the browser vitest project, so Chromium must be present.
+      # Gated on run == 'true' to keep skip-runs (no new version) cheap.
+      - name: Install Playwright browser
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          pnpm exec playwright install chromium
+          pnpm exec playwright install-deps chromium
+
       # Fixed apparatus: the current bench suite + toolchain measure each version's
       # npm-installed dist, so the series is comparable. The version set is
       # discovered from npm per scripts/metrics-history.config.ts. --force


### PR DESCRIPTION
## Why the metrics PR stopped appearing at v1.0
The "Regenerate Metrics" workflow fired on the 1.0.0 Release and its gate correctly flagged 1.0.0 as a new un-snapshotted version, so it ran the full regen (7m47s) — but **failed** at `Regenerate current metrics` (`pnpm metrics`), so the auto-PR never opened:

> `browserType.launch: Executable doesn't exist … chrome-headless-shell … Please run: pnpm exec playwright install`

`pnpm metrics` runs the browser vitest project (Playwright/Chromium), but `metrics-regen.yml` never installed the browser. `pr-checks.yml` does; this workflow didn't.

**Why it only surfaced at v1.0:** the history config's `since: '1.0.0'` floor excludes every pre-1.0 alpha/beta/rc, so on the automatic path the gate always evaluated "no missing version → skip" and never reached `pnpm metrics`. 1.0.0 is the first in-scope version, so this was the first automatic run to hit the latent missing-browser bug.

## Fix
Add the Playwright install (mirroring `pr-checks.yml`) after the gate, `if: steps.gate.outputs.run == 'true'` so skip-runs stay cheap.

Recovery for 1.0.0's snapshot: a `workflow_dispatch` of "Regenerate Metrics" (which I'm triggering from this branch) regenerates it and opens the metrics PR without waiting for the next release.