### PR TITLE
docs: scrub release-candidate references now that v1.0 has shipped

### DIFF
--- a/apps/docs/src/pages/guide/tooling/vuetify-cli.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-cli.md
@@ -264,22 +264,22 @@ Print the release notes for a Vuetify package without leaving the terminal:
 pnpm dlx @vuetify/cli release-notes v0
 
 # A specific version
-pnpm dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
+pnpm dlx @vuetify/cli release-notes v0 --version 1.0.0
 ```
 
 ```bash npm
 npx @vuetify/cli release-notes v0
-npx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
+npx @vuetify/cli release-notes v0 --version 1.0.0
 ```
 
 ```bash yarn
 yarn dlx @vuetify/cli release-notes v0
-yarn dlx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
+yarn dlx @vuetify/cli release-notes v0 --version 1.0.0
 ```
 
 ```bash bun
 bunx @vuetify/cli release-notes v0
-bunx @vuetify/cli release-notes v0 --version 1.0.0-rc.9
+bunx @vuetify/cli release-notes v0 --version 1.0.0
 ```
 
 :::

--- a/apps/docs/src/pages/introduction/why-vuetify0.md
+++ b/apps/docs/src/pages/introduction/why-vuetify0.md
@@ -242,7 +242,7 @@ Vuetify0 is already being merged into Vuetify's next major release. The first PR
 
 ### Road to v1
 
-**Alpha → Beta → Release Candidate → v1.0 (July 22, 2026)** — [see the full roadmap](/roadmap).
+**Alpha → Beta → Release Candidate → v1.0** — stable, shipped July 22, 2026. [See the full roadmap](/roadmap).
 
 What comes after v1: **Vuetify Paper** — a styled layer built on v0 that provides opinionated design system primitives. Emerald and Onyx are the first design systems. Build on v0 today; Paper gives you a head start on the styled layer when you're ready.
 

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -2,9 +2,9 @@
 title: Roadmap - Vuetify0 Development Timeline
 meta:
   - name: description
-    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 is a release candidate on the road to v1.0.
+    content: Track upcoming features, releases, milestones, and maturity status for @vuetify/v0 headless UI library. v0 is stable — v1.0 shipped July 22, 2026.
   - name: keywords
-    content: vuetify0, roadmap, release candidate, rc, beta, alpha, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
+    content: vuetify0, roadmap, stable, v1.0, semver, timeline, milestones, releases, features, maturity, stability, Vue 3, v0, headless ui
 features:
   level: 1
 related:
@@ -30,28 +30,28 @@ Expected dates for the v1.1–v1.5 minor releases, the net-new features landing 
 
 <DocsReleaseCalendar />
 
-## Release Candidate
+## Now Stable
 
-**Now a release candidate.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
+**v1.0 is here.** A headless UI framework for Vue 3 — composables and components that handle the logic so you can own the design. No opinions on styling. No markup you can't change. Just primitives that work.
 
-Alpha opened on April 7, 2026 for feedback; beta hardened the APIs. The release candidate locks the v1 stable set — what remains is final validation, documentation, and bug fixes. The final candidate, rc.9, lands July 21, 2026, with the stable v1.0.0 release the next day, July 22, 2026.
+Alpha opened on April 7, 2026 for feedback; beta hardened the APIs; the release candidate locked the v1 stable set. The stable `v1.0.0` release shipped July 22, 2026 — the public API surface is now committed under [SemVer](https://semver.org/).
 
 ### Road to v1
 
 <DocsTimeline :milestones="[
   { id: 'alpha', label: 'Alpha', date: 'April 7, 2026', description: 'Opened for feedback, bug reports, and contributions. APIs mostly stable, may evolve.' },
   { id: 'beta', label: 'Beta', date: 'June 2, 2026', description: 'API freeze. Focus shifts to stability, documentation, and edge cases.' },
-  { id: 'rc', label: 'RC', date: 'July 2, 2026', description: 'Release candidate for final testing and documentation. No new features. The final candidate, rc.9, lands July 21, 2026.', active: true },
-  { id: 'v1', label: 'v1.0', date: 'July 22, 2026', description: 'Stable release. v0 1.0.0 ships July 22, 2026.' },
+  { id: 'rc', label: 'RC', date: 'July 2, 2026', description: 'Release candidate for final testing and documentation. No new features.' },
+  { id: 'v1', label: 'v1.0', date: 'July 22, 2026', description: 'Stable release. v0 1.0.0 shipped July 22, 2026.', active: true },
 ]" />
 
-### What RC means
+### What v1.0 means
 
 This isn't a proof of concept. v0 is feature-complete for v1 and ready to build with.
 
-- **The stable set is locked.** 16 composables and 17 utilities are now marked stable — breaking changes require a major version. See the [maturity matrix](#maturity-matrix) below for the full breakdown.
+- **The stable set is locked.** 16 composables and 17 utilities are marked stable — breaking changes require a major version. See the [maturity matrix](#maturity-matrix) below for the full breakdown.
 - **v0 is being built directly into Vuetify.** The composables and patterns here are the same ones powering Vuetify's next generation. This isn't a side project — it's the core.
-- **This is the final validation window.** No new features land before v1.0 — every regression, gap, or rough edge you report gets priority. If something feels wrong, say so now.
+- **Development continues.** v1.1 and beyond are on the roadmap above, and preview APIs graduate to stable release by release. Every regression, gap, or rough edge you report still gets priority — if something feels wrong, say so.
 
 ### Try v0
 
@@ -122,11 +122,11 @@ v0 is the foundation layer being built directly into Vuetify's next generation. 
 
 ??? Can I use v0 in production?
 
-Yes. The v1 stable set is locked, and the release candidate is the build we intend to ship as v1.0. The core is solid and is already being used to build Vuetify itself. Preview APIs may still see minor, documented adjustments.
+Yes. `v1.0.0` is stable and shipped July 22, 2026. The v1 stable set is locked, and the core is already being used to build Vuetify itself. Preview APIs may still see minor, documented adjustments.
 
-??? Will APIs break before v1?
+??? Will stable APIs break?
 
-The stable set is locked — breaking changes to it now require a major version. Preview features may still evolve in minor releases, with every change documented in release notes. Alpha gathered the feedback; beta locked things down; RC is the final validation pass.
+No — the stable set is locked, and breaking changes to it require a major version. Preview features may still evolve in minor releases, with every change documented in release notes. Alpha gathered the feedback; beta locked things down; the release candidate was the final validation pass before v1.0.
 
 ??? What styling framework should I use with v0?
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -28,7 +28,7 @@
 
 Headless Vue 3 UI primitives and composables for building modern applications and design systems. `@vuetify/v0` is the foundation of the Vuetify ecosystem, offering lightweight, unstyled building blocks with full TypeScript support and accessibility features built-in.
 
-> **Note:** v0 is a release candidate — the v1 stable set is locked. Install with `npm i @vuetify/v0@rc`. Preview APIs may still see minor, documented changes before the stable v1.0.0 release on July 22, 2026 (final candidate, rc.9, lands July 21).
+> **Note:** v0 is stable — `v1.0.0` shipped July 22, 2026 and the stable API surface is locked under [SemVer](https://semver.org/). Preview-level APIs (flagged in the [roadmap](https://0.vuetifyjs.com/roadmap)) may still see documented changes.
 
 ## Repository Structure
 
@@ -300,7 +300,7 @@ pnpm validate
 
 ## Contributing
 
-Vuetify0 is a release candidate — open for final validation, bug reports, and contributions. The stable v1.0.0 release ships July 22, 2026 (final candidate, rc.9, on July 21). See the [Roadmap](https://0.vuetifyjs.com/roadmap#release-candidate) for what's planned and how to get involved.
+Vuetify0 is stable and open for bug reports, feature requests, and contributions. See the [Roadmap](https://0.vuetifyjs.com/roadmap) for what's planned and how to get involved.
 
 ## License
 


### PR DESCRIPTION
Now that `v0 1.0.0` shipped (July 22, 2026), the docs and README still described v0 as a *release candidate* and told people to install `@vuetify/v0@rc`. This flips the remaining prerelease status prose to stable, past-tense framing.

## Changes

- **README** (`packages/0/README.md`, root is a symlink to it):
  - Top note: `npm i @vuetify/v0@rc` + "release candidate … before the stable v1.0.0 release" → stable/SemVer note.
  - Contributing blurb drops the RC framing and the now-renamed `#release-candidate` anchor.
- **roadmap** (`apps/docs/src/pages/roadmap.md`):
  - `## Release Candidate` → `## Now Stable`; "**Now a release candidate.**" → "**v1.0 is here.**"
  - Timeline `active` flag moves `rc` → `v1`; v1 description → "shipped".
  - `### What RC means` → `### What v1.0 means`; "final validation window / no new features" bullet → "development continues, v1.1+ on the roadmap".
  - FAQ: "Can I use in production" + "Will APIs break before v1?" (→ "Will stable APIs break?") updated.
  - meta description + keywords updated.
- **why-vuetify0**: progression line marks v1.0 as shipped.
- **vuetify-cli**: `release-notes v0 --version 1.0.0-rc.9` examples → `1.0.0` (×4).

## Deliberately left alone

- Historical timeline milestones still name the RC phase — accurate as past phases.
- `CHANGELOG.md` RC entries — legitimate release history.
- `packages/paper/package.json` still `1.0.0-rc.9` — private/dormant, not published; a version bump is a release action, not a doc scrub. Flagged separately.
- Internal app `-beta` versions (root, docs, playground package.json) — not user-facing RC references.

## Test plan

- [x] Repo-wide grep: no remaining `@vuetify/v0@rc` installs, `#release-candidate` anchors, `rc.9` version examples, or "is a release candidate" status claims (outside CHANGELOG + historical timeline)
- [x] `<DocsTimeline>` milestone array well-formed; exactly one `active: true` (on v1)
- [ ] `pnpm build:docs` renders roadmap + touched pages