### PR TITLE
chore(bench): record why BASELINE_ANCHOR_HZ must not be captured on GHA

### DIFF
--- a/scripts/check-benchmark-artifacts.ts
+++ b/scripts/check-benchmark-artifacts.ts
@@ -108,7 +108,8 @@ function main (): void {
       console.warn(
         '[check-benchmark-artifacts] warning: no calibration baseline stored yet — numbers are raw. '
         + 'Capture `apparatus.anchors` into BASELINE_ANCHOR_HZ (scripts/lib/calibration.ts) to enable '
-        + 'host normalization.',
+        + 'host normalization — on the dedicated reference host, never from a GHA run '
+        + '(see .claude/specs/2026-07-24-dedicated-bench-host.md §6).',
       )
     }
   }

--- a/scripts/lib/calibration.ts
+++ b/scripts/lib/calibration.ts
@@ -52,22 +52,8 @@ export const ANCHOR_COUNT = 13
  * records `scale: 1, baseline: null`, so the pipeline behaves exactly as it
  * does today and nothing is silently rescaled.
  *
- * Do NOT capture this from a GHA run, however tempting a green metrics-regen
- * artifact looks. `runs-on: ubuntu-24.04` pins the image, not the CPU: the pool
- * spans ~1.9x in single-thread throughput across at least two vendors whose
- * anchors do not differ by a scalar (0.55–0.86 per-anchor, Xeon 6973P-C to EPYC
- * 7763), so a capture freezes whichever host that draw happened to land on. A
- * median of three GHA runs does not fix it either — with two vendors in three
- * draws the median just selects the majority vendor. An in-flight GHA capture
- * was halted for exactly this reason on 2026-07-24.
- *
- * The baseline belongs on the dedicated reference host. Capture procedure and
- * its acceptance bar — three runs agreeing within ±2% aggregate, no single
- * anchor beyond ±5% — are in `.claude/specs/2026-07-24-dedicated-bench-host.md`
- * §6. For reference, GHA does not clear that bar even against itself: the
- * committed 1.0.0/1.0.1 history anchors sit 0.99x/0.92x from the current
- * benchmarks.json anchors measured in the same job on the same host, worst
- * anchor 0.78x.
+ * Capture it on the dedicated reference host, never from a GHA run — procedure
+ * and acceptance bar in `.claude/specs/2026-07-24-dedicated-bench-host.md` §6.
  *
  * Changing these numbers re-defines the unit for the whole history series —
  * treat it as a deliberate re-baseline, never a tweak.

--- a/scripts/lib/calibration.ts
+++ b/scripts/lib/calibration.ts
@@ -45,17 +45,32 @@ export const ANCHOR_COUNT = 13
 /**
  * Anchor throughput (ops/s) on the reference run, keyed by bench name.
  *
- * `null` until a maintainer captures it from the first CI run of the anchor
- * suite, mirroring the `since: null` convention in maturity.json — the value is
- * only knowable once the measurement has actually happened on the reference
- * host, and guessing it would ossify a fictional unit. While null, `computeScale`
- * returns 1 and every artifact records `scale: 1, baseline: null`, so the
- * pipeline behaves exactly as it does today and nothing is silently rescaled.
+ * `null` until a maintainer captures it on the reference host, mirroring the
+ * `since: null` convention in maturity.json — the value is only knowable once
+ * the measurement has actually happened, and guessing it would ossify a
+ * fictional unit. While null, `computeScale` returns 1 and every artifact
+ * records `scale: 1, baseline: null`, so the pipeline behaves exactly as it
+ * does today and nothing is silently rescaled.
  *
- * To capture: run metrics-regen, read `apparatus.anchors` out of the produced
- * benchmarks.json, paste it here, and re-run so every snapshot is expressed in
- * the new unit. Changing these numbers re-defines the unit for the whole
- * history series — treat it as a deliberate re-baseline, never a tweak.
+ * Do NOT capture this from a GHA run, however tempting a green metrics-regen
+ * artifact looks. `runs-on: ubuntu-24.04` pins the image, not the CPU: the pool
+ * spans ~1.9x in single-thread throughput across at least two vendors whose
+ * anchors do not differ by a scalar (0.55–0.86 per-anchor, Xeon 6973P-C to EPYC
+ * 7763), so a capture freezes whichever host that draw happened to land on. A
+ * median of three GHA runs does not fix it either — with two vendors in three
+ * draws the median just selects the majority vendor. An in-flight GHA capture
+ * was halted for exactly this reason on 2026-07-24.
+ *
+ * The baseline belongs on the dedicated reference host. Capture procedure and
+ * its acceptance bar — three runs agreeing within ±2% aggregate, no single
+ * anchor beyond ±5% — are in `.claude/specs/2026-07-24-dedicated-bench-host.md`
+ * §6. For reference, GHA does not clear that bar even against itself: the
+ * committed 1.0.0/1.0.1 history anchors sit 0.99x/0.92x from the current
+ * benchmarks.json anchors measured in the same job on the same host, worst
+ * anchor 0.78x.
+ *
+ * Changing these numbers re-defines the unit for the whole history series —
+ * treat it as a deliberate re-baseline, never a tweak.
  */
 export const BASELINE_ANCHOR_HZ: Record<string, number> | null = null
 


### PR DESCRIPTION
## What

Comment-and-warning-text only. `BASELINE_ANCHOR_HZ` stays `null`, `computeScale` still returns 1, no artifact changes.

## Why

The doc comment on `BASELINE_ANCHOR_HZ` currently reads:

> To capture: run metrics-regen, read `apparatus.anchors` out of the produced benchmarks.json, paste it here…

Followed literally, that arms v0's benchmark unit off a GitHub Actions runner — which `.claude/specs/2026-07-24-dedicated-bench-host.md` §6 had already ruled out three days ago ("the in-flight GHA median-of-three capture was **halted rather than committed**"). The instruction and the decision disagree, and the instruction is the one a maintainer reads at the moment of temptation. `metrics:check`'s warning had the same gap — it named the constant but not the host.

Evidence the spec establishes, now cited at the constant:

- `runs-on: ubuntu-24.04` pins the image, not the CPU; the pool spans ~1.9x single-thread throughput.
- At least two vendors, and they do not differ by a scalar: 0.55–0.86 per-anchor Xeon 6973P-C → EPYC 7763. One scale factor cannot describe that.
- A median of three GHA runs does not help — with two vendors in three draws, the median selects the majority vendor, not a typical host.

Measured here on the committed artifacts, GHA also fails the spec's own acceptance bar (±2% aggregate, ±5% worst anchor) against *itself* — same job, same host, same runner image:

| comparison | trimmed gmean | per-anchor spread | worst anchor |
|---|---:|---:|---:|
| `1.0.0.json` (runs:1) vs `benchmarks.json` (runs:3) | 0.9909 | 0.916–1.015 | a06 map build 0.916 |
| `1.0.1.json` (runs:1) vs `benchmarks.json` (runs:3) | 0.9151 | 0.776–1.016 | a09 string build 0.776 |
| `1.0.1` vs `1.0.0` (both runs:1) | 0.9274 | 0.805–1.006 | a12 grouped aggregate 0.805 |

Part of that is 1-run vs 3-run median noise rather than host disagreement — but `metrics:history` snapshots *are* `runs:1`, so it is the noise the baseline would actually be asked to correct.

## Notes

- No changeset: `scripts/` only, and `changeset-reminder.js` gates on `packages/*/src/`. Ships no package version → `master` train, `chore` type.
- Verified: `node scripts/check-benchmark-artifacts.ts` exits 0 and emits the amended warning; eslint clean on both files.