### PR TITLE
fix(useBreakpoints): resolve initial state through matchMedia like update()

### DIFF
--- a/.changeset/fix-breakpoints-initial-matchmedia.md
+++ b/.changeset/fix-breakpoints-initial-matchmedia.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useBreakpoints): resolve initial state through matchMedia like update() (#730)
+
+`createBreakpoints()` previously derived its initial breakpoint name, band flags, and `isMobile` from an `innerWidth` comparison, while `update()` used `matchMedia`. At fractional zoom or with classic scrollbars the two can disagree, so bare `createBreakpoints()` consumers could get a wrong first paint that silently flipped band on the first resize. Initial state now resolves through the same matchMedia-based logic as `update()`. SSR and no-matchMedia environments keep the width-comparison fallback.

--- a/packages/0/src/composables/useBreakpoints/index.test.ts
+++ b/packages/0/src/composables/useBreakpoints/index.test.ts
@@ -293,6 +293,40 @@ describe('createBreakpoints', () => {
       })
     })
 
+    describe('initial state via matchMedia', () => {
+      it('should resolve initial state through matchMedia when it disagrees with innerWidth', () => {
+        // Fractional zoom / classic scrollbars: CSS media queries can
+        // disagree with innerWidth. matchMedia reports 1200, innerWidth 1024.
+        mockWindow.innerWidth = 1024
+        mockWindow.matchMedia = (query: string) => {
+          const match = query.match(/\(min-width:\s*(\d+)px\)/)
+          return { matches: match ? 1200 >= Number(match[1]) : false }
+        }
+
+        const context = createBreakpoints()
+
+        expect(context.name.value).toBe('lg')
+        expect(context.lg.value).toBe(true)
+        expect(context.lgAndUp.value).toBe(true)
+        expect(context.mdAndDown.value).toBe(false)
+        expect(context.isMobile.value).toBe(false)
+        expect(context.width.value).toBe(1024)
+      })
+
+      it('should keep clientWidth comparison for initial state when ssr is configured', () => {
+        mockWindow.innerWidth = 500
+        mockWindow.matchMedia = (query: string) => {
+          const match = query.match(/\(min-width:\s*(\d+)px\)/)
+          return { matches: match ? 500 >= Number(match[1]) : false }
+        }
+
+        const context = createBreakpoints({ ssr: { clientWidth: 1200 } })
+
+        expect(context.name.value).toBe('lg')
+        expect(context.isMobile.value).toBe(false)
+      })
+    })
+
     describe('window resize handling', () => {
       it('should update breakpoint when update is called multiple times', () => {
         mockWindow.innerWidth = 500
@@ -889,6 +923,11 @@ describe('createBreakpoints', () => {
       mockWindow.innerWidth = 1400
 
       const context = create()
+
+      // Initial state falls back to innerWidth without touching matchMedia
+      expect(context.name.value).toBe('lg')
+      expect(context.isMobile.value).toBe(false)
+
       context.update()
 
       expect(context.name.value).toBe('lg')

--- a/packages/0/src/composables/useBreakpoints/index.ts
+++ b/packages/0/src/composables/useBreakpoints/index.ts
@@ -142,59 +142,50 @@ export function createBreakpoints (_options: BreakpointsOptions = {}): Breakpoin
     ? (ssr.clientHeight ?? 0)
     : (IN_BROWSER ? window.innerHeight : 0)
 
-  let initialName: BreakpointName = 'xs'
-  for (let i = sorted.length - 1; i >= 0; i--) {
-    if (initialWidth >= sorted[i]![1]) {
-      initialName = sorted[i]![0]
-      break
-    }
-  }
-  const initialIndex = names.indexOf(initialName)
-
-  const name = shallowRef<BreakpointName>(initialName)
+  const name = shallowRef<BreakpointName>('xs')
   const width = shallowRef(initialWidth)
   const height = shallowRef(initialHeight)
-  const isMobile = shallowRef(initialWidth < mb!)
-  const xs = shallowRef(initialIndex === 0)
-  const sm = shallowRef(initialIndex === 1)
-  const md = shallowRef(initialIndex === 2)
-  const lg = shallowRef(initialIndex === 3)
-  const xl = shallowRef(initialIndex === 4)
-  const xxl = shallowRef(initialIndex === 5)
-  const smAndUp = shallowRef(initialIndex >= 1)
-  const mdAndUp = shallowRef(initialIndex >= 2)
-  const lgAndUp = shallowRef(initialIndex >= 3)
-  const xlAndUp = shallowRef(initialIndex >= 4)
-  const smAndDown = shallowRef(initialIndex <= 1)
-  const mdAndDown = shallowRef(initialIndex <= 2)
-  const lgAndDown = shallowRef(initialIndex <= 3)
-  const xlAndDown = shallowRef(initialIndex <= 4)
+  const isMobile = shallowRef(false)
+  const xs = shallowRef(false)
+  const sm = shallowRef(false)
+  const md = shallowRef(false)
+  const lg = shallowRef(false)
+  const xl = shallowRef(false)
+  const xxl = shallowRef(false)
+  const smAndUp = shallowRef(false)
+  const mdAndUp = shallowRef(false)
+  const lgAndUp = shallowRef(false)
+  const xlAndUp = shallowRef(false)
+  const smAndDown = shallowRef(false)
+  const mdAndDown = shallowRef(false)
+  const lgAndDown = shallowRef(false)
+  const xlAndDown = shallowRef(false)
 
-  function update () {
-    if (!IN_BROWSER) return
-
-    width.value = window.innerWidth
-    height.value = window.innerHeight
-
-    // Use matchMedia for breakpoint detection to guarantee
-    // alignment with CSS media queries at any zoom level.
-    // Falls back to innerWidth comparison when matchMedia is unavailable.
+  // Use matchMedia for breakpoint detection to guarantee
+  // alignment with CSS media queries at any zoom level.
+  // Falls back to a width comparison when matchMedia is unavailable.
+  function resolve (value: number, media: boolean) {
     let current: BreakpointName = 'xs'
     for (let i = sorted.length - 1; i >= 0; i--) {
       const px = sorted[i]![1]
-      if (SUPPORTS_MATCH_MEDIA ? window.matchMedia(`(min-width: ${px}px)`).matches : width.value >= px) {
+      if (media ? window.matchMedia(`(min-width: ${px}px)`).matches : value >= px) {
         current = sorted[i]![0]
         break
       }
     }
 
-    name.value = current
-
     const index = names.indexOf(current)
-
-    isMobile.value = isNumber(mb)
-      ? (SUPPORTS_MATCH_MEDIA ? !window.matchMedia(`(min-width: ${mb}px)`).matches : width.value < mb)
+    /* v8 ignore next 3 -- alternate arm is defensive: mb always resolves to a number via `?? breakpoints.md` */
+    const mobile = isNumber(mb)
+      ? (media ? !window.matchMedia(`(min-width: ${mb}px)`).matches : value < mb)
       : index < names.indexOf(mobileBreakpoint as BreakpointName)
+
+    return { current, index, mobile }
+  }
+
+  function apply ({ current, index, mobile }: ReturnType<typeof resolve>) {
+    name.value = current
+    isMobile.value = mobile
     xs.value = index === 0
     sm.value = index === 1
     md.value = index === 2
@@ -209,6 +200,21 @@ export function createBreakpoints (_options: BreakpointsOptions = {}): Breakpoin
     mdAndDown.value = index <= 2
     lgAndDown.value = index <= 3
     xlAndDown.value = index <= 4
+  }
+
+  // Initial state resolves through the same matchMedia-based logic as
+  // update() so a bare createBreakpoints() matches CSS media queries on
+  // first paint. SSR keeps the configured width comparison so server and
+  // client markup match; no-matchMedia environments keep the width comparison.
+  apply(resolve(initialWidth, !ssr && IN_BROWSER && SUPPORTS_MATCH_MEDIA))
+
+  function update () {
+    if (!IN_BROWSER) return
+
+    width.value = window.innerWidth
+    height.value = window.innerHeight
+
+    apply(resolve(width.value, SUPPORTS_MATCH_MEDIA))
   }
 
   return {


### PR DESCRIPTION
Closes #730

`createBreakpoints()` derived its initial breakpoint name, band flags, and `isMobile` from an `innerWidth` comparison, while `update()` used `matchMedia` (adopted in #157 for zoom/scrollbar-accurate alignment with CSS media queries). Bare `createBreakpoints()` consumers therefore got an innerWidth-derived first paint that could silently flip band on the first resize event.

## Changes

- Extracted a shared `resolve(value, media)` + `apply(resolution)` pair; both the init path and `update()` go through it, so the mechanism can no longer diverge.
- Initial state resolves via `matchMedia` when available in the browser; `update()` behavior is unchanged.
- Fallbacks preserved: SSR keeps the `ssr.clientWidth` width comparison (hydration-safe), no-matchMedia environments keep the width comparison.
- Regression tests: matchMedia disagreeing with `innerWidth` at init, SSR-configured init ignoring matchMedia, and no-matchMedia init falling back to `innerWidth`.