### PR TITLE
chore(bench): collapse generated metrics artifacts in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Generated metrics artifacts.
+#
+# These are written only by the metrics pipeline (scripts/run-bench-stable.ts ->
+# generate-metrics), never by hand. Each is 300-450KB of pretty-printed JSON, and
+# `metrics:history --force` rewrites every per-version snapshot on each release —
+# so a single regen PR churns tens of thousands of lines. #714 was 30,060
+# additions / 20,087 deletions for one added version. Nobody can review that, and
+# an unreviewable diff hides exactly the noise it should surface.
+#
+#   linguist-generated  collapses the diff on GitHub and drops it from language stats
+#   -diff               stops git generating a textual diff at all
+#
+# To actually compare two artifact sets, use the apparatus-aware tooling
+# (scripts/report-benchmark-delta.ts) rather than reading a raw diff — raw ops/s
+# are not comparable across runs on different hosts. See .claude/rules/benchmarks.md.
+apps/docs/public/benchmarks.json linguist-generated -diff
+apps/docs/src/data/metrics.json linguist-generated -diff
+apps/docs/src/data/metrics/*.json linguist-generated -diff
+
+# DO NOT add a global `* text=auto` here.
+#
+# packages/0/bench/calibration.test.ts asserts a sha256 of calibration.bench.ts
+# to stop a silent re-baseline of the whole benchmark history. Line-ending
+# normalization would change those bytes on checkout, so the guard would fail on
+# some platforms and pass on others — the worst possible failure mode for a
+# tripwire whose entire job is to be trustworthy.


### PR DESCRIPTION
Adds `.gitattributes` marking the generated metrics artifacts `linguist-generated -diff`.

## Why

The pipeline writes 300–450KB of pretty-printed JSON per artifact, and `metrics:history --force` rewrites every per-version snapshot on each release. #714 was **30,060 additions / 20,087 deletions** for one added version.

That made the auto-PR body's own instruction — *"Close this PR to discard if the delta looks like runner noise"* — unactionable: the noise you're asked to spot is exactly what a 50k-line diff hides.

## Effect

Verified by mutating `metrics.json` locally:

```
 apps/docs/src/data/metrics.json | Bin 340481 -> 342479 bytes
 1 file changed, 0 insertions(+), 0 deletions(-)
```

Comparison should go through `scripts/report-benchmark-delta.ts` regardless — raw ops/s aren't comparable across hosts (see #716).

## The `text=auto` warning in the file

`packages/0/bench/calibration.test.ts` asserts a sha256 of `calibration.bench.ts` to stop a silent re-baseline of the whole benchmark history. A global `* text=auto` would normalize line endings on checkout, so that guard would pass on some platforms and fail on others — the worst failure mode for a tripwire whose job is to be trustworthy. Documented inline so nobody adds it later.

## Scope

One file, no behavior change. Step 7 of the metrics-normalization plan; the rest is parked pending the bench-host decision.