### PR TITLE
fix(utilities): isObject narrows to Record<string, any> for correct interface narrowing

### DIFF
--- a/.changeset/fix-is-object-narrowing.md
+++ b/.changeset/fix-is-object-narrowing.md
@@ -1,0 +1,9 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(utilities): `isObject` narrows to `Record<string, any>` so interfaces and negative branches work (#723)
+
+`isObject` previously narrowed to `Record<string, unknown>`. That destroyed known property types on interface-typed values (TypeScript never grants interfaces an implicit index signature) and left `Record<string, any>` members alive in the `else` branch of a union. Both are incorrect narrowing, not a strictness win.
+
+The predicate is now `Record<string, any>`. Runtime is unchanged. Not breaking — the widened predicate is assignable from the old one for any program that already typechecked.

--- a/apps/docs/src/pages/guide/features/utilities.md
+++ b/apps/docs/src/pages/guide/features/utilities.md
@@ -428,8 +428,8 @@ if (!isNullOrUndefined(x)) {
 | `isString(x)` | `string` |
 | `isNumber(x)` | `number` (includes NaN) |
 | `isBoolean(x)` | `boolean` |
-| `isObject(x)` | `Record<string, unknown>` (excludes null and arrays) |
-| `isArray(x)` | `unknown[]` |
+| `isObject(x)` | `Record<string, any>` (excludes null and arrays)[^isobject-any] |
+| `isArray(x)` | the array member of `x`[^isarray-preserves] |
 | `isElement(x)` | `Element` |
 | `isNull(x)` | `null` |
 | `isUndefined(x)` | `undefined` |
@@ -439,6 +439,8 @@ if (!isNullOrUndefined(x)) {
 | `isNaN(x)` | `number` (only the NaN value)[^isnan-vs-global] |
 | `isThenable(x)` | `{ then: Function }`[^isthenable-duck-typed] |
 
+[^isobject-any]: The value type is `any` rather than `unknown` so that narrowing preserves what you already knew. TypeScript never grants an interface an implicit index signature, so a predicate of `Record<string, unknown>` would collapse an interface-typed value's known property types and would fail to remove object members in the `else` branch. `any` here widens only the *index* type — the union member itself survives narrowing intact.
+[^isarray-preserves]: Narrowing preserves the element type, so a `string[] | string` narrows to `string[]`, not `unknown[]`. Tuples keep their arity and `readonly` arrays stay `readonly`. When nothing more specific is known (e.g. `x: unknown`), it falls back to `unknown[]`.
 [^isnan-vs-global]: `isNaN` here uses `Number.isNaN()` internally — it does not coerce strings like the global `isNaN()`. `isNaN("foo")` returns `false`, not `true`.
 [^isthenable-duck-typed]: Duck-typed — matches native `Promise` instances and any other object exposing a callable `.then`, not just `instanceof Promise`. Use it to guard async-vs-sync return values; use `instanceof Promise` directly when only native promises should pass.
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -81,7 +81,10 @@ Non-negotiable. Each axiom carries a statement, a rationale, and a concrete anti
 
 **Why.** `any` silently disables type-checking downstream. A single `as any` in a composable propagates into every consumer that spreads it. `unknown` forces the consumer to narrow, which is the correct contract.
 
-**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` in `packages/0/src/` — with one sanctioned exception: the slot-return type in `defineSlots<{ default: (props: SlotProps) => any }>()`, which Volar requires for correct slot inference (see §8.8). That `=> any` types the slot's *return*, never a value or argument, so it disables no downstream checking.
+**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` in `packages/0/src/` — with two sanctioned exceptions:
+
+1. **Slot returns** — `defineSlots<{ default: (props: SlotProps) => any }>()`, which Volar requires for correct slot inference (see §8.8). That `=> any` types the slot's *return*, never a value or argument, so it disables no downstream checking.
+2. **`isObject` predicate** — `item is Record<string, any>` in `packages/0/src/utilities/helpers.ts`. `Record<string, unknown>` is *incorrect* as a type predicate: TypeScript never grants interfaces an implicit index signature, so the guard destroys known property types and fails to subtract `Record<string, any>` members in the `else` branch (issue #723). The `any` is only the *index* type of the predicate; it is not a value typed `any`, and it is not a license for `as any` elsewhere. Call sites that walk untyped trees and need checked property access must pin the read: `const inner: unknown = value.$value`. The private `isPlainObject` helper used by `mergeDeep` stays on `Record<string, unknown>` deliberately — it is not a public predicate and must keep index reads as `unknown`.
 
 **Anti-example (do not do this).**
 ```ts
@@ -859,6 +862,8 @@ See §2.2.
 ### 8.2 `unknown` over `any`
 
 When a type is genuinely indeterminate (e.g., ticket `value`), it is `unknown`. Narrowing happens at the point of use through `isObject`, `isString`, etc. [intent:79]
+
+**`isObject` caveat.** Guarding an `unknown` (or other indeterminate) value with `isObject` narrows to `Record<string, any>`, so property reads are `any` — not a further-checked type. That is intentional (see §2.2 exception 2): the alternative predicate collapses interface-typed unions. Prefer typed inputs (`interface` / object type in a union) when you need known properties after the guard; when walking untyped trees, pin intermediate reads to `unknown` before re-guarding.
 
 ### 8.3 `Readonly<Ref<T>>` return contract
 

--- a/packages/0/src/composables/createTokens/index.ts
+++ b/packages/0/src/composables/createTokens/index.ts
@@ -394,14 +394,16 @@ export function flatten (tokens: TokenCollection, prefix = '', flat = false): Fl
       if ('$value' in value) {
         flattened.push({ id, value: value as TokenAlias })
 
-        const inner = value.$value
+        // Pinned to unknown: isObject's index type is `any`, so reading through
+        // it unpinned would make the guards below compile-optional.
+        const inner: unknown = value.$value
         if (isObject(inner) && !flat) {
           for (const innerKey in inner) {
             if (!Object.hasOwn(inner, innerKey)) continue
             if (UNSAFE_KEYS.has(innerKey)) continue
             if (innerKey.startsWith('$')) continue
 
-            const child = inner[innerKey]
+            const child: unknown = inner[innerKey]
             const childId = `${id}.${innerKey}`
             if (!isObject(child)) {
               flattened.push({ id: childId, value: child as string | boolean | number })

--- a/packages/0/src/utilities/helpers.test.ts
+++ b/packages/0/src/utilities/helpers.test.ts
@@ -136,6 +136,32 @@ describe('helpers', () => {
         expect(isObject(new Map())).toBe(true)
         expect(isObject(/regex/)).toBe(true)
       })
+
+      // Narrowing is the point of the guard, so assert the narrowed types
+      // themselves. These are checked by `pnpm typecheck`, which includes
+      // `src/**/*.ts`; the runtime expectations only keep the branches live.
+      it('should preserve known props on interface-typed unions', () => {
+        interface Opts { tokens: number }
+        const value = { tokens: 3 } as string | Opts
+
+        if (isObject(value)) {
+          expectTypeOf(value.tokens).toEqualTypeOf<number>()
+          expect(value.tokens).toBe(3)
+        } else {
+          expectTypeOf(value).toEqualTypeOf<string>()
+        }
+      })
+
+      it('should subtract Record<string, any> from a union in the negative branch', () => {
+        const value = 'x' as string | boolean | Record<string, any>
+
+        if (isObject(value)) {
+          expectTypeOf(value).toEqualTypeOf<Record<string, any>>()
+        } else {
+          expectTypeOf(value).toEqualTypeOf<string | boolean>()
+          expect(value).toBe('x')
+        }
+      })
     })
 
     describe('isThenable', () => {

--- a/packages/0/src/utilities/helpers.ts
+++ b/packages/0/src/utilities/helpers.ts
@@ -99,6 +99,11 @@ export function isBoolean (item: unknown): item is boolean {
  * Returns false for null and arrays, even though `typeof null === 'object'`
  * and `typeof [] === 'object'` in JavaScript.
  *
+ * `Record<string, any>` is load-bearing: TypeScript does not grant interfaces
+ * an implicit index signature, so `Record<string, unknown>` destroys known
+ * property types on interface-typed values and fails to subtract
+ * `Record<string, any>` members in the negative branch.
+ *
  * @example
  * ```ts
  * isObject({})        // true
@@ -111,7 +116,8 @@ export function isBoolean (item: unknown): item is boolean {
  * @see {@link isNull} to check for null
  */
 /* #__NO_SIDE_EFFECTS__ */
-export function isObject (item: unknown): item is Record<string, unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: Record<string, unknown> breaks interface narrowing (#723)
+export function isObject (item: unknown): item is Record<string, any> {
   return typeof item === 'object' && item !== null && !Array.isArray(item)
 }
 

--- a/skills/vuetify0/references/REFERENCE.md
+++ b/skills/vuetify0/references/REFERENCE.md
@@ -463,7 +463,7 @@ import {
 } from '@vuetify/v0/utilities'
 
 if (isObject(value)) {
-  // value is Record<string, unknown>
+  // value is Record<string, any>
 }
 ```
 


### PR DESCRIPTION
Closes #723

### What

`isObject` previously narrowed to `Record<string, unknown>`. That is incorrect for two TypeScript reasons:

1. **Interfaces** never get implicit index signatures, so positive narrowing collapses known property types to `unknown`.
2. **Negative branch** cannot subtract `Record<string, any>` from a union, so object members survive `else`.

The predicate is now `Record<string, any>`. Runtime is unchanged.

In-package instance of the fix: `createContext` takes `CreateContextOptions` (an interface); after this change `keyOrOptions.suffix` is properly `string | undefined` instead of silently `unknown`.

### Why

Measured against vuetifyjs/vuetify#23039 (core adopting v0 guards): only this signature clears the four core typecheck failures (VTabs, mask, transition, tooltip). Sibling #745 found a zero-`any` path for `isArray`; that does not transfer here — every `unknown`-preserving candidate failed or matched the status quo.

### Also in this PR

- **Docs / skill** — type-guard table and `REFERENCE.md` updated for `isObject` and the already-stale `isArray` row from #745.
- **`createTokens.flatten`** — pin `$value` / child reads to `unknown` so recursive guards and casts stay real under the widened index type (typecheck stays green under `any` without this).
- **PHILOSOPHY §2.2 / §8.2** — second sanctioned `any` exception documented; unknown-input caveat on `isObject`.
- **`isPlainObject`** (private, drives `mergeDeep`) stays on `Record<string, unknown>` deliberately — not a public predicate; keeps index reads checked. No change to `mergeDeep`'s public signature.

### Tests

Type-level narrowing assertions in `helpers.test.ts` (same harness as #745):

- interface-typed union keeps known props in the positive branch
- `string | boolean | Record<string, any>` drops the Record in the negative branch

Not breaking — runtime identical; the widened predicate is assignable from the old one for any program that already typechecked.