### PR TITLE
fix(Input): make the type prop reactive

### DIFF
--- a/.changeset/fix-input-root-type-reactivity-757.md
+++ b/.changeset/fix-input-root-type-reactivity-757.md
@@ -1,0 +1,15 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Input): make the `type` prop reactive (#757)
+
+`Input.Root`'s `type` prop was destructured once at setup and assigned as a plain
+value onto `InputRootContext` — every sibling field on the context is a ref or
+getter, but `type` was not. `Input.Control` read that frozen value, so changing
+`:type` on `Input.Root` after mount (the classic password reveal-toggle pattern)
+never reached the rendered `<input>`'s DOM `type` attribute.
+
+`type` is now placed on the context as `toRef(() => type)`, and `Input.Control`
+reads `root.type.value`, matching how every other reactive context field is
+consumed.

--- a/packages/0/src/components/Input/InputControl.vue
+++ b/packages/0/src/components/Input/InputControl.vue
@@ -81,7 +81,7 @@
 
     return {
       'id': root.id,
-      'type': root.type,
+      'type': root.type.value,
       'name': root.name,
       'value': root.value.value,
       'form': root.form,

--- a/packages/0/src/components/Input/InputRoot.vue
+++ b/packages/0/src/components/Input/InputRoot.vue
@@ -51,7 +51,7 @@
     /** Form field name */
     readonly name?: string
     /** Input type */
-    readonly type: string
+    readonly type: Readonly<Ref<string>>
     /** Associate with form by ID */
     readonly form?: string
     /** Whether this input is required */
@@ -265,7 +265,7 @@
     id: input.id,
     label,
     name,
-    type,
+    type: toRef(() => type),
     form,
     required,
     descriptionId: input.descriptionId,

--- a/packages/0/src/components/Input/index.browser.test.ts
+++ b/packages/0/src/components/Input/index.browser.test.ts
@@ -87,6 +87,31 @@ describe('input', () => {
     })
   })
 
+  describe('type prop', () => {
+    it('should default the rendered input type to text', () => {
+      const { wrapper } = mountInput()
+
+      expect(wrapper.find('input').attributes('type')).toBe('text')
+    })
+
+    it('should set the rendered input type from the type prop', () => {
+      const { wrapper } = mountInput({ props: { type: 'password' } })
+
+      expect(wrapper.find('input').attributes('type')).toBe('password')
+    })
+
+    it('should react to post-mount changes to the type prop', async () => {
+      const { wrapper, wait } = mountInput({ props: { type: 'password' } })
+
+      expect(wrapper.find('input').attributes('type')).toBe('password')
+
+      await wrapper.setProps({ type: 'text' })
+      await wait()
+
+      expect(wrapper.find('input').attributes('type')).toBe('text')
+    })
+  })
+
   describe('slot props', () => {
     it('should expose id', () => {
       const { props } = mountInput({ props: { id: 'test-input' } })


### PR DESCRIPTION
Closes #757.

`Input.Root`'s `type` prop was destructured once at setup and assigned as a plain value onto `InputRootContext` (`readonly type: string` — every sibling field on the context interface is a ref or getter). `Input.Control` read that frozen value directly, so changing `:type` on `Input.Root` after mount — the classic password reveal-toggle pattern — never reached the rendered `<input>`'s DOM `type` attribute. Verified via `document.querySelector('input').type` before/after toggling a bound ref: it never changed.

## Fix

`type` is now placed on the context as `toRef(() => type)` (context field retyped to `Readonly<Ref<string>>`), and `Input.Control` reads `root.type.value`, matching how every other reactive field on the context is consumed.

## Tests

Added a `type prop` describe block to `index.browser.test.ts`:
- default type is `text`
- `type` prop sets the rendered input's `type` attribute
- a post-mount change to the `type` prop is reflected in the DOM (this is the regression test — it fails against the old code)

60 existing + new browser tests pass.