### PR TITLE
fix(Slider): default the thumb's accessible name

### DIFF
--- a/.changeset/fix-slider-thumb-accessible-name-740.md
+++ b/.changeset/fix-slider-thumb-accessible-name-740.md
@@ -1,0 +1,16 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Slider): default the thumb's accessible name (#740)
+
+`Slider.Thumb` renders `role="slider"` and read its accessible name only from
+the consumer-supplied `ariaLabel`/`ariaLabelledby` props, with no fallback —
+so the shape `Slider`'s own `@example` documents shipped a thumb with no name
+at all (axe `aria-input-field-name`, serious).
+
+`Slider.Thumb` now falls back to `locale.ti('Slider.label') ?? 'Slider'` when
+neither `ariaLabel` nor `ariaLabelledby` is provided, matching the pattern
+already used by `Pagination.Root`, `Breadcrumbs.Root` and `Carousel.Item`. A
+consumer-supplied `ariaLabel` still wins, and `ariaLabelledby` still suppresses
+`aria-label` entirely (previously both attributes could be set at once).

--- a/packages/0/src/components/Slider/SliderThumb.vue
+++ b/packages/0/src/components/Slider/SliderThumb.vue
@@ -16,6 +16,9 @@
   // Context
   import { useSliderRoot } from './SliderRoot.vue'
 
+  // Composables
+  import { useLocale } from '#v0/composables/useLocale'
+
   // Utilities
   import { isUndefined } from '#v0/utilities'
   import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs, useTemplateRef } from 'vue'
@@ -87,6 +90,7 @@
   } = defineProps<SliderThumbProps>()
 
   const root = useSliderRoot(namespace)
+  const locale = useLocale()
   const thumbRef = useTemplateRef<{ element: HTMLElement | null }>('thumb')
 
   const ticket = root.register()
@@ -172,7 +176,7 @@
       'aria-orientation': toValue(root.orientation),
       'aria-disabled': isDisabled.value,
       'aria-readonly': isReadonly.value ? true : undefined,
-      'aria-label': ariaLabel || undefined,
+      'aria-label': ariaLabelledby ? undefined : (ariaLabel || (locale.ti('Slider.label') ?? 'Slider')),
       'aria-labelledby': ariaLabelledby || undefined,
       'data-state': dataState.value,
       'data-disabled': isDisabled.value ? true : undefined,

--- a/packages/0/src/components/Slider/index.browser.test.ts
+++ b/packages/0/src/components/Slider/index.browser.test.ts
@@ -280,6 +280,24 @@ describe('slider', () => {
       expect(thumbProps().attrs['aria-label']).toBe('Volume')
     })
 
+    it('should fall back to a default aria-label when no ariaLabel prop is provided', async () => {
+      const model = ref([50])
+      const { thumbProps, wait } = mountSlider({ model })
+      await wait()
+      expect(thumbProps().attrs['aria-label']).toBe('Slider')
+    })
+
+    it('should suppress the default aria-label when ariaLabelledby is provided', async () => {
+      const model = ref([50])
+      const { thumbProps, wait } = mountSlider({
+        model,
+        thumbProps: [{ ariaLabelledby: 'my-label' }],
+      })
+      await wait()
+      expect(thumbProps().attrs['aria-label']).toBeUndefined()
+      expect(thumbProps().attrs['aria-labelledby']).toBe('my-label')
+    })
+
     it('should set data-state to idle by default', async () => {
       const model = ref([50])
       const { thumbProps, wait } = mountSlider({ model })


### PR DESCRIPTION
Closes #740.

`SliderRoot.vue` already has `label`/`ariaLabelledby` props, but they land on the `role="group"` wrapper — the `role="slider"` thumb itself reads its name only from its own `ariaLabel`/`ariaLabelledby` props, which default to `undefined`. The shape `Slider`'s own `@example` documents (`<Slider.Thumb />` with no `ariaLabel`) therefore ships a thumb with no accessible name at all (axe `aria-input-field-name`, serious). `aria-valuetext` is populated but is the value, not the name.

## Fix

`Slider.Thumb` now falls back to `locale.ti('Slider.label') ?? 'Slider'` when neither `ariaLabel` nor `ariaLabelledby` is set — the same locale-driven-default pattern already used by `Pagination.Root`, `Breadcrumbs.Root`, and `Carousel.Item`. A consumer-supplied `ariaLabel` still wins. Also tightened `aria-labelledby`/`aria-label` to be mutually exclusive (previously both could be emitted at once when a consumer passed both props).

## Tests

- Added a test asserting the default `aria-label` fallback.
- Added a test asserting `ariaLabelledby` suppresses the default `aria-label`.

92 existing + new browser tests pass.