### PR TITLE
chore(ci): stop scoping coverage by file type so no source falls between jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,11 +40,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      # Coverage is scoped to .ts (composables/utilities/plugins); component
-      # .vue coverage comes from the browser job below and Codecov merges the
-      # two flagged uploads into one project total.
+      # No --coverage.include override: both jobs report the full source set
+      # from the root vitest.config.ts and Codecov unions the two flagged
+      # uploads per line. Scoping this job to .ts hid every .vue belonging to a
+      # component tested in v0:unit rather than v0:browser (36 files across 8
+      # components had an SF: entry in neither report). The v8 provider only
+      # emits records for files a run actually loaded, so a wide include costs
+      # this job nothing — it does not backfill untouched files at 0%.
       - name: Run unit tests with coverage
-        run: pnpm test:run --coverage --project '!v0:browser' --coverage.include='packages/0/src/**/*.ts'
+        run: pnpm test:run --coverage --project '!v0:browser'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -80,10 +84,13 @@ jobs:
         run: pnpm exec playwright install chromium
       - name: Install Playwright system dependencies
         run: pnpm exec playwright install-deps chromium
-      # Coverage scoped to component .vue; composable .ts coverage comes from the
-      # unit job. Uploaded under the `browser` flag so Codecov merges the two.
+      # Uploaded under the `browser` flag so Codecov merges it with the unit
+      # flag. Scoping this job to component .vue threw away every .ts line a
+      # *.browser.test.ts was the only test to exercise, which is what forced
+      # PR #725 to duplicate its browser assertions as unit tests to recover
+      # codecov/patch (70.83% -> 100%). Keep the include wide.
       - name: Run component tests with coverage
-        run: pnpm exec vitest run --project v0:browser --coverage --coverage.include='packages/0/src/components/**/*.vue'
+        run: pnpm exec vitest run --project v0:browser --coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/packages/0/vitest.config.ts
+++ b/packages/0/vitest.config.ts
@@ -50,16 +50,11 @@ export default defineConfig({
     exclude: ['**/*.browser.test.{ts,tsx}'],
     setupFiles: ['./vitest.setup.ts'],
     testTimeout: 20_000,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json-summary'],
-      reportsDirectory: 'packages/0/coverage',
-      include: ['packages/0/src/**/*.{ts,vue}'],
-      exclude: [
-        '**/*.{test,spec,bench}.?(c|m)[jt]s',
-        '**/index.ts',
-        'packages/0/src/maturity.json',
-      ],
-    },
+    // No `coverage` block here on purpose. Vitest resolves coverage from the
+    // root config only; a project-level block is silently inert. The one that
+    // used to live here excluded `**/index.ts`, which is where every composable
+    // implementation lives (composables/<name>/index.ts) — had it ever been
+    // honoured it would have zeroed the bulk of the report. Coverage include /
+    // exclude belongs in the root vitest.config.ts.
   },
 })


### PR DESCRIPTION
## Problem

`pr-checks.yml` splits coverage collection by file extension:

| job | `--coverage.include` |
|---|---|
| `test` (unit) | `packages/0/src/**/*.ts` |
| `browser` | `packages/0/src/components/**/*.vue` |

That encodes an assumption — `.ts` is tested in `v0:unit`, `.vue` in `v0:browser` — that the repo does not honour in either direction.

### Direction 1 — `.vue` tested in `v0:unit` is invisible to both jobs

Eight components ship an `index.test.ts` (unit project) rather than an `index.browser.test.ts`. Their `.vue` files match neither job's include, so they have **no `SF:` entry in either lcov report** despite being tested:

| component | `.vue` files unmeasured |
|---|---|
| Carousel | 8 |
| NumberField | 7 |
| Progress | 7 |
| Image | 4 |
| Overflow | 3 |
| Rating | 3 |
| Tooltip | 3 |
| Locale | 1 |
| **total** | **36 of 172 (20.9%)** |

Measured for the first time, 30 of the 36 land at 100%. The six that do not are the layout-dependent ones, which is its own signal:

```
 83.33%   5/6    Progress/ProgressValue.vue
 84.62%  11/13   Tooltip/TooltipContent.vue
 89.11%  90/101  Carousel/CarouselViewport.vue
 93.10%  27/29   Overflow/OverflowRoot.vue
 95.24%  20/21   Overflow/OverflowItem.vue
 97.30%  36/37   Carousel/CarouselRoot.vue
```

### Direction 2 — `.ts` exercised only from a browser test is discarded

At `master` this is currently 4 lines (`createNested` 2, `createGroup` 1, `useStack` 1), so it looks harmless in aggregate — but it lands on `codecov/patch`, which is per-diff. It is exactly what happened to #725:

```
2a9856f  codecov/patch: failure — 70.83% of diff hit (target 96.40%)
a57c97c  codecov/patch: success — 100.00% of diff hit
```

The diff between those two commits is `useResizeObserver/index.test.ts | 126 +++++++++`. The fix for a coverage-config artifact was 126 lines of unit test duplicating what `index.browser.test.ts` already asserted.

## Fix

Drop both `--coverage.include` overrides. Each job reports the full source set from the root `vitest.config.ts`, and Codecov unions the two flagged uploads per line.

This is safe because the v8 provider does not backfill files a run never loaded — verified: the browser run emits 136 `SF:` records for 172 matching `.vue` files, not 172 at 0%. A wide include therefore costs the browser job nothing.

Also removes the `coverage` block from `packages/0/vitest.config.ts`. Vitest resolves coverage from the root config only, so a project-level block is silently inert — verified by the fact that composable `index.ts` files appear in the report despite that block excluding `**/index.ts`. Had it ever been honoured it would have zeroed most of the report, since every composable implementation lives at `composables/<name>/index.ts`. Better deleted than left as a config that lies about what it does.

## Why globs and not test placement

The blind spot is entirely a measurement artifact — all 36 files are already tested. Moving those eight components into `v0:browser` would change no coverage number, would add Chromium runtime, and would remove them from the pre-push hook, which runs `--project '!v0:browser'`. Test placement should follow what a test needs (real layout or not), not what the coverage config can see; making the globs match reality keeps that decision free.

## Verification

Both CI commands run locally at this branch, with the two lcov reports merged under Codecov's hit/partial/miss model:

```
OLD (current CI):    96.58%  hits=7478 partials=214 misses=51  files=259
NEW (wide includes): 96.38%  hits=8209 partials=243 misses=65  files=295
```

The model reproduces Codecov's last reported project total (96.41%) to within rounding, which is what gives confidence in the projection.

**Expect `codecov/project` to report roughly -0.19pp on this PR.** That is not a regression — it is 774 previously unmeasured lines entering the denominator, six of them genuinely partially covered. The alternative is keeping a number that is 0.19pp too flattering because a fifth of the component surface is not being looked at. No `codecov.yml` threshold is being added to hide it; the baseline resets on merge.

`pnpm lint`, `pnpm typecheck` and `pnpm repo:check` are clean.

## Follow-up (not this PR)

`Overflow`, `Carousel` and `Tooltip` are the components whose newly-visible gaps are concentrated in width/layout measurement, and they are tested in happy-dom. Worth revisiting whether those specific tests belong in `v0:browser` on their own merits.