### PR TITLE
chore(ci): upload lcov to Codecov instead of coverage-final.json

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/coverage-final.json
+          files: ./coverage/lcov.info
           flags: unit
           fail_ci_if_error: false
 
@@ -84,7 +84,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/coverage-final.json
+          files: ./coverage/lcov.info
           flags: browser
           fail_ci_if_error: false
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,11 @@ export default defineConfig({
     testTimeout: 20_000,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json'],
+      // 'json' (coverage-final.json) feeds the metrics pipeline; 'lcov' is what
+      // we upload to Codecov — @vitest/coverage-v8 4.1.10 emits a coverage-final
+      // shape Codecov 5 ingests but can't process (see PR #663 regression), and
+      // lcov parses reliably regardless of the v8 json format.
+      reporter: ['text', 'json', 'lcov'],
       include: ['packages/0/src/**/*.ts', 'packages/0/src/**/*.vue'],
       exclude: [
         '**/*.test.ts',


### PR DESCRIPTION
## Root cause

The coverage shield went dark because **PR #663** (`chore(deps): resolve Dependabot security alerts`) bumped `@vitest/coverage-v8` **4.1.5 → 4.1.10**. That version's `coverage-final.json` is something Codecov 5 **ingests but can't process into a report**.

Confirmed against Codecov's API — one commit flips it:

| commit | Codecov state |
|--------|---------------|
| `fcf628a6` (parent of #663) | **complete, 99.17%** ✓ |
| `ec330cff2` (#663) | **null** ✗ |
| everything since #663 | null ✗ |
| `HEAD~40` (older) | complete, 99.18% ✓ |

Uploads still succeed (`Upload queued for processing complete`); Codecov just can't turn the new v8 json into a report. Not a chronic Codecov problem, not our CI — a dependency format regression, matching "fine all year until ~30 commits ago."

## Fix

Add the `lcov` reporter and upload `coverage/lcov.info` to Codecov instead of `coverage-final.json`. lcov is a stable format Codecov parses regardless of coverage-v8's json shape — decouples us from this class of drift **without downgrading** (the #663 bump was a security fix, so reverting it is undesirable).

- `vitest.config.ts`: `reporter: ['text', 'json', 'lcov']` — `json` kept because `generate-metrics.js` reads `coverage-final.json`; `lcov` added for the upload.
- `pr-checks.yml`: both Codecov upload steps (unit + browser flags) now point at `./coverage/lcov.info`. Flags/scoping unchanged.

Supersedes #699 (the self-hosted-badge workaround, now closed).

## Test plan
- [x] YAML valid; diff minimal (2 files)
- [ ] After merge: PR-checks upload lcov, Codecov produces a report for the merge commit, README shield shows the % again