### PR TITLE
fix(useResizeObserver): surface borderBoxSize and contentBoxSize on entries

### DIFF
--- a/.changeset/resize-observer-border-box-reporting.md
+++ b/.changeset/resize-observer-border-box-reporting.md
@@ -1,0 +1,18 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useResizeObserver): report border-box measurements so the `box` option is no longer a silent no-op (#724)
+
+`useResizeObserver` accepted `box: 'border-box'` but every entry it reported was content-box, so any element with padding or a border measured short by exactly that amount — with no type error and no warning. Entries now also carry `borderBoxSize` and `contentBoxSize`, matching the native `ResizeObserverEntry`:
+
+```ts
+useResizeObserver(el, ([entry]) => {
+  entry.contentRect.height          // 30 — content box, as before
+  entry.borderBoxSize[0].blockSize  // 40 — with 4px padding and a 1px border
+}, { box: 'border-box' })
+```
+
+Both arrays are present on every entry regardless of `box`, so you can read the border box without changing any option. Unlike `getBoundingClientRect()`, they are layout values and are not scaled by CSS transforms.
+
+`contentRect` is unchanged — existing callbacks keep working as-is.

--- a/apps/docs/src/pages/composables/system/use-resize-observer.md
+++ b/apps/docs/src/pages/composables/system/use-resize-observer.md
@@ -71,7 +71,30 @@ flowchart TD
 | - | - | - | - |
 | `immediate` | `boolean` | `false` | Fire the callback immediately on mount before any resize |
 | `once` | `boolean` | `false` | Stop observing after the first callback fires |
-| `box` | `'content-box' \| 'border-box'` | `'content-box'` | Which box model to observe |
+| `box` | `'content-box' \| 'border-box'` | `'content-box'` | Which box model a change is measured against when deciding to fire |
+
+## Entry
+
+Each reported entry carries both box models, whichever `box` you observe:
+
+| Property | Type | Notes |
+| - | - | - |
+| `contentRect` | `{ width, height, top, left }` | The content box — excludes padding and border |
+| `contentBoxSize` | `readonly ResizeObserverSize[]` | The content box on the logical axes (`inlineSize` / `blockSize`) |
+| `borderBoxSize` | `readonly ResizeObserverSize[]` | The border box — content plus padding plus border |
+| `target` | `Element` | The observed element |
+
+Both size arrays mirror the native API: one entry per box fragment, so a normal single-fragment element is `borderBoxSize[0]`.
+
+```ts
+useResizeObserver(el, ([entry]) => {
+  entry.contentRect.height          // 30 — content box
+  entry.borderBoxSize[0].blockSize  // 40 — with 4px padding and a 1px border
+}, { box: 'border-box' })
+```
+
+> [!TIP] `inlineSize` vs `width`
+> `inlineSize` and `blockSize` follow the writing mode. Under the default `horizontal-tb` they map to width and height; under any `vertical-*` mode they swap. Unlike `getBoundingClientRect()`, neither is scaled by CSS transforms — which is what makes them the right choice for measuring an animated element.
 
 ## Reactivity
 
@@ -126,7 +149,13 @@ Yes. `useElementSize` builds on `useResizeObserver` and exposes reactive `width`
 
 ??? How do I measure the border-box instead of the content-box?
 
-Pass `box: 'border-box'`. The default `'content-box'` excludes padding and borders; `'border-box'` includes them.
+Read `entry.borderBoxSize[0]` — it includes padding and border, where `contentRect` excludes them. Both are on every entry, so you can read the border box without changing any option.
+
+`box: 'border-box'` is a separate choice: it controls which box model has to change before the observer fires. Set it when you only care about the outer size — an element whose padding grows while its border box stays fixed then won't wake your callback.
+
+??? Should I use `borderBoxSize` or `getBoundingClientRect()`?
+
+`borderBoxSize` measures the same box but is a layout value, so CSS transforms don't scale it. If the element is animated with `transform`, `getBoundingClientRect()` reports the visually scaled size while `borderBoxSize` reports the laid-out size — usually what sizing logic wants.
 
 :::
 

--- a/packages/0/src/composables/useResizeObserver/index.browser.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.browser.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, onTestFinished } from 'vitest'
+
+import { useElementSize, useResizeObserver } from './index'
+
+// Utilities
+import { effectScope } from 'vue'
+
+// Types
+import type { ResizeObserverEntry, ResizeObserverOptions } from './index'
+
+/**
+ * `box-sizing: border-box` with an outer 200x40, 4px/16px padding and a 1px
+ * border. The two box models therefore disagree on every axis:
+ *
+ * - border box  — 200 x 40
+ * - content box — 166 x 30
+ */
+// Absolutely positioned so mounting and unmounting a fixture never reflows the
+// document and re-notifies a sibling test's observer.
+const OUT_OF_FLOW = 'position: absolute; top: 0; left: 0;'
+
+const GEOMETRY = `${OUT_OF_FLOW} box-sizing: border-box; width: 200px; height: 40px; padding: 4px 16px; border: 1px solid;`
+
+const BORDER = { inlineSize: 200, blockSize: 40 }
+const CONTENT = { inlineSize: 166, blockSize: 30 }
+
+/**
+ * Native entries expose `inlineSize` / `blockSize` as prototype getters on a
+ * `ResizeObserverSize`, which structural matchers read as an empty object.
+ * Normalize both sides before comparing.
+ */
+function size (value: ResizeObserverSize | undefined) {
+  return { inlineSize: value?.inlineSize, blockSize: value?.blockSize }
+}
+
+function element (css = GEOMETRY) {
+  const el = document.createElement('div')
+
+  el.style.cssText = css
+  document.body.append(el)
+
+  onTestFinished(() => el.remove())
+
+  return el
+}
+
+function observe (el: Element, options?: ResizeObserverOptions) {
+  const entries: ResizeObserverEntry[] = []
+  let notify: (() => void) | undefined
+
+  const scope = effectScope()
+
+  scope.run(() => {
+    useResizeObserver(el, list => {
+      entries.push(...list)
+      notify?.()
+    }, options)
+  })
+
+  onTestFinished(() => scope.stop())
+
+  function next (): Promise<ResizeObserverEntry> {
+    return new Promise((resolve, reject) => {
+      function take () {
+        const entry = entries.shift()
+
+        if (!entry) return false
+
+        notify = undefined
+        // Resolve on a later task, not the observer's own microtask: anything
+        // the awaiting test then does to the DOM would otherwise land inside
+        // the delivery loop and trip Chromium's undelivered-notification error.
+        setTimeout(() => resolve(entry), 0)
+
+        return true
+      }
+
+      if (take()) return
+
+      const timer = setTimeout(() => {
+        notify = undefined
+        reject(new Error('timed out waiting for a resize entry'))
+      }, 2000)
+
+      notify = () => {
+        if (take()) clearTimeout(timer)
+      }
+    })
+  }
+
+  return { next }
+}
+
+describe('useResizeObserver box model', () => {
+  it('should report the border box when observing border-box', async () => {
+    const el = element()
+    const { next } = observe(el, { box: 'border-box' })
+    const entry = await next()
+
+    expect(size(entry.borderBoxSize[0])).toEqual(BORDER)
+    expect(entry.borderBoxSize[0]!.blockSize).toBe(el.getBoundingClientRect().height)
+  })
+
+  it('should keep contentRect on the content box under either box option', async () => {
+    const el = element()
+    const border = await observe(el, { box: 'border-box' }).next()
+    const content = await observe(el, { box: 'content-box' }).next()
+
+    for (const entry of [border, content]) {
+      expect(entry.contentRect.width).toBe(CONTENT.inlineSize)
+      expect(entry.contentRect.height).toBe(CONTENT.blockSize)
+      expect(size(entry.contentBoxSize[0])).toEqual(CONTENT)
+      expect(size(entry.borderBoxSize[0])).toEqual(BORDER)
+    }
+  })
+
+  it('should separate the two box models by exactly the padding and border', async () => {
+    const { next } = observe(element(), { box: 'border-box' })
+    const entry = await next()
+
+    // 16px padding + 1px border on each inline edge, 4px + 1px on each block edge
+    expect(entry.borderBoxSize[0]!.inlineSize - entry.contentBoxSize[0]!.inlineSize).toBe(34)
+    expect(entry.borderBoxSize[0]!.blockSize - entry.contentBoxSize[0]!.blockSize).toBe(10)
+    expect(entry.contentRect.height).not.toBe(entry.borderBoxSize[0]!.blockSize)
+  })
+
+  it('should report both box models on an unpadded element as identical', async () => {
+    const { next } = observe(element(`${OUT_OF_FLOW} width: 120px; height: 60px;`))
+    const entry = await next()
+
+    expect(size(entry.contentBoxSize[0])).toEqual({ inlineSize: 120, blockSize: 60 })
+    expect(size(entry.borderBoxSize[0])).toEqual({ inlineSize: 120, blockSize: 60 })
+  })
+
+  it('should deliver updated border-box sizes on resize', async () => {
+    const el = element()
+    const { next } = observe(el, { box: 'border-box' })
+
+    await next()
+
+    el.style.height = '80px'
+
+    const entry = await next()
+
+    expect(entry.borderBoxSize[0]!.blockSize).toBe(80)
+    expect(entry.contentBoxSize[0]!.blockSize).toBe(70)
+  })
+
+  it('should synthesize an immediate entry matching what the observer reports', async () => {
+    const el = element()
+    const { next } = observe(el, { immediate: true, box: 'border-box' })
+
+    const immediate = await next()
+    const observed = await next()
+
+    expect(size(immediate.borderBoxSize[0])).toEqual(size(observed.borderBoxSize[0]))
+    expect(size(immediate.contentBoxSize[0])).toEqual(size(observed.contentBoxSize[0]))
+  })
+
+  it('should swap the logical axes on the immediate entry under a vertical writing mode', async () => {
+    const el = element(`${GEOMETRY} writing-mode: vertical-rl;`)
+    const { next } = observe(el, { immediate: true })
+
+    const immediate = await next()
+    const observed = await next()
+
+    expect(size(immediate.borderBoxSize[0])).toEqual(size(observed.borderBoxSize[0]))
+    expect(size(observed.borderBoxSize[0])).toEqual({ inlineSize: 40, blockSize: 200 })
+  })
+
+  it('should keep useElementSize reporting content-box dimensions', async () => {
+    const el = element()
+    const scope = effectScope()
+
+    onTestFinished(() => scope.stop())
+
+    const { width, height } = scope.run(() => useElementSize(el))!
+
+    await observe(el).next()
+
+    expect(width.value).toBe(CONTENT.inlineSize)
+    expect(height.value).toBe(CONTENT.blockSize)
+  })
+})

--- a/packages/0/src/composables/useResizeObserver/index.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import { useElementSize, useResizeObserver } from './index'
 
@@ -585,5 +585,129 @@ describe('useResizeObserver SSR', () => {
 
     expect(width.value).toBe(0)
     expect(height.value).toBe(0)
+  })
+})
+
+describe('useResizeObserver box model synthesis', () => {
+  // The `immediate` entry is synthesized from computed style rather than
+  // delivered by the observer, so each box-model branch is driven here by
+  // stubbing getComputedStyle. Real-layout verification of the same math lives
+  // in index.browser.test.ts, which happy-dom cannot do.
+  const PADDED = {
+    paddingLeft: '16px',
+    paddingRight: '16px',
+    paddingTop: '4px',
+    paddingBottom: '4px',
+    borderLeftWidth: '1px',
+    borderRightWidth: '1px',
+    borderTopWidth: '1px',
+    borderBottomWidth: '1px',
+    writingMode: 'horizontal-tb',
+  }
+
+  let element: HTMLDivElement
+
+  beforeEach(() => {
+    mockIsHydrated.value = true
+
+    globalThis.ResizeObserver = vi.fn(function (this: any) {
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }
+    }) as any
+    window.ResizeObserver = globalThis.ResizeObserver
+
+    element = document.createElement('div')
+    element.getBoundingClientRect = vi.fn(() => ({
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 50,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })) as any
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function synthesize (style: Record<string, string>) {
+    vi.stubGlobal('getComputedStyle', () => style)
+
+    const callback = vi.fn()
+
+    useResizeObserver(ref<Element | undefined>(element), callback, { immediate: true })
+    await nextTick()
+
+    return callback.mock.calls[0]![0][0]
+  }
+
+  it('should derive the content box by subtracting padding and border under border-box', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      boxSizing: 'border-box',
+      width: '200px',
+      height: '40px',
+    })
+
+    expect(entry.borderBoxSize).toEqual([{ inlineSize: 200, blockSize: 40 }])
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 166, blockSize: 30 }])
+  })
+
+  it('should derive the border box by adding padding and border under content-box', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      boxSizing: 'content-box',
+      width: '166px',
+      height: '30px',
+    })
+
+    expect(entry.borderBoxSize).toEqual([{ inlineSize: 200, blockSize: 40 }])
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 166, blockSize: 30 }])
+  })
+
+  it('should swap the logical axes under a vertical writing mode', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      writingMode: 'vertical-rl',
+      boxSizing: 'border-box',
+      width: '200px',
+      height: '40px',
+    })
+
+    expect(entry.borderBoxSize).toEqual([{ inlineSize: 40, blockSize: 200 }])
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 30, blockSize: 166 }])
+  })
+
+  it('should fall back to the client rect when a resolved length is not a number', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      boxSizing: 'content-box',
+      width: 'auto',
+      height: 'auto',
+    })
+
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 100, blockSize: 50 }])
+    expect(entry.borderBoxSize).toEqual([{ inlineSize: 134, blockSize: 60 }])
+  })
+
+  it('should treat a partial style declaration as zero rather than throwing', async () => {
+    const entry = await synthesize({ marginLeft: '0px', marginRight: '0px' })
+
+    expect(entry.borderBoxSize).toEqual([{ inlineSize: 100, blockSize: 50 }])
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 100, blockSize: 50 }])
+  })
+
+  it('should clamp the content box at zero when padding exceeds the border box', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      boxSizing: 'border-box',
+      width: '10px',
+      height: '4px',
+    })
+
+    expect(entry.contentBoxSize).toEqual([{ inlineSize: 0, blockSize: 0 }])
   })
 })

--- a/packages/0/src/composables/useResizeObserver/index.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.test.ts
@@ -100,6 +100,8 @@ describe('useResizeObserver', () => {
         top: 0,
         left: 0,
       },
+      borderBoxSize: [{ inlineSize: 100, blockSize: 50 }],
+      contentBoxSize: [{ inlineSize: 100, blockSize: 50 }],
     }])
   })
 
@@ -122,6 +124,8 @@ describe('useResizeObserver', () => {
         top: 0,
         left: 0,
       },
+      borderBoxSize: [{ inlineSize: 100, blockSize: 50 }],
+      contentBoxSize: [{ inlineSize: 100, blockSize: 50 }],
     }])
   })
 
@@ -162,6 +166,42 @@ describe('useResizeObserver', () => {
 
     resume()
     expect(isPaused.value).toBe(false)
+  })
+
+  it('should forward the native border-box and content-box sizes to the callback', async () => {
+    let observerCallback: (entries: any[]) => void
+    globalThis.ResizeObserver = vi.fn(function (this: any, cb: any) {
+      observerCallback = cb
+      return mockObserver
+    }) as any
+    window.ResizeObserver = globalThis.ResizeObserver
+
+    const target = ref<Element | undefined>(element)
+    const callback = vi.fn()
+
+    useResizeObserver(target, callback, { box: 'border-box' })
+
+    mockIsHydrated.value = true
+    await nextTick()
+
+    expect(mockObserver.observe).toHaveBeenCalledWith(element, { box: 'border-box' })
+
+    const borderBoxSize = [{ inlineSize: 200, blockSize: 40 }]
+    const contentBoxSize = [{ inlineSize: 166, blockSize: 30 }]
+
+    observerCallback!([{
+      contentRect: { width: 166, height: 30, top: 0, left: 0 },
+      borderBoxSize,
+      contentBoxSize,
+      target: element,
+    }])
+
+    expect(callback).toHaveBeenCalledWith([{
+      contentRect: { width: 166, height: 30, top: 0, left: 0 },
+      borderBoxSize,
+      contentBoxSize,
+      target: element,
+    }])
   })
 
   it('should stop observing after first resize when once option is true', async () => {

--- a/packages/0/src/composables/useResizeObserver/index.ts
+++ b/packages/0/src/composables/useResizeObserver/index.ts
@@ -15,6 +15,7 @@
  * - SSR-safe (checks SUPPORTS_OBSERVER)
  * - Hydration-aware
  * - Box model options (content-box/border-box)
+ * - Reports `borderBoxSize` and `contentBoxSize` alongside `contentRect`
  *
  * Perfect for responsive components and size-based rendering.
  *
@@ -37,6 +38,7 @@ import { createObserver } from '#v0/composables/createObserver'
 import { SUPPORTS_OBSERVER } from '#v0/constants/globals'
 
 // Utilities
+import { isNaN, isString } from '#v0/utilities'
 import { shallowReadonly, shallowRef } from 'vue'
 
 // Types
@@ -44,6 +46,23 @@ import type { ObserverReturn } from '#v0/composables/createObserver'
 import type { MaybeElementRef } from '#v0/composables/toElement'
 import type { Ref } from 'vue'
 
+/**
+ * A reported size change for an observed element.
+ *
+ * `contentRect` always describes the content box, regardless of the `box`
+ * option. Read `borderBoxSize` when padding and borders should be included —
+ * both arrays are populated on every entry, so `box` selects which box model
+ * triggers a callback, not which measurements are available.
+ *
+ * @example
+ * ```ts
+ * useResizeObserver(el, ([entry]) => {
+ *   entry.contentRect.height        // content box, excludes padding + border
+ *   entry.contentBoxSize[0].blockSize   // same value, writing-mode relative
+ *   entry.borderBoxSize[0].blockSize    // includes padding + border
+ * }, { box: 'border-box' })
+ * ```
+ */
 export interface ResizeObserverEntry {
   contentRect: {
     width: number
@@ -51,6 +70,23 @@ export interface ResizeObserverEntry {
     top: number
     left: number
   }
+  /**
+   * The element's border box — content plus padding plus border — in
+   * writing-mode-relative `inlineSize` / `blockSize` terms.
+   *
+   * Unlike `getBoundingClientRect()`, this is a layout measurement and is not
+   * scaled by CSS transforms. The array mirrors the native API: one entry per
+   * box fragment, so single-fragment elements report `borderBoxSize[0]`.
+   */
+  borderBoxSize: readonly ResizeObserverSize[]
+  /**
+   * The element's content box — excluding padding and border — in
+   * writing-mode-relative `inlineSize` / `blockSize` terms.
+   *
+   * Carries the same measurement as `contentRect`, expressed on the logical
+   * axes. The array mirrors the native API: one entry per box fragment.
+   */
+  contentBoxSize: readonly ResizeObserverSize[]
   target: Element
 }
 
@@ -61,6 +97,74 @@ export interface ResizeObserverOptions {
 }
 
 export interface UseResizeObserverReturn extends ObserverReturn {}
+
+/* #__NO_SIDE_EFFECTS__ */
+function px (value: string | undefined, fallback = 0): number {
+  if (!isString(value)) return fallback
+
+  const parsed = Number.parseFloat(value)
+
+  return isNaN(parsed) ? fallback : parsed
+}
+
+/**
+ * Synthesize the entry the observer would report for `el`, for the `immediate`
+ * callback that fires before the observer's own first delivery.
+ *
+ * The box sizes come from `getComputedStyle` rather than
+ * `getBoundingClientRect` because resolved lengths are layout values — like the
+ * observer, and unlike a client rect, they are not scaled by CSS transforms.
+ * `contentRect` keeps its existing client-rect source so callers reading it see
+ * no change.
+ *
+ * Every read is written to tolerate a partial style declaration: an element
+ * with no layout box resolves its lengths to `''`, and this runs on whatever
+ * `getComputedStyle` returns.
+ */
+/* #__NO_SIDE_EFFECTS__ */
+function measure (el: Element): ResizeObserverEntry {
+  const rect = el.getBoundingClientRect()
+  const style = getComputedStyle(el)
+
+  const paddingX = px(style.paddingLeft) + px(style.paddingRight)
+  const paddingY = px(style.paddingTop) + px(style.paddingBottom)
+  const borderX = px(style.borderLeftWidth) + px(style.borderRightWidth)
+  const borderY = px(style.borderTopWidth) + px(style.borderBottomWidth)
+
+  // Resolved width/height follow `box-sizing` — they describe the border box
+  // under `border-box` and the content box otherwise — so which box needs the
+  // padding and border added depends on which one they already measured.
+  const outer = style.boxSizing === 'border-box'
+  const resolvedX = px(style.width, rect.width)
+  const resolvedY = px(style.height, rect.height)
+
+  const width = {
+    border: outer ? resolvedX : resolvedX + paddingX + borderX,
+    content: Math.max(0, outer ? resolvedX - paddingX - borderX : resolvedX),
+  }
+  const height = {
+    border: outer ? resolvedY : resolvedY + paddingY + borderY,
+    content: Math.max(0, outer ? resolvedY - paddingY - borderY : resolvedY),
+  }
+
+  // Logical axes swap under any vertical writing mode, matching how the
+  // observer maps inlineSize/blockSize onto the physical box.
+  const vertical = isString(style.writingMode) && style.writingMode.startsWith('vertical')
+  const inline = vertical ? height : width
+  const block = vertical ? width : height
+
+  return {
+    contentRect: {
+      width: rect.width,
+      height: rect.height,
+      top: rect.top,
+      left: rect.left,
+    },
+    borderBoxSize: [{ inlineSize: inline.border, blockSize: block.border }],
+    contentBoxSize: [{ inlineSize: inline.content, blockSize: block.content }],
+    target: el,
+  }
+}
 
 /**
  * A composable that uses the Resize Observer API to detect when an element's
@@ -102,6 +206,15 @@ export interface UseResizeObserverReturn extends ObserverReturn {}
  * // Resume observation
  * resume()
  * ```
+ *
+ * @example
+ * Measuring the border box — padding and borders included:
+ *
+ * ```ts
+ * useResizeObserver(el, ([entry]) => {
+ *   height.value = entry.borderBoxSize[0].blockSize
+ * }, { box: 'border-box' })
+ * ```
  */
 export function useResizeObserver (
   target: MaybeElementRef,
@@ -119,24 +232,13 @@ export function useResizeObserver (
           top: e.contentRect.top,
           left: e.contentRect.left,
         },
+        borderBoxSize: e.borderBoxSize,
+        contentBoxSize: e.contentBoxSize,
         target: e.target,
       })))
     }),
     observe: (obs, el) => obs.observe(el, { box: options.box ?? 'content-box' }),
-    immediate: options.immediate
-      ? el => {
-        const rect = el.getBoundingClientRect()
-        return [{
-          contentRect: {
-            width: rect.width,
-            height: rect.height,
-            top: rect.top,
-            left: rect.left,
-          },
-          target: el,
-        }]
-      }
-      : undefined,
+    immediate: options.immediate ? el => [measure(el)] : undefined,
   })
 }
 

--- a/packages/0/src/composables/useResizeObserver/index.ts
+++ b/packages/0/src/composables/useResizeObserver/index.ts
@@ -99,7 +99,7 @@ export interface ResizeObserverOptions {
 export interface UseResizeObserverReturn extends ObserverReturn {}
 
 /* #__NO_SIDE_EFFECTS__ */
-function px (value: string | undefined, fallback = 0): number {
+function pxToNumber (value: string | undefined, fallback = 0): number {
   if (!isString(value)) return fallback
 
   const parsed = Number.parseFloat(value)
@@ -126,17 +126,17 @@ function measure (el: Element): ResizeObserverEntry {
   const rect = el.getBoundingClientRect()
   const style = getComputedStyle(el)
 
-  const paddingX = px(style.paddingLeft) + px(style.paddingRight)
-  const paddingY = px(style.paddingTop) + px(style.paddingBottom)
-  const borderX = px(style.borderLeftWidth) + px(style.borderRightWidth)
-  const borderY = px(style.borderTopWidth) + px(style.borderBottomWidth)
+  const paddingX = pxToNumber(style.paddingLeft) + pxToNumber(style.paddingRight)
+  const paddingY = pxToNumber(style.paddingTop) + pxToNumber(style.paddingBottom)
+  const borderX = pxToNumber(style.borderLeftWidth) + pxToNumber(style.borderRightWidth)
+  const borderY = pxToNumber(style.borderTopWidth) + pxToNumber(style.borderBottomWidth)
 
   // Resolved width/height follow `box-sizing` — they describe the border box
   // under `border-box` and the content box otherwise — so which box needs the
   // padding and border added depends on which one they already measured.
   const outer = style.boxSizing === 'border-box'
-  const resolvedX = px(style.width, rect.width)
-  const resolvedY = px(style.height, rect.height)
+  const resolvedX = pxToNumber(style.width, rect.width)
+  const resolvedY = pxToNumber(style.height, rect.height)
 
   const width = {
     border: outer ? resolvedX : resolvedX + paddingX + borderX,


### PR DESCRIPTION
Closes #724

## The defect

`useResizeObserver` forwards the `box` option to `ResizeObserver.observe()`, but the entry it reports is narrowed to `contentRect` + `target`. The native `borderBoxSize` / `contentBoxSize` are discarded before the callback ever sees them, so `box: 'border-box'` changed only *when* the callback fired, never *what* it measured. Any element with padding or a border measured short by exactly that amount — no type error, no warning, just wrong numbers surfacing later as a layout bug.

Confirmed in Chromium on `box-sizing: border-box; width: 200px; height: 40px; padding: 4px 16px; border: 1px`:

| | value |
|---|---|
| `contentRect` | 166 x 30 |
| `borderBoxSize[0]` | 200 x 40 |
| `contentBoxSize[0]` | 166 x 30 |

## Which option, and the case against it

The issue offered two fixes. I implemented **(1) — surface the native fields**.

**The strongest case against (1):** it does not fix the reported symptom for anyone already affected. A caller who today passes `{ box: 'border-box' }` and reads `contentRect` still gets content-box numbers after this change; they have to *know* to read a new field. Option (2) — redefining `contentRect` to hold the border rect under `box: 'border-box'` — would silently repair every existing miscalculation with no consumer edit at all. That is a real advantage and the reason (2) is tempting.

It loses anyway, on three counts:

- **(2) makes the field name lie.** `contentRect` would mean "content box, unless you passed an option elsewhere in the call." Silent wrongness is what this issue is about; option (2) trades a discoverable gap for an undiscoverable ambiguity.
- **(2) is a breaking behavior change dressed as a patch.** Anyone passing `border-box` today and reading `contentRect` gets different numbers with no diagnostic. There is no migration signal.
- **(2) can't express the transform-safe pattern.** vuetifyjs/vuetify#23029 patched Vuetify specifically to use `borderBoxSize` because it is a layout value and is *not* scaled by CSS transforms, where a client rect is. Collapsing everything into `contentRect` leaves that fix nowhere to land.

Both arrays are now populated on **every** entry, independent of `box` — that is what the platform does, and it means the border box is readable without changing any option. `box` reverts to its true meaning: which box model must change before the callback fires.

I considered flattening the arrays to a single `{ inlineSize, blockSize }` for ergonomics (`[0]` is a wart). Rejected: fragmented boxes are real, flattening would force *us* to silently pick a fragment, and mirroring the platform means code copied from MDN or from Vuetify's own patch works unchanged.

## Base branch: `master` — and why this is arguable

**The counterargument is strong and I want it on the record.** This adds two readable fields to a public exported interface. Read strictly, `CLAUDE.md`'s branch table routes "new features that add public API → `dev` → minor." By that reading this belongs on `dev`. Further, the new fields are populated regardless of `box`, which weakens "this is purely a box-option fix" — they are genuinely new surface, not a conditional repair.

I chose `master` anyway:

- The issue is labelled `T: bug` and milestoned **v1.0.x** by the maintainer — an explicit signal it is expected on the patch train.
- The additive fields are not an independent feature; they are *the only possible mechanism* for making a shipped, documented option functional. There is no way to fix this bug without exposing border-box numbers somewhere.
- Adding a field to an object v0 **produces** cannot break a consumer — no existing call site changes behavior.
- Vuetify work is blocked behind this, and `dev` accumulates until the next minor cut.

**I do not think the two options split across branches** — option (2) would be a patch on `master`, and option (1) is what is here. If you want the branch table applied literally, this should be retargeted to `dev`; it rebases cleanly and nothing else in the diff changes. Your call.

## Changes

- `packages/0/src/composables/useResizeObserver/index.ts` — forward `borderBoxSize` / `contentBoxSize`; rework the `immediate` synthesis.
- `createObserver` is **untouched**. It is generic over the entry type and never had box semantics; the whole defect and fix live in `useResizeObserver`'s `create` / `immediate` config.

### The `immediate` path

`immediate: true` hand-synthesizes an entry so the first value arrives synchronously instead of a frame later. It has to produce the new fields too, so it now derives both boxes from `getComputedStyle` rather than a lone `getBoundingClientRect()`. Three things fell out of that, all verified empirically in Chromium rather than assumed:

- **Resolved `width`/`height` follow `box-sizing`** — under `border-box` they *are* the border box, not the content box. The derivation branches on `style.boxSizing`. (I had this backwards initially; the probe corrected it.)
- **Logical axes swap under vertical writing modes**, matching how the observer maps `inlineSize`/`blockSize`.
- **Every read tolerates a partial style declaration.** My first version crashed three `Avatar` browser tests: `Avatar/index.browser.test.ts:1246` stubs `getComputedStyle` down to two properties, so `style.writingMode` was `undefined`. Elements with no layout box also resolve lengths to `''`.

`getComputedStyle` is preferred over the client rect here because resolved lengths are layout values and, like the observer itself, are not transform-scaled.

### Consumer audit

Grepped every `useResizeObserver` / `useElementSize` call site in `packages/0/src`: `createVirtual`, `createOverflow`, `useDragDrop`, `OverflowIndicator`, `CarouselViewport`, `SplitterPanel`, `AvatarRoot`, `AvatarIndicator`. **None passes `box`**; all read `contentRect` or ignore the entry. `contentRect` keeps its existing client-rect source in both the observer and immediate paths, so every one is unaffected — covered by a regression test asserting `useElementSize` still reports content-box dimensions.

### Known adjacent defect — deliberately *not* fixed here

On the `immediate` path, `contentRect` is sourced from `getBoundingClientRect()`, which is the **border** box and in viewport coordinates — while every subsequent observer entry reports the **content** box in padding-relative coordinates. So `useElementSize` on a padded element reports 40, then 30 on the first real resize.

That is a separate, pre-existing bug, orthogonal to #724, and fixing it would change numbers for `Carousel` and `Overflow`. I left `contentRect` byte-identical and kept this PR purely additive. Worth its own issue.

## Verification

Actual output, run in the worktree:

- `pnpm build:0` — `Done!`
- `pnpm typecheck` — `packages/0`, `packages/paper`, `packages/genesis` all `Done`
- `pnpm test:run` — **180 files passed, 6465 passed | 3 skipped**, zero stderr
- `pnpm lint` — clean
- `pnpm build:docs` — `[vite-ssg] Build finished.`

### Tests

`index.browser.test.ts` (new, real Chromium — happy-dom has no layout engine, so box-model assertions are meaningless there): 8 tests covering border-box vs content-box on a padded+bordered element, the exact padding+border delta, an unpadded element where both agree, updated sizes on resize, immediate-vs-observer agreement, vertical writing mode, and the `useElementSize` regression guard.

`index.test.ts`: added a unit test asserting the native arrays are forwarded rather than dropped; updated the two assertions that pinned the exact immediate-entry shape.

## Blocked downstream

- vuetifyjs/vuetify#23041 slice 2 — `VVirtualScrollItem` is a border-box consumer; the v0 migration would otherwise silently switch it to content height and mis-size the scroller.
- `VFooter`, same observer slice.
- vuetifyjs/vuetify#23029's transform-safe measurement had no v0 equivalent to land on; `borderBoxSize` is now that equivalent.