### PR TITLE
fix(useResizeObserver): report the content box on the immediate entry's contentRect

### DIFF
--- a/.changeset/fix-resize-observer-immediate-content-box-729.md
+++ b/.changeset/fix-resize-observer-immediate-content-box-729.md
@@ -1,0 +1,17 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useResizeObserver): report the content box on the immediate entry's contentRect (#729)
+
+The `immediate` option synthesized its first entry from `getBoundingClientRect()`,
+which reports the border box in viewport coordinates. Every entry the real observer
+delivers afterwards reports the content box, positioned relative to the padding edge —
+contradicting `contentRect`'s own documented contract ("always describes the content
+box, regardless of the `box` option"). A consumer reading `contentRect` on mount (for
+example `useElementSize`, which hardcodes `immediate: true`) could see one set of
+numbers on mount and a different set on the first real resize, with no size change in
+between.
+
+`measure()` now derives `contentRect` from the same computed-style values it already
+uses for `contentBoxSize`/`borderBoxSize`, so the immediate and observed paths agree.

--- a/packages/0/src/composables/useResizeObserver/index.browser.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.browser.test.ts
@@ -155,6 +155,20 @@ describe('useResizeObserver box model', () => {
 
     expect(size(immediate.borderBoxSize[0])).toEqual(size(observed.borderBoxSize[0]))
     expect(size(immediate.contentBoxSize[0])).toEqual(size(observed.contentBoxSize[0]))
+    expect(immediate.contentRect).toEqual(observed.contentRect)
+  })
+
+  it('should report the immediate contentRect on the content box, positioned at the padding offset', async () => {
+    const el = element()
+    const { next } = observe(el, { immediate: true })
+
+    const immediate = await next()
+
+    expect(immediate.contentRect.width).toBe(CONTENT.inlineSize)
+    expect(immediate.contentRect.height).toBe(CONTENT.blockSize)
+    // 16px padding on the inline edges, 4px on the block edges (see GEOMETRY)
+    expect(immediate.contentRect.left).toBe(16)
+    expect(immediate.contentRect.top).toBe(4)
   })
 
   it('should swap the logical axes on the immediate entry under a vertical writing mode', async () => {

--- a/packages/0/src/composables/useResizeObserver/index.ts
+++ b/packages/0/src/composables/useResizeObserver/index.ts
@@ -114,8 +114,9 @@ function pxToNumber (value: string | undefined, fallback = 0): number {
  * The box sizes come from `getComputedStyle` rather than
  * `getBoundingClientRect` because resolved lengths are layout values — like the
  * observer, and unlike a client rect, they are not scaled by CSS transforms.
- * `contentRect` keeps its existing client-rect source so callers reading it see
- * no change.
+ * `contentRect` is derived from the same computed-style values, so it reports
+ * the content box positioned relative to the padding edge on this path too,
+ * matching what the observer's own entries report.
  *
  * Every read is written to tolerate a partial style declaration: an element
  * with no layout box resolves its lengths to `''`, and this runs on whatever
@@ -155,10 +156,10 @@ function measure (el: Element): ResizeObserverEntry {
 
   return {
     contentRect: {
-      width: rect.width,
-      height: rect.height,
-      top: rect.top,
-      left: rect.left,
+      width: width.content,
+      height: height.content,
+      top: pxToNumber(style.paddingTop),
+      left: pxToNumber(style.paddingLeft),
     },
     borderBoxSize: [{ inlineSize: inline.border, blockSize: block.border }],
     contentBoxSize: [{ inlineSize: inline.content, blockSize: block.content }],


### PR DESCRIPTION
Closes #729.

The `immediate` option synthesized its first entry from `getBoundingClientRect()`, which reports the **border box** in viewport coordinates. Every entry the real observer delivers afterwards reports the **content box**, positioned relative to the padding edge. This contradicts `contentRect`'s own documented contract:

> `contentRect` always describes the content box, regardless of the `box` option.

A consumer reading `contentRect` on mount (e.g. `useElementSize`, which hardcodes `immediate: true` and is used by `createOverflow` and `CarouselViewport`) could see one set of numbers on mount and a different set on the first real resize, with no actual size change in between.

## Fix

`measure()` already computes correct content-box values from `getComputedStyle` for `contentBoxSize`/`borderBoxSize`. `contentRect` now sources its `width`/`height` from the same content-box values, and its `top`/`left` from the padding offsets, matching what the observer's own entries report.

## Tests

- Extended the existing 'immediate entry matching what the observer reports' test to assert `contentRect` equality, not just the box-size arrays.
- Added a dedicated test asserting the immediate `contentRect` reports content-box dimensions positioned at the padding offset.

All 9 browser tests + 26 non-browser tests for this composable pass.