### PR TITLE
chore(metrics): resolve utilities benchmarks so their cards aren't Unmeasured

### DIFF
--- a/scripts/lib/benchmarks.ts
+++ b/scripts/lib/benchmarks.ts
@@ -233,5 +233,10 @@ export function extractName (filePath: string): string | null {
   if (composableMatch) return composableMatch[1]
   const componentMatch = filePath.match(/\/components\/([^/]+)\//)
   if (componentMatch) return componentMatch[1]
+  // Utilities are flat files (utilities/helpers.ts, utilities/helpers.bench.ts),
+  // not a dir/index pair — without this, a utilities bench (e.g. helpers) never
+  // gets a metrics.json entry and its docs card falls back to "Unmeasured".
+  const utilityMatch = filePath.match(/\/utilities\/([^/]+?)(?:\.(?:bench|test))?\.ts$/)
+  if (utilityMatch && utilityMatch[1] !== 'index') return utilityMatch[1]
   return null
 }


### PR DESCRIPTION
Follow-up from the benchmarks investigation. After #698 fixes the duplication (bench ran under both projects), the one *remaining* wrong "Unmeasured" card is **`helpers`**.

## Cause

`extractName` in `scripts/lib/benchmarks.ts` (used by both the benchmark generator and the coverage side of `generate-metrics.js`) matched only `composables/<name>/index.*` and `components/<name>/*`. Utilities are **flat files** (`utilities/helpers.ts`, `utilities/helpers.bench.ts`), so it returned `null` → no `metrics.json` entry for `helpers` → the docs card's tier lookup missed → `?? 'unmeasured'` fired, even though `helpers` has 5 real benches.

## Fix

Add a `utilities/<name>(.bench|.test)?.ts` match (excluding the `index` barrel). Verified against the real paths:

| path | → |
|------|---|
| `utilities/helpers.bench.ts` | `helpers` |
| `utilities/helpers.ts` | `helpers` |
| `utilities/index.ts` | `null` |
| `composables/createGroup/index.bench.ts` | `createGroup` (unchanged) |
| `components/Dialog/DialogRoot.vue` | `Dialog` (unchanged) |

Since the extractor is shared, utility **source** files now also get coverage entries in `metrics.json` — an addition, not a regression.

## Notes

- Takes effect after the next metrics regen. Sequence: merge this → re-run the metrics-regen workflow (or the next scheduled one) → `helpers` shows its real tier.
- The createGroup/createSingle/createStep "Unmeasured" cards in the original screenshot were **stale** (pre-1.0 regen); current `metrics.json` already has their tiers. This PR only addresses the live `helpers` case.
- Did not bundle the optional render-side dedup guard (`useBenchmarkData` `normalizeFiles`) the investigation suggested — #698 fixes the doubling at source; happy to add the belt-and-suspenders dedup as a separate PR if you want it.

## Test plan
- [x] `extractName` unit-checked against 7 real paths (all pass)
- [x] `eslint` clean
- [ ] After merge + regen: `helpers` card shows a tier instead of Unmeasured