### PR TITLE
fix(useProxyModel): hold a model value whose ticket has not registered

### DIFF
--- a/.changeset/fix-proxy-model-deferred-value-revert.md
+++ b/.changeset/fix-proxy-model-deferred-value-revert.md
@@ -1,0 +1,9 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useProxyModel): keep a v-model value whose item has not rendered yet
+
+Setting a v-model to a value whose item registers later — selecting a tab that is only rendered once it becomes active, or an option in a list that has not mounted — was immediately reverted to the previous selection. `useProxyModel` already defers such values so late-registering items resolve them, but the same tick wrote the old selection back over the model, discarding the value before its item could register. When the model is a writable `computed`, that write ran the setter, so the revert also fired the consumer's own side effects.
+
+Values with no registered item are now held until their item registers; a value whose item exists but was refused (disabled, or blocked by `mandatory`) still reverts as before.

--- a/packages/0/src/composables/useProxyModel/index.test.ts
+++ b/packages/0/src/composables/useProxyModel/index.test.ts
@@ -274,13 +274,35 @@ describe('useProxyModel', () => {
 
     selection.onboard([
       { id: 'item-1', value: 'value-1' },
+      { id: 'item-2', value: 'value-2', disabled: true },
     ])
 
-    // Try to assign a longer array — only known value selects; mandatory
-    // rejects clearing, so the actual selection doesn't change. The shallowEqual
-    // length-check forces a reset.
-    model.value = ['value-1', 'unknown']
+    // Try to assign a longer array — the extra value has a registered ticket that
+    // apply refuses because it is disabled, so the rejection is final rather than
+    // deferred. The shallowEqual length-check forces a reset.
+    model.value = ['value-1', 'value-2']
     expect(model.value).toEqual(['value-1'])
+  })
+
+  it('should hold a value whose ticket has not registered instead of reverting it', () => {
+    const selection = createSelection({ events: true, mandatory: true, multiple: true })
+    const model = ref<string[]>(['value-1'])
+    useProxyModel(selection, model, { multiple: true })
+
+    selection.onboard([
+      { id: 'item-1', value: 'value-1' },
+    ])
+
+    // 'value-2' is unregistered, so it is deferred rather than rejected — reverting
+    // here would discard the caller's intent before its ticket can register.
+    model.value = ['value-1', 'value-2']
+    expect(model.value).toEqual(['value-1', 'value-2'])
+
+    selection.onboard([
+      { id: 'item-2', value: 'value-2' },
+    ])
+
+    expect(Array.from(selection.selectedValues.value)).toEqual(['value-1', 'value-2'])
   })
 
   it('should not resurrect a stale value the model dropped before its ticket registered', () => {

--- a/packages/0/src/composables/useProxyModel/index.ts
+++ b/packages/0/src/composables/useProxyModel/index.ts
@@ -50,6 +50,7 @@ export interface ProxyModelTarget {
   selectedValues: { readonly value: Iterable<unknown> }
   apply: (values: unknown[], options?: { multiple?: boolean }) => void
   select?: (id: string | number) => void
+  browse?: (value: unknown) => readonly (string | number)[] | undefined
   multiple?: MaybeRefOrGetter<boolean>
   on?: (event: string, cb: (data: unknown) => void) => void
   off?: (event: string, cb: (data: unknown) => void) => void
@@ -106,13 +107,20 @@ export function useProxyModel (
   // so late registration reflects the CURRENT model, never a stale initial value.
   const pending = new Set<unknown>()
 
+  // An unselected value is only deferred when nothing has registered under it.
+  // If a ticket exists, the context refused it (disabled, mandatory) and the
+  // rejection is final — deferring would leave the model waiting forever.
+  function deferred (value: unknown) {
+    return !context.browse?.(value)?.length
+  }
+
   function reconcile (values: unknown[]) {
     context.apply(values, applyOptions)
 
     const selected = new Set(context.selectedValues.value)
     pending.clear()
     for (const value of values) {
-      if (!selected.has(value)) pending.add(value)
+      if (!selected.has(value) && deferred(value)) pending.add(value)
     }
   }
 
@@ -146,9 +154,14 @@ export function useProxyModel (
     syncing = true
     contextWatch.pause()
     reconcile(transformIn(val))
-    // Sync model back to actual selection state (apply may have rejected due to disabled/mandatory)
-    const actual = transformOut(Array.from(context.selectedValues.value))
-    if (!shallowEqual(val, actual)) model.value = actual
+    // Sync model back to actual selection state (apply may have rejected due to disabled/mandatory).
+    // Pending values are unregistered rather than rejected, so writing back here would discard the
+    // caller's intent before onRegister can resolve it — and for a model backed by a setter, the
+    // write echoes back as a fresh change that clears `pending` outright.
+    if (pending.size === 0) {
+      const actual = transformOut(Array.from(context.selectedValues.value))
+      if (!shallowEqual(val, actual)) model.value = actual
+    }
     contextWatch.resume()
     syncing = false
   }, { flush: 'sync', deep: toValue(multiple) })


### PR DESCRIPTION
## Description

Reported as: clicking a file in the v0play file panel that is not currently open in the tabs does nothing. The root cause is in `useProxyModel`, not the playground.

Setting a v-model to a value whose ticket has not registered yet is a supported case — `useProxyModel` parks it in `pending` so the `register:ticket` handler can resolve it once the item mounts. But the same synchronous tick then wrote the context's *current* selection back over the model:

```ts
const actual = transformOut(Array.from(context.selectedValues.value))
if (!shallowEqual(val, actual)) model.value = actual
```

That discards the caller's intent before registration can happen. The comment says the write-back covers `apply` rejecting for disabled/mandatory, but the code could not tell a **rejected** value from a merely **unregistered** one.

Where the model is a writable `computed` — the shape the playground uses, mapping the model onto `store.setActive()` — it is worse than a flicker: the write-back runs the setter, which is a real state change that echoes back as a fresh model change. That second pass runs `reconcile` again and clears `pending`, so when the tab finally registers, `onRegister` no longer has anything to resolve and the selection never moves.

Traced in the browser, clicking a closed file produced exactly that:

```
modelWatch { val: 'src/Second.vue', actual: 'src/App.vue', pending: ['src/Second.vue'] }
modelWatch { val: 'src/App.vue',    actual: 'src/App.vue', pending: [] }   <- echo clears pending
onRegister { value: 'src/Second.vue', pending: [], hit: false }            <- too late
```

## Fix

Distinguish deferred from rejected using the registry's existing value reverse-lookup (`browse`): a value with no registered ticket is held, and the write-back is skipped while anything is pending. A value whose ticket **does** exist but was refused (disabled, or blocked by `mandatory`) still reverts exactly as before. Targets without `browse` (e.g. the slider context) keep the previous behavior.

## Verification

Browser, against `pnpm dev:play`, both cases that were broken:

- Creating a new file now activates it (previously the tree and tabs both snapped back to `App.vue`).
- Closing a tab and re-clicking that file in the tree now activates it.
- Clicking a file that already had a tab still works.

Suites: `v0:unit` 4645 passed, `v0:browser` 1695 passed, `pnpm typecheck` clean.

One existing test changed. `should treat arrays of different length as not equal` used an *unregistered* value as a convenient way to make the array lengths differ, and asserted it was stripped — which is the bug this PR fixes, and contradicts the `pending`/`onRegister` machinery directly below it. It now uses a registered-but-disabled ticket, so it still exercises the `shallowEqual` length-check branch but against a genuine rejection. A regression test for the deferred case was added alongside it.