### PR TITLE
docs: fix stale pre-mode claims and review nits from #737

### DIFF
--- a/.claude/rules/new-feature-checklist.md
+++ b/.claude/rules/new-feature-checklist.md
@@ -1,14 +1,5 @@
 ---
-paths:
-  - packages/0/src/components/**
-  - packages/0/src/composables/**
-  - packages/0/src/maturity.json
-  - packages/0/src/surface.test.ts
-  - packages/0/README.md
-  - README.md
-  - apps/docs/src/pages/components/**
-  - apps/docs/src/pages/composables/**
-  - apps/docs/src/examples/**
+paths: ['packages/0/src/components/**', 'packages/0/src/composables/**', 'packages/0/src/maturity.json', 'packages/0/src/surface.test.ts', 'packages/0/README.md', 'README.md', 'apps/docs/src/pages/components/**', 'apps/docs/src/pages/composables/**', 'apps/docs/src/examples/**']
 ---
 
 # New Feature Checklist

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: releasing
-description: Authoring a changeset, or cutting a release for @vuetify/v0 and the @paper/* design systems. Use when writing a .changeset/*.md file, deciding what belongs in changelog copy, exiting changesets pre/beta mode, or cutting a stable release. Covers the changeset content contract, the two version domains, and the pre-exit steps.
+description: Authoring a changeset, or cutting a release for @vuetify/v0 and the @paper/* design systems. Use when writing a .changeset/*.md file, deciding what belongs in changelog copy, re-entering or exiting changesets pre/beta mode, or reviewing a Version Packages PR. Covers the changeset content contract, the two version domains, and optional pre-channel workflow.
 ---
 
 # Releasing
@@ -8,6 +8,15 @@ description: Authoring a changeset, or cutting a release for @vuetify/v0 and the
 Changesets-driven. Pushing to `master` opens/updates a "Version Packages" PR; merging it publishes to npm (tokenless OIDC) and mints the GitHub releases (`.github/workflows/release.yml`).
 
 The branch model — which base branch a PR targets by change type — lives in the root `CLAUDE.md` and is always loaded. This skill covers what happens once the PR is on the right branch.
+
+## Commands
+
+```bash
+pnpm changeset         # Author a changeset — once per change
+pnpm release:prepare   # Pre-release validation (validate + build)
+```
+
+Publishing is automated via the Version Packages PR on `master` — do not `npm publish` by hand.
 
 ## Changeset content contract
 
@@ -22,12 +31,12 @@ The `.changeset/*.md` body renders verbatim into the changelog and GitHub releas
 - **Substrate** — `@vuetify/v0` is the sole published substrate, versioned and released on its own `v<version>` GitHub release. `@vuetify/paper` is `private`/dormant and no longer part of the changesets `fixed` group.
 - **Design systems** (`@paper/*`, e.g. `@paper/genesis`) version and release independently, each on its own `name@version` release. Note `@paper/genesis` depends on `@vuetify/v0`, so a substrate **major** bump (e.g. `1.x` → `2.0.0`) leaves genesis's `^` range and changesets will also bump + republish genesis. That is expected — review it in the "Version Packages" PR before merging.
 
-## Exiting beta / cutting a stable release
+## Pre / beta channel (optional)
 
-The repo is in changesets **pre mode** (`.changeset/pre.json`, `beta` dist-tag); every release is `…-beta.N` published under the `beta` tag. Before the first stable release:
+Stable releases are the default. The repo is **not** in changesets pre mode unless `.changeset/pre.json` exists. To enter a prerelease channel again:
 
-1. `pnpm changeset pre exit`
-2. Commit the removal of `.changeset/pre.json`
-3. Let the next "Version Packages" PR produce the clean `1.0.0`, then merge it
+1. `pnpm changeset pre enter <tag>` (e.g. `beta` or `rc`)
+2. Ship pre-releases via the normal Version Packages flow (`…-<tag>.N` under that dist-tag)
+3. Before the next stable cut: `pnpm changeset pre exit`, commit the removal of `.changeset/pre.json`, then merge the Version Packages PR that produces the clean stable version
 
-Skipping `pre exit` ships `1.0.0-beta.N` (or mistags it) instead of a real `1.0.0`.
+Skipping `pre exit` ships another pre version (or mistags) instead of a real stable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Vue 3 headless UI primitives and composables. Unstyled, logic-focused building b
 
 Never hand-roll a helper, type, or environment check that the package already exports. Read the barrels before writing:
 
-- `#v0/utilities` — type guards, `mergeDeep`, `useId`, `clamp`, `range`
+- `#v0/utilities` — type guards (incl. `isThenable`), `mergeDeep`, `useId`, `clamp`, `range`
 - `#v0/types` — `ID`, `Extensible`, `MaybeArray`, `DeepPartial`, `Activation`
 - `#v0/constants/globals` — `IN_BROWSER`, `SUPPORTS_*` (never write `typeof window !== 'undefined'`)
 
@@ -41,7 +41,7 @@ Scripts live in the root `package.json` — read it for the full list. The non-o
 ```bash
 pnpm lint:fix         # Always use lint:fix, never plain lint
 pnpm validate         # lint + typecheck + test
-pnpm metrics          # Regenerate performance metrics (required after editing a .bench.ts)
+pnpm metrics          # CI metrics-regen only — do not commit artifacts from feature branches; local: pnpm test:bench
 pnpm repo:check       # knip + sherif
 pnpm changeset        # Author a changeset — run once per change, see "Releasing"
 ```
@@ -67,7 +67,7 @@ Three long-lived branches; a PR's base is chosen by the semver impact of the cha
 
 ### Authoring a changeset / cutting a release
 
-The repo is in changesets **pre mode** (`beta` dist-tag). For the changeset content contract, the two version domains (`@vuetify/v0` vs `@paper/*`), and the pre-exit steps for a stable release, invoke the **`releasing`** skill.
+For the changeset content contract, the two version domains (`@vuetify/v0` vs `@paper/*`), and optional pre/beta channel workflow, invoke the **`releasing`** skill (`.claude/skills/releasing/SKILL.md`).
 
 ## Conventions
 
@@ -103,4 +103,4 @@ See `.claude/rules/` for path-scoped documentation:
 - `benchmarks.md` - Standards for `*.bench.ts` files
 - `docs.md` - Architecture for `apps/docs/**`
 - `testing.md` - Standards for `*.test.ts` files
-- `new-feature-checklist.md` - Required files when adding a component or composable
+- `new-feature-checklist.md` - Required files when adding a component or composable (path-scoped)

--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -88,9 +88,11 @@ features:
 - `#v0` → `packages/0/src`
 - `#paper` → `packages/paper/src`
 
-## Live Examples with DocsExample
+## Live Examples
 
-To add interactive examples to documentation pages:
+Feature pages (components/composables): use `::: gn-example` — full authoring rules in `.claude/rules/docs.md`. Do not hand-roll `<DocsExample>` imports on those pages.
+
+`.vue` pages that still mount examples directly:
 
 **1. Create the example file** in `src/examples/`:
 ```
@@ -99,7 +101,7 @@ src/examples/composables/{composable}/basic.vue
 src/examples/guide/{guide-name}/example.vue
 ```
 
-**2. Import in the markdown page** using `<script setup>`:
+**2. Import** using `<script setup>`:
 ```vue
 <script setup>
 import BasicExample from '@/examples/components/tabs/basic.vue'
@@ -107,7 +109,7 @@ import BasicExampleRaw from '@/examples/components/tabs/basic.vue?raw'
 </script>
 ```
 
-**3. Use DocsExample** with the component as slot and raw code as prop:
+**3. Mount DocsExample** with the component as slot and raw code as prop:
 ```vue
 <DocsExample file="basic.vue" :code="BasicExampleRaw">
   <BasicExample />
@@ -128,7 +130,7 @@ import BasicExampleRaw from '@/examples/components/tabs/basic.vue?raw'
 - **Always prefer @vuetify/v0 composables** over raw browser APIs or custom implementations. Check `mcp__vuetify-mcp__get_vuetify0_composable_list` before writing event listeners, observers, or state management.
 - UnoCSS utilities for all styling
 - Prefer markdown for documentation pages
-- **Examples**: Use `::: example` blocks in `.md` pages for live demos; use `<DocsExample>` directly only in `.vue` pages
+- **Examples**: `::: gn-example` on feature pages (see `.claude/rules/docs.md`); `<DocsExample>` only in `.vue` pages; legacy `::: example` for guides/index only
 - **Callouts**: Use `> [!TIP]`, `> [!NOTE]`, `> [!WARNING]`, `> [!CAUTION]`, `> [!IMPORTANT]` for alerts (GitHub-aligned). Use `> [!ASKAI] question` to prompt Ask AI—phrase as a question the user would ask (e.g., "How do I add validation?"), not a question to the user. Use `> [!TOUR] tour-id` to embed a clickable tour callout—the tour name and description are pulled from the discovery registry automatically.
 
 The skill-level placement quiz is **not** a callout directive: it is the `AppSkillQuiz` component (rendered under the Skill Levels section of `guide/essentials/using-the-docs.md`), which drives `DocsQuestion` off the central bank in `apps/docs/src/skillz/questions/{track}.json`. Each attempt samples a level-spread subset and builds each question's options from its `answers` + a fresh draw from its own `distractors` pool; completing it suggests a skill level the reader can apply to the docs filter.


### PR DESCRIPTION
## Summary

Follow-up to #737. That PR correctly trimmed always-loaded context and scoped the checklist, but it migrated **present-tense pre-mode instructions** into the new `releasing` skill after the repo had already exited pre mode (#687) and shipped stable `1.0.x`.

### Critical
- Drop “the repo is in changesets pre mode” from `CLAUDE.md` and `.claude/skills/releasing/SKILL.md`
- Reframe as optional pre-channel workflow (`pre enter` → ship → `pre exit`), gated on `.changeset/pre.json` existing

### Important
- Explicit path on the skill pointer: `.claude/skills/releasing/SKILL.md`
- `pnpm metrics` comment: CI metrics-regen only; local iteration is `pnpm test:bench` (do not commit artifacts from feature branches)
- Checklist `paths:` frontmatter matches sibling single-line style

### Suggestions
- Keep `isThenable` named in the utilities pointer
- `release:prepare` listed under skill Commands
- Checklist marked path-scoped in Detailed Rules index
- `apps/docs/CLAUDE.md`: `::: gn-example` is canonical for feature pages; DocsExample recipe scoped to `.vue` pages

## Test plan
- [x] No `.changeset/pre.json` on master; skill no longer claims pre mode as current
- [x] Skill file resolves at the path CLAUDE.md cites
- [x] Checklist `paths:` globs unchanged, style aligned with other rules
- [x] Skim CLAUDE / skill / docs CLAUDE in a fresh agent turn for residual pre/beta present-tense