### PR TITLE
fix(NumberField): default accessible name on spinbutton via locale

### DIFF
--- a/.changeset/fix-numberfield-default-aria-label.md
+++ b/.changeset/fix-numberfield-default-aria-label.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(NumberField): default accessible name on the spinbutton (#772)
+
+`NumberField.Control` rendered no accessible name unless a `label` or `ariaLabelledby` prop was set, failing the axe `label` rule in the documented default shape. The spinbutton now falls back to the locale-driven `NumberField.label` message (default: "Number"), matching the increment/decrement buttons. Providing `label` or `ariaLabelledby` overrides the default as before.

--- a/packages/0/src/components/NumberField/NumberFieldControl.vue
+++ b/packages/0/src/components/NumberField/NumberFieldControl.vue
@@ -15,6 +15,9 @@
   // Context
   import { useNumberFieldRoot } from './NumberFieldRoot.vue'
 
+  // Composables
+  import { useLocale } from '#v0/composables/useLocale'
+
   // Utilities
   import { isNull } from '#v0/utilities'
   import { mergeProps, onMounted, shallowRef, toRef, useAttrs, watch } from 'vue'
@@ -57,6 +60,7 @@
   } = defineProps<NumberFieldControlProps>()
 
   const root = useNumberFieldRoot(namespace)
+  const locale = useLocale()
 
   const leap = Math.max(1, Math.round(root.numeric.leap / root.numeric.step))
 
@@ -182,7 +186,7 @@
       'aria-valuemin': Number.isFinite(root.numeric.min) ? root.numeric.min : undefined,
       'aria-valuemax': Number.isFinite(root.numeric.max) ? root.numeric.max : undefined,
       'aria-invalid': invalid || undefined,
-      'aria-label': root.ariaLabelledby ? undefined : (root.label || undefined),
+      'aria-label': root.ariaLabelledby ? undefined : (root.label || (locale.ti('NumberField.label') ?? 'Number')),
       'aria-labelledby': root.ariaLabelledby || undefined,
       'aria-describedby': describedby.value,
       'aria-errormessage': (root.hasError.value && root.errors.value.length > 0) ? root.errorId : undefined,

--- a/packages/0/src/components/NumberField/index.test.ts
+++ b/packages/0/src/components/NumberField/index.test.ts
@@ -785,11 +785,22 @@ describe('numberField', () => {
       expect(controlEl().attributes('aria-labelledby')).toBe('my-label')
     })
 
-    it('should not set aria-label when no label prop is provided', async () => {
+    it('should default aria-label on control when no label prop is provided', async () => {
       const model = ref<number | null>(5)
       const { controlEl, wait } = mountNumberField({ model })
       await wait()
+      expect(controlEl().attributes('aria-label')).toBe('Number')
+    })
+
+    it('should not default aria-label when only ariaLabelledby is provided', async () => {
+      const model = ref<number | null>(5)
+      const { controlEl, wait } = mountNumberField({
+        model,
+        props: { ariaLabelledby: 'my-label' },
+      })
+      await wait()
       expect(controlEl().attributes('aria-label')).toBeUndefined()
+      expect(controlEl().attributes('aria-labelledby')).toBe('my-label')
     })
   })
 

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -52,6 +52,7 @@ export default {
   NumberField: {
     decrement: 'Decrement',
     increment: 'Increment',
+    label: 'Number',
   },
   Pagination: {
     currentPage: 'Page {page}, current',


### PR DESCRIPTION
Closes #741

The spinbutton input rendered by `NumberField.Control` shipped with no accessible name in its documented default shape (axe `label` rule, critical). #640 added the `ariaLabelledby` mechanism but no default, and the increment/decrement buttons were already locale-named while the input was not.

When neither `label` nor `ariaLabelledby` is provided, the control now emits `aria-label: locale.ti('NumberField.label') ?? 'Number'` — the same locale-default answer landing for Slider (#740) and Rating (#739), following the `PaginationRoot` precedent. Providing either naming prop suppresses the default.