### PR TITLE
chore(release): pre-skip already-published packages in changeset publish

### DIFF
--- a/scripts/changeset-publish.js
+++ b/scripts/changeset-publish.js
@@ -6,18 +6,39 @@
 // falls through to this publish step. `changeset publish` is meant to be
 // idempotent — see the version already on npm, skip it, exit 0 — but its
 // pre-publish version check misreads the registry as empty in the tokenless-OIDC
-// runner (`info … has not been published on npm` for a version that *is* live),
-// re-attempts the publish, and npm rejects it with EPUBLISHCONFLICT
-// ("cannot publish over the previously published versions: X"). That turned every
-// post-release master push into a red Release run even though nothing was wrong.
+// runner (`info … has not been published on npm` for a version that *is* live)
+// and re-attempts the publish. npm rejects it, and under pnpm the E403 arrives in
+// pnpm's `{ code, message }` shape rather than npm's `{ summary, detail }`. That
+// shape crashes @changesets/cli with an unguarded `undefined.includes(...)`
+// TypeError inside `isAlreadyPublishedError` — a hard crash that happens BEFORE it
+// prints the `an error occurred while publishing X: …` line this wrapper used to
+// classify against (changesets #2099 / #2184). The crash exits non-zero with no
+// per-package error lines, so the old text-matching swallow could not recognize
+// it: every post-release master push turned red, and because the publish step
+// failed, `published` was never set and the GitHub-release step was skipped — the
+// exact failure that stranded @vuetify/v0@1.0.1 on npm with no v1.0.1 release.
 //
-// This wrapper swallows a failure ONLY when every package that failed did so for
-// that specific already-published reason. Any other error (auth, network, a real
-// partial publish, a genuinely new version that failed) still propagates and fails
-// the workflow loud. A run that publishes a genuinely new version keeps working:
-// its `New tag:` lines reach stdout so the changesets action still sets its
-// `published` / `publishedPackages` outputs and the release steps fire.
+// The fix is to never let changeset publish re-attempt an already-live version in
+// the first place: before publishing, any non-private workspace package whose
+// current version is already on npm is temporarily marked `private` on disk (a
+// CI-only edit, always restored) so `changeset publish` skips it. That removes the
+// only path to the crash. Genuinely-new versions are untouched — they publish and
+// print their `New tag:` lines, so the changesets action still sets its `published`
+// / `publishedPackages` outputs and the release steps fire.
+//
+// Two swallows remain as defense-in-depth for anything the pre-skip misses (e.g. a
+// version that lands on npm between the precheck and the publish attempt):
+//   1. a non-zero exit where every per-package error is an already-published
+//      conflict, and
+//   2. the crash signature — a non-zero exit with NO parseable per-package error
+//      lines — but only when the registry confirms every version we intended to
+//      publish is now live (nothing was actually stranded).
+// Any other failure (auth, network, a real partial publish, a genuinely new
+// version that failed to land) still propagates and fails the workflow loud, and
+// neither swallow ever fabricates `New tag:` lines: a clean skip must leave
+// `published` false so the release step is skipped, not looped on a no-op.
 import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 
 // Matches npm's already-published rejection in either phrasing.
 const ALREADY_PUBLISHED = /cannot publish over the previously published|EPUBLISHCONFLICT/i
@@ -26,33 +47,80 @@ const ALREADY_PUBLISHED = /cannot publish over the previously published|EPUBLISH
 // underlying error message we classify against.
 const PUBLISH_ERROR = /an error occurred while publishing (\S+): (.+)/g
 
-const result = spawnSync('pnpm', ['exec', 'changeset', 'publish'], { encoding: 'utf8' })
+// `npm view name@version` exits non-zero when that exact version is not on the
+// registry — the "is it published?" signal used both to pre-skip already-live
+// packages and to confirm a crash stranded nothing.
+function onNpm (name, version) {
+  return spawnSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'ignore' }).status === 0
+}
 
-// Forward the child's streams verbatim so the changesets action can still parse
-// `New tag:` lines from stdout for its published-packages outputs.
-if (result.stdout) process.stdout.write(result.stdout)
-if (result.stderr) process.stderr.write(result.stderr)
+// Discover every publishable (non-private) workspace package and split it into the
+// versions already on npm (pre-skip these) and the ones this run should publish.
+const skip = []
+const pending = []
+for (const dir of readdirSync('packages')) {
+  const path = `packages/${dir}/package.json`
+  if (!existsSync(path)) continue
 
-if (result.error) throw result.error
+  const raw = readFileSync(path, 'utf8')
+  const pkg = JSON.parse(raw)
+  if (!pkg.name || pkg.private) continue
 
-const code = result.status ?? 1
+  if (onNpm(pkg.name, pkg.version)) skip.push({ path, raw, pkg })
+  else pending.push({ name: pkg.name, version: pkg.version })
+}
 
-if (code !== 0) {
-  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
-  const errors = [...output.matchAll(PUBLISH_ERROR)].map(match => match[2])
+// Temporarily mark the already-live packages private so `changeset publish` skips
+// them and never hits the crashing re-publish path. Reformatting is irrelevant —
+// the exact original bytes are restored in the `finally` below before this process
+// exits, so nothing here is ever committed.
+for (const { path, pkg } of skip) {
+  console.log(`[changeset-publish] ${pkg.name}@${pkg.version} already on npm — skipping to avoid re-publish crash`)
+  writeFileSync(path, `${JSON.stringify({ ...pkg, private: true }, null, 2)}\n`)
+}
 
-  // No per-package error lines means the failure was something else entirely
-  // (build, auth, crash) — never swallow that.
-  const everyErrorIsAlreadyPublished =
-    errors.length > 0 && errors.every(message => ALREADY_PUBLISHED.test(message))
+try {
+  const result = spawnSync('pnpm', ['exec', 'changeset', 'publish'], { encoding: 'utf8' })
 
-  if (everyErrorIsAlreadyPublished) {
-    console.log(
-      `\n[changeset-publish] All ${errors.length} publish failure(s) were "already published" ` +
-      'conflicts — nothing new to release. Treating as a no-op success.',
-    )
-  } else {
-    // Non-zero exit (without process.exit) fails the release step loud.
-    process.exitCode = code
+  // Forward the child's streams verbatim so the changesets action can still parse
+  // `New tag:` lines from stdout for its published-packages outputs.
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+
+  if (result.error) throw result.error
+
+  const code = result.status ?? 1
+
+  if (code !== 0) {
+    const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+    const errors = [...output.matchAll(PUBLISH_ERROR)].map(match => match[2])
+
+    const everyErrorIsAlreadyPublished =
+      errors.length > 0 && errors.every(message => ALREADY_PUBLISHED.test(message))
+
+    // Crash signature: a non-zero exit with no per-package error lines at all
+    // (the OIDC/pnpm TypeError above). Safe to swallow only if nothing we meant to
+    // publish was left stranded — every pending version is now live on npm.
+    const crashStrandedNothing =
+      errors.length === 0 && pending.every(p => onNpm(p.name, p.version))
+
+    if (everyErrorIsAlreadyPublished) {
+      console.log(
+        `\n[changeset-publish] All ${errors.length} publish failure(s) were "already published" ` +
+        'conflicts — nothing new to release. Treating as a no-op success.',
+      )
+    } else if (crashStrandedNothing) {
+      console.log(
+        '\n[changeset-publish] changeset publish exited non-zero with no per-package error lines ' +
+        '(the known OIDC/pnpm crash), but every version this run intended to publish is live on ' +
+        'npm — nothing stranded. Treating as a no-op success.',
+      )
+    } else {
+      // Non-zero exit (without process.exit) fails the release step loud.
+      process.exitCode = code
+    }
   }
+} finally {
+  // Always restore the manifests we touched, whatever the publish outcome.
+  for (const { path, raw } of skip) writeFileSync(path, raw)
 }


### PR DESCRIPTION
## Problem

The Release workflow runs on every push to `master`. When the "Version Packages" PR is merged and no changesets remain, the changesets action falls through to `pnpm release` → `scripts/changeset-publish.js` → `changeset publish`.

Under tokenless OIDC + pnpm, `changeset publish`'s pre-publish version check misreads the registry as empty for a version that **is** live and re-attempts the publish. npm rejects it with E403, but under pnpm the error arrives in pnpm's `{ code, message }` shape rather than npm's `{ summary, detail }`. `@changesets/cli` then hits an unguarded `undefined.includes(...)` **TypeError** inside `isAlreadyPublishedError` — a hard crash that exits non-zero **with no per-package `an error occurred while publishing X:` lines**.

The existing wrapper only swallowed failures it could match against those per-package lines, so it could not recognize the crash: the publish step went red, `published` was never set, and the gated GitHub-release step was skipped. That is exactly what stranded `@vuetify/v0@1.0.1` on npm with no `v1.0.1` GitHub release (the missing release has since been minted manually).

Upstream: changesets [#2099](https://github.com/changesets/changesets/issues/2099), [#2184](https://github.com/changesets/changesets/issues/2184) — still unfixed in `@changesets/cli@2.31.1`.

## Fix

Prevent the crash instead of classifying it after the fact. Before publishing, any non-private workspace package whose **current version is already on npm** is temporarily marked `private` on disk (CI-only, always restored in a `finally` — verified byte-exact round-trip) so `changeset publish` skips it and never re-attempts the publish. That removes the only path to the crash.

- Genuinely-new versions are untouched: they publish and print their `New tag:` lines, so the changesets action's `published` / `publishedPackages` outputs and the release steps fire exactly as before.
- Steady-state post-release re-push: every publishable version is already live → all pre-skipped → `changeset publish` attempts nothing → clean exit 0, `published` stays false, release step cleanly skipped (no red board, no fabricated tags).

A null-safe fallback swallow also covers the crash signature (non-zero exit, no parseable error lines) **only** when the registry confirms every intended version is live — never fabricating `New tag:` lines, so a clean skip never loops the release step on a no-op.

## Verification

- `node --check` clean; private-toggle → restore is byte-identical, working tree stays clean.
- Partition verified against real npm at the post-release master state: `@vuetify/v0@1.0.1` + `@paper/genesis@1.0.0` both correctly pre-skipped, `pending` empty.

Scope: release-pipeline script only (`scripts/`), no package source touched.