### PR TITLE
fix(useResizeObserver): report content box from immediate entries

### DIFF
--- a/.changeset/fix-resize-observer-immediate-content-box-729.md
+++ b/.changeset/fix-resize-observer-immediate-content-box-729.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useResizeObserver): report the content box from `immediate` entries (#729)
+
+With `immediate: true`, the first synthesized entry's `contentRect` carried border-box dimensions in viewport coordinates, scaled by CSS transforms — every later entry from the observer reports the content box with padding offsets. The immediate entry now matches native semantics: `width`/`height` are the content box and `top`/`left` are the computed padding offsets, so `useElementSize` reports content-box dimensions from mount instead of jumping on the first resize.

--- a/packages/0/src/composables/useResizeObserver/index.browser.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.browser.test.ts
@@ -155,6 +155,8 @@ describe('useResizeObserver box model', () => {
 
     expect(size(immediate.borderBoxSize[0])).toEqual(size(observed.borderBoxSize[0]))
     expect(size(immediate.contentBoxSize[0])).toEqual(size(observed.contentBoxSize[0]))
+    expect(immediate.contentRect).toEqual(observed.contentRect)
+    expect(immediate.contentRect).toEqual({ width: 166, height: 30, top: 4, left: 16 })
   })
 
   it('should swap the logical axes on the immediate entry under a vertical writing mode', async () => {

--- a/packages/0/src/composables/useResizeObserver/index.test.ts
+++ b/packages/0/src/composables/useResizeObserver/index.test.ts
@@ -656,6 +656,17 @@ describe('useResizeObserver box model synthesis', () => {
     expect(entry.contentBoxSize).toEqual([{ inlineSize: 166, blockSize: 30 }])
   })
 
+  it('should report the content box and padding offsets on the immediate contentRect', async () => {
+    const entry = await synthesize({
+      ...PADDED,
+      boxSizing: 'border-box',
+      width: '200px',
+      height: '40px',
+    })
+
+    expect(entry.contentRect).toEqual({ width: 166, height: 30, top: 4, left: 16 })
+  })
+
   it('should derive the border box by adding padding and border under content-box', async () => {
     const entry = await synthesize({
       ...PADDED,

--- a/packages/0/src/composables/useResizeObserver/index.ts
+++ b/packages/0/src/composables/useResizeObserver/index.ts
@@ -111,11 +111,13 @@ function pxToNumber (value: string | undefined, fallback = 0): number {
  * Synthesize the entry the observer would report for `el`, for the `immediate`
  * callback that fires before the observer's own first delivery.
  *
- * The box sizes come from `getComputedStyle` rather than
+ * Every measurement comes from `getComputedStyle` rather than
  * `getBoundingClientRect` because resolved lengths are layout values — like the
  * observer, and unlike a client rect, they are not scaled by CSS transforms.
- * `contentRect` keeps its existing client-rect source so callers reading it see
- * no change.
+ * `contentRect` mirrors the native entry: width/height are the content box and
+ * top/left are the padding offsets, so the immediate entry matches what the
+ * observer reports next. The client rect only remains as the fallback when a
+ * resolved length is not numeric (e.g. a detached element).
  *
  * Every read is written to tolerate a partial style declaration: an element
  * with no layout box resolves its lengths to `''`, and this runs on whatever
@@ -126,8 +128,14 @@ function measure (el: Element): ResizeObserverEntry {
   const rect = el.getBoundingClientRect()
   const style = getComputedStyle(el)
 
-  const paddingX = pxToNumber(style.paddingLeft) + pxToNumber(style.paddingRight)
-  const paddingY = pxToNumber(style.paddingTop) + pxToNumber(style.paddingBottom)
+  const padding = {
+    top: pxToNumber(style.paddingTop),
+    left: pxToNumber(style.paddingLeft),
+    right: pxToNumber(style.paddingRight),
+    bottom: pxToNumber(style.paddingBottom),
+  }
+  const paddingX = padding.left + padding.right
+  const paddingY = padding.top + padding.bottom
   const borderX = pxToNumber(style.borderLeftWidth) + pxToNumber(style.borderRightWidth)
   const borderY = pxToNumber(style.borderTopWidth) + pxToNumber(style.borderBottomWidth)
 
@@ -155,10 +163,10 @@ function measure (el: Element): ResizeObserverEntry {
 
   return {
     contentRect: {
-      width: rect.width,
-      height: rect.height,
-      top: rect.top,
-      left: rect.left,
+      width: width.content,
+      height: height.content,
+      top: padding.top,
+      left: padding.left,
     },
     borderBoxSize: [{ inlineSize: inline.border, blockSize: block.border }],
     contentBoxSize: [{ inlineSize: inline.content, blockSize: block.content }],


### PR DESCRIPTION
The `immediate: true` entry was synthesized from `getBoundingClientRect()`, so its `contentRect` reported border-box dimensions in viewport coordinates, scaled by CSS transforms — while every subsequent observer entry reports the content box with padding offsets. This contradicted the file's own JSDoc ("contentRect always describes the content box, regardless of the box option") and made `useElementSize` jump from border-box to content-box on the first real resize.

`measure()` now mirrors native entry semantics: `contentRect.width`/`height` are the content-box values already derived from computed styles for `contentBoxSize`, and `top`/`left` are the computed padding offsets. The client rect remains only as the fallback when a resolved length is non-numeric.

Closes #729