### PR TITLE
docs(ai-tools): compute SKILL.md size instead of hardcoding

### DIFF
--- a/apps/docs/build/generate-llms-full.ts
+++ b/apps/docs/build/generate-llms-full.ts
@@ -11,6 +11,7 @@ import type { Plugin, ViteDevServer } from 'vite'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PAGES_DIR = resolve(__dirname, '../src/pages')
 const BASE_URL = 'https://0.vuetifyjs.com'
+const SKILL_PATH = resolve(__dirname, '../../../skills/vuetify0/SKILL.md')
 
 const VIRTUAL_MODULE_ID = 'virtual:llms-stats'
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
@@ -18,6 +19,7 @@ const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
 export interface LlmsStats {
   llms: { size: number, sizeFormatted: string }
   llmsFull: { size: number, sizeFormatted: string }
+  skill: { size: number, sizeFormatted: string }
 }
 
 function formatSize (bytes: number): string {
@@ -299,10 +301,12 @@ export default function generateLlmsFullPlugin (): Plugin {
 
     const llmsSize = new TextEncoder().encode(llmsContent).length
     const llmsFullSize = new TextEncoder().encode(llmsFullContent).length
+    const skillSize = readFileSync(SKILL_PATH).byteLength
 
     statsCache = {
       llms: { size: llmsSize, sizeFormatted: formatSize(llmsSize) },
       llmsFull: { size: llmsFullSize, sizeFormatted: formatSize(llmsFullSize) },
+      skill: { size: skillSize, sizeFormatted: formatSize(skillSize) },
     }
 
     return statsCache

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -31,7 +31,7 @@ v0 provides machine-readable documentation files following the [llms.txt](https:
 | - | - | - | - |
 | <a href="/llms.txt" target="_blank" class="v0-link">llms.txt↗</a> | {{ llmsStats.llms.sizeFormatted }} | Curated index with links | Quick context, navigation |
 | <a href="/llms-full.txt" target="_blank" class="v0-link whitespace-nowrap">llms-full.txt↗</a> | {{ llmsStats.llmsFull.sizeFormatted }} | Complete documentation | Deep understanding, code generation |
-| <a href="/SKILL.md" target="_blank" class="v0-link">SKILL.md↗</a> | ~5KB | Patterns & anti-patterns | Claude Code, Grok Build, Cursor, Windsurf |
+| <a href="/SKILL.md" target="_blank" class="v0-link">SKILL.md↗</a> | {{ llmsStats.skill.sizeFormatted }} | Patterns & anti-patterns | Claude Code, Grok Build, Cursor, Windsurf |
 
 > [!ASKAI] How do I configure my AI agent to consume llms-full.txt?
 


### PR DESCRIPTION
The Available Files table on the AI Tools page hardcoded `~5KB` for SKILL.md, while the sibling `llms.txt` and `llms-full.txt` rows already read from the `virtual:llms-stats` module.

SKILL.md is generated by `scripts/generate-skill.ts` and has since grown to 17 KB, so the published figure understated it by roughly 3x.

Adds a `skill` entry to `LlmsStats` so the row is computed from the source file and stays accurate as v0 gains exports.

Note: `getStats()` now throws if `skills/vuetify0/SKILL.md` is missing, where `copy-markdown.ts` tolerates its absence and logs. Happy to make it tolerant instead if that divergence is unwanted.