### PR TITLE
fix(useProxyModel): accept contexts that narrow browse's value type

### DIFF
--- a/packages/0/src/composables/useProxyModel/index.ts
+++ b/packages/0/src/composables/useProxyModel/index.ts
@@ -34,6 +34,7 @@ import { isArray, isFunction } from '#v0/utilities'
 import { onScopeDispose, toValue, watch } from 'vue'
 
 // Types
+import type { ID } from '#v0/types'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 
 export interface ProxyModelOptions {
@@ -50,7 +51,10 @@ export interface ProxyModelTarget {
   selectedValues: { readonly value: Iterable<unknown> }
   apply: (values: unknown[], options?: { multiple?: boolean }) => void
   select?: (id: string | number) => void
-  browse?: (value: unknown) => readonly (string | number)[] | undefined
+  // Contexts type browse by their own ticket value — Slider's is a
+  // ShallowRef<number> — so an `unknown` parameter here would reject them under
+  // contravariance. `never` accepts any of them; the call site widens instead.
+  browse?: (value: never) => readonly ID[] | undefined
   multiple?: MaybeRefOrGetter<boolean>
   on?: (event: string, cb: (data: unknown) => void) => void
   off?: (event: string, cb: (data: unknown) => void) => void
@@ -111,7 +115,7 @@ export function useProxyModel (
   // If a ticket exists, the context refused it (disabled, mandatory) and the
   // rejection is final — deferring would leave the model waiting forever.
   function deferred (value: unknown) {
-    return !context.browse?.(value)?.length
+    return !context.browse?.(value as never)?.length
   }
 
   function reconcile (values: unknown[]) {


### PR DESCRIPTION
Fixes the `typecheck` failure on `master` introduced by #727.

## The break

#727 added `browse?: (value: unknown) => …` to `ProxyModelTarget`. Under `strictFunctionTypes` a *function-typed property* is checked contravariantly, so a context whose `browse` narrows the value type no longer satisfies the interface:

```
Types of property 'browse' are incompatible.
  Type '(value: ShallowRef<number> | undefined) => readonly ID[] | undefined'
    is not assignable to type '(value: unknown) => readonly (string | number)[] | undefined'.
      Type 'unknown' is not assignable to type 'ShallowRef<number> | undefined'.
```

`createRegistry` types it `browse: (value: E['value']) => readonly ID[] | undefined`, and both `ProgressContext` and `SliderContext` key their tickets on a `ShallowRef<number>` — so `ProgressRoot.vue:104` and `SliderRoot.vue:190` both fail.

`master` is currently red on `typecheck` at adaace94d, which also takes down the Release workflow and every open PR.

## The fix

Method shorthand would give bivariant parameters and fix this outright, but the repo forbids it (`@typescript-eslint/method-signature-style`). Instead `browse` takes `never`, which every concrete implementation satisfies contravariantly, and the single call site widens with an explicit cast — putting the unsoundness at the one spot that is actually unsound (we call `browse` with a model value of unknown type; a miss just returns `undefined`) rather than in the shared contract.

The return type is also named `ID` rather than a restated `string | number`, matching `createRegistry.browse`.

No changeset: #727 is unreleased and its own changeset covers the feature, and a parameter-variance annotation is mechanism, not release-note copy.