### PR TITLE
docs(roadmap): source milestone dates from the release-calendar constant

### DIFF
--- a/apps/docs/src/components/docs/DocsRoadmap.vue
+++ b/apps/docs/src/components/docs/DocsRoadmap.vue
@@ -65,7 +65,7 @@
       : [...showAll.value, key]
   }
 
-  function formatDate (date: string | null): string {
+  function formatDate (date: string | null | undefined): string {
     if (!date) return 'No due date'
     return new Date(date).toLocaleDateString('en-US', {
       month: 'short',
@@ -235,10 +235,10 @@
                       <h3 class="font-semibold">{{ milestone.title }}</h3>
 
                       <span
-                        v-if="milestone.due_on"
+                        v-if="milestone.date"
                         class="text-xs px-2 py-0.5 rounded-full bg-surface-tint"
                       >
-                        {{ formatDate(milestone.due_on) }}
+                        {{ formatDate(milestone.date) }}
                       </span>
                     </div>
 

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -171,6 +171,16 @@ export function stabilizingFor (title: string): ResolvedFeature[] {
   return resolve(ROADMAP_BUCKETS[title]?.stabilizing)
 }
 
+/**
+ * Resolve a milestone title's expected release date. This is the published
+ * calendar's single source of truth for dates — the roadmap store overlays it
+ * so both the calendar and the milestone list render the same value, rather
+ * than the calendar reading the constant and the list reading GitHub `due_on`.
+ */
+export function dateFor (title: string): string | undefined {
+  return ROADMAP_BUCKETS[title]?.date
+}
+
 /** Ordered, fully resolved releases for the release-calendar view. */
 export function releases (): ResolvedRelease[] {
   return Object.entries(ROADMAP_BUCKETS).map(([title, bucket]) => ({

--- a/apps/docs/src/stores/roadmap.ts
+++ b/apps/docs/src/stores/roadmap.ts
@@ -3,7 +3,7 @@
 import { createStorage, isArray, isNull, useLogger } from '@vuetify/v0'
 
 import { CACHE_TTL } from '@/constants/cache'
-import { type ResolvedFeature, auditBuckets, featuresFor } from '@/constants/roadmap-buckets'
+import { type ResolvedFeature, auditBuckets, dateFor, featuresFor } from '@/constants/roadmap-buckets'
 
 // Utilities
 import { defineStore } from 'pinia'
@@ -21,6 +21,13 @@ export interface Milestone extends GitHubMilestone {
   issues?: GitHubIssue[]
   issuesLoading?: boolean
   features?: ResolvedFeature[]
+  /**
+   * Display date: the published calendar date for this milestone, falling back
+   * to GitHub `due_on` for milestones with no calendar entry (e.g. historical
+   * v0.x releases). The calendar constant is the source of truth for v1.x — see
+   * `dateFor`.
+   */
+  date?: string | null
 }
 
 interface State {
@@ -105,8 +112,8 @@ export const useRoadmapStore = defineStore('roadmap', {
       // Check cache first
       const cached = storage.get<Milestone[] | null>('milestones', null)
       if (isArray(cached.value)) {
-        // Re-resolve features on read so bucket edits reflect without waiting for cache TTL.
-        this.milestones = cached.value.map(m => ({ ...m, features: featuresFor(m.title) }))
+        // Re-resolve features and date on read so bucket edits reflect without waiting for cache TTL.
+        this.milestones = cached.value.map(m => ({ ...m, features: featuresFor(m.title), date: dateFor(m.title) ?? m.due_on }))
         return
       }
 
@@ -139,7 +146,7 @@ export const useRoadmapStore = defineStore('roadmap', {
         this.milestones = [
           ...assignHorizons(openMilestones),
           ...closedMilestones.map(m => ({ ...m, horizon: 'done' as TimeHorizon })),
-        ].map(m => ({ ...m, features: featuresFor(m.title) }))
+        ].map(m => ({ ...m, features: featuresFor(m.title), date: dateFor(m.title) ?? m.due_on }))
 
         storage.set('milestones', this.milestones)
       } catch (error: unknown) {


### PR DESCRIPTION
The roadmap page mounted both `DocsRoadmap` (milestone list) and `DocsReleaseCalendar` (calendar grid) — the former rendered dates from GitHub milestone `due_on`, the latter from the `ROADMAP_BUCKETS` constant. Two independent date sources on one page, agreeing only by hand-syncing.

This adds `dateFor(title)` to `roadmap-buckets.ts` and has the roadmap store overlay a resolved `date` on each milestone (same pattern it already uses for `features`): the calendar constant date when one exists, falling back to GitHub `due_on` for milestones with no bucket entry (historical v0.x). `DocsRoadmap` now renders `milestone.date`.

Result: v1.x dates derive from a single source (the constant) across both components; GitHub `due_on` becomes mirrored metadata the docs no longer depend on. No regression on the Completed horizon — v0.x milestones fall back to their real `due_on`.