### PR TITLE
test(vapor): bump harness to vue 3.6.0-rc.2

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -205,9 +205,10 @@ jobs:
           git fetch origin "$GITHUB_BASE_REF" --depth=1
           pnpm metrics:check
 
-  # Vapor parity tests run on a beta Vue (tests/vapor, vue@3.6.0-beta), pinned
-  # separately from the rest of the repo. Non-blocking: a Vapor regression
-  # surfaces as a visible signal without redding the build on a beta hiccup.
+  # Vapor parity tests run on a pre-release Vue (tests/vapor, vue@3.6.0-rc),
+  # pinned separately from the rest of the repo. Non-blocking: a Vapor
+  # regression surfaces as a visible signal without redding the build on a
+  # pre-release hiccup.
   vapor:
     needs: prepare
     runs-on: ubuntu-latest

--- a/apps/docs/src/pages/guide/integration/vapor.md
+++ b/apps/docs/src/pages/guide/integration/vapor.md
@@ -16,12 +16,12 @@ related:
 
 # Vapor
 
-[Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1) is Vue's compiler-optimized runtime that ships without the virtual DOM, compiling templates to direct DOM operations. v0 is built to keep working under Vapor.
+[Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-rc.1) is Vue's compiler-optimized runtime that ships without the virtual DOM, compiling templates to direct DOM operations. v0 is built to keep working under Vapor.
 
 <DocsPageFeatures :frontmatter />
 
 > [!IMPORTANT]
-> Vapor mode ships in **Vue 3.6**, which is still in beta. This page describes a **forward-compatibility target**, not a stable guarantee. v0 itself is published against Vue `>=3.5`; the Vapor support below is verified on a pinned Vue 3.6 beta and exercised by a dedicated test suite, but treat it as experimental until Vue 3.6 is stable.
+> Vapor mode ships in **Vue 3.6**, now in release-candidate phase with Vapor feature-complete. This page describes a **forward-compatibility target**, not a stable guarantee. v0 itself is published against Vue `>=3.5`; the Vapor support below is verified on a pinned Vue 3.6 release candidate and exercised by a dedicated test suite, but treat it as pre-release until Vue 3.6 is stable.
 
 ## Why v0 is a good fit for Vapor
 
@@ -34,7 +34,7 @@ This is a standing design rule, not an afterthought: every new v0 abstraction is
 
 ## What is verified today
 
-v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`) that mounts real Vapor components against a pinned Vue 3.6 beta[^beta-pin] and asserts:
+v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`) that mounts real Vapor components against a pinned Vue 3.6 release candidate[^rc-pin] and asserts:
 
 | Area | What it proves |
 | - | - |
@@ -42,7 +42,7 @@ v0 ships an isolated Vapor test suite (`tests/vapor`, run with `pnpm test:vapor`
 | Composables | `createSelection` registers items, updates reactive state, and drives Vapor DOM updates from inside a Vapor `setup`. |
 | Component interop | A classic (vdom) v0 component renders inside a Vapor app through `vaporInteropPlugin`, including slot content forwarded from a Vapor parent[^interop-slots]. |
 
-[^beta-pin]: Pinned to `vue@3.6.0-beta.15` — the newest 3.6 beta old enough to clear the workspace's install-age policy. The Vapor surface the suite touches (the `vapor` SFC attribute, `createVaporApp`, `vaporInteropPlugin`) has been stable across the beta line; bump the pin as 3.6 nears release.
+[^rc-pin]: Pinned to `vue@3.6.0-rc.2`. The Vapor surface the suite touches (the `vapor` SFC attribute, `createVaporApp`, `vaporInteropPlugin`) has been stable across the beta and RC lines; the pin moves to `3.6.0` when stable ships.
 [^instance-shim]: Vapor exposes the active instance on Vue 3.6's `currentInstance` export; `getCurrentInstance()` returns `null` inside a Vapor component by design ([vuejs/core discussion #13629](https://github.com/orgs/vuejs/discussions/13629)). v0 reads `currentInstance` when present and falls back to `getCurrentInstance()` on Vue 3.5 — see `utilities/instance.ts`.
 [^interop-slots]: Interop is directional. A vdom component rendering inside a Vapor parent (the tested path) works; passing Vapor slots *into* a vdom component needs `renderSlot` rather than `slots.default()`, per [Vue's Vapor notes](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1). Keep a region in one rendering mode where you can.
 
@@ -95,16 +95,16 @@ createApp(App)
 
 ## Current limitations
 
-- **Vue 3.6 is beta.** The runtime, the `vapor` SFC attribute, and `vaporInteropPlugin` are stabilizing; APIs can still shift before release.
+- **Vue 3.6 is a release candidate.** Vapor is feature-complete as of rc.1; APIs are unlikely to shift, but nothing is guaranteed until 3.6.0 ships.
 - **Coverage is representative, not exhaustive.** The suite proves the instance-context substrate, a registry composable, and component interop. It does not yet mount every component under Vapor.
 - **Interop has rough edges.** Vapor↔vdom interop still has edge cases, so keep a given region in one rendering mode where you can.
 
 ## Verifying it yourself
 
-The Vapor suite is intentionally kept out of the default test run (it depends on a beta Vue). Run it directly:
+The Vapor suite is intentionally kept out of the default test run (it depends on a pre-release Vue). Run it directly:
 
 ```bash
 pnpm test:vapor
 ```
 
-See `tests/vapor/README.md` in the repository for the toolchain setup and the beta-specific configuration notes.
+See `tests/vapor/README.md` in the repository for the toolchain setup and the pre-release configuration notes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,7 +438,7 @@ importers:
         version: 2.1.15(vue@3.5.39(typescript@6.0.3))
       '@vue/test-utils':
         specifier: 'catalog:'
-        version: 2.4.11(@vue/compiler-dom@3.6.0-beta.15)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
+        version: 2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       markdown-it:
         specifier: 'catalog:'
         version: 14.3.0
@@ -694,7 +694,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: 'catalog:'
-        version: 0.21.10(jiti@2.7.0)(postcss@8.5.16)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)
+        version: 0.21.10(jiti@2.7.0)(postcss@8.5.19)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)
       rollup-plugin-sass:
         specifier: 'catalog:'
         version: 1.15.3(rollup@4.59.0)
@@ -719,10 +719,10 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))
+        version: 6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
       '@vue/runtime-vapor':
-        specifier: 3.6.0-beta.15
-        version: 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
+        specifier: 3.6.0-rc.2
+        version: 3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)
       happy-dom:
         specifier: 'catalog:'
         version: 20.10.6
@@ -733,8 +733,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@28.1.0(supports-color@8.1.1))(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vue:
-        specifier: 3.6.0-beta.15
-        version: 3.6.0-beta.15(typescript@6.0.3)
+        specifier: 3.6.0-rc.2
+        version: 3.6.0-rc.2(typescript@6.0.3)
 
 packages:
 
@@ -3540,29 +3540,29 @@ packages:
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
-  '@vue/compiler-core@3.6.0-beta.15':
-    resolution: {integrity: sha512-TtzIgaBexYK1CAtZZBPQunaXtXx2sf3TS/F1LT9m+tnqtvuAi9SBt3Sa+aWb8/0cnon0H5UQrOenQZgiTQdCYw==}
+  '@vue/compiler-core@3.6.0-rc.2':
+    resolution: {integrity: sha512-Xx79h4EpJktQBShelXNKaRuvn9N6YsYL1j+RXdvPKzI+8tohYziBJbxOFGAkdcOKBwKc2SIWV4DOlTAMhE96yQ==}
 
   '@vue/compiler-dom@3.5.39':
     resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
 
-  '@vue/compiler-dom@3.6.0-beta.15':
-    resolution: {integrity: sha512-RG1pNFEvFTdUS6GjnkXnCD8wkTm6lmSCg0uimExYioYY6jBteU7uZGmW1UvweZ1FzgXTTOIzj0PGaXi2qDYeVQ==}
+  '@vue/compiler-dom@3.6.0-rc.2':
+    resolution: {integrity: sha512-dRTdTdi/KXzHYIkHtyjGxepTIxnsZ/hB3v1osnS8c4MeycAyzkSoZW6OZkXXN4oVVVU6NKXds1XtKAEKVVw7nA==}
 
   '@vue/compiler-sfc@3.5.39':
     resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
 
-  '@vue/compiler-sfc@3.6.0-beta.15':
-    resolution: {integrity: sha512-QEcaQnw1PLmIqEZHUd2WrxSHj8hwPBI6GWZ2QGdsczhInral/PHoTtdDdnh6OgF/nmczS03+SpZ3LvAdtnF0Ag==}
+  '@vue/compiler-sfc@3.6.0-rc.2':
+    resolution: {integrity: sha512-EZWTNh0UwdxvrBJkFc6+dqfwuUSdTVHDIohQcGDPCqGaYTHOfUL20b+grEAzlyxB741KrVBUb7qqpes92hAh2w==}
 
   '@vue/compiler-ssr@3.5.39':
     resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
-  '@vue/compiler-ssr@3.6.0-beta.15':
-    resolution: {integrity: sha512-0/CLPSiIrbXjuBZzBxd9NvC4GTLHFWFseSEb4rhlY3qx7hyP6qdE0BHYnuobz/0ce+YdrSoL6M6rAqolZuC2fg==}
+  '@vue/compiler-ssr@3.6.0-rc.2':
+    resolution: {integrity: sha512-lqHSdQTmlhKX3dNEvR1TcspUzDlTR82T7BYLDzfvTwAqGXxAI2WJfyGJPcNpPjPKYEMI9JRGF32DU8TlHLx1AA==}
 
-  '@vue/compiler-vapor@3.6.0-beta.15':
-    resolution: {integrity: sha512-iu5iZ04/d+QO5CnoYXJDEjS/rp2kkUOqGwC8wUAKFJSv2+9/APA0hMCr8xHBnGPr4QurvBu2xto3vwYSaPhIzg==}
+  '@vue/compiler-vapor@3.6.0-rc.2':
+    resolution: {integrity: sha512-QbrA01pbj9xemF2McgBopyaOwj3kQGN0W1GW5EdFXORIT4fQQJpmUOj40h99S3bk09gLs5bFTRS4YE+Oyw/F9w==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -3591,8 +3591,8 @@ packages:
   '@vue/reactivity@3.5.39':
     resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
 
-  '@vue/reactivity@3.6.0-beta.15':
-    resolution: {integrity: sha512-TX2Im+/SD9l+diT7ZqWjLLdoSnVp1k5+GIegg6MOWaFLiTkOZ+ZbbFr+ANTyn9cLu5RryALLipCCz9ug4d10/g==}
+  '@vue/reactivity@3.6.0-rc.2':
+    resolution: {integrity: sha512-B01EoSTcaVQiJwZDoSoeKYClVgj60BHN43oHEcxXhPVLdxsXI0SOiQuskUskQDZn2ma08llICKJohL60o+UamA==}
 
   '@vue/repl@4.7.1':
     resolution: {integrity: sha512-8w5Z3cyqBJ5ufzXO2eut2stzb7aX/ZnSva2d3ee8eEINEB7FG2JYwc14eAHHHGGuoXOGN5v4cyb5ti/YZGcwlg==}
@@ -3600,35 +3600,33 @@ packages:
   '@vue/runtime-core@3.5.39':
     resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
 
-  '@vue/runtime-core@3.6.0-beta.15':
-    resolution: {integrity: sha512-0lGFf6tN7L9b5it3PApFwL+fUDCmg2Gk/Q2HxKP7wukWqYlRYN/5XtzLHamRJjiXVAjzi24SDpD/uCC2gE/geA==}
+  '@vue/runtime-core@3.6.0-rc.2':
+    resolution: {integrity: sha512-qFV61Hbg6LyEGxJiVRJYuiIfryxrfO4+cgW1esxtkR1/pvemULwG6KpFImsJDwcC+YxrtvndXGM5PRVwUCGuiA==}
 
   '@vue/runtime-dom@3.5.39':
     resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
 
-  '@vue/runtime-dom@3.6.0-beta.15':
-    resolution: {integrity: sha512-glceCzw46XQSRSfKRD9iRfGCuWVkWWRC4Sx8bWNM2RHM1Oki9Sa4mmTLeXu7S2Rwjhfx2aIcghQ4XhoENL8xfg==}
+  '@vue/runtime-dom@3.6.0-rc.2':
+    resolution: {integrity: sha512-clIE/xk0b61t30BPKoOXZep253nhWdjyw7iac53yy2KN0nxAupkb6x3ImOI9iljjXqOW5lYdNVHNxNlcx3iA1Q==}
 
-  '@vue/runtime-vapor@3.6.0-beta.15':
-    resolution: {integrity: sha512-nS/yKrXsKPiFed3zzfihMVoA0xqmN+UDvd1ezLCmFj0tDw6TNo3NnPH0/M5NrX40L4i7h8dMpIkwA63ExpoeAA==}
+  '@vue/runtime-vapor@3.6.0-rc.2':
+    resolution: {integrity: sha512-8EpxbNyT629k/52el4D7PxXmZtiYhJRBHPXJR7CZw0OluiADtT9W8J+XB83EVlzHmFUysXcd+mGWmuHwIhuHZA==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-beta.15
+      '@vue/runtime-dom': 3.6.0-rc.2
 
   '@vue/server-renderer@3.5.39':
     resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
     peerDependencies:
       vue: 3.5.39
 
-  '@vue/server-renderer@3.6.0-beta.15':
-    resolution: {integrity: sha512-jj5E0KsP7dPS+tJ3AAF/XRm4qtSrOGWhIYqXoe31DHJDswbRAS68p/hhkzaozezlnQld8w2xHntd0I4YbXb1KA==}
-    peerDependencies:
-      vue: 3.6.0-beta.15
+  '@vue/server-renderer@3.6.0-rc.2':
+    resolution: {integrity: sha512-TIsqoYljs6b0wfoCDhv4EeU3Du2a8gTadkaTGMjIYLTLlO4p8r4VdDqfNp/ZMAm87bW4ST1naBMRe+bXQBpAeQ==}
 
   '@vue/shared@3.5.39':
     resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
-  '@vue/shared@3.6.0-beta.15':
-    resolution: {integrity: sha512-wyjMjw2AmP6h9qNpVZAO77rgxd6+jcMu+2Wmg9729mmR+V5HPweBSKWggioSNR6NBazMMGY4ekb5U9DUp1KRFg==}
+  '@vue/shared@3.6.0-rc.2':
+    resolution: {integrity: sha512-Tz44lKLjxhWRu3GJ38768dc2hW4XhDtTB5aUo5fCMis6YDyFzwQYkrD/B9SuQ1v/ailv6UVR3wSHiujNXSjMCQ==}
 
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
@@ -5990,6 +5988,10 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   posthog-js@1.398.0:
     resolution: {integrity: sha512-1+1FPmP6sw1NxtFz5YI1MqwpvRrGGJIedvczk8rJ7YD0Ez3pjolQ21krc+iKrpkvuoNjORZATGOYpUtaL5yWjQ==}
 
@@ -7221,8 +7223,8 @@ packages:
       typescript:
         optional: true
 
-  vue@3.6.0-beta.15:
-    resolution: {integrity: sha512-KMz/cLpxspxVOX0MyRGRd+ppW9qpajuxaE1/xLcs1uRsYYD7Sc0G/56TpVX9uDjVdcgFwWIBfG9Ukj92XUP1TQ==}
+  vue@3.6.0-rc.2:
+    resolution: {integrity: sha512-pBgoISqETcufJ1e92vVW2/D5MEbCm2XHlC/5dq3hWq8s17tx9v5BEdYv4hojJ0yEEDidYxUL7itS+vV32wfZrw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -9567,14 +9569,14 @@ snapshots:
 
   '@tsconfig/node24@24.0.4': {}
 
-  '@tsdown/css@0.21.10(jiti@2.7.0)(postcss@8.5.16)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)':
+  '@tsdown/css@0.21.10(jiti@2.7.0)(postcss@8.5.19)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       lightningcss: 1.32.0
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.21.0)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(yaml@2.9.0)
       rolldown: 1.0.0-rc.17
       tsdown: 0.21.10(@arethetypeswrong/core@0.18.4)(@tsdown/css@0.21.10)(oxc-resolver@11.21.3)(publint@0.3.21)(synckit@0.11.12)(typescript@6.0.3)(vue-tsc@3.2.7(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.19
       sass: 1.101.0
       sass-embedded: 1.100.0
     transitivePeerDependencies:
@@ -10065,11 +10067,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-beta.15(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vue: 3.6.0-beta.15(typescript@6.0.3)
+      vue: 3.6.0-rc.2(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.0)(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -10199,10 +10201,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-beta.15':
+  '@vue/compiler-core@3.6.0-rc.2':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-rc.2
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -10212,10 +10214,10 @@ snapshots:
       '@vue/compiler-core': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/compiler-dom@3.6.0-beta.15':
+  '@vue/compiler-dom@3.6.0-rc.2':
     dependencies:
-      '@vue/compiler-core': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/compiler-core': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
 
   '@vue/compiler-sfc@3.5.39':
     dependencies:
@@ -10229,17 +10231,17 @@ snapshots:
       postcss: 8.5.16
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-beta.15':
+  '@vue/compiler-sfc@3.6.0-rc.2':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.6.0-beta.15
-      '@vue/compiler-dom': 3.6.0-beta.15
-      '@vue/compiler-ssr': 3.6.0-beta.15
-      '@vue/compiler-vapor': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/compiler-core': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/compiler-ssr': 3.6.0-rc.2
+      '@vue/compiler-vapor': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.16
+      postcss: 8.5.19
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.39':
@@ -10247,16 +10249,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/compiler-ssr@3.6.0-beta.15':
+  '@vue/compiler-ssr@3.6.0-rc.2':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
 
-  '@vue/compiler-vapor@3.6.0-beta.15':
+  '@vue/compiler-vapor@3.6.0-rc.2':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/compiler-dom': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -10307,9 +10309,9 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.39
 
-  '@vue/reactivity@3.6.0-beta.15':
+  '@vue/reactivity@3.6.0-rc.2':
     dependencies:
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/shared': 3.6.0-rc.2
 
   '@vue/repl@4.7.1(patch_hash=fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33)': {}
 
@@ -10318,10 +10320,10 @@ snapshots:
       '@vue/reactivity': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/runtime-core@3.6.0-beta.15':
+  '@vue/runtime-core@3.6.0-rc.2':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/reactivity': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
 
   '@vue/runtime-dom@3.5.39':
     dependencies:
@@ -10330,18 +10332,18 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/runtime-dom@3.6.0-beta.15':
+  '@vue/runtime-dom@3.6.0-rc.2':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.15
-      '@vue/runtime-core': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/reactivity': 3.6.0-rc.2
+      '@vue/runtime-core': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)':
+  '@vue/runtime-vapor@3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.15
-      '@vue/runtime-dom': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/reactivity': 3.6.0-rc.2
+      '@vue/runtime-dom': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
 
   '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -10349,15 +10351,15 @@ snapshots:
       '@vue/shared': 3.5.39
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vue/server-renderer@3.6.0-beta.15(vue@3.6.0-beta.15(typescript@6.0.3))':
+  '@vue/server-renderer@3.6.0-rc.2':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-beta.15
-      '@vue/shared': 3.6.0-beta.15
-      vue: 3.6.0-beta.15(typescript@6.0.3)
+      '@vue/compiler-ssr': 3.6.0-rc.2
+      '@vue/runtime-dom': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
 
   '@vue/shared@3.5.39': {}
 
-  '@vue/shared@3.6.0-beta.15': {}
+  '@vue/shared@3.6.0-rc.2': {}
 
   '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -10368,9 +10370,9 @@ snapshots:
     optionalDependencies:
       '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-beta.15)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.15
+      '@vue/compiler-dom': 3.6.0-rc.2
       js-beautify: 1.15.4
       vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.2.8
@@ -12952,12 +12954,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.21.0)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.16
+      postcss: 8.5.19
       tsx: 4.21.0
       yaml: 2.9.0
 
@@ -12972,6 +12974,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -13841,7 +13849,7 @@ snapshots:
       unrun: 0.2.37(synckit@0.11.12)
     optionalDependencies:
       '@arethetypeswrong/core': 0.18.4
-      '@tsdown/css': 0.21.10(jiti@2.7.0)(postcss@8.5.16)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)
+      '@tsdown/css': 0.21.10(jiti@2.7.0)(postcss@8.5.19)(sass-embedded@1.100.0)(sass@1.101.0)(tsdown@0.21.10)(tsx@4.21.0)(yaml@2.9.0)
       publint: 0.3.21
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14315,14 +14323,14 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vue@3.6.0-beta.15(typescript@6.0.3):
+  vue@3.6.0-rc.2(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.15
-      '@vue/compiler-sfc': 3.6.0-beta.15
-      '@vue/runtime-dom': 3.6.0-beta.15
-      '@vue/runtime-vapor': 3.6.0-beta.15(@vue/runtime-dom@3.6.0-beta.15)
-      '@vue/server-renderer': 3.6.0-beta.15(vue@3.6.0-beta.15(typescript@6.0.3))
-      '@vue/shared': 3.6.0-beta.15
+      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/compiler-sfc': 3.6.0-rc.2
+      '@vue/runtime-dom': 3.6.0-rc.2
+      '@vue/runtime-vapor': 3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)
+      '@vue/server-renderer': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.2
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,6 +102,8 @@ ignoredBuiltDependencies:
 minimumReleaseAge: 20160
 
 minimumReleaseAgeExclude:
+  - vue
+  - '@vue/*'
   - '@vuetify/auth'
   - vite
   - brace-expansion

--- a/tests/vapor/README.md
+++ b/tests/vapor/README.md
@@ -1,17 +1,18 @@
 # @vuetify-private/vapor-tests
 
-Isolated [Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-beta.1)
+Isolated [Vue Vapor mode](https://github.com/vuejs/core/releases/tag/v3.6.0-rc.1)
 parity tests for `@vuetify/v0`. This package verifies — with **real Vapor
 renders**, not mocks — that v0's composables and components work under Vue's
 vdom-less runtime.
 
 ## Why this is a separate package
 
-Vapor ships in **Vue 3.6** (still beta). The rest of the monorepo is pinned to
-`vue@3.5.33` via the catalog, and we don't want a beta Vue in the default test
-run. So this package:
+Vapor ships in **Vue 3.6**, which is in release-candidate phase (Vapor is
+feature-complete as of rc.1). The rest of the monorepo is pinned to Vue 3.5 via
+the catalog, and we don't want a pre-release Vue in the default test run. So
+this package:
 
-- Declares its **own** `vue@3.6.0-beta.15` + `@vue/runtime-vapor@3.6.0-beta.15`
+- Declares its **own** `vue@3.6.0-rc.2` + `@vue/runtime-vapor@3.6.0-rc.2`
   devDependencies. pnpm installs them alongside the 3.5 copy; `packages/0`
   is untouched.
 - Lives under `tests/*`, which the root `vitest.config.ts`
@@ -29,7 +30,7 @@ pnpm --filter @vuetify-private/vapor-tests test
 
 | File | Proves |
 |------|--------|
-| `test/smoke.test.ts` | The beta toolchain compiles + mounts a `<script setup vapor>` SFC and reacts. If this fails, the harness is broken, not v0. |
+| `test/smoke.test.ts` | The pre-release toolchain compiles + mounts a `<script setup vapor>` SFC and reacts. If this fails, the harness is broken, not v0. |
 | `test/instance.vapor.test.ts` | `utilities/instance.ts` works under a real Vapor render: `getCurrentInstance()` is genuinely `null`, yet the `currentInstance` shim still detects the instance and `useId()` resolves. `instance.test.ts` can only mock this. |
 | `test/composables.vapor.test.ts` | `createSelection` (registry + reactive tickets + computed Set) runs in a Vapor setup and drives Vapor DOM updates. |
 | `test/context.vapor.test.ts` | `createContext` carries a value from a Vapor ancestor to a Vapor descendant — the provide/inject substrate beneath every v0 compound component. |
@@ -37,7 +38,7 @@ pnpm --filter @vuetify-private/vapor-tests test
 
 ## Why the vitest config is unusual
 
-Two beta-specific traps, both handled in `vitest.config.ts`:
+Two toolchain traps, both handled in `vitest.config.ts`:
 
 1. **Vue's `node` export condition resolves to a Vapor-less build.** `vue`'s
    `.` export maps `node` → `index.mjs` → the full CJS build, which does **not**
@@ -51,9 +52,13 @@ Two beta-specific traps, both handled in `vitest.config.ts`:
    the `__VUE_*__` feature flags are replaced via `define`, and the packages are
    `inline`d so Vite (not Node) transforms them.
 
-## Beta pin
+## RC pin
 
-`3.6.0-beta.15` is deliberate: it is the newest 3.6 beta older than the
-workspace's `minimumReleaseAge` (14 days), so it installs without a policy
-exclusion. Bump it as 3.6 stabilizes; the Vapor API (`vapor` attribute,
-`createVaporApp`, `vaporInteropPlugin`) has been stable across the beta line.
+`3.6.0-rc.2` is the newest 3.6 release candidate. RCs land faster than the
+workspace's `minimumReleaseAge` (14 days) clears them, so `vue` and `@vue/*`
+sit in `minimumReleaseAgeExclude` — safe because both are exact-pinned
+everywhere (default catalog + this package), so no floating range can pull an
+un-aged release. Bump the pin to `3.6.0` when stable ships and drop the
+exclusions once it clears the age window; the Vapor API (`vapor` attribute,
+`createVaporApp`, `vaporInteropPlugin`) has been stable across the beta and RC
+lines.

--- a/tests/vapor/package.json
+++ b/tests/vapor/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Isolated Vue 3.6 Vapor-mode parity tests for @vuetify/v0. Runs on a beta Vue, deliberately kept out of the default test run.",
+  "description": "Isolated Vue 3.6 Vapor-mode parity tests for @vuetify/v0. Runs on a pre-release Vue, deliberately kept out of the default test run.",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
-    "@vue/runtime-vapor": "3.6.0-beta.15",
+    "@vue/runtime-vapor": "3.6.0-rc.2",
     "happy-dom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vue": "3.6.0-beta.15"
+    "vue": "3.6.0-rc.2"
   }
 }

--- a/tests/vapor/src/bench/Checklist.vue
+++ b/tests/vapor/src/bench/Checklist.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+  // Classic (vdom) checklist: N compound checkboxes (Root + Indicator each).
+  // Baseline for the interop overhead comparison.
+
+  // Framework
+  import { Checkbox } from '@vuetify/v0/components'
+
+  const { count = 200 } = defineProps<{
+    count?: number
+  }>()
+</script>
+
+<template>
+  <div data-bench="vdom">
+    <label v-for="i in count" :key="i">
+      <Checkbox.Root data-cb>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Root>
+      Item {{ i }}
+    </label>
+  </div>
+</template>

--- a/tests/vapor/src/bench/ChecklistBridge.vue
+++ b/tests/vapor/src/bench/ChecklistBridge.vue
@@ -1,0 +1,18 @@
+<script setup vapor lang="ts">
+  // Context
+// Vapor parent that renders the classic checklist as ONE component: exactly
+  // one interop crossing, everything beneath is vdom-in-vdom. Isolates the
+  // crossing-count multiplier from the per-crossing cost.
+
+  import Checklist from './Checklist.vue'
+
+  const { count = 200 } = defineProps<{
+    count?: number
+  }>()
+</script>
+
+<template>
+  <div data-bench="vapor-bridge">
+    <Checklist :count />
+  </div>
+</template>

--- a/tests/vapor/src/bench/ChecklistVapor.vue
+++ b/tests/vapor/src/bench/ChecklistVapor.vue
@@ -1,0 +1,23 @@
+<script setup vapor lang="ts">
+  // Vapor parent with the SAME template as Checklist.vue: every Checkbox.Root
+  // and Checkbox.Indicator is a classic (vdom) component instantiated from
+  // Vapor-compiled slot content — each one is its own interop crossing.
+
+  // Framework
+  import { Checkbox } from '@vuetify/v0/components'
+
+  const { count = 200 } = defineProps<{
+    count?: number
+  }>()
+</script>
+
+<template>
+  <div data-bench="vapor-inline">
+    <label v-for="i in count" :key="i">
+      <Checkbox.Root data-cb>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Root>
+      Item {{ i }}
+    </label>
+  </div>
+</template>

--- a/tests/vapor/test/interop-overhead.test.ts
+++ b/tests/vapor/test/interop-overhead.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+// Utilities
+import { createVaporApp, vaporInteropPlugin } from '@vue/runtime-vapor'
+import { createApp } from 'vue'
+
+// Fixtures
+import Checklist from '../src/bench/Checklist.vue'
+import ChecklistBridge from '../src/bench/ChecklistBridge.vue'
+import ChecklistVapor from '../src/bench/ChecklistVapor.vue'
+
+// Interop overhead measurement, NOT a parity test: mounts the same 200
+// compound checkboxes three ways and reports mount time + retained heap.
+// Gated behind VAPOR_BENCH so `pnpm test:vapor` / CI never pay for it:
+//
+//   VAPOR_BENCH=1 NODE_OPTIONS=--expose-gc \
+//     pnpm --filter=@vuetify-private/vapor-tests exec vitest run test/interop-overhead.test.ts
+//
+// happy-dom timings are comparative (pure JS, no layout) — trust the ratios,
+// not the absolute milliseconds.
+
+const COUNT = 200
+const ROUNDS = 20
+const WARMUP = 5
+const HEAP_APPS = 5
+
+type Mounted = { host: HTMLElement, unmount: () => void }
+
+function mountClassic (component: any, props: Record<string, unknown>): Mounted {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const app = createApp(component, props)
+  app.mount(host)
+  return {
+    host,
+    unmount: () => {
+      app.unmount()
+      host.remove()
+    },
+  }
+}
+
+function mountVaporRoot (component: any, props: Record<string, unknown>): Mounted {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const app = createVaporApp(component, props)
+  app.use(vaporInteropPlugin)
+  app.mount(host)
+  return {
+    host,
+    unmount: () => {
+      app.unmount()
+      host.remove()
+    },
+  }
+}
+
+const VARIANTS: Array<{ name: string, mount: () => Mounted }> = [
+  { name: 'vdom-root', mount: () => mountClassic(Checklist, { count: COUNT }) },
+  { name: 'vapor-inline', mount: () => mountVaporRoot(ChecklistVapor, { count: COUNT }) },
+  { name: 'vapor-bridge', mount: () => mountVaporRoot(ChecklistBridge, { count: COUNT }) },
+]
+
+function median (values: number[]): number {
+  const sorted = values.toSorted((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]!
+}
+
+describe.runIf(process.env.VAPOR_BENCH)('interop overhead (200 compound checkboxes)', () => {
+  it('should measure mount time and retained heap per variant', () => {
+    const times = new Map<string, number[]>(VARIANTS.map(v => [v.name, []]))
+
+    for (const variant of VARIANTS) {
+      const probe = variant.mount()
+      expect(probe.host.querySelectorAll('button').length).toBe(COUNT)
+      probe.unmount()
+    }
+
+    for (let round = 0; round < WARMUP + ROUNDS; round++) {
+      for (let offset = 0; offset < VARIANTS.length; offset++) {
+        const variant = VARIANTS[(round + offset) % VARIANTS.length]!
+        const start = performance.now()
+        const mounted = variant.mount()
+        const elapsed = performance.now() - start
+        mounted.unmount()
+        if (round >= WARMUP) times.get(variant.name)!.push(elapsed)
+      }
+    }
+
+    const gc = (globalThis as any).gc as (() => void) | undefined
+    const heap = new Map<string, number>()
+
+    if (gc) {
+      for (const variant of VARIANTS) {
+        gc()
+        gc()
+        const before = process.memoryUsage().heapUsed
+        const apps = Array.from({ length: HEAP_APPS }, () => variant.mount())
+        gc()
+        gc()
+        heap.set(variant.name, (process.memoryUsage().heapUsed - before) / HEAP_APPS)
+        for (const app of apps) app.unmount()
+      }
+    }
+
+    const base = median(times.get('vdom-root')!)
+    const baseHeap = heap.get('vdom-root')
+
+    for (const variant of VARIANTS) {
+      const ms = median(times.get(variant.name)!)
+      const retained = heap.get(variant.name)
+      console.log([
+        variant.name.padEnd(14),
+        `mount ${ms.toFixed(2)}ms`,
+        `(${(ms / base * 100 - 100).toFixed(0).padStart(4)}% vs vdom)`,
+        retained && baseHeap
+          ? `retained ${(retained / 1024).toFixed(0)}KB (${(retained / baseHeap * 100 - 100).toFixed(0)}% vs vdom)`
+          : 'retained n/a (run with --expose-gc)',
+      ].join('  '))
+    }
+  })
+})

--- a/tests/vapor/test/smoke.test.ts
+++ b/tests/vapor/test/smoke.test.ts
@@ -10,7 +10,7 @@ import type { VaporMount } from './mount'
 
 import Counter from '../src/Counter.vue'
 
-// Smoke test: proves the beta toolchain (vue@3.6 + @vue/runtime-vapor +
+// Smoke test: proves the pre-release toolchain (vue@3.6 + @vue/runtime-vapor +
 // @vitejs/plugin-vue) can compile a <script setup vapor> SFC, mount it, and
 // observe reactive DOM updates. Nothing v0-specific here — if this fails, the
 // harness is broken, not v0.


### PR DESCRIPTION
## What

Vue 3.6 entered release-candidate phase (rc.1 Jul 18, rc.2 Jul 22) with Vapor declared feature-complete. This bumps the isolated Vapor parity harness from `vue@3.6.0-beta.15` to `3.6.0-rc.2` and updates every place that still described 3.6 as beta.

- `tests/vapor/package.json` — pin `vue` + `@vue/runtime-vapor` to `3.6.0-rc.2`
- `pnpm-workspace.yaml` — add `vue` / `@vue/*` to `minimumReleaseAgeExclude`: RCs land faster than the 14-day age gate clears them. Safe because `vue` is exact-pinned everywhere (default catalog + harness), so no floating range can pull an un-aged release; drop the exclusions once `3.6.0` stable clears the window (rationale recorded in `tests/vapor/README.md`)
- `tests/vapor/README.md`, `apps/docs/.../guide/integration/vapor.md`, `pr-checks.yml` comment — beta → RC wording; pin-rationale section rewritten
- Left intact: two links to the `v3.6.0-beta.1` release notes that are citations (that's where Vue published the interop/`renderSlot` guidance)

## Verification

`pnpm test:vapor` on rc.2: 5 files / 10 tests, all passing, unmodified — including the `currentInstance` shim probe, `createSelection` + `createContext` under real Vapor renders, and vdom-under-Vapor interop via `vaporInteropPlugin`.

## Interop overhead measurement

Third commit adds a `VAPOR_BENCH`-gated measurement (never runs in `pnpm test:vapor`/CI): the same 200 compound checkboxes (`Checkbox.Root` + `Checkbox.Indicator`) mounted three ways on rc.2 / happy-dom, 20 interleaved rounds, medians:

| variant | crossings | mount | retained heap |
| - | - | - | - |
| classic root (baseline) | 0 | 82.5ms | — |
| Vapor root, parts inline in Vapor template | ~401 | +44% | +12% |
| Vapor root, one classic bridge component | 1 | +5% | −3% |

Total vdom instance count is identical across variants — the interop crossing count (a function of parts-per-control under a Vapor parent) is the driver of `vaporInteropPlugin` overhead, not v0's own mount work. Reproduce with:

```bash
VAPOR_BENCH=1 NODE_OPTIONS=--expose-gc \
  pnpm --filter=@vuetify-private/vapor-tests exec vitest run test/interop-overhead.test.ts
```
