### PR TITLE
docs: trim derivable content from CLAUDE.md and lazy-load release + checklist guidance

### DIFF
--- a/.claude/rules/new-feature-checklist.md
+++ b/.claude/rules/new-feature-checklist.md
@@ -1,3 +1,16 @@
+---
+paths:
+  - packages/0/src/components/**
+  - packages/0/src/composables/**
+  - packages/0/src/maturity.json
+  - packages/0/src/surface.test.ts
+  - packages/0/README.md
+  - README.md
+  - apps/docs/src/pages/components/**
+  - apps/docs/src/pages/composables/**
+  - apps/docs/src/examples/**
+---
+
 # New Feature Checklist
 
 **Applies to:** Adding any new component or composable to `packages/0/`.

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: releasing
+description: Authoring a changeset, or cutting a release for @vuetify/v0 and the @paper/* design systems. Use when writing a .changeset/*.md file, deciding what belongs in changelog copy, exiting changesets pre/beta mode, or cutting a stable release. Covers the changeset content contract, the two version domains, and the pre-exit steps.
+---
+
+# Releasing
+
+Changesets-driven. Pushing to `master` opens/updates a "Version Packages" PR; merging it publishes to npm (tokenless OIDC) and mints the GitHub releases (`.github/workflows/release.yml`).
+
+The branch model — which base branch a PR targets by change type — lives in the root `CLAUDE.md` and is always loaded. This skill covers what happens once the PR is on the right branch.
+
+## Changeset content contract
+
+The `.changeset/*.md` body renders verbatim into the changelog and GitHub release notes — it is release-note copy, not a commit message. Don't budget by character count; budget by what belongs:
+
+- **First line** — conventional-commit summary `type(Scope): what changed (#PR)`, written from the consumer's side, not the diff's. It stands alone as the whole changeset when it already answers both questions a consumer asks — *does this affect me, and must I do anything?* A title that instead restates the diff (what code moved) is a commit message in changeset frontmatter — that is the failure to avoid, body or not.
+- **Body (optional)** — add one when the title can't answer those questions itself: a behavior delta, a performance change worth quantifying (state the magnitude), a breaking/migration step, or new public options or escape hatches. Length is earned by impact, not padded to a target.
+- **Never the mechanism** — internal composables touched, private fields, refactors mirrored from a sibling go in the PR description and commit body, never the changelog.
+
+## Two version domains
+
+- **Substrate** — `@vuetify/v0` is the sole published substrate, versioned and released on its own `v<version>` GitHub release. `@vuetify/paper` is `private`/dormant and no longer part of the changesets `fixed` group.
+- **Design systems** (`@paper/*`, e.g. `@paper/genesis`) version and release independently, each on its own `name@version` release. Note `@paper/genesis` depends on `@vuetify/v0`, so a substrate **major** bump (e.g. `1.x` → `2.0.0`) leaves genesis's `^` range and changesets will also bump + republish genesis. That is expected — review it in the "Version Packages" PR before merging.
+
+## Exiting beta / cutting a stable release
+
+The repo is in changesets **pre mode** (`.changeset/pre.json`, `beta` dist-tag); every release is `…-beta.N` published under the `beta` tag. Before the first stable release:
+
+1. `pnpm changeset pre exit`
+2. Commit the removal of `.changeset/pre.json`
+3. Let the next "Version Packages" PR produce the clean `1.0.0`, then merge it
+
+Skipping `pre exit` ships `1.0.0-beta.N` (or mistags it) instead of a real `1.0.0`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,39 +6,13 @@ Vue 3 headless UI primitives and composables. Unstyled, logic-focused building b
 
 **STOP. Check existing functionality first.**
 
-### Use Built-in Utilities (`#v0/utilities`)
+### Use What Already Ships
 
-| Utility | Purpose |
-|---------|---------|
-| `isFunction`, `isString`, `isNumber`, `isBoolean` | Type guards |
-| `isObject`, `isArray`, `isNull`, `isUndefined` | Type guards |
-| `isNullOrUndefined`, `isPrimitive`, `isSymbol`, `isNaN`, `isElement` | Type guards |
-| `isThenable` | Duck-typed thenable check (any object with a `.then` method) |
-| `mergeDeep(target, ...sources)` | Deep merge with `DeepPartial<T>` |
-| `useId()` | SSR-safe ID (Vue's useId in components, counter fallback) |
-| `clamp(value, min, max)` | Clamp number to range |
-| `range(length, start)` | Create sequential number array |
+Never hand-roll a helper, type, or environment check that the package already exports. Read the barrels before writing:
 
-### Use Built-in Types (`#v0/types`)
-
-| Type | Purpose |
-|------|---------|
-| `ID` | Identifier type (`string \| number`) for registry tickets |
-| `Extensible<T>` | Preserves string literal autocomplete while allowing arbitrary strings |
-| `MaybeArray<T>` | Union accepting single value or array (`T \| T[]`) |
-| `DeepPartial<T>` | Recursively makes all properties optional |
-| `Activation` | Keyboard activation mode (`'automatic' \| 'manual'`) |
-
-### Use Built-in Constants (`#v0/constants/globals`)
-
-| Constant | Purpose |
-|----------|---------|
-| `IN_BROWSER` | SSR-safe `typeof window !== 'undefined'` |
-| `SUPPORTS_TOUCH` | Touch device detection |
-| `SUPPORTS_MATCH_MEDIA` | matchMedia availability |
-| `SUPPORTS_OBSERVER` | ResizeObserver availability |
-| `SUPPORTS_INTERSECTION_OBSERVER` | IntersectionObserver availability |
-| `SUPPORTS_MUTATION_OBSERVER` | MutationObserver availability |
+- `#v0/utilities` — type guards, `mergeDeep`, `useId`, `clamp`, `range`
+- `#v0/types` — `ID`, `Extensible`, `MaybeArray`, `DeepPartial`, `Activation`
+- `#v0/constants/globals` — `IN_BROWSER`, `SUPPORTS_*` (never write `typeof window !== 'undefined'`)
 
 ### Check Existing Composables & Components (`#v0/composables`, `#v0/components`)
 
@@ -60,45 +34,16 @@ import { createRegistry } from '#v0/composables'
 - **`@vuetify/v0`** (`packages/0/`): Headless components and composables
 - **`@vuetify/paper`** (`packages/paper/`): Styling primitives depending on v0 — **not published (dormant)**
 
-## Apps
-
-- **Dev** (`dev/`): Dev environment
-- **Playground** (`apps/playground/`): Browser-based editor with live preview
-- **Docs** (`apps/docs/`): VitePress-style documentation
-
 ## Commands
 
-```bash collapse
-# Development
-pnpm dev              # Dev environment
-pnpm dev:docs         # Documentation
+Scripts live in the root `package.json` — read it for the full list. The non-obvious ones:
 
-# Build
-pnpm build            # All packages
-pnpm build:0          # @vuetify/v0 only
-pnpm build:paper      # @vuetify/paper only
-pnpm build:apps       # All apps
-pnpm build:all        # Everything
-
-# Quality
-pnpm test             # Watch mode
-pnpm test:run         # CI mode
-pnpm test:bench       # Run benchmarks
-pnpm metrics          # Generate performance metrics
-pnpm typecheck        # All packages
-pnpm lint:fix         # Always use lint:fix, not lint
+```bash
+pnpm lint:fix         # Always use lint:fix, never plain lint
 pnpm validate         # lint + typecheck + test
-
-# Release (Changesets)
-pnpm changeset        # Author a changeset for your PR (run per change)
-pnpm release:prepare  # Pre-release validation (validate + build)
-# Publishing is automated: pushing to master opens a "Version Packages" PR;
-# merging it builds, publishes to npm via OIDC, and creates the GitHub releases.
-# Base branch by change type: fix/patch → master, feat/minor → dev, breaking/major → next.
-# Currently in PRE mode (beta dist-tag) — see "Releasing" below before cutting stable.
-
-# Repo health
+pnpm metrics          # Regenerate performance metrics (required after editing a .bench.ts)
 pnpm repo:check       # knip + sherif
+pnpm changeset        # Author a changeset — run once per change, see "Releasing"
 ```
 
 ## Releasing
@@ -120,26 +65,9 @@ Three long-lived branches; a PR's base is chosen by the semver impact of the cha
 - **Design systems** (`@paper/*`) version independently; a DS feature still targets `dev` (it's a minor bump for that package).
 - CI (`pr-checks.yml`) and the changeset reminder (`changeset-reminder.yml`) run on PRs into all three branches; `release.yml` triggers on `master` pushes only.
 
-### Changeset content contract
+### Authoring a changeset / cutting a release
 
-The `.changeset/*.md` body renders verbatim into the changelog and GitHub release notes — it is release-note copy, not a commit message. Don't budget by character count; budget by what belongs:
-
-- **First line** — conventional-commit summary `type(Scope): what changed (#PR)`, written from the consumer's side, not the diff's. It stands alone as the whole changeset when it already answers both questions a consumer asks — *does this affect me, and must I do anything?* A title that instead restates the diff (what code moved) is a commit message in changeset frontmatter — that is the failure to avoid, body or not.
-- **Body (optional)** — add one when the title can't answer those questions itself: a behavior delta, a performance change worth quantifying (state the magnitude), a breaking/migration step, or new public options or escape hatches. Length is earned by impact, not padded to a target.
-- **Never the mechanism** — internal composables touched, private fields, refactors mirrored from a sibling go in the PR description and commit body, never the changelog.
-
-- **Substrate** — `@vuetify/v0` is the sole published substrate, versioned and released on its own `v<version>` GitHub release. `@vuetify/paper` is `private`/dormant and no longer part of the changesets `fixed` group.
-- **Design systems** (`@paper/*`, e.g. `@paper/genesis`) version and release independently, each on its own `name@version` release. Note `@paper/genesis` depends on `@vuetify/v0`, so a substrate **major** bump (e.g. `1.x` → `2.0.0`) leaves genesis's `^` range and changesets will also bump + republish genesis. That is expected — review it in the "Version Packages" PR before merging.
-
-### Exiting beta / cutting a stable release
-
-The repo is in changesets **pre mode** (`.changeset/pre.json`, `beta` dist-tag); every release is `…-beta.N` published under the `beta` tag. Before the first stable release:
-
-1. `pnpm changeset pre exit`
-2. Commit the removal of `.changeset/pre.json`
-3. Let the next "Version Packages" PR produce the clean `1.0.0`, then merge it
-
-Skipping `pre exit` ships `1.0.0-beta.N` (or mistags it) instead of a real `1.0.0`.
+The repo is in changesets **pre mode** (`beta` dist-tag). For the changeset content contract, the two version domains (`@vuetify/v0` vs `@paper/*`), and the pre-exit steps for a stable release, invoke the **`releasing`** skill.
 
 ## Conventions
 
@@ -162,19 +90,6 @@ Skipping `pre exit` ships `1.0.0-beta.N` (or mistags it) instead of a real `1.0.
 - Colocated with source (`*.test.ts`, components `*.browser.test.ts`)
 - Focus: edge cases, error conditions, async, SSR safety
 
-## Requirements
-
-- **Node**: >=26
-- **pnpm**: >=10.6
-
-## Build Tooling
-
-- **Build**: tsdown
-- **Dev**: Vite
-- **Test**: Vitest
-- **Lint**: ESLint (vuetify config)
-- **Style**: UnoCSS
-
 ## Worktrees
 
 Worktree directory: `.claude/worktrees/` — always use this location for all worktrees.
@@ -188,3 +103,4 @@ See `.claude/rules/` for path-scoped documentation:
 - `benchmarks.md` - Standards for `*.bench.ts` files
 - `docs.md` - Architecture for `apps/docs/**`
 - `testing.md` - Standards for `*.test.ts` files
+- `new-feature-checklist.md` - Required files when adding a component or composable

--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -11,22 +11,7 @@ docs: message                  # No scope needed
 docs(ComponentName): message   # With scope when specific
 ```
 
-## Commands
-
-```bash
-pnpm dev       # Start on port 8000
-pnpm build     # SSG build
-pnpm preview   # Preview build
-```
-
-## Stack
-
-- **SSG**: vite-ssg (generates static HTML)
-- **Routing**: vue-router 5 (file-based, built-in) + vite-plugin-vue-layouts-next
-- **Markdown**: unplugin-vue-markdown + Shiki + Mermaid
-- **Styling**: UnoCSS with `presetWind4()` (Tailwind v4 syntax, integrated reset)
-- **State**: Pinia
-- **PWA**: vite-plugin-pwa
+`pnpm dev` serves on port 8000. Remaining scripts and the stack are in this app's `package.json` and `vite.config.ts`.
 
 ## Routing & Layouts
 
@@ -96,62 +81,12 @@ features:
 ---
 ```
 
-## Structure
-
-```
-src/
-├── components/
-│   ├── app/          # App shell (AppHeader, AppDrawer, etc.)
-│   ├── docs/         # Doc components (DocsExample, DocsApi, DocsToc, etc.)
-│   └── home/         # Homepage components
-├── composables/      # App-specific composables
-├── examples/         # Live examples loaded by DocsExample
-│   ├── components/   # examples/components/{component}/
-│   └── composables/  # examples/composables/{composable}/
-├── layouts/          # Page layouts
-├── pages/            # File-based routing (.vue and .md)
-│   ├── api/          # Dynamic API reference pages ([name].vue)
-│   ├── components/   # disclosure, primitives, providers, semantic
-│   ├── composables/  # foundation, forms, plugins, registration, selection, system, transformers, utilities
-│   ├── guide/        # How-to guides
-│   ├── introduction/ # Getting started, FAQ, contributing
-│   └── utilities/    # Utility docs
-├── plugins/          # Vue plugins
-├── stores/           # Pinia stores
-└── utilities/        # Helpers
-
-build/
-├── api-names.ts      # Shared API name discovery for SSG routes
-├── generate-api.ts   # virtual:api - component/composable API extraction
-├── generate-nav.ts   # virtual:nav - navigation structure
-├── generate-search-index.ts  # Search index generation
-└── markdown.ts       # Markdown processing
-```
-
 ## Path Aliases
 
 - `@` → `src/`
 - `@vuetify/v0` → `packages/0/src`
 - `#v0` → `packages/0/src`
 - `#paper` → `packages/paper/src`
-
-## Key Components
-
-| Component | Purpose |
-|-----------|---------|
-| `DocsCallout` | GitHub-style callouts (`> [!TIP]`, `> [!NOTE]`, `> [!WARNING]`, `> [!CAUTION]`, `> [!IMPORTANT]`, `> [!ASKAI]`, `> [!TOUR]`) |
-| `DocsExample` | Live examples from `examples/` with code |
-| `DocsMarkup` | Syntax-highlighted code blocks |
-| `DocsApi` | Auto-generated API tables with inline/links toggle |
-| `DocsApiLinks` | Card grid linking to dedicated API pages |
-| `DocsToc` | Auto-generated table of contents |
-| `DocsCodeGroup` | Tabbed code examples |
-| `DocsMermaid` | Mermaid diagram renderer |
-| `DocsPageFeatures` | Renders frontmatter features badge |
-| `DocsBackToTop` | Scroll-to-top button |
-| `DocsBackmatter` | Page footer with last commit info |
-| `DocsNavigator` | Prev/next page navigation |
-| `DocsReleases` | Release changelog display |
 
 ## Live Examples with DocsExample
 
@@ -204,23 +139,6 @@ The skill-level placement quiz is **not** a callout directive: it is the `AppSki
 
 ## App Composables
 
-| Composable | Purpose |
-|------------|---------|
-| `useHighlighter` | Shiki code highlighting |
-| `useHighlightCode` | Code block highlighting |
-| `useToc` | Table of contents generation |
-| `useScrollSpy` | Active section tracking |
-| `useScrollPersist` | Scroll position persistence |
-| `useClipboard` | Copy to clipboard |
-| `useThemeToggle` | Dark/light mode toggle |
-| `useAsk` | AI Q&A chat with page context |
-| `useMarkdown` | Runtime markdown → HTML (GitHub API content, AI responses); also exports `renderInline` for single lines. Never instantiate `Marked` in a component — this is the only runtime markdown pipeline |
+Browse `src/composables/` for the full set. One rule that isn't obvious from the source:
 
-## Virtual Modules
-
-| Module | Purpose |
-|--------|---------|
-| `virtual:api` | Component/composable API data extracted at build time |
-| `virtual:nav` | Navigation structure generated from pages |
-
-Import via `import data from 'virtual:api'`. Types in `vite-env.d.ts`.
+- `useMarkdown` is the **only** runtime markdown → HTML pipeline (GitHub API content, AI responses); it also exports `renderInline` for single lines. Never instantiate `Marked` in a component — extend `useMarkdown` instead.


### PR DESCRIPTION
## Problem

Three memory files load into context on **every turn** and carry content a session can reconstruct from the codebase itself:

| File | Before | After | Scope |
|------|--------|-------|-------|
| `CLAUDE.md` | 9,691 ch | 5,554 ch | always |
| `.claude/rules/new-feature-checklist.md` | 13,982 ch, always-loaded | path-scoped | was always, now scoped |
| `apps/docs/CLAUDE.md` | 8,839 ch | 5,584 ch | nested (`apps/docs`) |

`new-feature-checklist.md` was the only file in `.claude/rules/` without `paths:` frontmatter, despite its own first line reading *"Applies to: Adding any new component or composable to `packages/0/`."* It loaded while answering questions, editing docs, or triaging issues.

The root `CLAUDE.md` was also self-contradictory: line 45 stated *"The skill is the source of truth; this file does not duplicate the inventory"* — directly below 33 lines duplicating exactly that inventory.

## What changed

**`CLAUDE.md`**
- Cut the `#v0/utilities` / `#v0/types` / `#v0/constants/globals` tables, replaced with a 3-line pointer to the barrels. The `vuetify0` skill remains the inventory source of truth.
- Cut the Apps list (`ls`), Requirements (`engines`), and Build Tooling (`package.json`).
- Collapsed the script dump to the five non-guessable entries, keeping `lint:fix` over `lint`, `repo:check`, and `metrics` after a `.bench.ts` edit.
- Moved the changeset content contract, the two version domains, and the beta pre-exit steps into a new `releasing` skill. **The branch-model table stays resident** — base-branch routing applies to every PR and must not depend on a skill being invoked.
- Added `new-feature-checklist.md` to the Detailed Rules index now that it is scoped.

**`.claude/rules/new-feature-checklist.md`** — added `paths:` frontmatter covering `packages/0/src/components/**`, `packages/0/src/composables/**`, `maturity.json`, `surface.test.ts`, both READMEs, and the docs pages/examples it instructs you to create.

**`apps/docs/CLAUDE.md`** — cut the Stack list, `src/` tree, Key Components table, and Virtual Modules table (all derivable; several already covered by the path-scoped `.claude/rules/docs.md`). Preserved the `useMarkdown` *"only runtime markdown pipeline, never instantiate `Marked` in a component"* rule, which was buried inside the App Composables table.

**`.claude/skills/releasing/SKILL.md`** — new, holds the migrated release content.

## Not changed

No behavior, no source, no CI. Every "never do X" prohibition was kept. Path aliases and the UnoCSS theme block stayed despite being technically derivable — short, high-traffic, and cheap.

## Result

~7.4k characters (~1.9k est. tokens) off always-loaded context per session, plus ~3.5k est. tokens no longer loaded outside new-feature work.
