### PR TITLE
fix(ci): metrics-regen skip summary + reopen closed auto-PR

### DIFF
--- a/.github/workflows/metrics-regen.yml
+++ b/.github/workflows/metrics-regen.yml
@@ -13,6 +13,9 @@ name: Regenerate Metrics
 # sanctioned chain. Release runs on every master push (most just open the
 # "Version Packages" PR and publish nothing), so the job gates on upstream
 # success AND a newly published 1.x version that has no snapshot yet — see `gate`.
+#
+# Manual re-measure (apparatus change, discarded PR, etc.): Actions → this
+# workflow → Run workflow (workflow_dispatch). That always regenerates.
 on:
   workflow_run:
     workflows: [Release]
@@ -57,6 +60,15 @@ jobs:
           if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ -z "$MISSING" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "No new 1.x version to bench — skipping regen."
+            {
+              echo "### Metrics regen skipped"
+              echo ""
+              echo "Automatic \`workflow_run\` only regenerates when a published 1.x"
+              echo "version has no snapshot yet (\`--print-missing\` was empty)."
+              echo ""
+              echo "To force a full re-measure (e.g. after apparatus changes), use"
+              echo "**Actions → Regenerate Metrics → Run workflow** (\`workflow_dispatch\`)."
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "Regenerating — missing: ${MISSING:-<none; manual dispatch>}"
@@ -65,9 +77,8 @@ jobs:
       # Fixed apparatus (see scripts/lib/bench-stable.ts + .claude/rules/benchmarks.md):
       #   ubuntu-24.04 + .nvmrc Node, v0:unit only, maxWorkers=1, no file parallelism,
       #   V0_BENCH_TARGET=dist, median of 3 runs (current) / 1 run (history).
-      # Playwright is NOT required — benches never use v0:browser.
+      # Coverage for metrics is v0:unit only — no Playwright.
 
-      # Snapshot previous canaries before overwrite for the PR delta report.
       - name: Snapshot previous benchmarks.json
         if: steps.gate.outputs.run == 'true'
         run: |
@@ -101,6 +112,20 @@ jobs:
             echo "report=_(no previous benchmarks.json to compare)_" >> "$GITHUB_OUTPUT"
           fi
           pnpm metrics:check
+
+      # create-pull-request will not open a *new* PR if one was closed for this
+      # branch — it only updates the branch. Reopen so "Close to discard" is not
+      # a one-way trap on the next regen.
+      - name: Reopen closed metrics-regen PR if needed
+        if: steps.gate.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=$(gh pr view chore/metrics-regen --json state -q .state 2>/dev/null || echo none)
+          echo "chore/metrics-regen PR state: $state"
+          if [ "$state" = "CLOSED" ]; then
+            gh pr reopen chore/metrics-regen
+          fi
 
       - name: Open/update auto-PR
         if: steps.gate.outputs.run == 'true'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:ssr": "vitest run --reporter=verbose hydration",
     "test:bench:json": "vitest bench --run --project v0:unit --maxWorkers=1 --no-file-parallelism --outputJson apps/docs/public/benchmarks.json",
     "bench": "vitest --reporter=default bench --project v0:unit --maxWorkers=1 --no-file-parallelism",
-    "metrics": "pnpm test:coverage && pnpm build:0 && pnpm metrics:bench && node scripts/generate-metrics.js",
+    "metrics": "pnpm exec vitest run --coverage --project v0:unit && pnpm build:0 && pnpm metrics:bench && node scripts/generate-metrics.js",
     "metrics:bench": "V0_BENCH_TARGET=dist node scripts/run-bench-stable.ts --runs 3 --out apps/docs/public/benchmarks.json",
     "metrics:history": "node scripts/generate-metrics-history.ts",
     "metrics:check": "node scripts/check-benchmark-artifacts.ts",


### PR DESCRIPTION
## Why

Manual metrics regen **did** produce a PR (#703), then it was closed. Later Actions runs went **green but no-op** because automatic `workflow_run` skips when `1.0.0` already has a snapshot — that looked like “regen worked with no PR.”

Also: closing the auto-PR used to trap the branch (`create-pull-request` updates a closed PR’s branch but does not reopen it).

## Changes

- Gate skip writes a **step summary** explaining how to force a re-measure (`workflow_dispatch`)
- **Reopen** a closed `chore/metrics-regen` PR before `create-pull-request`
- `pnpm metrics` coverage is **v0:unit only** (no Playwright for metrics-regen)

## Already done outside this PR

- Reopened https://github.com/vuetifyjs/0/pull/703 (regenerated artifacts from the earlier dispatch) — review/merge that for the numbers themselves