### PR TITLE
fix(Input): make type prop reactive on InputRoot context

### DIFF
--- a/.changeset/fix-input-root-type-reactivity.md
+++ b/.changeset/fix-input-root-type-reactivity.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Input): make the `type` prop reactive (#757)
+
+`Input.Root`'s `type` prop was captured once at setup, so binding `:type` to a ref and toggling it after mount (e.g. `'password'` ↔ `'text'`) never updated the rendered `<input>`'s type. The prop now flows reactively through the root context, and `Input.Control` reflects post-mount changes.

--- a/packages/0/src/components/Input/InputControl.vue
+++ b/packages/0/src/components/Input/InputControl.vue
@@ -81,7 +81,7 @@
 
     return {
       'id': root.id,
-      'type': root.type,
+      'type': root.type.value,
       'name': root.name,
       'value': root.value.value,
       'form': root.form,

--- a/packages/0/src/components/Input/InputRoot.vue
+++ b/packages/0/src/components/Input/InputRoot.vue
@@ -51,7 +51,7 @@
     /** Form field name */
     readonly name?: string
     /** Input type */
-    readonly type: string
+    readonly type: Readonly<Ref<string>>
     /** Associate with form by ID */
     readonly form?: string
     /** Whether this input is required */
@@ -265,7 +265,7 @@
     id: input.id,
     label,
     name,
-    type,
+    type: toRef(() => type),
     form,
     required,
     descriptionId: input.descriptionId,

--- a/packages/0/src/components/Input/index.browser.test.ts
+++ b/packages/0/src/components/Input/index.browser.test.ts
@@ -769,6 +769,20 @@ describe('input', () => {
     })
   })
 
+  describe('type prop', () => {
+    it('should update the control type when type changes after mount', async () => {
+      const { wrapper, wait } = mountInput({ props: { type: 'password' } })
+      const control = wrapper.find('input')
+
+      expect(control.attributes('type')).toBe('password')
+
+      await wrapper.setProps({ type: 'text' })
+      await wait()
+
+      expect(control.attributes('type')).toBe('text')
+    })
+  })
+
   describe('input control events', () => {
     it('should update model via native input event', async () => {
       const model = ref('')


### PR DESCRIPTION
`Input.Root` captured the `type` prop once at setup as a plain `readonly type: string` on `InputRootContext` — the only non-reactive field on the context. Binding `:type` to a ref and toggling it after mount (e.g. `'password'` ↔ `'text'`) never updated the rendered `<input>`'s DOM type.

- `InputRootContext.type` is now `Readonly<Ref<string>>`, provided via `toRef(() => type)` like the sibling fields
- `Input.Control` reads it reactively, so the control's `type` attribute tracks post-mount changes
- Regression test added to the colocated browser suite; changeset included (patch)

Closes #757