### PR TITLE
fix(Select, Combobox): correct the documented Item example to avoid double role=option

### DIFF
--- a/.changeset/fix-select-combobox-item-double-role-738.md
+++ b/.changeset/fix-select-combobox-item-double-role-738.md
@@ -1,0 +1,18 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Select, Combobox): correct the documented Item example to avoid double `role="option"` (#738)
+
+`Select.Item` and `Combobox.Item` already bind their full `attrs` bundle (including
+`role="option"`) onto their own non-renderless `Atom`. Both components' `@example`
+JSDoc then spread that same `attrs` object onto a child `<div>` inside the default
+slot — which `.claude/rules/components.md` documents as unsupported outside
+`renderless` mode: it renders `role="option"` twice (`listbox > div[role="option"] >
+div[role="option"]`, failing axe's `aria-required-parent`) and double-fires every
+handler in `attrs`, once on the child and again via bubbling to the Atom.
+
+Added `renderless` to the documented `Select.Item` / `Combobox.Item` usage in both
+components' `@example` blocks, so the consumer's own element is the only one
+rendered — matching how `packages/0/src/components/fixtures/Select.vue` and
+`Combobox.vue` (and every real docs example) already use these components.

--- a/packages/0/src/components/Combobox/index.ts
+++ b/packages/0/src/components/Combobox/index.ts
@@ -61,6 +61,7 @@ import Root from './ComboboxRoot.vue'
  *         :key="item.id"
  *         :id="item.id"
  *         :value="item.label"
+ *         renderless
  *         v-slot="{ isSelected, attrs }"
  *       >
  *         <div v-bind="attrs">{{ item.label }}</div>
@@ -171,7 +172,7 @@ export const Combobox = {
    *
    * @example
    * ```vue
-   * <Combobox.Item id="apple" value="Apple" v-slot="{ isSelected, isHighlighted, attrs }">
+   * <Combobox.Item id="apple" value="Apple" renderless v-slot="{ isSelected, isHighlighted, attrs }">
    *   <div v-bind="attrs" :class="{ highlighted: isHighlighted }">
    *     Apple {{ isSelected ? '✓' : '' }}
    *   </div>

--- a/packages/0/src/components/Select/index.ts
+++ b/packages/0/src/components/Select/index.ts
@@ -57,6 +57,7 @@ import Value from './SelectValue.vue'
  *         :key="item.id"
  *         :id="item.id"
  *         :value="item.label"
+ *         renderless
  *         v-slot="{ isSelected, attrs }"
  *       >
  *         <div v-bind="attrs">{{ item.label }}</div>
@@ -183,7 +184,7 @@ export const Select = {
    * </script>
    *
    * <template>
-   *   <Select.Item id="apple" value="Apple" v-slot="{ isSelected, attrs }">
+   *   <Select.Item id="apple" value="Apple" renderless v-slot="{ isSelected, attrs }">
    *     <div v-bind="attrs">Apple {{ isSelected ? '✓' : '' }}</div>
    *   </Select.Item>
    * </template>


### PR DESCRIPTION
Closes #738.

`Select.Item` (and, identically, `Combobox.Item`) binds its whole `attrs` bundle — including `role="option"` — onto its own `Atom`, which is not `renderless` by default. Both components' `@example` JSDoc then spread that same `attrs` object onto a child `<div>` inside the default slot:

```vue
<Select.Item id="apple" value="Apple" v-slot="{ isSelected, attrs }">
  <div v-bind="attrs">Apple {{ isSelected ? '✓' : '' }}</div>
</Select.Item>
```

`.claude/rules/components.md` documents this as unsupported outside `renderless` mode — spreading `attrs` onto a child in non-renderless mode renders the ARIA role twice (`listbox > div[role="option"] > div[role="option"]`, failing axe's `aria-required-parent`) and double-fires every handler in `attrs` once on the child and again via bubbling to the Atom. The documented shape is exactly this bug.

## Fix

Added `renderless` to the documented `Select.Item` / `Combobox.Item` usage in both components' `@example` blocks (the top-level module example and each component's own JSDoc), so the consumer's own element is the only one rendered. This matches how `packages/0/src/components/fixtures/Select.vue` / `Combobox.vue` and every real docs example (`apps/docs/src/examples/components/select/*`, `combobox/*`) already use these components — none of them spread `attrs` on a child, so none were actually affected by the bug; only the documented `@example` shape was.

Per the issue, `Combobox.Item` is structurally identical to `Select.Item` (same `as='div'` default, same non-renderless `attrs` spread) and didn't appear in the #736 sweep only because the harness never got Combobox's listbox open to audit — checked it by hand here and it has the identical example bug, now fixed alongside Select.

Documentation-only change; the fixture used by the a11y sweep was already correct, so all 53 existing `a11y.browser.test.ts` tests pass unchanged.