### PR TITLE
fix(NumberField): default the spinbutton's accessible name

### DIFF
--- a/.changeset/fix-numberfield-spinbutton-accessible-name-741.md
+++ b/.changeset/fix-numberfield-spinbutton-accessible-name-741.md
@@ -1,0 +1,16 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(NumberField): default the spinbutton's accessible name (#741)
+
+`NumberField`'s `label` and `ariaLabelledby` props both collapsed to `undefined`
+when a consumer supplied neither — including the shape `NumberField`'s own
+`@example` documents — so the `role="spinbutton"` input shipped with no
+accessible name at all (axe `label`, critical).
+
+`NumberField.Control` now falls back to a locale-driven default (`locale.ti('NumberField.label') ?? 'Number'`)
+when no `label` or `ariaLabelledby` is provided, matching the precedent already
+set by the increment/decrement buttons (`NumberField.increment`/`NumberField.decrement`).
+A consumer-supplied `label` still takes priority, and `ariaLabelledby` still
+suppresses `aria-label` entirely.

--- a/packages/0/src/components/NumberField/NumberFieldControl.vue
+++ b/packages/0/src/components/NumberField/NumberFieldControl.vue
@@ -15,6 +15,9 @@
   // Context
   import { useNumberFieldRoot } from './NumberFieldRoot.vue'
 
+  // Composables
+  import { useLocale } from '#v0/composables/useLocale'
+
   // Utilities
   import { isNull } from '#v0/utilities'
   import { mergeProps, onMounted, shallowRef, toRef, useAttrs, watch } from 'vue'
@@ -57,6 +60,7 @@
   } = defineProps<NumberFieldControlProps>()
 
   const root = useNumberFieldRoot(namespace)
+  const locale = useLocale()
 
   const leap = Math.max(1, Math.round(root.numeric.leap / root.numeric.step))
 
@@ -182,7 +186,7 @@
       'aria-valuemin': Number.isFinite(root.numeric.min) ? root.numeric.min : undefined,
       'aria-valuemax': Number.isFinite(root.numeric.max) ? root.numeric.max : undefined,
       'aria-invalid': invalid || undefined,
-      'aria-label': root.ariaLabelledby ? undefined : (root.label || undefined),
+      'aria-label': root.ariaLabelledby ? undefined : (root.label || (locale.ti('NumberField.label') ?? 'Number')),
       'aria-labelledby': root.ariaLabelledby || undefined,
       'aria-describedby': describedby.value,
       'aria-errormessage': (root.hasError.value && root.errors.value.length > 0) ? root.errorId : undefined,

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -785,11 +785,21 @@ describe('numberField', () => {
       expect(controlEl().attributes('aria-labelledby')).toBe('my-label')
     })
 
-    it('should not set aria-label when no label prop is provided', async () => {
+    it('should fall back to a default aria-label when no label prop is provided', async () => {
       const model = ref<number | null>(5)
       const { controlEl, wait } = mountNumberField({ model })
       await wait()
-      expect(controlEl().attributes('aria-label')).toBeUndefined()
+      expect(controlEl().attributes('aria-label')).toBe('Number')
+    })
+
+    it('should prefer the label prop over the default aria-label', async () => {
+      const model = ref<number | null>(5)
+      const { controlEl, wait } = mountNumberField({
+        model,
+        props: { label: 'Quantity' },
+      })
+      await wait()
+      expect(controlEl().attributes('aria-label')).toBe('Quantity')
     })
   })
 


### PR DESCRIPTION
Closes #741.

`NumberField`'s `role="spinbutton"` input reads `aria-label` from `root.label`, but that prop has no default — and `aria-labelledby` requires the consumer to point at an existing element. The shape `NumberField`'s own `@example` documents supplies neither, so the spinbutton ships with no accessible name at all (axe `label`, critical).

This is not covered by #640 (`labelledBy` prop, merged) — that closes the case where a label element exists elsewhere in the DOM, but does nothing when the consumer supplies no naming mechanism at all, which is exactly the documented default shape.

## Fix

`NumberField.Control` now falls back to `locale.ti('NumberField.label') ?? 'Number'` when neither `label` nor `ariaLabelledby` is set — matching the precedent already used by the increment/decrement buttons (`NumberField.increment` / `NumberField.decrement`), which are already named this way. A consumer-supplied `label` still wins, and `ariaLabelledby` still suppresses `aria-label` entirely.

## Tests

- Replaced the (now-incorrect) 'should not set aria-label when no label prop is provided' test with one asserting the default fallback.
- Added a test confirming an explicit `label` prop still wins over the default.

139 existing + new component tests pass.