### PR TITLE
feat(utilities): shadow-DOM-aware getActiveElement for focus checks

### DIFF
--- a/.changeset/shadow-aware-active-element.md
+++ b/.changeset/shadow-aware-active-element.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(utilities): add `getActiveElement()` and use it for shadow-DOM-aware focus checks
+
+New `getActiveElement()` utility resolves the deepest focused element by walking open shadow roots — `document.activeElement` returns the shadow *host* when focus is inside a custom element, which silently breaks focus logic. `useHotkey` (typing guard), `useClickOutside` (iframe-outside check), and `useDragDrop`'s keyboard adapter now use it, so their focus checks stay correct when v0 runs inside a web component / shadow root. Returns the same value as `document.activeElement` in light DOM; open shadow roots only (closed roots can't be traversed).

--- a/packages/0/src/composables/useClickOutside/index.ts
+++ b/packages/0/src/composables/useClickOutside/index.ts
@@ -44,7 +44,7 @@ import { toArray } from '#v0/composables/toArray'
 import { IN_BROWSER } from '#v0/constants/globals'
 
 // Utilities
-import { isElement, isFunction, isNull, isNullOrUndefined, isString } from '#v0/utilities'
+import { getActiveElement, isElement, isFunction, isNull, isNullOrUndefined, isString } from '#v0/utilities'
 import { onScopeDispose, shallowReadonly, shallowRef, toRef, toValue } from 'vue'
 
 // Types
@@ -383,7 +383,7 @@ export function useClickOutside (
     if (event.defaultPrevented) return
 
     if (document.activeElement instanceof HTMLIFrameElement) {
-      const iframeIsOutside = getTargets().every(el => !el.contains(document.activeElement))
+      const iframeIsOutside = getTargets().every(el => !el.contains(getActiveElement()))
       const [selectors, elements] = resolveIgnoreTargets()
 
       if (iframeIsOutside && !isIgnored(document.activeElement, selectors, elements)) {

--- a/packages/0/src/composables/useDragDrop/adapters/keyboard.ts
+++ b/packages/0/src/composables/useDragDrop/adapters/keyboard.ts
@@ -18,7 +18,7 @@ import { IN_BROWSER } from '#v0/constants/globals'
 import { DragDropAdapter } from './adapter'
 
 // Utilities
-import { isNull } from '#v0/utilities'
+import { getActiveElement, isNull } from '#v0/utilities'
 
 // Types
 import type { DragType } from '../'
@@ -72,7 +72,7 @@ export class KeyboardAdapter<Z extends DragType = DragType> extends DragDropAdap
 
     // Arrow form so `this.locate` / `this.activate` / `this.step` resolve on the adapter instance.
     const onKeydown = (event: KeyboardEvent) => {
-      const focused = document.activeElement
+      const focused = getActiveElement()
       if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
       if (isEditable(focused)) return
       const ticket = this.locate(focused, context)

--- a/packages/0/src/composables/useHotkey/index.ts
+++ b/packages/0/src/composables/useHotkey/index.ts
@@ -37,7 +37,7 @@ import { IN_BROWSER } from '#v0/constants/globals'
 import { splitKeyCombination, splitKeySequence, MODIFIERS } from './parsing'
 
 // Utilities
-import { isNull, isUndefined } from '#v0/utilities'
+import { getActiveElement, isNull, isUndefined } from '#v0/utilities'
 import { onScopeDispose, shallowReadonly, shallowRef, toRef, toValue, watch } from 'vue'
 
 // Types
@@ -166,7 +166,7 @@ export function useHotkey (
     if (!IN_BROWSER) return false
     if (toValue(inputs)) return false
 
-    const activeElement = document.activeElement as HTMLElement | null
+    const activeElement = getActiveElement() as HTMLElement | null
     /* v8 ignore next -- defensive: document.activeElement is always set in happy-dom */
     if (!activeElement) return false
 

--- a/packages/0/src/maturity.json
+++ b/packages/0/src/maturity.json
@@ -741,6 +741,11 @@
       "since": "0.1.11",
       "category": "utilities"
     },
+    "getActiveElement": {
+      "level": "preview",
+      "since": null,
+      "category": "utilities"
+    },
     "hexToRgb": {
       "level": "preview",
       "since": "0.1.11",

--- a/packages/0/src/surface.test.ts
+++ b/packages/0/src/surface.test.ts
@@ -44,7 +44,7 @@ const COMPONENTS = [
 ]
 
 const UTILITIES = [
-  'UNSAFE_KEYS', 'V0Error', 'apca', 'clamp', 'foreground', 'hexToRgb', 'instanceExists', 'instanceName', 'isArray', 'isBoolean', 'isElement', 'isFunction', 'isNaN', 'isNull', 'isNullOrUndefined', 'isNumber', 'isObject', 'isPrimitive', 'isString', 'isSymbol', 'isThenable', 'isUndefined', 'isV0Error', 'mergeDeep', 'range', 'resolveIds', 'resolveIndexes', 'rgbToHex', 'useId',
+  'UNSAFE_KEYS', 'V0Error', 'apca', 'clamp', 'foreground', 'getActiveElement', 'hexToRgb', 'instanceExists', 'instanceName', 'isArray', 'isBoolean', 'isElement', 'isFunction', 'isNaN', 'isNull', 'isNullOrUndefined', 'isNumber', 'isObject', 'isPrimitive', 'isString', 'isSymbol', 'isThenable', 'isUndefined', 'isV0Error', 'mergeDeep', 'range', 'resolveIds', 'resolveIndexes', 'rgbToHex', 'useId',
 ]
 
 describe('public surface', () => {

--- a/packages/0/src/utilities/helpers.test.ts
+++ b/packages/0/src/utilities/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 // Utilities
 import {
@@ -16,6 +16,7 @@ import {
   isPrimitive,
   isSymbol,
   isNaN,
+  getActiveElement,
   mergeDeep,
   clamp,
   range,
@@ -438,6 +439,49 @@ describe('helpers', () => {
         expect(isNaN({})).toBe(false)
         expect(isNaN(null)).toBe(false)
       })
+    })
+  })
+
+  describe('getActiveElement', () => {
+    it('should return document.activeElement in light DOM', () => {
+      const input = document.createElement('input')
+      document.body.append(input)
+      try {
+        input.focus()
+        expect(getActiveElement()).toBe(input)
+      } finally {
+        input.remove()
+      }
+    })
+
+    it('should return document.body when nothing is focused', () => {
+      const result = getActiveElement()
+      expect(result).toBe(document.body)
+    })
+
+    it('should return null when document is undefined (SSR)', () => {
+      const originalDocument = globalThis.document
+      vi.stubGlobal('document', undefined)
+      try {
+        expect(getActiveElement()).toBeNull()
+      } finally {
+        vi.stubGlobal('document', originalDocument)
+      }
+    })
+
+    it('should pierce open shadow roots to find the deepest focused element', () => {
+      const host = document.createElement('div')
+      const shadow = host.attachShadow({ mode: 'open' })
+      const input = document.createElement('input')
+      shadow.append(input)
+      document.body.append(host)
+      try {
+        input.focus()
+        expect(getActiveElement()).toBe(input)
+        expect(document.activeElement).toBe(host)
+      } finally {
+        host.remove()
+      }
     })
   })
 

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -204,6 +204,30 @@ export function isElement (item: unknown): item is Element {
 }
 
 /**
+ * Resolve the deepest focused element, piercing open shadow roots.
+ *
+ * `document.activeElement` returns the shadow *host* when focus is inside an
+ * open shadow root — walk down through open roots so focus/keyboard logic
+ * resolves the real focused element (e.g. a control inside a custom element).
+ * Returns the same value as `document.activeElement` in light DOM, and `null`
+ * under SSR. Closed shadow roots can't be traversed.
+ *
+ * @example
+ * ```ts
+ * const active = getActiveElement()
+ * ```
+ */
+/* #__NO_SIDE_EFFECTS__ */
+export function getActiveElement (): Element | null {
+  if (typeof document === 'undefined') return null
+  let active = document.activeElement
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement
+  }
+  return active
+}
+
+/**
  * Checks if a value is null
  *
  * @param item The value to check


### PR DESCRIPTION
Hardens v0 for the open-Shadow-DOM / web-component case, prompted by the v3/v4 VMenu keyboard-nav bug (vuetifyjs/vuetify#23024).

## Context
`document.activeElement` returns the shadow **host**, not the focused descendant, inside an open shadow root — which silently breaks focus logic. In v4 this broke VList/VMenu arrow-nav. **v0's core nav is already immune** (`useRovingFocus`/`useVirtualFocus` are registry/state-driven, not `document.activeElement`-driven; `useClickOutside` already uses `composedPath()`; `usePopover` uses native Popover + CSS anchor-name with no `getElementById`). This PR closes the remaining peripheral reads.

## Change
- Add `getActiveElement()` to `#v0/utilities` (`helpers.ts`) — walks open shadow roots; same value as `document.activeElement` in light DOM; SSR-safe (`null`); open roots only.
- Use it in the three remaining raw `document.activeElement` sites: `useHotkey` (typing guard), `useClickOutside` (iframe-outside check), `useDragDrop` keyboard adapter.
- Surface freeze + `maturity.json` (utilities, `preview`) updated for the new export; changeset added (`minor`).

## Not covered
`Portal` still teleports `to: 'body'` by default, so overlays escape the shadow root (styles/focus cross the boundary) — mitigable via `to` = a shadow-internal target; documenting for embedders is a separate follow-up, not a focus bug.