### PR TITLE
test: add advisory axe-core accessibility sweep for every component

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -99,13 +99,15 @@ jobs:
   # Automated accessibility audit: axe-core over every component, mounted in the
   # shape its own @example JSDoc documents, in the same real Chromium the
   # browser job uses. Advisory on purpose — see the header comment in
-  # packages/0/src/components/a11y.browser.test.ts. Delete `continue-on-error`
-  # to make it a gate once the count reaches zero.
+  # packages/0/src/components/a11y.browser.test.ts.
+  #
+  # Gate (two edits, not one): assert on `violations` in the sweep file, then
+  # drop `continue-on-error` below once the count reaches zero. Manifest and
+  # render smoke still fail hard via the `browser` job (same `*.browser.test.ts`).
   #
   # Its own job rather than a step on `browser` so the breakdown gets its own
-  # step summary instead of being buried under the coverage upload, and so a
-  # future flip to blocking is a one-line change. Same cache key as `browser`,
-  # so Chromium restores rather than re-downloads.
+  # step summary instead of being buried under the coverage upload. Same cache
+  # key as `browser`, so Chromium restores rather than re-downloads.
   a11y:
     needs: prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -96,6 +96,54 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+  # Automated accessibility audit: axe-core over every component, mounted in the
+  # shape its own @example JSDoc documents, in the same real Chromium the
+  # browser job uses. Advisory on purpose — see the header comment in
+  # packages/0/src/components/a11y.browser.test.ts. Delete `continue-on-error`
+  # to make it a gate once the count reaches zero.
+  #
+  # Its own job rather than a step on `browser` so the breakdown gets its own
+  # step summary instead of being buried under the coverage upload, and so a
+  # future flip to blocking is a one-line change. Same cache key as `browser`,
+  # so Chromium restores rather than re-downloads.
+  a11y:
+    needs: prepare
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Cache Playwright browser
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-1.61.0-${{ runner.os }}
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
+      # --reporter=verbose because the default reporter swallows console output
+      # from browser tests, and the report the sweep prints is the deliverable.
+      - name: Run accessibility sweep
+        run: |
+          set -o pipefail
+          pnpm exec vitest run --project v0:browser --reporter=verbose \
+            packages/0/src/components/a11y.browser.test.ts 2>&1 | tee a11y.log
+      - name: Publish violation breakdown
+        if: always()
+        run: |
+          set -uo pipefail
+          {
+            echo '## Accessibility audit (advisory)'
+            echo
+            echo '```'
+            awk '/--- v0 a11y report ---/{flag=1; next} /--- end v0 a11y report ---/{flag=0} flag' a11y.log \
+              || echo 'No report in the run log — the sweep failed before afterAll ran.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Upload success ≠ processed report. Codecov queues OK then sometimes leaves
   # commit state/totals null (badge graph → "unknown"). Surface that here so we
   # don't ship a green CI over a dark coverage signal. Non-blocking: processing

--- a/apps/docs/src/pages/guide/features/accessibility.md
+++ b/apps/docs/src/pages/guide/features/accessibility.md
@@ -124,6 +124,20 @@ it('passes accessibility audit', async () => {
 })
 ```
 
+`vitest-axe` is a Node package — it reaches for `node:module` on import, so it works in a jsdom or happy-dom test environment and not in Vitest's browser mode. If your components are tested in a real browser, drop the wrapper and call `axe-core` directly:
+
+```ts MyComponent.browser.test.ts
+import axe from 'axe-core'
+
+it('passes accessibility audit', async () => {
+  const { container } = render(MyComponent)
+  const results = await axe.run(container)
+  expect(results.violations).toEqual([])
+})
+```
+
+Prefer the browser form where you can. Layout-dependent rules — colour contrast, target size, element overlap — need real computed styles, and a simulated DOM either skips them or answers from a layout that does not exist. v0 audits its own components this way; see `packages/0/src/components/a11y.browser.test.ts`.
+
 ### Manual Testing Checklist
 
 Use this checklist during manual QA:

--- a/packages/0/package.json
+++ b/packages/0/package.json
@@ -157,6 +157,7 @@
     "@vitest/browser-playwright": "catalog:",
     "@vue/compiler-dom": "catalog:",
     "@vue/test-utils": "catalog:",
+    "axe-core": "catalog:",
     "launchdarkly-js-client-sdk": "catalog:",
     "posthog-js": "catalog:",
     "tsdown": "catalog:",

--- a/packages/0/src/components/a11y.browser.test.ts
+++ b/packages/0/src/components/a11y.browser.test.ts
@@ -11,6 +11,17 @@ import CarouselFixture from './fixtures/Carousel.vue'
 import CheckboxFixture from './fixtures/Checkbox.vue'
 import CollapsibleFixture from './fixtures/Collapsible.vue'
 import ComboboxFixture from './fixtures/Combobox.vue'
+import AlertDialogDegenerate from './fixtures/degenerate/AlertDialog.vue'
+import AvatarDegenerate from './fixtures/degenerate/Avatar.vue'
+import ButtonDegenerate from './fixtures/degenerate/Button.vue'
+import CheckboxDegenerate from './fixtures/degenerate/Checkbox.vue'
+import ComboboxDegenerate from './fixtures/degenerate/Combobox.vue'
+import DialogDegenerate from './fixtures/degenerate/Dialog.vue'
+import ImageDegenerate from './fixtures/degenerate/Image.vue'
+import InputDegenerate from './fixtures/degenerate/Input.vue'
+import RadioDegenerate from './fixtures/degenerate/Radio.vue'
+import SwitchDegenerate from './fixtures/degenerate/Switch.vue'
+import ToggleDegenerate from './fixtures/degenerate/Toggle.vue'
 import DialogFixture from './fixtures/Dialog.vue'
 import ExpansionPanelFixture from './fixtures/ExpansionPanel.vue'
 import FormFixture from './fixtures/Form.vue'
@@ -71,6 +82,12 @@ import type { AxeViolation } from './fixtures/audit'
  * 35 test files that already assert `aria-*` by hand are not replaced by this —
  * they check the attribute the author remembered; this checks the ones nobody
  * thought to.
+ *
+ * Two passes, counted and reported separately. `FIXTURES` is the documented
+ * shape — the number a consumer following the docs would hit. `DEGENERATE` is
+ * that same shape with a documented-*optional* part removed, which is where the
+ * defects that actually ship live; see its own docblock for the membership rule
+ * and for why the two counts are not summed.
  *
  * The sweep does not fail on violations. The first pass is red by design: the
  * open a11y batch (#608, #611-#616) was found by manual audit *after* those 35
@@ -135,6 +152,57 @@ const FIXTURES: Record<string, unknown> = {
 }
 
 /**
+ * Degenerate shapes — the second half of #732's open question.
+ *
+ * `FIXTURES` above audits each component in the shape its own `@example`
+ * documents, and a documented example is written by someone thinking about the
+ * example. The failure mode that actually ships is the *omission*: the optional
+ * sub-component nobody mounted, the optional prop nobody passed. #608 is
+ * exactly that — `Dialog.Content` emits `aria-labelledby={titleId}` whether or
+ * not `Dialog.Title` exists — and the canonical sweep only caught its Progress
+ * half by the accident that Progress's own example happens to omit the label.
+ *
+ * The membership rule, so this map does not drift into a grab bag: a component
+ * earns a degenerate fixture when its canonical fixture supplies an accessible
+ * name, or mounts a labelling sub-component, that the API leaves optional. The
+ * fixture is that same shape with the optional part removed and nothing else
+ * changed.
+ *
+ * Components whose canonical fixture *already* omits its optional name are
+ * absent by that rule, not by oversight — NumberField, Progress, Rating,
+ * Select and Slider are degenerate as documented, which is why they are in the
+ * first-pass count already.
+ *
+ * These are consumer mistakes, not v0 defects, and a headless library cannot
+ * stop a consumer from omitting a name. What the sweep is asking is narrower
+ * and is v0's problem: does the component *degrade* to a merely-unnamed widget,
+ * or does it degrade to a broken one — a dangling IDREF, a role stripped of a
+ * property it requires? The first is the consumer's to fix. The second is ours,
+ * and it is invisible from the documented shape.
+ *
+ * Reported separately from the canonical count below so the headline number
+ * stays the one a consumer following the docs would hit.
+ */
+const DEGENERATE: Record<string, unknown> = {
+  AlertDialog: AlertDialogDegenerate,
+  Avatar: AvatarDegenerate,
+  Button: ButtonDegenerate,
+  Checkbox: CheckboxDegenerate,
+  Combobox: ComboboxDegenerate,
+  Dialog: DialogDegenerate,
+  Image: ImageDegenerate,
+  Input: InputDegenerate,
+  Radio: RadioDegenerate,
+  Switch: SwitchDegenerate,
+  Toggle: ToggleDegenerate,
+}
+
+/** Distinguishes the two passes in the report; `summarize` groups by subject. */
+function degenerate (name: string) {
+  return `${name} (degenerate)`
+}
+
+/**
  * Shipped components, per maturity.json — the same registry that drives the
  * docs badges. `draft` entries are planned components with no source yet.
  * Deriving the expected set from it rather than from this file is what makes
@@ -164,13 +232,86 @@ function dedupe (collected: AxeViolation[]) {
 }
 
 const violations: AxeViolation[] = []
+const omissions: AxeViolation[] = []
 
 afterAll(() => {
-  // Single place the count is published. Fenced by markers so the `a11y` job
-  // can lift it out of the run log and into the GitHub step summary without
+  // Single place the counts are published. Fenced by markers so the `a11y` job
+  // can lift them out of the run log and into the GitHub step summary without
   // the sweep needing filesystem access it does not have — it runs in Chromium.
-  console.log(`\n${REPORT_START}\n${summarize(violations)}\n${REPORT_END}\n`)
+  // Both sections sit inside one fence; the job's awk lifts the whole block.
+  console.log(
+    `\n${REPORT_START}\n` +
+    `${summarize(violations)}\n\n` +
+    `--- degenerate shapes (documented-optional parts omitted) ---\n` +
+    `${summarize(omissions)}\n` +
+    `${REPORT_END}\n`,
+  )
 })
+
+/**
+ * Mount one fixture into a `<main>` landmark, audit it collapsed and expanded,
+ * and return what axe found alongside the number of elements the fixture put on
+ * the page — the caller asserts on that, because a fixture that renders nothing
+ * passes every axe rule silently.
+ *
+ * A bare `<div>` hung off `<body>` is not a page, and axe is right to say so —
+ * every component would otherwise report `region` ("all content must be
+ * contained by landmarks") for markup the component does not own. The `<main>`
+ * fixes the actual defect rather than turning the rule off, so the published
+ * count stays the components' own.
+ */
+async function sweep (subject: string, fixture: unknown) {
+  const container = document.createElement('main')
+  document.body.append(container)
+
+  const before = document.body.querySelectorAll('*').length
+
+  const wrapper = mount(fixture as any, {
+    attachTo: container,
+    global: {
+      plugins: [
+        createStackPlugin(),
+        createLocalePlugin(),
+        createRtlPlugin(),
+        createTooltipPlugin(),
+        createNotificationsPlugin(),
+        createThemePlugin({
+          default: 'light',
+          themes: {
+            light: { dark: false, colors: { primary: '#1976d2' } },
+            dark: { dark: true, colors: { primary: '#90caf9' } },
+          },
+        }),
+      ],
+    },
+  })
+
+  await settle()
+
+  const rendered = document.body.querySelectorAll('*').length - before
+
+  // document.body, not wrapper.element: Dialog, Popover, Select, Combobox,
+  // Tooltip and Snackbar teleport their content out of the mount point, and
+  // that content is where most of their ARIA lives.
+  const collected = await audit(subject, document.body)
+
+  // Audit the expanded state too. Select and Combobox own their open state
+  // internally — there is no prop to start them open — so the only way to see
+  // the listbox markup is to press the thing a user would press. Roots that
+  // expose an open v-model are already mounted open by their fixture.
+  const trigger = document.body.querySelector<HTMLElement>('[aria-expanded="false"]')
+
+  if (trigger) {
+    trigger.click()
+    await settle()
+    collected.push(...await audit(subject, document.body))
+  }
+
+  wrapper.unmount()
+  container.remove()
+
+  return { rendered, violations: dedupe(collected) }
+}
 
 describe('accessibility sweep', () => {
   it('should have a fixture for every shipped component', () => {
@@ -184,67 +325,36 @@ describe('accessibility sweep', () => {
     expect({ missing, orphaned }).toEqual({ missing: [], orphaned: [] })
   })
 
+  it('should base every degenerate shape on a canonical fixture', () => {
+    // Deliberately not a completeness check — degenerate shapes are opt-in, and
+    // most components have no optional name to remove. What must hold is that a
+    // degenerate shape is a *delta* against a documented one: without the
+    // canonical fixture beside it there is no baseline, and a violation it
+    // reports cannot be attributed to the omission rather than to the component.
+    const orphaned = Object.keys(DEGENERATE).filter(name => !(name in FIXTURES)).toSorted()
+
+    expect(orphaned).toEqual([])
+  })
+
   for (const [name, fixture] of Object.entries(FIXTURES)) {
     it(`should record axe violations for ${name}`, async () => {
-      // A bare `<div>` hung off `<body>` is not a page, and axe is right to say
-      // so — every component would otherwise report `region` ("all content must
-      // be contained by landmarks") for markup the component does not own. Give
-      // the harness a `<main>` landmark instead of turning the rule off, so the
-      // published count stays the components' own.
-      const container = document.createElement('main')
-      document.body.append(container)
+      const result = await sweep(name, fixture)
 
-      const before = document.body.querySelectorAll('*').length
+      // The one thing asserted per fixture. Violations themselves are
+      // collected, not asserted — see the header comment.
+      expect(result.rendered).toBeGreaterThan(0)
 
-      const wrapper = mount(fixture as any, {
-        attachTo: container,
-        global: {
-          plugins: [
-            createStackPlugin(),
-            createLocalePlugin(),
-            createRtlPlugin(),
-            createTooltipPlugin(),
-            createNotificationsPlugin(),
-            createThemePlugin({
-              default: 'light',
-              themes: {
-                light: { dark: false, colors: { primary: '#1976d2' } },
-                dark: { dark: true, colors: { primary: '#90caf9' } },
-              },
-            }),
-          ],
-        },
-      })
+      violations.push(...result.violations)
+    })
+  }
 
-      await settle()
+  for (const [name, fixture] of Object.entries(DEGENERATE)) {
+    it(`should record axe violations for ${name} with its optional parts omitted`, async () => {
+      const result = await sweep(degenerate(name), fixture)
 
-      // A fixture that renders nothing passes every axe rule, silently. That is
-      // the one way this sweep could report a clean component while auditing an
-      // empty page, so it is the one thing asserted per fixture. Violations
-      // themselves are collected, not asserted — see the header comment.
-      expect(document.body.querySelectorAll('*').length).toBeGreaterThan(before)
+      expect(result.rendered).toBeGreaterThan(0)
 
-      // document.body, not wrapper.element: Dialog, Popover, Select, Combobox,
-      // Tooltip and Snackbar teleport their content out of the mount point, and
-      // that content is where most of their ARIA lives.
-      const collected = await audit(name, document.body)
-
-      // Audit the expanded state too. Select and Combobox own their open state
-      // internally — there is no prop to start them open — so the only way to
-      // see the listbox markup is to press the thing a user would press. Roots
-      // that expose an open v-model are already mounted open by their fixture.
-      const trigger = document.body.querySelector<HTMLElement>('[aria-expanded="false"]')
-
-      if (trigger) {
-        trigger.click()
-        await settle()
-        collected.push(...await audit(name, document.body))
-      }
-
-      violations.push(...dedupe(collected))
-
-      wrapper.unmount()
-      container.remove()
+      omissions.push(...result.violations)
     })
   }
 })

--- a/packages/0/src/components/a11y.browser.test.ts
+++ b/packages/0/src/components/a11y.browser.test.ts
@@ -1,0 +1,250 @@
+import { afterAll, describe, expect, it } from 'vitest'
+
+// Context
+import AlertDialogFixture from './fixtures/AlertDialog.vue'
+import AspectRatioFixture from './fixtures/AspectRatio.vue'
+import AtomFixture from './fixtures/Atom.vue'
+import AvatarFixture from './fixtures/Avatar.vue'
+import BreadcrumbsFixture from './fixtures/Breadcrumbs.vue'
+import ButtonFixture from './fixtures/Button.vue'
+import CarouselFixture from './fixtures/Carousel.vue'
+import CheckboxFixture from './fixtures/Checkbox.vue'
+import CollapsibleFixture from './fixtures/Collapsible.vue'
+import ComboboxFixture from './fixtures/Combobox.vue'
+import DialogFixture from './fixtures/Dialog.vue'
+import ExpansionPanelFixture from './fixtures/ExpansionPanel.vue'
+import FormFixture from './fixtures/Form.vue'
+import GroupFixture from './fixtures/Group.vue'
+import ImageFixture from './fixtures/Image.vue'
+import InputFixture from './fixtures/Input.vue'
+import LocaleFixture from './fixtures/Locale.vue'
+import NumberFieldFixture from './fixtures/NumberField.vue'
+import OverflowFixture from './fixtures/Overflow.vue'
+import PaginationFixture from './fixtures/Pagination.vue'
+import PopoverFixture from './fixtures/Popover.vue'
+import PortalFixture from './fixtures/Portal.vue'
+import PresenceFixture from './fixtures/Presence.vue'
+import ProgressFixture from './fixtures/Progress.vue'
+import RadioFixture from './fixtures/Radio.vue'
+import RatingFixture from './fixtures/Rating.vue'
+import ScrimFixture from './fixtures/Scrim.vue'
+import SelectFixture from './fixtures/Select.vue'
+import SelectionFixture from './fixtures/Selection.vue'
+import SingleFixture from './fixtures/Single.vue'
+import SliderFixture from './fixtures/Slider.vue'
+import SnackbarFixture from './fixtures/Snackbar.vue'
+import SplitterFixture from './fixtures/Splitter.vue'
+import StepFixture from './fixtures/Step.vue'
+import SwitchFixture from './fixtures/Switch.vue'
+import TabsFixture from './fixtures/Tabs.vue'
+import ThemeFixture from './fixtures/Theme.vue'
+import ToggleFixture from './fixtures/Toggle.vue'
+import TooltipFixture from './fixtures/Tooltip.vue'
+import TreeviewFixture from './fixtures/Treeview.vue'
+
+// Composables
+import { createStackPlugin } from '#v0/composables/useStack'
+
+import {
+  createLocalePlugin,
+  createNotificationsPlugin,
+  createRtlPlugin,
+  createThemePlugin,
+  createTooltipPlugin,
+} from '#v0/composables'
+import maturity from '#v0/maturity.json'
+
+import { audit, REPORT_END, REPORT_START, summarize } from './fixtures/audit'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// Types
+import type { AxeViolation } from './fixtures/audit'
+
+/**
+ * Advisory accessibility sweep.
+ *
+ * Every shipped component is mounted in the shape its own `@example` JSDoc
+ * tells users to write, then handed to axe-core running in real Chromium. The
+ * 35 test files that already assert `aria-*` by hand are not replaced by this —
+ * they check the attribute the author remembered; this checks the ones nobody
+ * thought to.
+ *
+ * The sweep does not fail on violations. The first pass is red by design: the
+ * open a11y batch (#608, #611-#616) was found by manual audit *after* those 35
+ * files passed, and #608 and #613 map onto stock axe rules. Gating on day one
+ * buys either a red master or a pile of rule suppressions written to deadline,
+ * and a suppression written to get CI green is a permanently invisible
+ * violation. This reports; the burn-down happens in its own PRs; the gate goes
+ * on by deleting `continue-on-error` from the `a11y` job in pr-checks.yml and
+ * asserting on `violations` here.
+ *
+ * axe-core direct rather than `vitest-axe`, which the accessibility guide
+ * recommends to users: `vitest-axe` reaches for `node:module` at import time
+ * and cannot load in browser mode at either 0.1.0 or 1.0.0-pre.5. It is a
+ * jsdom/happy-dom tool. Running the audit where layout is simulated is the
+ * thing this sweep exists to avoid, so the wrapper goes and the engine stays.
+ */
+
+// One fixture per shipped component. Listed rather than globbed, matching the
+// explicit-array convention in src/surface.test.ts — a component entering or
+// leaving the sweep should be a reviewable diff, not a side effect of a glob.
+const FIXTURES: Record<string, unknown> = {
+  AlertDialog: AlertDialogFixture,
+  AspectRatio: AspectRatioFixture,
+  Atom: AtomFixture,
+  Avatar: AvatarFixture,
+  Breadcrumbs: BreadcrumbsFixture,
+  Button: ButtonFixture,
+  Carousel: CarouselFixture,
+  Checkbox: CheckboxFixture,
+  Collapsible: CollapsibleFixture,
+  Combobox: ComboboxFixture,
+  Dialog: DialogFixture,
+  ExpansionPanel: ExpansionPanelFixture,
+  Form: FormFixture,
+  Group: GroupFixture,
+  Image: ImageFixture,
+  Input: InputFixture,
+  Locale: LocaleFixture,
+  NumberField: NumberFieldFixture,
+  Overflow: OverflowFixture,
+  Pagination: PaginationFixture,
+  Popover: PopoverFixture,
+  Portal: PortalFixture,
+  Presence: PresenceFixture,
+  Progress: ProgressFixture,
+  Radio: RadioFixture,
+  Rating: RatingFixture,
+  Scrim: ScrimFixture,
+  Select: SelectFixture,
+  Selection: SelectionFixture,
+  Single: SingleFixture,
+  Slider: SliderFixture,
+  Snackbar: SnackbarFixture,
+  Splitter: SplitterFixture,
+  Step: StepFixture,
+  Switch: SwitchFixture,
+  Tabs: TabsFixture,
+  Theme: ThemeFixture,
+  Toggle: ToggleFixture,
+  Tooltip: TooltipFixture,
+  Treeview: TreeviewFixture,
+}
+
+/**
+ * Shipped components, per maturity.json — the same registry that drives the
+ * docs badges. `draft` entries are planned components with no source yet.
+ * Deriving the expected set from it rather than from this file is what makes
+ * the manifest check below load-bearing: promoting a component out of draft
+ * without writing it a fixture fails the sweep.
+ */
+const SHIPPED = Object.entries(maturity.components)
+  .filter(([, entry]) => entry.level !== 'draft')
+  .map(([name]) => name)
+  .toSorted()
+
+/** Let Vue flush, then let the browser paint, so axe sees settled layout. */
+function settle () {
+  return nextTick().then(() => new Promise(resolve => requestAnimationFrame(resolve)))
+}
+
+/** The same violation found in both the collapsed and expanded pass is one violation. */
+function dedupe (collected: AxeViolation[]) {
+  const seen = new Map<string, AxeViolation>()
+
+  for (const violation of collected) {
+    const key = `${violation.rule}::${violation.nodes.join('|')}`
+    if (!seen.has(key)) seen.set(key, violation)
+  }
+
+  return [...seen.values()]
+}
+
+const violations: AxeViolation[] = []
+
+afterAll(() => {
+  // Single place the count is published. Fenced by markers so the `a11y` job
+  // can lift it out of the run log and into the GitHub step summary without
+  // the sweep needing filesystem access it does not have — it runs in Chromium.
+  console.log(`\n${REPORT_START}\n${summarize(violations)}\n${REPORT_END}\n`)
+})
+
+describe('accessibility sweep', () => {
+  it('should have a fixture for every shipped component', () => {
+    const covered = Object.keys(FIXTURES)
+    const missing = SHIPPED.filter(name => !covered.includes(name))
+    const orphaned = covered.filter(name => !SHIPPED.includes(name)).toSorted()
+
+    // The one assertion in this file that is allowed to fail, and what makes
+    // the sweep a sweep: a component with no fixture is not a component that
+    // passed the audit.
+    expect({ missing, orphaned }).toEqual({ missing: [], orphaned: [] })
+  })
+
+  for (const [name, fixture] of Object.entries(FIXTURES)) {
+    it(`should record axe violations for ${name}`, async () => {
+      // A bare `<div>` hung off `<body>` is not a page, and axe is right to say
+      // so — every component would otherwise report `region` ("all content must
+      // be contained by landmarks") for markup the component does not own. Give
+      // the harness a `<main>` landmark instead of turning the rule off, so the
+      // published count stays the components' own.
+      const container = document.createElement('main')
+      document.body.append(container)
+
+      const before = document.body.querySelectorAll('*').length
+
+      const wrapper = mount(fixture as any, {
+        attachTo: container,
+        global: {
+          plugins: [
+            createStackPlugin(),
+            createLocalePlugin(),
+            createRtlPlugin(),
+            createTooltipPlugin(),
+            createNotificationsPlugin(),
+            createThemePlugin({
+              default: 'light',
+              themes: {
+                light: { dark: false, colors: { primary: '#1976d2' } },
+                dark: { dark: true, colors: { primary: '#90caf9' } },
+              },
+            }),
+          ],
+        },
+      })
+
+      await settle()
+
+      // A fixture that renders nothing passes every axe rule, silently. That is
+      // the one way this sweep could report a clean component while auditing an
+      // empty page, so it is the one thing asserted per fixture. Violations
+      // themselves are collected, not asserted — see the header comment.
+      expect(document.body.querySelectorAll('*').length).toBeGreaterThan(before)
+
+      // document.body, not wrapper.element: Dialog, Popover, Select, Combobox,
+      // Tooltip and Snackbar teleport their content out of the mount point, and
+      // that content is where most of their ARIA lives.
+      const collected = await audit(name, document.body)
+
+      // Audit the expanded state too. Select and Combobox own their open state
+      // internally — there is no prop to start them open — so the only way to
+      // see the listbox markup is to press the thing a user would press. Roots
+      // that expose an open v-model are already mounted open by their fixture.
+      const trigger = document.body.querySelector<HTMLElement>('[aria-expanded="false"]')
+
+      if (trigger) {
+        trigger.click()
+        await settle()
+        collected.push(...await audit(name, document.body))
+      }
+
+      violations.push(...dedupe(collected))
+
+      wrapper.unmount()
+      container.remove()
+    })
+  }
+})

--- a/packages/0/src/components/a11y.browser.test.ts
+++ b/packages/0/src/components/a11y.browser.test.ts
@@ -73,6 +73,7 @@ import { nextTick } from 'vue'
 
 // Types
 import type { AxeViolation } from './fixtures/audit'
+import type { Component } from 'vue'
 
 /**
  * Advisory accessibility sweep.
@@ -94,21 +95,27 @@ import type { AxeViolation } from './fixtures/audit'
  * files passed, and #608 and #613 map onto stock axe rules. Gating on day one
  * buys either a red master or a pile of rule suppressions written to deadline,
  * and a suppression written to get CI green is a permanently invisible
- * violation. This reports; the burn-down happens in its own PRs; the gate goes
- * on by deleting `continue-on-error` from the `a11y` job in pr-checks.yml and
- * asserting on `violations` here.
+ * violation. This reports; the burn-down happens in its own PRs. To gate: assert
+ * on `violations` here **and** drop `continue-on-error` from the `a11y` job in
+ * pr-checks.yml (two edits, not one).
  *
- * axe-core direct rather than `vitest-axe`, which the accessibility guide
- * recommends to users: `vitest-axe` reaches for `node:module` at import time
- * and cannot load in browser mode at either 0.1.0 or 1.0.0-pre.5. It is a
- * jsdom/happy-dom tool. Running the audit where layout is simulated is the
- * thing this sweep exists to avoid, so the wrapper goes and the engine stays.
+ * axe-core direct rather than `vitest-axe`: the accessibility guide still shows
+ * `vitest-axe` for jsdom/happy-dom, and documents `axe-core` for browser mode.
+ * `vitest-axe` reaches for `node:module` at import time and cannot load in
+ * browser mode. Running the audit where layout is simulated is the thing this
+ * sweep exists to avoid, so the wrapper goes and the engine stays.
+ *
+ * Open strategies (fixtures force open where the API allows; the rest expand here):
+ * - Dialog / Popover / Tooltip / Collapsible / ExpansionPanel / AlertDialog — `v-model` open in fixture
+ * - Treeview — `open-all` in fixture (flip lives on Activator, not the treeitem)
+ * - Select — click `[aria-expanded="false"]`
+ * - Combobox — **focus** the combobox control (`openOn: 'focus'`), not click
  */
 
 // One fixture per shipped component. Listed rather than globbed, matching the
 // explicit-array convention in src/surface.test.ts — a component entering or
 // leaving the sweep should be a reviewable diff, not a side effect of a glob.
-const FIXTURES: Record<string, unknown> = {
+const FIXTURES = {
   AlertDialog: AlertDialogFixture,
   AspectRatio: AspectRatioFixture,
   Atom: AtomFixture,
@@ -149,7 +156,7 @@ const FIXTURES: Record<string, unknown> = {
   Toggle: ToggleFixture,
   Tooltip: TooltipFixture,
   Treeview: TreeviewFixture,
-}
+} as const satisfies Record<string, Component>
 
 /**
  * Degenerate shapes — the second half of #732's open question.
@@ -165,25 +172,24 @@ const FIXTURES: Record<string, unknown> = {
  * The membership rule, so this map does not drift into a grab bag: a component
  * earns a degenerate fixture when its canonical fixture supplies an accessible
  * name, or mounts a labelling sub-component, that the API leaves optional. The
- * fixture is that same shape with the optional part removed and nothing else
- * changed.
+ * fixture is that same shape with the primary optional name/labelling surface
+ * removed.
  *
  * Components whose canonical fixture *already* omits its optional name are
- * absent by that rule, not by oversight — NumberField, Progress, Rating,
- * Select and Slider are degenerate as documented, which is why they are in the
- * first-pass count already.
+ * absent by that rule, not by oversight — NumberField, Progress, Rating, and
+ * Slider are degenerate as documented, which is why they are in the first-pass
+ * count already.
  *
- * These are consumer mistakes, not v0 defects, and a headless library cannot
- * stop a consumer from omitting a name. What the sweep is asking is narrower
- * and is v0's problem: does the component *degrade* to a merely-unnamed widget,
- * or does it degrade to a broken one — a dangling IDREF, a role stripped of a
- * property it requires? The first is the consumer's to fix. The second is ours,
- * and it is invisible from the documented shape.
+ * The question is whether the component *degrades* to a merely-unnamed widget
+ * (consumer's fix) or to a broken one — a dangling IDREF, a role stripped of a
+ * required property (v0's fix). Dialog and AlertDialog without Title are the
+ * latter; nameless Button/Checkbox/etc. are the former. Both show up here so the
+ * report can distinguish them.
  *
  * Reported separately from the canonical count below so the headline number
  * stays the one a consumer following the docs would hit.
  */
-const DEGENERATE: Record<string, unknown> = {
+const DEGENERATE = {
   AlertDialog: AlertDialogDegenerate,
   Avatar: AvatarDegenerate,
   Button: ButtonDegenerate,
@@ -195,7 +201,7 @@ const DEGENERATE: Record<string, unknown> = {
   Radio: RadioDegenerate,
   Switch: SwitchDegenerate,
   Toggle: ToggleDegenerate,
-}
+} as const satisfies Partial<Record<keyof typeof FIXTURES, Component>>
 
 /** Distinguishes the two passes in the report; `summarize` groups by subject. */
 function degenerate (name: string) {
@@ -219,32 +225,88 @@ function settle () {
   return nextTick().then(() => new Promise(resolve => requestAnimationFrame(resolve)))
 }
 
+/**
+ * Strip open-state attrs so the same control audited collapsed and expanded
+ * does not count as two violations (e.g. Select activator `button-name`).
+ */
+function normalizeNode (html: string) {
+  return html
+    .replaceAll(/\s*aria-expanded="(?:true|false)"/gi, '')
+    .replaceAll(/\s*data-state="[^"]*"/gi, '')
+    .replaceAll(/\s*data-open(?:="[^"]*")?/gi, '')
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+}
+
 /** The same violation found in both the collapsed and expanded pass is one violation. */
 function dedupe (collected: AxeViolation[]) {
   const seen = new Map<string, AxeViolation>()
 
   for (const violation of collected) {
-    const key = `${violation.rule}::${violation.nodes.join('|')}`
+    const identity = violation.nodes.map(normalizeNode).toSorted().join('|')
+    const key = `${violation.subject}::${violation.rule}::${identity}`
     if (!seen.has(key)) seen.set(key, violation)
   }
 
   return [...seen.values()]
 }
 
+/**
+ * Open disclosures so listboxes / nested content enter the DOM.
+ * Returns whether anything newly expanded (for the unverified list).
+ */
+async function openDisclosures (): Promise<boolean> {
+  const before = document.body.querySelectorAll('[aria-expanded="true"]').length
+  const closed = [...document.body.querySelectorAll<HTMLElement>('[aria-expanded="false"]')]
+
+  for (const el of closed) {
+    // Combobox Control is an input and opens on focus (`openOn: 'focus'`).
+    // Select.Activator is role="combobox" on a *button* and opens on click —
+    // do not treat every combobox as focus-open.
+    if (el.matches('input, textarea')) {
+      el.focus()
+      continue
+    }
+
+    // Treeview: aria-expanded is on treeitem; flip is on the Activator child.
+    if (el.getAttribute('role') === 'treeitem') {
+      const activator = el.querySelector<HTMLElement>('button, [tabindex], a')
+      ;(activator ?? el).click()
+      continue
+    }
+
+    el.click()
+  }
+
+  await settle()
+
+  const after = document.body.querySelectorAll('[aria-expanded="true"]').length
+  const listbox = document.body.querySelector('[role="listbox"]')
+
+  return after > before || Boolean(listbox)
+}
+
 const violations: AxeViolation[] = []
 const omissions: AxeViolation[] = []
+/** Subjects that had a closed disclosure we failed to open — clean line is unverified. */
+const unverified: string[] = []
 
 afterAll(() => {
   // Single place the counts are published. Fenced by markers so the `a11y` job
   // can lift them out of the run log and into the GitHub step summary without
   // the sweep needing filesystem access it does not have — it runs in Chromium.
   // Both sections sit inside one fence; the job's awk lifts the whole block.
+  const unverifiedBlock = unverified.length > 0
+    ? `\nunverified open (do not treat clean as clean):\n${unverified.map(name => `  ${name}`).join('\n')}\n`
+    : ''
+
   console.log(
     `\n${REPORT_START}\n` +
     `${summarize(violations)}\n\n` +
     `--- degenerate shapes (documented-optional parts omitted) ---\n` +
-    `${summarize(omissions)}\n` +
-    `${REPORT_END}\n`,
+    `${summarize(omissions)}` +
+    unverifiedBlock +
+    `\n${REPORT_END}\n`,
   )
 })
 
@@ -258,15 +320,16 @@ afterAll(() => {
  * every component would otherwise report `region` ("all content must be
  * contained by landmarks") for markup the component does not own. The `<main>`
  * fixes the actual defect rather than turning the rule off, so the published
- * count stays the components' own.
+ * count stays the components' own. Portal still fires `region` correctly when
+ * it teleports outside the landmark.
  */
-async function sweep (subject: string, fixture: unknown) {
+async function sweep (subject: string, fixture: Component) {
   const container = document.createElement('main')
   document.body.append(container)
 
   const before = document.body.querySelectorAll('*').length
 
-  const wrapper = mount(fixture as any, {
+  const wrapper = mount(fixture, {
     attachTo: container,
     global: {
       plugins: [
@@ -295,15 +358,14 @@ async function sweep (subject: string, fixture: unknown) {
   // that content is where most of their ARIA lives.
   const collected = await audit(subject, document.body)
 
-  // Audit the expanded state too. Select and Combobox own their open state
-  // internally — there is no prop to start them open — so the only way to see
-  // the listbox markup is to press the thing a user would press. Roots that
-  // expose an open v-model are already mounted open by their fixture.
-  const trigger = document.body.querySelector<HTMLElement>('[aria-expanded="false"]')
+  // Audit the expanded state too. Select / Combobox own open state internally —
+  // there is no prop to start them open — so expand via openDisclosures().
+  // Roots that expose an open v-model (or open-all) are already mounted open.
+  const closed = document.body.querySelectorAll('[aria-expanded="false"]').length
 
-  if (trigger) {
-    trigger.click()
-    await settle()
+  if (closed > 0) {
+    const opened = await openDisclosures()
+    if (!opened) unverified.push(subject)
     collected.push(...await audit(subject, document.body))
   }
 
@@ -340,8 +402,6 @@ describe('accessibility sweep', () => {
     it(`should record axe violations for ${name}`, async () => {
       const result = await sweep(name, fixture)
 
-      // The one thing asserted per fixture. Violations themselves are
-      // collected, not asserted — see the header comment.
       expect(result.rendered).toBeGreaterThan(0)
 
       violations.push(...result.violations)

--- a/packages/0/src/components/fixtures/AlertDialog.vue
+++ b/packages/0/src/components/fixtures/AlertDialog.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { AlertDialog } from '../AlertDialog/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <AlertDialog.Root v-model="open">
+    <AlertDialog.Activator>Delete Item</AlertDialog.Activator>
+
+    <AlertDialog.Content>
+      <AlertDialog.Title>Are you sure?</AlertDialog.Title>
+      <AlertDialog.Description>This action cannot be undone.</AlertDialog.Description>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action>Confirm</AlertDialog.Action>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+</template>

--- a/packages/0/src/components/fixtures/AspectRatio.vue
+++ b/packages/0/src/components/fixtures/AspectRatio.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { AspectRatio } from '../AspectRatio/index'
+</script>
+
+<template>
+  <AspectRatio :ratio="16 / 9">
+    <img alt="A landscape" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+  </AspectRatio>
+</template>

--- a/packages/0/src/components/fixtures/Atom.vue
+++ b/packages/0/src/components/fixtures/Atom.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+  import { Atom } from '../Atom/index'
+</script>
+
+<template>
+  <Atom as="button">Click me</Atom>
+</template>

--- a/packages/0/src/components/fixtures/Avatar.vue
+++ b/packages/0/src/components/fixtures/Avatar.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+  import { Avatar } from '../Avatar/index'
+</script>
+
+<template>
+  <Avatar.Root>
+    <Avatar.Image alt="Jane Doe" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" />
+    <Avatar.Fallback>JD</Avatar.Fallback>
+  </Avatar.Root>
+</template>

--- a/packages/0/src/components/fixtures/Breadcrumbs.vue
+++ b/packages/0/src/components/fixtures/Breadcrumbs.vue
@@ -3,16 +3,32 @@
 </script>
 
 <template>
-  <Breadcrumbs.Root>
-    <Breadcrumbs.List>
+  <!--
+    Narrow root so Overflow selects the Ellipsis; without constraint capacity is
+    Infinity, Ellipsis stays hidden, and Activator never becomes a live disclosure.
+  -->
+  <Breadcrumbs.Root style="width: 6rem; overflow: hidden">
+    <Breadcrumbs.List style="display: flex; gap: 4px; overflow: hidden">
       <Breadcrumbs.Item text="Home">
         <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
       </Breadcrumbs.Item>
 
       <Breadcrumbs.Divider />
 
+      <Breadcrumbs.Ellipsis>
+        <Breadcrumbs.Activator />
+      </Breadcrumbs.Ellipsis>
+
+      <Breadcrumbs.Divider />
+
       <Breadcrumbs.Item text="Products">
         <Breadcrumbs.Link href="/products">Products</Breadcrumbs.Link>
+      </Breadcrumbs.Item>
+
+      <Breadcrumbs.Divider />
+
+      <Breadcrumbs.Item text="Electronics">
+        <Breadcrumbs.Link href="/electronics">Electronics</Breadcrumbs.Link>
       </Breadcrumbs.Item>
 
       <Breadcrumbs.Divider />

--- a/packages/0/src/components/fixtures/Breadcrumbs.vue
+++ b/packages/0/src/components/fixtures/Breadcrumbs.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+  import { Breadcrumbs } from '../Breadcrumbs/index'
+</script>
+
+<template>
+  <Breadcrumbs.Root>
+    <Breadcrumbs.List>
+      <Breadcrumbs.Item text="Home">
+        <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
+      </Breadcrumbs.Item>
+
+      <Breadcrumbs.Divider />
+
+      <Breadcrumbs.Item text="Products">
+        <Breadcrumbs.Link href="/products">Products</Breadcrumbs.Link>
+      </Breadcrumbs.Item>
+
+      <Breadcrumbs.Divider />
+
+      <Breadcrumbs.Item text="Shoes">
+        <Breadcrumbs.Page>Shoes</Breadcrumbs.Page>
+      </Breadcrumbs.Item>
+    </Breadcrumbs.List>
+  </Breadcrumbs.Root>
+</template>

--- a/packages/0/src/components/fixtures/Button.vue
+++ b/packages/0/src/components/fixtures/Button.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { Button } from '../Button/index'
+</script>
+
+<template>
+  <Button.Root>
+    <Button.Content>Click me</Button.Content>
+  </Button.Root>
+</template>

--- a/packages/0/src/components/fixtures/Carousel.vue
+++ b/packages/0/src/components/fixtures/Carousel.vue
@@ -10,5 +10,6 @@
 
     <Carousel.Previous>Previous</Carousel.Previous>
     <Carousel.Next>Next</Carousel.Next>
+    <Carousel.LiveRegion />
   </Carousel.Root>
 </template>

--- a/packages/0/src/components/fixtures/Carousel.vue
+++ b/packages/0/src/components/fixtures/Carousel.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+  import { Carousel } from '../Carousel/index'
+</script>
+
+<template>
+  <Carousel.Root circular>
+    <Carousel.Viewport>
+      <Carousel.Item v-for="i in 5" :key="i" :value="i">Slide {{ i }}</Carousel.Item>
+    </Carousel.Viewport>
+
+    <Carousel.Previous>Previous</Carousel.Previous>
+    <Carousel.Next>Next</Carousel.Next>
+  </Carousel.Root>
+</template>

--- a/packages/0/src/components/fixtures/Checkbox.vue
+++ b/packages/0/src/components/fixtures/Checkbox.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+  import { Checkbox } from '../Checkbox/index'
+</script>
+
+<template>
+  <label>
+    <Checkbox.Root>
+      <Checkbox.Indicator>&#10003;</Checkbox.Indicator>
+    </Checkbox.Root>
+    I agree to terms
+  </label>
+</template>

--- a/packages/0/src/components/fixtures/Collapsible.vue
+++ b/packages/0/src/components/fixtures/Collapsible.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Collapsible } from '../Collapsible/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Collapsible.Root v-model="open">
+    <Collapsible.Activator>
+      <Collapsible.Cue />
+      Toggle content
+    </Collapsible.Activator>
+
+    <Collapsible.Content>Content goes here.</Collapsible.Content>
+  </Collapsible.Root>
+</template>

--- a/packages/0/src/components/fixtures/Combobox.vue
+++ b/packages/0/src/components/fixtures/Combobox.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Combobox } from '../Combobox/index'
+
+  const selected = ref()
+  const items = [
+    { id: 'apple', label: 'Apple' },
+    { id: 'banana', label: 'Banana' },
+    { id: 'cherry', label: 'Cherry' },
+  ]
+</script>
+
+<template>
+  <Combobox.Root v-model="selected">
+    <Combobox.Activator>
+      <Combobox.Control placeholder="Search..." />
+      <Combobox.Cue />
+    </Combobox.Activator>
+
+    <Combobox.Content>
+      <Combobox.Item
+        v-for="item in items"
+        :id="item.id"
+        :key="item.id"
+        v-slot="{ attrs }"
+        :value="item.label"
+      >
+        <div v-bind="attrs">{{ item.label }}</div>
+      </Combobox.Item>
+
+      <Combobox.Empty>No results found</Combobox.Empty>
+    </Combobox.Content>
+  </Combobox.Root>
+</template>

--- a/packages/0/src/components/fixtures/Combobox.vue
+++ b/packages/0/src/components/fixtures/Combobox.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
   // Utilities
-  import { ref } from 'vue'
+  import { shallowRef } from 'vue'
 
   import { Combobox } from '../Combobox/index'
 
-  const selected = ref()
+  const selected = shallowRef()
   const items = [
     { id: 'apple', label: 'Apple' },
     { id: 'banana', label: 'Banana' },
@@ -20,14 +20,14 @@
     </Combobox.Activator>
 
     <Combobox.Content>
+      <!-- Item already binds option attrs on its Atom; do not re-spread. -->
       <Combobox.Item
         v-for="item in items"
         :id="item.id"
         :key="item.id"
-        v-slot="{ attrs }"
         :value="item.label"
       >
-        <div v-bind="attrs">{{ item.label }}</div>
+        {{ item.label }}
       </Combobox.Item>
 
       <Combobox.Empty>No results found</Combobox.Empty>

--- a/packages/0/src/components/fixtures/Dialog.vue
+++ b/packages/0/src/components/fixtures/Dialog.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Dialog } from '../Dialog/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Dialog.Root v-model="open">
+    <Dialog.Activator>Open Dialog</Dialog.Activator>
+
+    <Dialog.Content>
+      <Dialog.Title>Dialog Title</Dialog.Title>
+      <Dialog.Description>Dialog description text.</Dialog.Description>
+      <p>Dialog content goes here.</p>
+      <Dialog.Close>Close</Dialog.Close>
+    </Dialog.Content>
+  </Dialog.Root>
+</template>

--- a/packages/0/src/components/fixtures/ExpansionPanel.vue
+++ b/packages/0/src/components/fixtures/ExpansionPanel.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { ExpansionPanel } from '../ExpansionPanel/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <ExpansionPanel.Group>
+    <ExpansionPanel.Root v-model="open">
+      <ExpansionPanel.Header>
+        <ExpansionPanel.Activator>Click to expand</ExpansionPanel.Activator>
+      </ExpansionPanel.Header>
+
+      <ExpansionPanel.Content>Content goes here.</ExpansionPanel.Content>
+    </ExpansionPanel.Root>
+  </ExpansionPanel.Group>
+</template>

--- a/packages/0/src/components/fixtures/Form.vue
+++ b/packages/0/src/components/fixtures/Form.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Form } from '../Form/index'
+
+  const valid = shallowRef<boolean | null>(null)
+</script>
+
+<template>
+  <Form v-model="valid">
+    <button type="submit">Submit</button>
+    <button type="reset">Reset</button>
+  </Form>
+</template>

--- a/packages/0/src/components/fixtures/Group.vue
+++ b/packages/0/src/components/fixtures/Group.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Group } from '../Group/index'
+
+  const selected = ref([])
+</script>
+
+<template>
+  <Group.Root v-model="selected">
+    <Group.Item value="a">Option A</Group.Item>
+    <Group.Item value="b">Option B</Group.Item>
+  </Group.Root>
+</template>

--- a/packages/0/src/components/fixtures/Image.vue
+++ b/packages/0/src/components/fixtures/Image.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Image } from '../Image/index'
+</script>
+
+<template>
+  <Image.Root src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    <Image.Img alt="A photo" height="1" width="1" />
+    <Image.Placeholder>Loading...</Image.Placeholder>
+    <Image.Fallback>Failed to load</Image.Fallback>
+  </Image.Root>
+</template>

--- a/packages/0/src/components/fixtures/Input.vue
+++ b/packages/0/src/components/fixtures/Input.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Input } from '../Input/index'
+
+  const email = ref('')
+</script>
+
+<template>
+  <Input.Root v-model="email" label="Email">
+    <Input.Control />
+    <Input.Description>We'll never share your email.</Input.Description>
+
+    <Input.Error v-slot="{ errors }">
+      <span v-for="error in errors" :key="error">{{ error }}</span>
+    </Input.Error>
+  </Input.Root>
+</template>

--- a/packages/0/src/components/fixtures/Locale.vue
+++ b/packages/0/src/components/fixtures/Locale.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { Locale } from '../Locale/index'
+</script>
+
+<template>
+  <Locale locale="fr">
+    <p>Bonjour</p>
+  </Locale>
+</template>

--- a/packages/0/src/components/fixtures/NumberField.vue
+++ b/packages/0/src/components/fixtures/NumberField.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { NumberField } from '../NumberField/index'
+
+  const value = ref<number | null>(0)
+</script>
+
+<template>
+  <NumberField.Root v-model="value" :max="100" :min="0">
+    <NumberField.Decrement>-</NumberField.Decrement>
+    <NumberField.Control />
+    <NumberField.Increment>+</NumberField.Increment>
+  </NumberField.Root>
+</template>

--- a/packages/0/src/components/fixtures/Overflow.vue
+++ b/packages/0/src/components/fixtures/Overflow.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+  import { Overflow } from '../Overflow/index'
+
+  const tags = ['alpha', 'beta', 'gamma', 'delta']
+</script>
+
+<template>
+  <Overflow.Root style="display: flex; gap: 8px; overflow: hidden; width: 120px">
+    <Overflow.Item v-for="tag in tags" :key="tag">{{ tag }}</Overflow.Item>
+    <Overflow.Indicator v-slot="{ count }">+{{ count }} more</Overflow.Indicator>
+  </Overflow.Root>
+</template>

--- a/packages/0/src/components/fixtures/Pagination.vue
+++ b/packages/0/src/components/fixtures/Pagination.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Pagination } from '../Pagination/index'
+
+  const page = ref(1)
+</script>
+
+<template>
+  <Pagination.Root v-model="page" :size="100">
+    <Pagination.First />
+    <Pagination.Prev />
+    <Pagination.Item :value="1" />
+    <Pagination.Item :value="2" />
+    <Pagination.Ellipsis />
+    <Pagination.Next />
+    <Pagination.Last />
+  </Pagination.Root>
+</template>

--- a/packages/0/src/components/fixtures/Popover.vue
+++ b/packages/0/src/components/fixtures/Popover.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Popover } from '../Popover/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Popover.Root v-model="open">
+    <Popover.Activator>Click to toggle</Popover.Activator>
+    <Popover.Content>Popover content goes here.</Popover.Content>
+  </Popover.Root>
+</template>

--- a/packages/0/src/components/fixtures/Portal.vue
+++ b/packages/0/src/components/fixtures/Portal.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Portal } from '../Portal/index'
+</script>
+
+<template>
+  <Portal>
+    <template #default="{ zIndex }">
+      <div :style="{ zIndex }">Overlay content</div>
+    </template>
+  </Portal>
+</template>

--- a/packages/0/src/components/fixtures/Presence.vue
+++ b/packages/0/src/components/fixtures/Presence.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Presence } from '../Presence/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Presence v-slot="{ attrs }" v-model="open">
+    <div v-bind="attrs">Content</div>
+  </Presence>
+</template>

--- a/packages/0/src/components/fixtures/Progress.vue
+++ b/packages/0/src/components/fixtures/Progress.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Progress } from '../Progress/index'
+
+  const value = shallowRef(60)
+</script>
+
+<template>
+  <Progress.Root :model-value="value">
+    <Progress.Track>
+      <Progress.Fill />
+    </Progress.Track>
+
+    <Progress.Value />
+  </Progress.Root>
+</template>

--- a/packages/0/src/components/fixtures/Radio.vue
+++ b/packages/0/src/components/fixtures/Radio.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Radio } from '../Radio/index'
+
+  const selected = ref<string>()
+</script>
+
+<template>
+  <Radio.Group v-model="selected">
+    <label>
+      <Radio.Root value="a">
+        <Radio.Indicator>&#9679;</Radio.Indicator>
+      </Radio.Root>
+      Option A
+    </label>
+
+    <label>
+      <Radio.Root value="b">
+        <Radio.Indicator>&#9679;</Radio.Indicator>
+      </Radio.Root>
+      Option B
+    </label>
+  </Radio.Group>
+</template>

--- a/packages/0/src/components/fixtures/Rating.vue
+++ b/packages/0/src/components/fixtures/Rating.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Rating } from '../Rating/index'
+
+  const rating = shallowRef(0)
+</script>
+
+<template>
+  <Rating.Root v-model="rating">
+    <Rating.Item
+      v-for="i in 5"
+      :key="i"
+      v-slot="{ state }"
+      as="button"
+      :index="i"
+    >
+      {{ state === 'full' ? '&#9733;' : '&#9734;' }}
+    </Rating.Item>
+  </Rating.Root>
+</template>

--- a/packages/0/src/components/fixtures/Scrim.vue
+++ b/packages/0/src/components/fixtures/Scrim.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+  import { Scrim } from '../Scrim/index'
+</script>
+
+<template>
+  <Scrim style="position: fixed; inset: 0; background: rgba(0, 0, 0, 0.5)" />
+</template>

--- a/packages/0/src/components/fixtures/Select.vue
+++ b/packages/0/src/components/fixtures/Select.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Select } from '../Select/index'
+
+  const selected = ref()
+  const items = [
+    { id: 'apple', label: 'Apple' },
+    { id: 'banana', label: 'Banana' },
+    { id: 'cherry', label: 'Cherry' },
+  ]
+</script>
+
+<template>
+  <Select.Root v-model="selected">
+    <Select.Activator>
+      <Select.Value v-slot="{ selectedValue }">{{ selectedValue }}</Select.Value>
+      <Select.Placeholder>Pick a fruit</Select.Placeholder>
+    </Select.Activator>
+
+    <Select.Content>
+      <Select.Item
+        v-for="item in items"
+        :id="item.id"
+        :key="item.id"
+        v-slot="{ attrs }"
+        :value="item.label"
+      >
+        <div v-bind="attrs">{{ item.label }}</div>
+      </Select.Item>
+    </Select.Content>
+  </Select.Root>
+</template>

--- a/packages/0/src/components/fixtures/Select.vue
+++ b/packages/0/src/components/fixtures/Select.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
   // Utilities
-  import { ref } from 'vue'
+  import { shallowRef } from 'vue'
 
   import { Select } from '../Select/index'
 
-  const selected = ref()
+  const selected = shallowRef()
   const items = [
     { id: 'apple', label: 'Apple' },
     { id: 'banana', label: 'Banana' },
@@ -20,14 +20,17 @@
     </Select.Activator>
 
     <Select.Content>
+      <!--
+        Item already binds role="option" on its Atom. Do not re-spread attrs onto
+        a child — that is the double-fire hazard and produces nested options.
+      -->
       <Select.Item
         v-for="item in items"
         :id="item.id"
         :key="item.id"
-        v-slot="{ attrs }"
         :value="item.label"
       >
-        <div v-bind="attrs">{{ item.label }}</div>
+        {{ item.label }}
       </Select.Item>
     </Select.Content>
   </Select.Root>

--- a/packages/0/src/components/fixtures/Selection.vue
+++ b/packages/0/src/components/fixtures/Selection.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Selection } from '../Selection/index'
+
+  const selected = ref([])
+</script>
+
+<template>
+  <Selection.Root v-model="selected" multiple>
+    <Selection.Item v-slot="{ attrs }" value="a">
+      <button v-bind="attrs">Option A</button>
+    </Selection.Item>
+
+    <Selection.Item v-slot="{ attrs }" value="b">
+      <button v-bind="attrs">Option B</button>
+    </Selection.Item>
+  </Selection.Root>
+</template>

--- a/packages/0/src/components/fixtures/Single.vue
+++ b/packages/0/src/components/fixtures/Single.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Single } from '../Single/index'
+
+  const selected = ref()
+</script>
+
+<template>
+  <Single.Root v-model="selected">
+    <Single.Item value="option1">Option 1</Single.Item>
+    <Single.Item value="option2">Option 2</Single.Item>
+  </Single.Root>
+</template>

--- a/packages/0/src/components/fixtures/Slider.vue
+++ b/packages/0/src/components/fixtures/Slider.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Slider } from '../Slider/index'
+
+  const value = ref([50])
+</script>
+
+<template>
+  <Slider.Root v-model="value" :max="100" :min="0">
+    <Slider.Track>
+      <Slider.Range />
+    </Slider.Track>
+
+    <Slider.Thumb />
+  </Slider.Root>
+</template>

--- a/packages/0/src/components/fixtures/Snackbar.vue
+++ b/packages/0/src/components/fixtures/Snackbar.vue
@@ -3,14 +3,15 @@
 </script>
 
 <template>
+  <!--
+    Static portal shape (not Queue-over-empty-store). The queue example only
+    mounts Root when items exist; an empty notifications store would pass the
+    rendered>0 check on the portal shell and never audit status/alert or Close.
+  -->
   <Snackbar.Portal>
-    <Snackbar.Queue v-slot="{ items }">
-      <template v-for="item in items" :key="item.id">
-        <Snackbar.Root :id="item.id">
-          <Snackbar.Content>{{ item.subject }}</Snackbar.Content>
-          <Snackbar.Close />
-        </Snackbar.Root>
-      </template>
-    </Snackbar.Queue>
+    <Snackbar.Root>
+      <Snackbar.Content>Saved</Snackbar.Content>
+      <Snackbar.Close />
+    </Snackbar.Root>
   </Snackbar.Portal>
 </template>

--- a/packages/0/src/components/fixtures/Snackbar.vue
+++ b/packages/0/src/components/fixtures/Snackbar.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+  import { Snackbar } from '../Snackbar/index'
+</script>
+
+<template>
+  <Snackbar.Portal>
+    <Snackbar.Queue v-slot="{ items }">
+      <template v-for="item in items" :key="item.id">
+        <Snackbar.Root :id="item.id">
+          <Snackbar.Content>{{ item.subject }}</Snackbar.Content>
+          <Snackbar.Close />
+        </Snackbar.Root>
+      </template>
+    </Snackbar.Queue>
+  </Snackbar.Portal>
+</template>

--- a/packages/0/src/components/fixtures/Splitter.vue
+++ b/packages/0/src/components/fixtures/Splitter.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Splitter } from '../Splitter/index'
+</script>
+
+<template>
+  <Splitter.Root orientation="horizontal">
+    <Splitter.Panel :default-size="60" :min-size="20">Left content</Splitter.Panel>
+    <Splitter.Handle />
+    <Splitter.Panel :default-size="40" :min-size="20">Right content</Splitter.Panel>
+  </Splitter.Root>
+</template>

--- a/packages/0/src/components/fixtures/Step.vue
+++ b/packages/0/src/components/fixtures/Step.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Step } from '../Step/index'
+</script>
+
+<template>
+  <Step.Root>
+    <Step.Item value="account">Account</Step.Item>
+    <Step.Item value="profile">Profile</Step.Item>
+    <Step.Item value="review">Review</Step.Item>
+  </Step.Root>
+</template>

--- a/packages/0/src/components/fixtures/Switch.vue
+++ b/packages/0/src/components/fixtures/Switch.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Switch } from '../Switch/index'
+
+  const enabled = ref(false)
+</script>
+
+<template>
+  <label>
+    <Switch.Root v-model="enabled">
+      <Switch.Track>
+        <Switch.Thumb />
+      </Switch.Track>
+    </Switch.Root>
+    Enable notifications
+  </label>
+</template>

--- a/packages/0/src/components/fixtures/Tabs.vue
+++ b/packages/0/src/components/fixtures/Tabs.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Tabs } from '../Tabs/index'
+
+  const selected = ref('profile')
+</script>
+
+<template>
+  <Tabs.Root v-model="selected">
+    <Tabs.List label="Account settings">
+      <Tabs.Item value="profile">Profile</Tabs.Item>
+      <Tabs.Item value="password">Password</Tabs.Item>
+      <Tabs.Item disabled value="billing">Billing</Tabs.Item>
+    </Tabs.List>
+
+    <Tabs.Panel value="profile">Profile content</Tabs.Panel>
+    <Tabs.Panel value="password">Password content</Tabs.Panel>
+    <Tabs.Panel value="billing">Billing content</Tabs.Panel>
+  </Tabs.Root>
+</template>

--- a/packages/0/src/components/fixtures/Theme.vue
+++ b/packages/0/src/components/fixtures/Theme.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { Theme } from '../Theme/index'
+</script>
+
+<template>
+  <Theme theme="dark">
+    <p>Themed content</p>
+  </Theme>
+</template>

--- a/packages/0/src/components/fixtures/Toggle.vue
+++ b/packages/0/src/components/fixtures/Toggle.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+  import { Toggle } from '../Toggle/index'
+</script>
+
+<template>
+  <Toggle.Root>
+    <Toggle.Indicator>&#10003;</Toggle.Indicator>
+    Bold
+  </Toggle.Root>
+</template>

--- a/packages/0/src/components/fixtures/Tooltip.vue
+++ b/packages/0/src/components/fixtures/Tooltip.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Tooltip } from '../Tooltip/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Tooltip.Root v-model="open">
+    <Tooltip.Activator>Hover me</Tooltip.Activator>
+    <Tooltip.Content>Helpful description</Tooltip.Content>
+  </Tooltip.Root>
+</template>

--- a/packages/0/src/components/fixtures/Treeview.vue
+++ b/packages/0/src/components/fixtures/Treeview.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+  import { Treeview } from '../Treeview/index'
+</script>
+
+<template>
+  <Treeview.Root>
+    <Treeview.List>
+      <Treeview.Item>
+        <Treeview.Activator>Documents</Treeview.Activator>
+
+        <Treeview.Content>
+          <Treeview.Group>
+            <Treeview.Item>
+              <Treeview.Activator>Resume.pdf</Treeview.Activator>
+            </Treeview.Item>
+          </Treeview.Group>
+        </Treeview.Content>
+      </Treeview.Item>
+    </Treeview.List>
+  </Treeview.Root>
+</template>

--- a/packages/0/src/components/fixtures/Treeview.vue
+++ b/packages/0/src/components/fixtures/Treeview.vue
@@ -3,7 +3,8 @@
 </script>
 
 <template>
-  <Treeview.Root>
+  <!-- open-all so nested treeitems are in the DOM for the audit (expand is on Activator, not the treeitem). -->
+  <Treeview.Root open-all>
     <Treeview.List>
       <Treeview.Item>
         <Treeview.Activator>Documents</Treeview.Activator>

--- a/packages/0/src/components/fixtures/audit.ts
+++ b/packages/0/src/components/fixtures/audit.ts
@@ -1,0 +1,127 @@
+import axe from 'axe-core'
+
+// Types
+import type { AxeResults, ElementContext, Result, RunOptions } from 'axe-core'
+
+/** Fences the report in the run log so the `a11y` CI job can lift it out verbatim. */
+export const REPORT_START = '--- v0 a11y report ---'
+export const REPORT_END = '--- end v0 a11y report ---'
+
+/**
+ * A single axe-core violation, flattened to the shape the sweep reports on.
+ */
+export interface AxeViolation {
+  /** Fixture the violation was found in — a component directory name. */
+  subject: string
+  /** axe-core rule id, e.g. `aria-valid-attr-value`. */
+  rule: string
+  impact: string
+  help: string
+  helpUrl: string
+  /** One entry per offending element, as an html snippet. */
+  nodes: string[]
+}
+
+/**
+ * Rules axe-core only makes sense of when it is looking at a whole document:
+ * landmarks, page title, `<html lang>`, a single `<h1>`. The sweep mounts one
+ * component into a bare container, so these fire on structure the component
+ * does not own and cannot fix.
+ *
+ * Nothing here is disabled. The sweep runs every rule axe-core ships and
+ * reports everything it finds; this list only lets the summary separate
+ * "the component is wrong" from "the harness is not a page", so that the
+ * published count is not quietly inflated by the harness.
+ */
+const PAGE_LEVEL_RULES = new Set([
+  'bypass',
+  'document-title',
+  'html-has-lang',
+  'html-lang-valid',
+  'html-xml-lang-mismatch',
+  'landmark-one-main',
+  'page-has-heading-one',
+  'region',
+])
+
+/**
+ * Run axe-core over `element` and flatten the result.
+ *
+ * Deliberately passes no `rules` / `runOnly` option — an auditor configured
+ * down to the rules we already pass is not an auditor.
+ */
+export async function audit (
+  subject: string,
+  element: ElementContext,
+  options: RunOptions = {},
+): Promise<AxeViolation[]> {
+  const results: AxeResults = await axe.run(element, options)
+
+  return results.violations.map((violation: Result) => ({
+    subject,
+    rule: violation.id,
+    impact: violation.impact ?? 'unknown',
+    help: violation.help,
+    helpUrl: violation.helpUrl,
+    nodes: violation.nodes.map(node => node.html),
+  }))
+}
+
+/**
+ * Render the collected violations as a per-rule breakdown, then a per-subject
+ * one. Printed by the sweep so the count lands in the CI log rather than in a
+ * reviewer's head.
+ */
+export function summarize (violations: AxeViolation[]): string {
+  if (violations.length === 0) return 'axe: no violations'
+
+  const byRule = new Map<string, AxeViolation[]>()
+  const bySubject = new Map<string, AxeViolation[]>()
+
+  for (const violation of violations) {
+    byRule.set(violation.rule, [...(byRule.get(violation.rule) ?? []), violation])
+    bySubject.set(violation.subject, [...(bySubject.get(violation.subject) ?? []), violation])
+  }
+
+  const lines: string[] = []
+  const elements = violations.reduce((total, violation) => total + violation.nodes.length, 0)
+
+  lines.push(
+    `axe: ${violations.length} violations (${elements} elements) across ` +
+    `${bySubject.size} components, ${byRule.size} distinct rules`,
+    '',
+    'by rule:',
+  )
+
+  const rules = [...byRule.entries()].toSorted((a, b) => b[1].length - a[1].length)
+
+  for (const [rule, hits] of rules) {
+    const nodes = hits.flatMap(hit => hit.nodes)
+    const scope = PAGE_LEVEL_RULES.has(rule) ? ' [page-level — check the harness before the component]' : ''
+    const subjects = [...new Set(hits.map(hit => hit.subject))].toSorted().join(', ')
+
+    lines.push(
+      `  ${rule} (${hits[0].impact}) — ${nodes.length} elements in ${subjects}${scope}`,
+      `      ${hits[0].help}`,
+      `      ${hits[0].helpUrl}`,
+      ...nodes.slice(0, 3).map(node => `      > ${node.replaceAll(/\s+/g, ' ').slice(0, 160)}`),
+    )
+  }
+
+  lines.push('', 'by component:')
+
+  const subjects = [...bySubject.entries()].toSorted((a, b) => b[1].length - a[1].length)
+
+  for (const [subject, hits] of subjects) {
+    const counted = [...new Set(hits.map(hit => hit.rule))]
+      .map(rule => {
+        const elements = hits.filter(hit => hit.rule === rule).flatMap(hit => hit.nodes).length
+        return elements > 1 ? `${rule} x${elements}` : rule
+      })
+      .toSorted()
+
+    lines.push(`  ${subject} — ${counted.join(', ')}`)
+  }
+
+  return lines.join('\n')
+}

--- a/packages/0/src/components/fixtures/audit.ts
+++ b/packages/0/src/components/fixtures/audit.ts
@@ -1,25 +1,28 @@
 import axe from 'axe-core'
 
 // Types
-import type { AxeResults, ElementContext, Result, RunOptions } from 'axe-core'
+import type { AxeResults, ElementContext, ImpactValue, Result, RunOptions } from 'axe-core'
 
 /** Fences the report in the run log so the `a11y` CI job can lift it out verbatim. */
 export const REPORT_START = '--- v0 a11y report ---'
 export const REPORT_END = '--- end v0 a11y report ---'
+
+/** axe impact plus the synthetic fallback when axe omits one. */
+export type AxeImpact = NonNullable<ImpactValue> | 'unknown'
 
 /**
  * A single axe-core violation, flattened to the shape the sweep reports on.
  */
 export interface AxeViolation {
   /** Fixture the violation was found in — a component directory name. */
-  subject: string
+  readonly subject: string
   /** axe-core rule id, e.g. `aria-valid-attr-value`. */
-  rule: string
-  impact: string
-  help: string
-  helpUrl: string
+  readonly rule: string
+  readonly impact: AxeImpact
+  readonly help: string
+  readonly helpUrl: string
   /** One entry per offending element, as an html snippet. */
-  nodes: string[]
+  readonly nodes: readonly string[]
 }
 
 /**
@@ -28,10 +31,14 @@ export interface AxeViolation {
  * component into a bare container, so these fire on structure the component
  * does not own and cannot fix.
  *
+ * `region` is intentionally **not** here. The harness wraps mounts in `<main>`
+ * so bulk `region` noise is gone; remaining hits (e.g. Portal teleported to
+ * `<body>`) are real placement findings — flag them as component/docs decisions,
+ * not harness noise.
+ *
  * Nothing here is disabled. The sweep runs every rule axe-core ships and
  * reports everything it finds; this list only lets the summary separate
- * "the component is wrong" from "the harness is not a page", so that the
- * published count is not quietly inflated by the harness.
+ * "the component is wrong" from "the harness is not a page".
  */
 const PAGE_LEVEL_RULES = new Set([
   'bypass',
@@ -41,7 +48,6 @@ const PAGE_LEVEL_RULES = new Set([
   'html-xml-lang-mismatch',
   'landmark-one-main',
   'page-has-heading-one',
-  'region',
 ])
 
 /**
@@ -60,7 +66,7 @@ export async function audit (
   return results.violations.map((violation: Result) => ({
     subject,
     rule: violation.id,
-    impact: violation.impact ?? 'unknown',
+    impact: (violation.impact ?? 'unknown') as AxeImpact,
     help: violation.help,
     helpUrl: violation.helpUrl,
     nodes: violation.nodes.map(node => node.html),
@@ -72,7 +78,7 @@ export async function audit (
  * one. Printed by the sweep so the count lands in the CI log rather than in a
  * reviewer's head.
  */
-export function summarize (violations: AxeViolation[]): string {
+export function summarize (violations: readonly AxeViolation[]): string {
   if (violations.length === 0) return 'axe: no violations'
 
   const byRule = new Map<string, AxeViolation[]>()
@@ -101,9 +107,9 @@ export function summarize (violations: AxeViolation[]): string {
     const subjects = [...new Set(hits.map(hit => hit.subject))].toSorted().join(', ')
 
     lines.push(
-      `  ${rule} (${hits[0].impact}) — ${nodes.length} elements in ${subjects}${scope}`,
-      `      ${hits[0].help}`,
-      `      ${hits[0].helpUrl}`,
+      `  ${rule} (${hits[0]!.impact}) — ${nodes.length} elements in ${subjects}${scope}`,
+      `      ${hits[0]!.help}`,
+      `      ${hits[0]!.helpUrl}`,
       ...nodes.slice(0, 3).map(node => `      > ${node.replaceAll(/\s+/g, ' ').slice(0, 160)}`),
     )
   }
@@ -115,8 +121,8 @@ export function summarize (violations: AxeViolation[]): string {
   for (const [subject, hits] of subjects) {
     const counted = [...new Set(hits.map(hit => hit.rule))]
       .map(rule => {
-        const elements = hits.filter(hit => hit.rule === rule).flatMap(hit => hit.nodes).length
-        return elements > 1 ? `${rule} x${elements}` : rule
+        const count = hits.filter(hit => hit.rule === rule).flatMap(hit => hit.nodes).length
+        return count > 1 ? `${rule} x${count}` : rule
       })
       .toSorted()
 

--- a/packages/0/src/components/fixtures/degenerate/AlertDialog.vue
+++ b/packages/0/src/components/fixtures/degenerate/AlertDialog.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { AlertDialog } from '../../AlertDialog/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <AlertDialog.Root v-model="open">
+    <AlertDialog.Activator>Delete</AlertDialog.Activator>
+
+    <AlertDialog.Content>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action>Delete</AlertDialog.Action>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Avatar.vue
+++ b/packages/0/src/components/fixtures/degenerate/Avatar.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+  import { Avatar } from '../../Avatar/index'
+</script>
+
+<template>
+  <Avatar.Root>
+    <Avatar.Image src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" />
+    <Avatar.Fallback>JD</Avatar.Fallback>
+  </Avatar.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Button.vue
+++ b/packages/0/src/components/fixtures/degenerate/Button.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Button } from '../../Button/index'
+</script>
+
+<template>
+  <Button.Root>
+    <svg height="16" viewBox="0 0 16 16" width="16">
+      <path d="M4 8h8" stroke="currentColor" />
+    </svg>
+  </Button.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Checkbox.vue
+++ b/packages/0/src/components/fixtures/degenerate/Checkbox.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { Checkbox } from '../../Checkbox/index'
+</script>
+
+<template>
+  <Checkbox.Root>
+    <Checkbox.Indicator>&#10003;</Checkbox.Indicator>
+  </Checkbox.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Combobox.vue
+++ b/packages/0/src/components/fixtures/degenerate/Combobox.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Combobox } from '../../Combobox/index'
+
+  const selected = ref()
+  const items = [
+    { id: 'apple', label: 'Apple' },
+    { id: 'banana', label: 'Banana' },
+    { id: 'cherry', label: 'Cherry' },
+  ]
+</script>
+
+<template>
+  <Combobox.Root v-model="selected">
+    <Combobox.Activator>
+      <Combobox.Control />
+      <Combobox.Cue />
+    </Combobox.Activator>
+
+    <Combobox.Content>
+      <Combobox.Item
+        v-for="item in items"
+        :id="item.id"
+        :key="item.id"
+        v-slot="{ attrs }"
+        :value="item.label"
+      >
+        <div v-bind="attrs">{{ item.label }}</div>
+      </Combobox.Item>
+    </Combobox.Content>
+  </Combobox.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Combobox.vue
+++ b/packages/0/src/components/fixtures/degenerate/Combobox.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
   // Utilities
-  import { ref } from 'vue'
+  import { shallowRef } from 'vue'
 
   import { Combobox } from '../../Combobox/index'
 
-  const selected = ref()
+  const selected = shallowRef()
   const items = [
     { id: 'apple', label: 'Apple' },
     { id: 'banana', label: 'Banana' },
@@ -13,6 +13,10 @@
 </script>
 
 <template>
+  <!--
+    Degenerate: no accessible name on the control (placeholder dropped).
+    Empty omitted so the only intentional omission is naming.
+  -->
   <Combobox.Root v-model="selected">
     <Combobox.Activator>
       <Combobox.Control />
@@ -24,10 +28,9 @@
         v-for="item in items"
         :id="item.id"
         :key="item.id"
-        v-slot="{ attrs }"
         :value="item.label"
       >
-        <div v-bind="attrs">{{ item.label }}</div>
+        {{ item.label }}
       </Combobox.Item>
     </Combobox.Content>
   </Combobox.Root>

--- a/packages/0/src/components/fixtures/degenerate/Dialog.vue
+++ b/packages/0/src/components/fixtures/degenerate/Dialog.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+  // Utilities
+  import { shallowRef } from 'vue'
+
+  import { Dialog } from '../../Dialog/index'
+
+  const open = shallowRef(true)
+</script>
+
+<template>
+  <Dialog.Root v-model="open">
+    <Dialog.Activator>Open Dialog</Dialog.Activator>
+
+    <Dialog.Content>
+      <p>Dialog content goes here.</p>
+      <Dialog.Close>Close</Dialog.Close>
+    </Dialog.Content>
+  </Dialog.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Image.vue
+++ b/packages/0/src/components/fixtures/degenerate/Image.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+  import { Image } from '../../Image/index'
+</script>
+
+<template>
+  <Image.Root src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    <Image.Img height="1" width="1" />
+    <Image.Placeholder>Loading...</Image.Placeholder>
+    <Image.Fallback>Failed to load</Image.Fallback>
+  </Image.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Input.vue
+++ b/packages/0/src/components/fixtures/degenerate/Input.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
   // Utilities
-  import { ref } from 'vue'
+  import { shallowRef } from 'vue'
 
   import { Input } from '../../Input/index'
 
-  const email = ref('')
+  const email = shallowRef('')
 </script>
 
 <template>
+  <!-- Degenerate: label / description / error omitted; no placeholder name either. -->
   <Input.Root v-model="email">
-    <Input.Control placeholder="Email" />
+    <Input.Control />
   </Input.Root>
 </template>

--- a/packages/0/src/components/fixtures/degenerate/Input.vue
+++ b/packages/0/src/components/fixtures/degenerate/Input.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Input } from '../../Input/index'
+
+  const email = ref('')
+</script>
+
+<template>
+  <Input.Root v-model="email">
+    <Input.Control placeholder="Email" />
+  </Input.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Radio.vue
+++ b/packages/0/src/components/fixtures/degenerate/Radio.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Radio } from '../../Radio/index'
+
+  const selected = ref<string>()
+</script>
+
+<template>
+  <Radio.Group v-model="selected">
+    <Radio.Root value="a">
+      <Radio.Indicator>&#9679;</Radio.Indicator>
+    </Radio.Root>
+
+    <Radio.Root value="b">
+      <Radio.Indicator>&#9679;</Radio.Indicator>
+    </Radio.Root>
+  </Radio.Group>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Switch.vue
+++ b/packages/0/src/components/fixtures/degenerate/Switch.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+  // Utilities
+  import { ref } from 'vue'
+
+  import { Switch } from '../../Switch/index'
+
+  const enabled = ref(false)
+</script>
+
+<template>
+  <Switch.Root v-model="enabled">
+    <Switch.Track>
+      <Switch.Thumb />
+    </Switch.Track>
+  </Switch.Root>
+</template>

--- a/packages/0/src/components/fixtures/degenerate/Toggle.vue
+++ b/packages/0/src/components/fixtures/degenerate/Toggle.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+  import { Toggle } from '../../Toggle/index'
+</script>
+
+<template>
+  <Toggle.Root>
+    <Toggle.Indicator>&#10003;</Toggle.Indicator>
+  </Toggle.Root>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ catalogs:
     '@vuetify/auth':
       specifier: 0.1.8
       version: 0.1.8
+    axe-core:
+      specifier: ^4.12.1
+      version: 4.12.1
     client-zip:
       specifier: ^2.5.0
       version: 2.5.0
@@ -633,6 +636,9 @@ importers:
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
+      axe-core:
+        specifier: 'catalog:'
+        version: 4.12.1
       launchdarkly-js-client-sdk:
         specifier: 'catalog:'
         version: 3.9.3
@@ -3777,6 +3783,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
@@ -10494,6 +10504,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   '@adobe/leonardo-contrast-colors': ^1.1.0
   '@ant-design/colors': ^8.0.1
   '@arethetypeswrong/cli': ^0.18.4
+  axe-core: ^4.12.1
   '@changesets/changelog-github': ^0.7.0
   '@changesets/cli': ^2.31.0
   '@flagsmith/flagsmith': ^11.0.0
@@ -85,6 +86,7 @@ catalog:
   vite-ssg: ^28.3.0
   vite-ssg-sitemap: ^0.10.0
   vitest: ^4.1.10
+
   vue: 3.5.39
   vue-component-meta: 3.2.7
   vue-i18n: ^11.4.6


### PR DESCRIPTION
Closes #732.

## What lands

- `axe-core` in the workspace catalog + `packages/0` devDependencies.
- `packages/0/src/components/a11y.browser.test.ts` — a sweep over all 40 shipped components, running in the `v0:browser` project's real Chromium.
- `packages/0/src/components/fixtures/` — one `.vue` per component holding the usage its own `@example` JSDoc documents, plus the audit/report helper.
- An `a11y` CI job, `continue-on-error: true`, that tees the breakdown into the GitHub step summary.
- A correction to `guide/features/accessibility.md` — see "Not vitest-axe" below.

No violations are fixed here. The point of the first pass is the number.

## The number

```
axe: 10 violations (13 elements) across 7 components, 8 distinct rules
```

| rule | impact | elements | components |
|---|---|---|---|
| `aria-required-parent` | critical | 3 | Select |
| `aria-allowed-attr` | critical | 2 | Selection |
| `button-name` | critical | 2 | Select |
| `label` | critical | 1 | NumberField |
| `aria-input-field-name` | serious | 2 | Rating, Slider |
| `aria-progressbar-name` | serious | 1 | Progress |
| `nested-interactive` | serious | 1 | Rating |
| `region` | moderate | 1 | Portal |

Three of these are the open batch, found independently:

- **`aria-progressbar-name` on Progress** is #608. `ProgressRoot` emits `aria-labelledby="v-0-label"` whether or not `Progress.Label` is mounted; the dangling IDREF leaves the progressbar with no accessible name. PR #638 is the fix.
- **`aria-allowed-attr` on Selection** is #613 — `<button aria-selected="false">`, an attribute `button` does not allow without an appropriate role. PR #633 is the fix.
- **`button-name` on Select** is the `SelectActivator` half of #613. PR #635 is the fix.

Five are new:

- **`aria-required-parent` on Select** — three `role="option"` elements whose nearest ancestor is not a `listbox`/`group`. `aria-controls` points at the listbox id, but the options are not inside it.
- **`nested-interactive` + `aria-input-field-name` on Rating** — `RatingRoot` renders `role="slider"` and `Rating.Item as="button"` puts focusable buttons inside it. The slider also has no accessible name.
- **`aria-input-field-name` on Slider** — `role="slider"` with `aria-valuetext` but no `aria-label`/`aria-labelledby`.
- **`label` on NumberField** — the spinbutton `<input>` has no associated label. Adjacent to #640, which adds `labelledBy` for the `aria-labelledby` case; this is the plain `<label>` case.
- **`region` on Portal** — content teleported to `<body>` sits outside any landmark. Arguably inherent to teleporting and arguably a documentation note rather than a fix; flagging, not asserting.

Follow-ups are filed:

| finding | issue |
|---|---|
| `aria-required-parent` — Select | #738 |
| `nested-interactive` + `aria-input-field-name` — Rating | #739 |
| `aria-input-field-name` — Slider | #740 |
| `label` — NumberField | #741 |
| `region` — Portal | #742 (filed as a decision, not a defect) |

#738 turned out not to be the finding it looked like. `Select.Content` does render `role="listbox"` and the items *are* nested inside it — but `SelectItem` binds its `attrs` onto its own non-renderless `Atom` while `Select.Item`'s `@example` spreads that same `attrs` onto a child `<div>`, so every option renders twice and the inner one's nearest role ancestor is another `option`. That is also the `attrs` double-fire hazard `.claude/rules/components.md` already documents, so one correction to the example fixes both.

**This was a floor, not a ceiling** — and the second commit raises it. See "Degenerate shapes" below.

## Degenerate shapes

The fixtures above are each component's *documented* usage, and a documented example is written by someone thinking about the example. The failure mode that ships is the **omission**: the optional sub-component nobody mounted, the optional prop nobody passed. #608 is exactly that shape, and the canonical sweep caught only its Progress third — by the accident that Progress's own example happens not to render a `Progress.Label`.

`packages/0/src/components/fixtures/degenerate/` is the other half of #732's open question: 11 fixtures, each the canonical shape with one documented-optional part removed and nothing else changed.

```
axe: 10 violations (11 elements) across 10 components, 4 distinct rules
```

| rule | impact | elements | components |
|---|---|---|---|
| `button-name` | critical | 6 | Button, Checkbox, Radio, Switch, Toggle |
| `aria-dialog-name` | serious | 2 | AlertDialog, Dialog |
| `image-alt` | critical | 2 | Avatar, Image |
| `label` | critical | 1 | Combobox |

**Two of these are ours. Eight are not, and that is the useful result.**

`aria-dialog-name` on **Dialog and AlertDialog** is the finding this pass exists for:

```html
<dialog role="dialog" aria-modal="true" aria-labelledby="v-0-title" aria-describedby="v-0-description" open>
```

No `Dialog.Title` is mounted, so `v-0-title` resolves to nothing. The dialog has a dangling IDREF and no accessible name. That is #608's actual failure mode and the two-thirds of it #638 does not fix — #638 is Progress-scoped. It is invisible from the documented shape, which mounts a Title, which is the whole argument for this pass.

The remaining eight are consumer omissions. A headless library cannot stop a consumer from failing to name a widget, and it should not try. The question the sweep is actually asking is narrower and *is* v0's: does the component **degrade to a merely-unnamed widget, or to a broken one** — a dangling IDREF, a role stripped of a property it requires? Everywhere except the two Dialogs, v0 degrades correctly. `button-name`, `image-alt` and `label` firing on a nameless control is axe working as intended, not v0 misbehaving.

Design notes:

- **A stated membership rule, not a grab bag.** A component earns a degenerate fixture when its canonical fixture supplies an accessible name, or mounts a labelling sub-component, that the API leaves optional. NumberField, Progress, Rating, Select and Slider are absent because their canonical fixtures *already* omit theirs — which is why they are in the first-pass count above.
- **Counted separately, never summed.** The canonical number stays the one a consumer following the docs would hit; it is unchanged at 10 / 13 / 7 / 8. Both sections sit inside the existing report fence, so the `a11y` job's `awk` lifts them together with no workflow change.
- **A known gap, stated rather than papered over.** The sweep opens a collapsed widget by clicking `[aria-expanded="false"]`. Combobox's listbox does not open from that click, so its options are never in the DOM to audit — and `Combobox.Item` is structurally identical to `Select.Item`, down to the same `<div v-bind="attrs">` in its own example. Read Combobox's clean line in the report as *unverified*, not clean. Noted in #738.
- **The manifest check is deliberately not a completeness check.** Degenerate shapes are opt-in — most components have no optional name to remove. What is asserted is that every degenerate key has a canonical fixture beside it: without the baseline, a violation cannot be attributed to the omission rather than to the component.

## Not `vitest-axe`

#732 proposed `vitest-axe`, on the reasoning that the docs already recommend it. It does not work here:

```
FAIL  src/components/a11y.browser.test.ts
Caused by: TypeError: (0 , __commonJSMin(...)(...).createRequire) is not a function
 ❯ node_modules/vitest-axe/dist/index.js:9:29
```

`vitest-axe@0.1.0` calls `module.createRequire` at import time. `1.0.0-pre.5` drops that but pulls `chalk`, which fails to resolve `tinyrainbow` in the browser environment. Both are Node packages; `vitest-axe` is a jsdom/happy-dom tool, which is why reka-ui's use of it comes bundled with a `getComputedStyle` monkeypatch.

Running the auditor where layout is simulated is the one thing #732 argues against, so the wrapper goes and the engine stays — `vitest-axe` wraps `axe-core`, and `axe-core` is a browser library that needs no wrapper to run in a browser. `guide/features/accessibility.md` now documents both forms and says which to reach for.

## Design decisions

**Sweep, not per-component assertions.** #732 left this open, leaning sweep. A dedicated file guarantees no component is silently unaudited and keeps axe out of the hot path of the 25 existing `*.browser.test.ts` files. The manifest check derives its expected set from `maturity.json` — the registry that already drives the docs badges — so promoting a component out of `draft` without writing a fixture fails the sweep. Enforcement lives outside this file on purpose.

**Explicit fixture list, not `import.meta.glob`.** Matches the convention `src/surface.test.ts` sets and states outright: a committed array so a surface change is a reviewable diff rather than a silent side effect.

**A `<main>` harness instead of disabling `region`.** Mounted into a bare `<div>`, 25 of 40 components reported `region` — content not contained by a landmark, true of the harness and not of the component. reka-ui's answer is a global `configureAxe` disabling the rule. Wrapping the mount point in `<main>` fixes the actual defect instead, and `region` still fires for Portal, correctly. **No axe rule is disabled and no `runOnly` is passed** — an auditor configured down to the rules you already pass is not an auditor.

**Separate job, not a step on `browser`.** Mirrors the existing `vapor` job, which is this repo's own pattern for non-blocking signal. Keeps the breakdown in its own step summary rather than buried under the coverage upload, leaves the `browser` job's Codecov behavior untouched, and makes the flip to blocking a one-line deletion. Same Playwright cache key, so Chromium restores rather than re-downloads.

## Verification

All run at this branch:

```
pnpm lint                                  clean
pnpm typecheck                             packages/0, paper, genesis — Done
pnpm repo:check                            knip + sherif — No issues found
pnpm build                                 Build complete
pnpm test:run --project '!v0:browser'      147 files, 4769 passed | 1 skipped
pnpm exec vitest run --project v0:browser   34 files, 1756 passed | 2 skipped
```

Sweep itself: 53 tests passed, ~4s, zero `[Vue warn]` output (the repo's zero-stderr policy). The CI extraction step was verified locally by running the same `awk` over the run log. Re-run after the degenerate commit: `pnpm lint` clean, `pnpm typecheck` Done, `pnpm exec vitest run --project v0:browser` 34 files, 1768 passed | 2 skipped.

## Related

Stacked conceptually on #735 (coverage globs) but textually independent — different hunks of `pr-checks.yml`, no conflict either merge order. The fixtures land under `**/fixtures/**`, already excluded by the root coverage config, so they do not enter coverage under either PR's include set.
