### PR TITLE
chore(ci): restore Codecov coverage badge via API totals

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,8 +50,12 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          disable_search: true
           flags: unit
-          fail_ci_if_error: false
+          name: unit
+          slug: vuetifyjs/0
+          fail_ci_if_error: true
+          verbose: true
 
   # Component tests run in a real browser (Playwright/Chromium) and are kept in
   # their own job so a render/timing flake can't red the unit + coverage signal.
@@ -85,8 +89,44 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          disable_search: true
           flags: browser
-          fail_ci_if_error: false
+          name: browser
+          slug: vuetifyjs/0
+          fail_ci_if_error: true
+          verbose: true
+
+  # Upload success ≠ processed report. Codecov queues OK then sometimes leaves
+  # commit state/totals null (badge graph → "unknown"). Surface that here so we
+  # don't ship a green CI over a dark coverage signal. Non-blocking: processing
+  # can lag; the annotation is the loud signal until reports complete again.
+  codecov-health:
+    needs: [test, browser]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Poll Codecov commit report
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          url="https://api.codecov.io/api/v2/github/vuetifyjs/repos/0/commits/${SHA}"
+          echo "Polling $url"
+          state=""
+          coverage=""
+          for attempt in 1 2 3 4 5 6; do
+            body=$(curl -fsS "$url" || true)
+            state=$(printf '%s' "$body" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("state") or "")' 2>/dev/null || true)
+            coverage=$(printf '%s' "$body" | python3 -c 'import sys,json; d=json.load(sys.stdin); t=d.get("totals") or {}; print(t.get("coverage") if isinstance(t, dict) else "")' 2>/dev/null || true)
+            echo "attempt=$attempt state=${state:-null} coverage=${coverage:-null}"
+            if [ -n "$state" ] && [ "$state" != "null" ] && [ -n "$coverage" ]; then
+              echo "Codecov report complete: state=$state coverage=$coverage"
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "::warning::Codecov upload queued but commit ${SHA} still has state/totals null after ~2m. Repo totals badge may be stale; check https://app.codecov.io/github/vuetifyjs/0/commit/${SHA}"
+          exit 0
 
   repo-integrity:
     needs: prepare

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -7,7 +7,13 @@
 
 <p align="center">
   <a href="https://codecov.io/github/vuetifyjs/0">
-    <img src="https://img.shields.io/codecov/c/github/vuetifyjs/0" alt="Coverage">
+    <!--
+      shields.io/codecov scrapes Codecov's graph/badge.svg, which has been stuck
+      on "unknown" for this repo even when API v2 repo totals are complete
+      (~99%). Point at the same Codecov numbers via the public API instead —
+      still their signal, not a self-hosted %.
+    -->
+    <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.codecov.io%2Fapi%2Fv2%2Fgithub%2Fvuetifyjs%2Frepos%2F0%2F&query=%24.totals.coverage&suffix=%25&label=coverage&color=brightgreen" alt="Coverage">
   </a>
   <a href="https://www.npmjs.com/package/@vuetify/v0">
     <img src="https://img.shields.io/npm/dt/@vuetify/v0.svg" alt="Downloads">


### PR DESCRIPTION
## Summary

- **Badge:** README coverage shield no longer uses `img.shields.io/codecov/...` (scrapes Codecov SVG → stuck on `unknown`). It now uses shields **dynamic JSON** against Codecov **API v2 repo totals** — still Codecov's number (~99.17%), not a self-hosted %.
- **CI:** Codecov uploads set `fail_ci_if_error: true`, `verbose: true`, `disable_search: true`, explicit `slug`/`name`/`flags`.
- **Health:** New non-blocking `codecov-health` job on master push polls the commit report for ~2m and emits a `::warning::` if state/totals stay null (upload-ok / process-null class of failure).

## Why not self-host

Self-hosting a % from our own `coverage-final.json` is display-only cosplay of Codecov. Rejected — the badge must remain an independent Codecov signal.

## Known residual

Per-commit reports on master have been `state: null` since ~1.0 release day (last complete: `f9dbbd98`, 99.17%). Uploads still queue successfully. Repo-level totals remain the last complete report — badge will show that until Codecov processes new commits again. The health job is how we notice.

## Test plan

- [ ] Confirm README badge renders `coverage: 99.17%` (or current API total), not `unknown`
- [ ] PR Checks: unit + browser Codecov steps succeed with `fail_ci_if_error: true`
- [ ] After merge to master, `codecov-health` either reports complete or leaves a visible warning annotation
- [ ] Link still points at https://codecov.io/github/vuetifyjs/0