### PR TITLE
fix(utilities): preserve element types, tuples and readonly in isArray narrowing

### DIFF
--- a/.changeset/fix-is-array-narrowing.md
+++ b/.changeset/fix-is-array-narrowing.md
@@ -1,0 +1,11 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(utilities): `isArray` now preserves element types, tuples and `readonly` when narrowing (#744)
+
+`isArray` narrowed everything to `unknown[]`, which erased the element type of arrays whose elements involve `any`, turned `readonly` array unions into an intersection that is not an array of anything, and left the array constituent in place in the `else` branch. Guarding a `readonly string[] | string` gave you neither `readonly string[]` in the `if` nor `string` in the `else`.
+
+Narrowing is now exact: element types, tuple arity and `readonly` survive the guard, and the `else` branch drops exactly the array constituents. `unknown` and `any` inputs narrow as before (`unknown[]` and `any[]`), so mutation and assignment to `unknown[]` keep compiling.
+
+Not breaking — runtime is unchanged, and every input either narrows identically or more precisely than before.

--- a/packages/0/src/utilities/helpers.test.ts
+++ b/packages/0/src/utilities/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 // Utilities
 import {
@@ -190,6 +190,75 @@ describe('helpers', () => {
         expect(isArray({})).toBe(false)
         expect(isArray('array')).toBe(false)
         expect(isArray({ length: 3 })).toBe(false)
+      })
+
+      // Narrowing is the point of the guard, so assert the narrowed types
+      // themselves. These are checked by `pnpm typecheck`, which includes
+      // `src/**/*.ts`; the runtime expectations only keep the branches live.
+      it('should preserve element types when narrowing a union', () => {
+        const value = ['a'] as string[] | string
+
+        if (isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<string[]>()
+          expect(value[0]).toBe('a')
+        } else {
+          expectTypeOf(value).toEqualTypeOf<string>()
+        }
+      })
+
+      it('should preserve readonly arrays and drop them from the else branch', () => {
+        const value = 'a' as readonly string[] | string
+
+        if (isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<readonly string[]>()
+        } else {
+          expectTypeOf(value).toEqualTypeOf<string>()
+          expect(value).toBe('a')
+        }
+      })
+
+      it('should preserve tuple arity', () => {
+        const value = ['a', 1] as [string, number] | string
+
+        if (isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<[string, number]>()
+          expect(value[1]).toBe(1)
+        }
+      })
+
+      it('should preserve interface element types', () => {
+        interface Rule { name: string }
+        const value = [{ name: 'required' }] as Rule | Rule[]
+
+        if (isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<Rule[]>()
+          expect(value[0].name).toBe('required')
+        } else {
+          expectTypeOf(value).toEqualTypeOf<Rule>()
+        }
+      })
+
+      it('should keep every array constituent of a multi-array union', () => {
+        const value = [1] as number[] | string[] | boolean
+
+        if (value !== true && isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<number[] | string[]>()
+          expect(value[0]).toBe(1)
+        }
+      })
+
+      it('should fall back to unknown[] for an unknown value, keeping it mutable', () => {
+        const value: unknown = ['a']
+
+        if (isArray(value)) {
+          expectTypeOf(value).toEqualTypeOf<unknown[]>()
+
+          const slot: unknown[] = value
+
+          value.push('b')
+
+          expect(slot).toEqual(['a', 'b'])
+        }
       })
     })
 

--- a/packages/0/src/utilities/helpers.test.ts
+++ b/packages/0/src/utilities/helpers.test.ts
@@ -241,7 +241,7 @@ describe('helpers', () => {
       it('should keep every array constituent of a multi-array union', () => {
         const value = [1] as number[] | string[] | boolean
 
-        if (value !== true && isArray(value)) {
+        if (isArray(value)) {
           expectTypeOf(value).toEqualTypeOf<number[] | string[]>()
           expect(value[0]).toBe(1)
         }

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -152,9 +152,30 @@ export function isThenable (item: unknown): item is { then: Function } {
  * isArray([1, 2, 3]) // true
  * isArray('string')  // false
  * ```
+ *
+ * @remarks The guard keeps whichever array constituents the input already had —
+ * element types, tuple arity and `readonly` all survive, and the `else` branch
+ * drops exactly those constituents. Three branches, in order:
+ *
+ * 1. `0 extends (1 & T)` detects an `any` input and yields `T[]` (`any[]`),
+ *    matching `Array.isArray` so callback parameters stay contextually typed.
+ * 2. Nothing array-shaped to extract (an `unknown` value, say) falls back to
+ *    `unknown[]`, reproducing the previous narrowing so mutation and assignment
+ *    to `unknown[]` keep compiling.
+ * 3. Otherwise the array constituents of `T` pass through untouched.
+ *
+ * `NoInfer<T[]>` widens the parameter just enough for TypeScript to accept the
+ * first branch (a predicate must be assignable to its parameter's type) without
+ * letting an array argument capture the inference site.
  */
 /* #__NO_SIDE_EFFECTS__ */
-export function isArray (item: unknown): item is unknown[] {
+export function isArray<T> (
+  item: T | NoInfer<T[]>,
+): item is 0 extends (1 & T)
+  ? T[]
+  : [Extract<T, readonly unknown[]>] extends [never]
+      ? T & unknown[]
+      : Extract<T, readonly unknown[]> {
   return Array.isArray(item)
 }
 


### PR DESCRIPTION
closes #744

### What

`isArray` discarded the parameter's type before narrowing:

```ts
export function isArray (item: unknown): item is unknown[]
```

This PR narrows through `Extract<T, readonly unknown[]>` instead, so array constituents pass through untouched.

```ts
export function isArray<T> (
  item: T | NoInfer<T[]>,
): item is 0 extends (1 & T)
  ? T[]
  : [Extract<T, readonly unknown[]>] extends [never]
    ? T & unknown[]
    : Extract<T, readonly unknown[]> {
  return Array.isArray(item)
}
```

Runtime is untouched — it is `Array.isArray` before and after.

### Why the signature looks like that

Read the branches in order:

1. `0 extends (1 & T)` detects an `any` input and yields `T[]` — i.e. `any[]`, exactly what `Array.isArray` gives, so callback parameters stay contextually typed. Without it, 5 sites in Vuetify core start failing `TS7006 implicitly has an 'any' type`.
2. Nothing array-shaped to extract (an `unknown` value) falls back to `unknown[]` — the *existing* narrowing, so `.push()` and assignment to `unknown[]` keep compiling. Plain `Extract` collapses `unknown` to `never` here, which is why D below is not the answer.
3. Otherwise the array constituents of `T` pass through.

`NoInfer<T[]>` in the parameter is load-bearing. A type predicate must be assignable to its parameter's declared type, and `T[]` is not assignable to a bare `T`, so branch 1 is a hard `TS2677` without it. Widening to a plain `T | T[]` fixes `TS2677` but lets an array argument capture the inference site — `T` infers the *element* rather than the value — which measured 19 probe errors. `NoInfer` admits the branch while leaving inference to the `T` position alone. Requires TypeScript ≥ 5.4.

### Method — measured, not reasoned

Every candidate was compiled against two real workloads, following the method used on #723:

- **Probe** — 20 narrowing scenarios (unions, `readonly`, tuples, interfaces, nested arrays, mutation, `unknown`/`any` inputs, negative branches). A candidate "fails" a scenario when the block does not typecheck.
- **Core** — core's `refactor/v0-type-guards` branch (vuetifyjs/vuetify#23039, `adf8eaaaa2`) in a throwaway worktree with `@vuetify/v0` pointed at a locally built dist, **all 87 `Array.isArray` call sites across 45 files converted** to v0's `isArray`, then core's own `tsgo -p tsconfig.checks.json --noEmit`.

| # | Signature | Probe | Core | Verdict |
|---|---|---|---|---|
| A | `(item: unknown): item is unknown[]` (before) | 5 | **6** | status quo |
| — | `Array.isArray` itself, for reference | 2 | 0 | the bar to clear |
| B | `(item: any): item is any[]` | 2 | **0** | clean; costs the zero-`any` invariant |
| C | `<T>(item: T): item is T & readonly unknown[]` | 10 | **59** | catastrophic |
| D | `<T>(item: T): item is Extract<T, readonly unknown[]>` | 5 | 7 | `unknown` → `never` |
| E | `<T = unknown>(item: unknown): item is T[]` | 5 | **6 — byte-identical to A** | dead |
| F | `(item: unknown): item is readonly unknown[]` | 4 | — | breaks mutation |
| I | overloads `<T>(item: T \| readonly T[]) …` + `unknown` | 3 | 6 | overload resolution unpredictable |
| **P** | this PR | **2** | **1** | **shipped** |

Both of the intuitive candidates lose. **E** — "make it generic, let the caller choose" — repairs *nothing*, because every real call site is inference-free, so `T` falls to its default and the errors come out byte-identical to the status quo. That is the same negative result #723 found for `isObject`. **C** — identity-preserving intersection — is ten times worse than doing nothing, because `T & readonly unknown[]` keeps non-array constituents alive inside the true branch.

P's 2 remaining probe errors are both in one artificial scenario (a passthrough over a naked generic, `<T>(v: T | readonly T[]): readonly T[]`), and `Array.isArray` fails it too.

### The one remaining error in core is the fix working

```
src/util/helpers.ts(87,54): error TS4104: The type 'readonly (string | number)[]'
  is 'readonly' and cannot be assigned to the mutable type '(string | number)[]'.
```

Core's `SelectItemKey` declares `readonly (string | number)[]`; `getNestedValue` declares `path: (string | number)[]`. Core has been passing a `readonly` array into a mutable parameter, and *both* the old guard and `Array.isArray` hide it — the former by producing an intersection, the latter by widening to `any[]`. Core's fix is one word (`path: readonly (string | number)[]`), after which all 87 converted sites typecheck clean. Verified.

### Exact narrowing

Asserted with `toEqualTypeOf` in `helpers.test.ts`:

| Input | Narrows to | `else` branch |
|---|---|---|
| `string[] \| string` | `string[]` | `string` |
| `readonly string[] \| string` | `readonly string[]` | `string` |
| `Record<string, any>[] \| Record<string, any>` | `Record<string, any>[]` | `Record<string, any>` |
| `[string, number] \| string` | `[string, number]` | `string` |
| `Rule \| Rule[]` (interface) | `Rule[]` | `Rule` |
| `number[] \| string[] \| boolean` | `number[] \| string[]` | `boolean` |
| `unknown` | `unknown[]` (mutable) | `unknown` |
| `any` | `any[]` | `any` |

### Tests

Six new cases in `packages/0/src/utilities/helpers.test.ts` assert the **narrowing**, not just the runtime boolean — `expectTypeOf(...).toEqualTypeOf<...>()` in the `if`/`else` branches, with runtime expectations alongside to keep the branches live.

`expectTypeOf` has precedent in the repo (`src/surface.test.ts`) and these assertions are genuinely enforced: `packages/0/tsconfig.json` includes `src/**/*.ts`, so `pnpm typecheck` checks them. Confirmed by deliberately weakening one assertion to `unknown[]`:

```
src/utilities/helpers.test.ts(202,45): error TS2344: Type 'unknown[]' does not satisfy
  the constraint '"Expected: unknown, Actual: never"[]'.
```

They are in `helpers.test.ts` (unit project), not a `*.browser.test.ts`, so they count toward patch coverage on `helpers.ts`.

### Is it breaking?

**No.** Runtime is unchanged. The `unknown` and `any` fallbacks reproduce the current narrowing exactly — including mutation and assignment to `unknown[]` — and those are the two inputs that dominate real guard usage. Every other input narrows to something *strictly more precise*, and code written against a less precise type keeps compiling against a more precise one.

The one honest caveat: a consumer that had **explicitly annotated** a narrowed value as `unknown[]` in a position requiring mutability, on an input where this now yields `readonly …[]`, would newly error. That requires a `readonly` source array — precisely the case that is broken today, so such code cannot currently be compiling for the right reason.

### Base branch: `master`

Per `CLAUDE.md`, `master` is the patch train and `dev` is for new public API. This is a corrected signature on an existing export — no new component, composable, prop, option or exported type; the conditional is inlined rather than pulled into `#v0/types` specifically so it adds no surface. Applying the repo's test — *would this surface exist if the bug didn't?* — `isArray` would exist either way, so it is a fix, not a feature.

The one thing that gives pause is that a signature change is visible to consumers in a way a normal patch is not; someone pinned to `unknown[]` could see a type-level difference. That is real but does not move the branch: the change is non-breaking by the analysis above, `isArray` is `stable` rather than `mature` in `maturity.json` (the "breaking changes require a major" rung attaches to `mature`), and routing a fix to `dev` would strand vuetifyjs/vuetify#23039 behind a minor cut for no semver benefit.

### Verification

```
$ pnpm build:0
Done!

$ pnpm typecheck
packages/0 typecheck: Done
packages/paper typecheck: Done
packages/genesis typecheck: Done

$ pnpm test:run
 Test Files  180 passed (180)
      Tests  6490 passed | 3 skipped (6493)
```

Changeset included (`patch`, `fix(utilities)`).

### Follow-ups

- vuetifyjs/vuetify#23039 is unblocked — the ~86-site adoption can proceed, with the one-word `getNestedValue` fix.
- #723 (`isObject`) is the sibling defect and still open.
- #723's note flags `toArray` for the same review; it is built on `isArray`, so it is worth re-checking now that this has landed.
