### PR TITLE
fix(Slider): default accessible name via locale when unlabeled

### DIFF
--- a/.changeset/fix-slider-default-aria-label-740.md
+++ b/.changeset/fix-slider-default-aria-label-740.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Slider): default accessible name via locale when unlabeled (#771)
+
+`Slider.Thumb` rendered `role="slider"` with no accessible name unless `ariaLabel` or `ariaLabelledby` was passed, failing axe's `aria-input-field-name` rule (serious) out of the box. The thumb now defaults its `aria-label` to the localized `Slider.label` message, falling back to "Slider", and skips the default when `ariaLabelledby` is provided so the referenced label wins.

--- a/packages/0/src/components/Slider/SliderThumb.vue
+++ b/packages/0/src/components/Slider/SliderThumb.vue
@@ -16,6 +16,9 @@
   // Context
   import { useSliderRoot } from './SliderRoot.vue'
 
+  // Composables
+  import { useLocale } from '#v0/composables/useLocale'
+
   // Utilities
   import { isUndefined } from '#v0/utilities'
   import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs, useTemplateRef } from 'vue'
@@ -87,6 +90,7 @@
   } = defineProps<SliderThumbProps>()
 
   const root = useSliderRoot(namespace)
+  const locale = useLocale()
   const thumbRef = useTemplateRef<{ element: HTMLElement | null }>('thumb')
 
   const ticket = root.register()
@@ -172,7 +176,7 @@
       'aria-orientation': toValue(root.orientation),
       'aria-disabled': isDisabled.value,
       'aria-readonly': isReadonly.value ? true : undefined,
-      'aria-label': ariaLabel || undefined,
+      'aria-label': ariaLabel || (ariaLabelledby ? undefined : locale.ti('Slider.label') ?? 'Slider'),
       'aria-labelledby': ariaLabelledby || undefined,
       'data-state': dataState.value,
       'data-disabled': isDisabled.value ? true : undefined,

--- a/packages/0/src/components/Slider/index.browser.test.ts
+++ b/packages/0/src/components/Slider/index.browser.test.ts
@@ -280,6 +280,24 @@ describe('slider', () => {
       expect(thumbProps().attrs['aria-label']).toBe('Volume')
     })
 
+    it('should default aria-label via locale when unlabeled', async () => {
+      const model = ref([50])
+      const { thumbProps, wait } = mountSlider({ model })
+      await wait()
+      expect(thumbProps().attrs['aria-label']).toBeDefined()
+    })
+
+    it('should not emit default aria-label when aria-labelledby is set', async () => {
+      const model = ref([50])
+      const { thumbProps, wait } = mountSlider({
+        model,
+        thumbProps: [{ ariaLabelledby: 'thumb-label' }],
+      })
+      await wait()
+      expect(thumbProps().attrs['aria-label']).toBeUndefined()
+      expect(thumbProps().attrs['aria-labelledby']).toBe('thumb-label')
+    })
+
     it('should set data-state to idle by default', async () => {
       const model = ref([50])
       const { thumbProps, wait } = mountSlider({ model })

--- a/packages/0/src/locale/messages/en/index.test.ts
+++ b/packages/0/src/locale/messages/en/index.test.ts
@@ -6,7 +6,7 @@ describe('locale/messages/en', () => {
   it('should export an English aria-string catalog for every v0 component namespace', () => {
     expect(en).toBeTypeOf('object')
 
-    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Snackbar', 'Splitter']) {
+    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Slider', 'Snackbar', 'Splitter']) {
       expect(en).toHaveProperty(key)
     }
   })

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -66,6 +66,9 @@ export default {
   Rating: {
     valueText: '{value} of {size} stars',
   },
+  Slider: {
+    label: 'Slider',
+  },
   Snackbar: {
     close: 'Dismiss',
   },


### PR DESCRIPTION
Closes #740

`Slider.Thumb` carries `role="slider"` but shipped with no accessible name unless `ariaLabel` or `ariaLabelledby` was passed — axe `aria-input-field-name`, serious. The issue quotes `SliderRoot`, but the name must land on the element with `role="slider"`, which is the thumb (Root emits `role="group"`); the fix lands there.

- Default `aria-label` is now `locale.ti('Slider.label') ?? 'Slider'` when neither `ariaLabel` nor `ariaLabelledby` is provided, matching the `Pagination.Root` locale-default precedent.
- When `ariaLabelledby` is provided, the default is suppressed — labelledby wins, no double-naming.
- Locale keys are ad-hoc per component (no central key list), so no message-file change.

Sibling issues #741 and #739 land the same locale-default answer for their components.