### PR TITLE
docs(AppBanner): point CTA to the v1.0 announcement post

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -60,7 +60,7 @@
     <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 
     <div class="min-w-0 truncate pe-6">
-      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <RouterLink class="underline underline-offset-2" to="/releases">release notes</RouterLink>.</span>
+      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <a class="underline underline-offset-2" href="https://vtfy.link/announcing-vuetify0-v1" rel="noopener" target="_blank">announcement</a>.</span>
     </div>
 
     <button


### PR DESCRIPTION
Swaps the release banner CTA from the internal `/releases` route to the now-published announcement blog: https://vtfy.link/announcing-vuetify0-v1 (opens in a new tab). Link text `release notes` → `announcement` to match the destination.

`BANNER_ID` left as `v1.0-live` (no bump) — so readers who already dismissed the banner won't see it re-appear. If you'd rather the launch re-show for everyone who dismissed it, bump `BANNER_ID` and I'll update.