### PR TITLE
chore(bench): complete the useResizeObserver mock in createVirtual bench

### DIFF
--- a/packages/0/src/composables/createVirtual/index.bench.ts
+++ b/packages/0/src/composables/createVirtual/index.bench.ts
@@ -29,7 +29,10 @@ import type { Ref } from 'vue'
 // MOCKS - Required for lifecycle-dependent code
 // =============================================================================
 
-vi.mock('#v0/composables/useResizeObserver', () => ({
+vi.mock('#v0/composables/useResizeObserver', async importOriginal => ({
+  // spread the real module so co-exports (e.g. useElementSize) survive the mock —
+  // a partial factory drops them and breaks any importer of that path
+  ...await importOriginal<typeof import('#v0/composables/useResizeObserver')>(),
   useResizeObserver: (target: Ref<HTMLElement | undefined>, callback: (entries: ResizeObserverEntry[]) => void) => {
     if (target.value) {
       callback([{


### PR DESCRIPTION
Second blocker for the metrics-regen auto-PR (after the Playwright install in #690).

With the browser now installed, `pnpm metrics` ran the browser benchmarks and died at:
> `SyntaxError: '…/useResizeObserver/index.ts' does not provide an export named 'useElementSize'`

`createVirtual/index.bench.ts` `vi.mock`s `#v0/composables/useResizeObserver` with a factory returning only `{ useResizeObserver }`. That module also exports `useElementSize`; the partial mock drops it, so any importer of that path fails ESM link → the browser bench suite fails → `pnpm metrics` exits 1 → no metrics PR.

**Fix:** spread `importOriginal()` so co-exports survive, override only `useResizeObserver`.

Merging this should let the metrics-regen auto-run produce the `chore/metrics-regen` PR: the Release workflow fires on this merge, and 1.0.0 is still un-snapshotted so the gate runs the full regen. (No manual dispatch needed — the workflow checks out `master` for content, so it had to merge first anyway.)