### PR TITLE
fix(useBreakpoints): resolve the initial breakpoint via matchMedia, not innerWidth

### DIFF
--- a/.changeset/fix-breakpoints-initial-matchmedia-730.md
+++ b/.changeset/fix-breakpoints-initial-matchmedia-730.md
@@ -1,0 +1,16 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useBreakpoints): resolve the initial breakpoint via matchMedia, not innerWidth (#730)
+
+`createBreakpoints`'s initial state was resolved by comparing `window.innerWidth` against
+the breakpoint thresholds, while `update()` resolved the same state through `matchMedia`.
+At non-100% zoom or with a non-overlay scrollbar the two can disagree, so a direct
+`createBreakpoints()` consumer (e.g. Vuetify's `display` composable outside SSR mode)
+could render one breakpoint band on first paint and silently flip to another on the
+first resize event, with no real viewport change in between.
+
+`createBreakpoints()` now runs `update()` once synchronously when `IN_BROWSER && !ssr`,
+so the initial band is resolved the same way as every subsequent one. The SSR path is
+unchanged and still seeds from `ssr.clientWidth` to keep hydration markup matching.

--- a/packages/0/src/composables/useBreakpoints/index.test.ts
+++ b/packages/0/src/composables/useBreakpoints/index.test.ts
@@ -121,6 +121,35 @@ describe('createBreakpoints', () => {
         expect(context.xxl.value).toBe(false)
       })
 
+      it('should resolve the initial breakpoint via matchMedia, not innerWidth, when they disagree', () => {
+        // innerWidth says 'lg' (>= 1280), matchMedia says 'md' — simulates
+        // the fractional-zoom / scrollbar-width straddle described in #730.
+        mockWindow.innerWidth = 1280
+        mockWindow.matchMedia = (query: string) => {
+          const match = query.match(/\(min-width:\s*(\d+)px\)/)
+          const threshold = match ? Number(match[1]) : 0
+          return { matches: threshold <= 1024 }
+        }
+
+        const context = createBreakpoints()
+
+        expect(context.name.value).toBe('md')
+        expect(context.lg.value).toBe(false)
+        expect(context.md.value).toBe(true)
+      })
+
+      it('should not resolve the initial breakpoint via matchMedia when ssr dimensions are provided', () => {
+        mockWindow.matchMedia = (query: string) => {
+          const match = query.match(/\(min-width:\s*(\d+)px\)/)
+          const threshold = match ? Number(match[1]) : 0
+          return { matches: threshold <= 1024 }
+        }
+
+        const context = createBreakpoints({ ssr: { clientWidth: 1280 } })
+
+        expect(context.name.value).toBe('lg')
+      })
+
       it('should accept custom breakpoint options', () => {
         const customOptions = {
           namespace: 'v0:breakpoints',

--- a/packages/0/src/composables/useBreakpoints/index.ts
+++ b/packages/0/src/composables/useBreakpoints/index.ts
@@ -211,6 +211,13 @@ export function createBreakpoints (_options: BreakpointsOptions = {}): Breakpoin
     xlAndDown.value = index <= 4
   }
 
+  // The initial band above is seeded from window.innerWidth, which can
+  // disagree with the matchMedia-based resolution update() uses (see #730 —
+  // fractional zoom and scrollbar width can straddle a threshold). Running
+  // update() once here aligns first paint with every subsequent frame.
+  // The SSR branch is left alone so hydration markup keeps matching.
+  if (IN_BROWSER && !ssr) update()
+
   return {
     breakpoints,
     mobileBreakpoint,


### PR DESCRIPTION
Closes #730.

`createBreakpoints`'s initial state was resolved by comparing `window.innerWidth` against the breakpoint thresholds, while `update()` resolved the same state through `matchMedia` (adopted in the #157 fix). At non-100% zoom, or with a non-overlay scrollbar, the two can disagree on which side of a threshold the viewport falls — so a direct `createBreakpoints()` consumer (e.g. Vuetify's `display` composable outside SSR mode) could render one breakpoint band on first paint and silently flip to another on the first resize event, with no real viewport change in between.

The plugin's `setup` hook already called `context.update()` once at mount to paper over this, which is why the bug was invisible to plugin consumers — it only shows up for the bare factory.

## Fix

`createBreakpoints()` now runs `update()` once synchronously when `IN_BROWSER && !ssr`, so the initial band is resolved the same way as every subsequent one. The SSR branch is untouched and still seeds from `ssr.clientWidth` so hydration markup keeps matching.

## Tests

Added two cases to `index.test.ts`:
- initial breakpoint resolves via `matchMedia` when it disagrees with `innerWidth`
- SSR-seeded initial state is unaffected (still resolves from `ssr.clientWidth`, not `matchMedia`)

All 66 existing + new tests pass.

## Note

Per the issue, this is a behavior change for bare-factory, non-SSR consumers: the initial band can differ from before, though only in cases where it previously disagreed with the very next resize/update — i.e. it's a correction, not a regression.