### PR TITLE
test(createVirtual): preserve useElementSize export in useResizeObserver bench mock

### DIFF
--- a/packages/0/src/composables/createVirtual/index.bench.ts
+++ b/packages/0/src/composables/createVirtual/index.bench.ts
@@ -29,20 +29,24 @@ import type { Ref } from 'vue'
 // MOCKS - Required for lifecycle-dependent code
 // =============================================================================
 
-vi.mock('#v0/composables/useResizeObserver', () => ({
-  useResizeObserver: (target: Ref<HTMLElement | undefined>, callback: (entries: ResizeObserverEntry[]) => void) => {
-    if (target.value) {
-      callback([{
-        target: target.value,
-        contentRect: { height: 600, width: 400 },
-        borderBoxSize: [],
-        contentBoxSize: [],
-        devicePixelContentBoxSize: [],
-      }] as unknown as ResizeObserverEntry[])
-    }
-    return { stop: vi.fn() }
-  },
-}))
+vi.mock('#v0/composables/useResizeObserver', async () => {
+  const actual = await vi.importActual('#v0/composables/useResizeObserver')
+  return {
+    ...actual,
+    useResizeObserver: (target: Ref<HTMLElement | undefined>, callback: (entries: ResizeObserverEntry[]) => void) => {
+      if (target.value) {
+        callback([{
+          target: target.value,
+          contentRect: { height: 600, width: 400 },
+          borderBoxSize: [],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        }] as unknown as ResizeObserverEntry[])
+      }
+      return { stop: vi.fn() }
+    },
+  }
+})
 
 vi.mock('#v0/constants/globals', async () => {
   const actual = await vi.importActual('#v0/constants/globals')


### PR DESCRIPTION
## Problem

The metrics-regen auto-PR stopped opening after the 1.0.0 release. With the Playwright-browser fix (#690) in place, the `Regenerate current metrics` step now clears the browser tests but `vitest bench` fails to import a test file:

```
Error: Failed to import test file .../createVirtual/index.bench.ts
Caused by: SyntaxError: The requested module '.../useResizeObserver/index.ts'
does not provide an export named 'useElementSize'
```

## Cause

`createVirtual/index.bench.ts` mocks `#v0/composables/useResizeObserver` with a factory that returned **only** `useResizeObserver`. That module has since gained a second export, `useElementSize` (consumed by `createOverflow`). Any importer of `useElementSize` resolving through the mock hits a missing export and throws at import time, failing the whole bench run and blocking the metrics PR.

## Fix

Spread the real module via `vi.importActual` and override only `useResizeObserver`, so every other export (now and future) passes through. Mirrors the adjacent `#v0/constants/globals` mock in the same file.

Audited the other `*.bench.ts` files: this is the only one mocking an internal `#v0` module, so no sibling fix is needed.

## Verification

- `pnpm exec eslint` clean on the file.
- Unblocks the metrics-regen `workflow_dispatch`; a re-run after merge should regenerate the 1.0.0 snapshot and open the `chore/metrics-regen` PR.