### PR TITLE
chore(playground): make the active file visible in the file tree

### DIFF
--- a/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
@@ -423,7 +423,7 @@
           v-else
           :aria-expanded="!isFile(id) ? tree.opened(id) : undefined"
           :aria-selected="current(id) ? true : undefined"
-          class="group/row flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer select-none hover:bg-[color-mix(in_srgb,var(--v0-on-surface),transparent_94%)] transition-colors"
+          class="group/row flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer select-none rounded-s-md hover:bg-[color-mix(in_srgb,var(--v0-on-surface),transparent_94%)] transition-colors"
           :class="current(id) ? 'opacity-100 !bg-[color-mix(in_srgb,var(--v0-primary),transparent_88%)]' : isConfig(id) ? 'opacity-50' : 'opacity-80'"
           :data-id="id"
           role="treeitem"

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorFileTree.vue
@@ -139,6 +139,10 @@
     return VALID_EXT.test(id)
   }
 
+  function current (id: string) {
+    return isFile(id) && id === activeFile.value
+  }
+
   function fileExt (id: string) {
     const ext = id.split('.').pop()
     return ext ? EXT_ICONS[ext] : undefined
@@ -418,9 +422,9 @@
         <div
           v-else
           :aria-expanded="!isFile(id) ? tree.opened(id) : undefined"
-          :aria-selected="isFile(id) && id === activeFile ? true : undefined"
-          class="group/row flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer select-none hover:bg-surface-tint transition-colors"
-          :class="isFile(id) && id === activeFile ? 'opacity-100 bg-surface-tint' : isConfig(id) ? 'opacity-50' : 'opacity-80'"
+          :aria-selected="current(id) ? true : undefined"
+          class="group/row flex items-center gap-1.5 py-1 pr-2 text-sm cursor-pointer select-none hover:bg-[color-mix(in_srgb,var(--v0-on-surface),transparent_94%)] transition-colors"
+          :class="current(id) ? 'opacity-100 !bg-[color-mix(in_srgb,var(--v0-primary),transparent_88%)]' : isConfig(id) ? 'opacity-50' : 'opacity-80'"
           :data-id="id"
           role="treeitem"
           :style="{ paddingInlineStart: `${depth * 8 + 8}px` }"
@@ -452,7 +456,7 @@
             <span v-else class="w-[14px]" />
           </template>
 
-          <span class="flex-1 truncate" :class="isFile(id) ? 'opacity-80' : 'font-medium opacity-60'">
+          <span class="flex-1 truncate" :class="current(id) ? 'font-medium opacity-100' : isFile(id) ? 'opacity-80' : 'font-medium opacity-60'">
             {{ tree.get(id)?.value }}
           </span>
 


### PR DESCRIPTION
## Description

The file panel's active-file highlight was invisible. The active row painted `bg-surface-tint` — the exact color the panel's `<nav>` already uses for its own background — so the selected file rendered identically to every other row. `hover:bg-surface-tint` was a no-op for the same reason.

Active rows now paint a 12%-alpha `--v0-primary` tint and hover a 6%-alpha `--v0-on-surface` wash, both via `color-mix`, so they track the theme in light and dark instead of hardcoding a shade. The active state carries `!` so it wins over hover, and an active row's label goes to full opacity — which also un-dims a config file (normally `opacity-50`) while it's the one being edited.

Extracted the repeated `isFile(id) && id === activeFile` predicate into `current(id)`, now used by the row class, the label class, and `aria-selected`.

## Verification

Driven in a real browser against `pnpm dev:play`; computed styles read off the live DOM:

- **Light** — panel `#eeeef0`, active row `oklab(0.623 -0.033 -0.185 / 0.12)` — distinct (screenshot confirms a visible band).
- **Dark** — panel `#2a2a2a`, active row `oklab(0.811 0.041 -0.093 / 0.12)` — distinct.
- **Hover** — inactive row picks up the 6% wash (previously no change at all).
- **Active + hover** — active tint holds; hover does not override it.
- **Switching files** — clicked `src/main.ts`; `aria-selected` and the tint moved with it, and its config dimming lifted from `0.5` to `1`.

ESLint clean.