### PR TITLE
fix(Rating): name the slider and drop focusable stars from examples

### DIFF
--- a/.changeset/rating-slider-a11y.md
+++ b/.changeset/rating-slider-a11y.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(Rating): name the slider and drop focusable stars from examples (#773)
+
+`Rating.Root` now exposes `ariaLabel` and `ariaLabelledby` props and always emits an accessible name on the `role="slider"` element — a locale-driven "Rating" default applies when neither is set. Documented examples no longer render `Rating.Item` as `<button>`, so the slider contains no focusable descendants; items stay non-focusable spans and click-to-select is unchanged.

--- a/apps/docs/src/examples/components/rating/ReviewForm.vue
+++ b/apps/docs/src/examples/components/rating/ReviewForm.vue
@@ -52,10 +52,8 @@
             <Rating.Item
               v-for="i in 5"
               :key="i"
-              as="button"
-              class="relative size-8 text-2xl cursor-pointer focus:outline-none"
+              class="relative size-8 inline-flex items-center justify-center text-2xl cursor-pointer select-none"
               :index="i"
-              type="button"
             >
               <template #default="{ state }">
                 <span v-if="state === 'half'" class="relative inline-flex">

--- a/apps/docs/src/examples/components/rating/basic.vue
+++ b/apps/docs/src/examples/components/rating/basic.vue
@@ -12,8 +12,7 @@
         <Rating.Item
           v-for="i in 5"
           :key="i"
-          as="button"
-          class="size-8 text-xl cursor-pointer focus:outline-none [&[data-state=full]]:text-amber-500 [&[data-state=empty]]:text-on-surface-variant/40"
+          class="size-8 inline-flex items-center justify-center text-xl cursor-pointer select-none [&[data-state=full]]:text-amber-500 [&[data-state=empty]]:text-on-surface-variant/40"
           :index="i"
         >
           <template #default="{ state }">

--- a/packages/0/src/components/Rating/RatingRoot.vue
+++ b/packages/0/src/components/Rating/RatingRoot.vue
@@ -54,6 +54,10 @@
     disabled?: MaybeRefOrGetter<boolean>
     /** Show value, prevent changes */
     readonly?: MaybeRefOrGetter<boolean>
+    /** Accessible name for the slider */
+    ariaLabel?: string
+    /** ID of element that labels this slider */
+    ariaLabelledby?: string
     /** Form field name — triggers hidden input */
     name?: string
     /** Namespace for context provision */
@@ -79,6 +83,8 @@
       'aria-valuemin': 0
       'aria-valuemax': number
       'aria-valuetext': string
+      'aria-label': string | undefined
+      'aria-labelledby': string | undefined
       'aria-disabled': boolean
       'aria-readonly': true | undefined
       'data-disabled': true | undefined
@@ -108,6 +114,8 @@
     half = false,
     disabled = false,
     readonly: _readonly = false,
+    ariaLabel,
+    ariaLabelledby,
     name,
     namespace = 'v0:rating:root',
   } = defineProps<RatingRootProps>()
@@ -184,6 +192,8 @@
       'aria-valuemin': 0,
       'aria-valuemax': rating.size,
       'aria-valuetext': locale.ti('Rating.valueText', { value: rating.value.value, size: rating.size }) ?? `${rating.value.value} of ${rating.size} stars`,
+      'aria-label': ariaLabel || (ariaLabelledby ? undefined : locale.ti('Rating.label') ?? 'Rating'),
+      'aria-labelledby': ariaLabelledby || undefined,
       'aria-disabled': isDisabled.value,
       'aria-readonly': isReadonly.value ? true : undefined,
       'data-disabled': isDisabled.value ? true : undefined,

--- a/packages/0/src/components/Rating/index.test.ts
+++ b/packages/0/src/components/Rating/index.test.ts
@@ -351,6 +351,36 @@ describe('rating', () => {
         wrapper.unmount()
       })
 
+      it('should have a default aria-label', async () => {
+        const { rootProps, wait } = mountRating()
+        await wait()
+
+        expect(rootProps().attrs['aria-label']).toBeDefined()
+      })
+
+      it('should prefer the ariaLabel prop over the default', async () => {
+        const { rootProps, wait } = mountRating({ props: { ariaLabel: 'Product rating' } })
+        await wait()
+
+        expect(rootProps().attrs['aria-label']).toBe('Product rating')
+      })
+
+      it('should omit the default aria-label when ariaLabelledby is set', async () => {
+        const { rootProps, wait } = mountRating({ props: { ariaLabelledby: 'rating-label' } })
+        await wait()
+
+        expect(rootProps().attrs['aria-label']).toBeUndefined()
+        expect(rootProps().attrs['aria-labelledby']).toBe('rating-label')
+      })
+
+      it('should render no focusable descendants inside the slider', async () => {
+        const { wrapper, wait } = mountRating()
+        await wait()
+
+        expect(wrapper.find('button').exists()).toBe(false)
+        expect(wrapper.find('[role="slider"] [tabindex]').exists()).toBe(false)
+      })
+
       it('should set aria-disabled to false when not disabled', async () => {
         const { rootProps, wait } = mountRating()
         await wait()

--- a/packages/0/src/components/Rating/index.ts
+++ b/packages/0/src/components/Rating/index.ts
@@ -39,7 +39,6 @@ import Root from './RatingRoot.vue'
  *       v-for="i in 5"
  *       :key="i"
  *       :index="i"
- *       as="button"
  *       v-slot="{ state }"
  *     >
  *       {{ state === 'full' ? '★' : '☆' }}
@@ -75,7 +74,6 @@ export const Rating = {
    *       v-for="i in 5"
    *       :key="i"
    *       :index="i"
-   *       as="button"
    *       v-slot="{ state }"
    *     >
    *       {{ state === 'full' ? '★' : '☆' }}
@@ -106,7 +104,6 @@ export const Rating = {
    * <template>
    *   <Rating.Item
    *     :index="1"
-   *     as="button"
    *     class="[&[data-state=full]]:text-amber-500 [&[data-state=empty]]:text-gray-300"
    *     v-slot="{ state }"
    *   >
@@ -142,7 +139,6 @@ export const Rating = {
    *       v-for="i in 5"
    *       :key="i"
    *       :index="i"
-   *       as="button"
    *       v-slot="{ state }"
    *     >
    *       {{ state === 'full' ? '★' : '☆' }}

--- a/packages/0/src/components/fixtures/Rating.vue
+++ b/packages/0/src/components/fixtures/Rating.vue
@@ -13,7 +13,6 @@
       v-for="i in 5"
       :key="i"
       v-slot="{ state }"
-      as="button"
       :index="i"
     >
       {{ state === 'full' ? '&#9733;' : '&#9734;' }}

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -64,6 +64,7 @@ export default {
     status: 'Page {page} of {pages}',
   },
   Rating: {
+    label: 'Rating',
     valueText: '{value} of {size} stars',
   },
   Snackbar: {


### PR DESCRIPTION
Closes #739

Fixes both axe violations on `Rating.Root`'s `role="slider"` element: `nested-interactive` and `aria-input-field-name` (both serious).

**Design decision — slider retained over radiogroup.** `RatingRoot` already implements the full slider keyboard contract (Arrow/Home/End drive the rating), and `Rating.Item` already defaults to a non-focusable `span`. The defect was the documented examples putting `as="button"` on items, nesting focusable controls inside the slider leaf widget. Examples, fixture, and `@example` JSDoc now use the default span; click-to-select still works through the item's bound `onClick`. Veto here if you'd rather move to the radiogroup pattern instead.

**Accessible name.** New `ariaLabel` / `ariaLabelledby` props on `Rating.Root`; when neither is set the slider falls back to `locale.ti('Rating.label') ?? 'Rating'` — same naming default as the sibling fixes #740 (Slider, #771) and #741 (NumberField).