### PR TITLE
fix(v0): accept Vue 3.6 prereleases in the peer range

### DIFF
--- a/.changeset/npm-discovery-and-vue-36-peer.md
+++ b/.changeset/npm-discovery-and-vue-36-peer.md
@@ -1,0 +1,9 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(v0): accept Vue 3.6 prereleases and surface npm discovery metadata
+
+`@vuetify/v0` now installs cleanly alongside `vue@3.6.0-rc.x`. The previous `vue` peer range of `>=3.5.0` excluded prereleases per semver, so any project on a 3.6 release candidate hit `ERESOLVE`; the range is now `>=3.5.0 || >=3.6.0-0`. No change for projects on stable Vue.
+
+The package also publishes `keywords`, `homepage`, and `bugs` for the first time, and the `description` now leads with what the package is — headless, unstyled, accessible Vue 3 primitives and composables.

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -1,7 +1,28 @@
 {
   "name": "@vuetify/v0",
   "version": "1.0.1",
-  "description": "A meta UI framework for building applications, component libraries, and design systems with Vue 3",
+  "description": "Headless, unstyled, accessible Vue 3 primitives and composables — a meta UI framework for building applications, component libraries, and design systems",
+  "keywords": [
+    "vue",
+    "vue3",
+    "headless",
+    "headless-ui",
+    "unstyled",
+    "composables",
+    "primitives",
+    "accessible",
+    "accessibility",
+    "a11y",
+    "wai-aria",
+    "design-system",
+    "component-library",
+    "ui",
+    "vuetify"
+  ],
+  "homepage": "https://0.vuetifyjs.com",
+  "bugs": {
+    "url": "https://github.com/vuetifyjs/0/issues"
+  },
   "license": "MIT",
   "funding": [
     {
@@ -97,7 +118,7 @@
     "@material/material-color-utilities": ">=0.3.0",
     "launchdarkly-js-client-sdk": "^3.0.0",
     "posthog-js": "^1.0.0",
-    "vue": ">=3.5.0",
+    "vue": ">=3.5.0 || >=3.6.0-0",
     "vue-i18n": ">=10.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -21,7 +21,7 @@
   ],
   "homepage": "https://0.vuetifyjs.com",
   "bugs": {
-    "url": "https://github.com/vuetifyjs/0/issues"
+    "url": "https://issues.vuetifyjs.com/?repo=vuetify0&type=bug"
   },
   "license": "MIT",
   "funding": [


### PR DESCRIPTION
## Description

Two changes to `packages/0/package.json`, both currently blocking adoption in ways that are invisible from inside the repo.

### 1. Vue 3.6 prereleases fail to install (the real fix)

The `vue` peer range was `>=3.5.0`. Per semver, a range without a prerelease comparator **does not match prerelease versions**, so `vue@3.6.0-rc.2` falls outside it and any project on a 3.6 RC hits `ERESOLVE` installing `@vuetify/v0`.

Verified rather than assumed:

| version | `>=3.5.0` (before) | `>=3.5.0 \|\| >=3.6.0-0` (after) |
|---|---|---|
| `3.4.0` | ❌ | ❌ |
| `3.5.13` | ✅ | ✅ |
| `3.6.0-rc.2` | ❌ | ✅ |
| `3.6.0` | ✅ | ✅ |
| `3.7.1` | ✅ | ✅ |

Resolution for stable Vue is unchanged; the only new versions admitted are 3.6 prereleases. This has a natural expiry — once 3.6.0 goes stable the old range would have covered it anyway.

### 2. npm discovery metadata was absent

`keywords`, `homepage`, and `bugs` were all missing, so npm had nothing to match the package against its own obvious search terms. Added, plus the `description` now leads with what the package *is* (headless, unstyled, accessible Vue 3 primitives and composables) before what it's *for*. The meta-framework framing is preserved in the second half.

Metadata only reaches the registry on publish, hence the changeset.

## Markup

N/A — no source or template changes.

<!-- generated with Claude Code -->