### PR TITLE
docs(Select): fix double role=option in Item examples

### DIFF
--- a/.changeset/select-item-double-option.md
+++ b/.changeset/select-item-double-option.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+docs(Select): fix double role=option in Item examples (#775)
+
+The documented `Select.Item` and `Combobox.Item` usage spread the slot `attrs` onto an inner element inside a non-renderless Item, so following it produced a nested duplicate `role="option"` (axe `aria-required-parent`, critical) and click handlers that fired twice. The Treeview `Cue`/`Checkbox`/`Indicator`/`SelectAll` and Radio `Root`/`Group` examples had the same shape. If you copied any of these, remove the inner `v-bind="attrs"` spread and put your content directly in the slot — or add `renderless` so your element is the only one rendered.

--- a/apps/docs/src/examples/components/treeview/basic.vue
+++ b/apps/docs/src/examples/components/treeview/basic.vue
@@ -35,7 +35,7 @@
             v-if="item.children"
             class="inline-flex items-center border-none bg-transparent p-0 cursor-pointer text-on-surface hover:text-primary"
           >
-            <Treeview.Cue v-slot="{ attrs }">
+            <Treeview.Cue v-slot="{ attrs }" renderless>
               <svg
                 v-bind="attrs"
                 class="size-3.5 opacity-60 transition-transform data-[state=open]:rotate-90"

--- a/packages/0/src/components/Combobox/index.ts
+++ b/packages/0/src/components/Combobox/index.ts
@@ -61,9 +61,8 @@ import Root from './ComboboxRoot.vue'
  *         :key="item.id"
  *         :id="item.id"
  *         :value="item.label"
- *         v-slot="{ isSelected, attrs }"
  *       >
- *         <div v-bind="attrs">{{ item.label }}</div>
+ *         {{ item.label }}
  *       </Combobox.Item>
  *       <Combobox.Empty>No results found</Combobox.Empty>
  *     </Combobox.Content>
@@ -171,10 +170,13 @@ export const Combobox = {
    *
    * @example
    * ```vue
-   * <Combobox.Item id="apple" value="Apple" v-slot="{ isSelected, isHighlighted, attrs }">
-   *   <div v-bind="attrs" :class="{ highlighted: isHighlighted }">
-   *     Apple {{ isSelected ? '✓' : '' }}
-   *   </div>
+   * <Combobox.Item
+   *   id="apple"
+   *   value="Apple"
+   *   class="data-[highlighted]:bg-primary"
+   *   v-slot="{ isSelected }"
+   * >
+   *   Apple {{ isSelected ? '✓' : '' }}
    * </Combobox.Item>
    * ```
    */

--- a/packages/0/src/components/Radio/RadioGroup.vue
+++ b/packages/0/src/components/Radio/RadioGroup.vue
@@ -162,7 +162,7 @@
      * @example
      * ```vue
      * <template>
-     *   <Radio.Group v-slot="{ isNoneSelected, attrs }">
+     *   <Radio.Group v-slot="{ isNoneSelected, attrs }" renderless>
      *     <div v-bind="attrs">
      *       <p v-if="isNoneSelected">Please select an option</p>
      *       <Radio.Root value="a">Option A</Radio.Root>

--- a/packages/0/src/components/Radio/RadioRoot.vue
+++ b/packages/0/src/components/Radio/RadioRoot.vue
@@ -171,8 +171,8 @@
      * @example
      * ```vue
      * <template>
-     *   <Radio.Root v-slot="{ isChecked, select, attrs }" value="a">
-     *     <div v-bind="attrs" v-on:click="select">
+     *   <Radio.Root v-slot="{ isChecked, attrs }" value="a" renderless>
+     *     <div v-bind="attrs">
      *       <span :class="{ 'font-bold': isChecked }">Option A</span>
      *     </div>
      *   </Radio.Root>

--- a/packages/0/src/components/Select/index.ts
+++ b/packages/0/src/components/Select/index.ts
@@ -57,9 +57,8 @@ import Value from './SelectValue.vue'
  *         :key="item.id"
  *         :id="item.id"
  *         :value="item.label"
- *         v-slot="{ isSelected, attrs }"
  *       >
- *         <div v-bind="attrs">{{ item.label }}</div>
+ *         {{ item.label }}
  *       </Select.Item>
  *     </Select.Content>
  *   </Select.Root>
@@ -183,8 +182,8 @@ export const Select = {
    * </script>
    *
    * <template>
-   *   <Select.Item id="apple" value="Apple" v-slot="{ isSelected, attrs }">
-   *     <div v-bind="attrs">Apple {{ isSelected ? '✓' : '' }}</div>
+   *   <Select.Item id="apple" value="Apple" v-slot="{ isSelected }">
+   *     Apple {{ isSelected ? '✓' : '' }}
    *   </Select.Item>
    * </template>
    * ```

--- a/packages/0/src/components/Treeview/index.ts
+++ b/packages/0/src/components/Treeview/index.ts
@@ -167,7 +167,7 @@ export const Treeview = {
    *
    * @example
    * ```vue
-   * <Treeview.Cue v-slot="{ attrs }">
+   * <Treeview.Cue v-slot="{ attrs }" renderless>
    *   <span v-bind="attrs">▶</span>
    * </Treeview.Cue>
    * ```
@@ -197,7 +197,7 @@ export const Treeview = {
    *
    * @example
    * ```vue
-   * <Treeview.Checkbox v-slot="{ attrs, isSelected, isMixed }">
+   * <Treeview.Checkbox v-slot="{ attrs, isSelected, isMixed }" renderless>
    *   <span v-bind="attrs">{{ isMixed ? '−' : isSelected ? '✓' : '○' }}</span>
    * </Treeview.Checkbox>
    * ```
@@ -211,7 +211,7 @@ export const Treeview = {
    *
    * @example
    * ```vue
-   * <Treeview.Indicator v-slot="{ attrs }">
+   * <Treeview.Indicator v-slot="{ attrs }" renderless>
    *   <span v-bind="attrs">●</span>
    * </Treeview.Indicator>
    * ```
@@ -228,7 +228,7 @@ export const Treeview = {
    *
    * @example
    * ```vue
-   * <Treeview.SelectAll v-slot="{ attrs, isAllSelected, isMixed }">
+   * <Treeview.SelectAll v-slot="{ attrs, isAllSelected, isMixed }" renderless>
    *   <button v-bind="attrs">
    *     {{ isMixed ? '−' : isAllSelected ? '✓' : '○' }} Select All
    *   </button>


### PR DESCRIPTION
Closes #738

The Select compound and Item `@example` blocks spread slot `attrs` onto an inner `<div>` inside a non-renderless `Select.Item`. The Item already binds those attrs (`role="option"`, `onClick`) on its own Atom, so the documented usage rendered `listbox > div[role=option] > div[role=option]` — axe `aria-required-parent` (critical) — and double-fired the click handler. Fixed by putting content directly in the slot; the fixture and docs select examples already had the corrected shape.

## Bug-family sweep

Checked every component binding `slotProps.attrs` on a non-renderless Atom for the same `@example` defect:

**Same defect, fixed:**
- `Combobox` — both barrel `@examples` (compound + Item) had the identical inner-div spread; corrected the same way (Item highlight styling moved to a `data-[highlighted]` class on the component)
- `Treeview` — Cue/Checkbox/Indicator/SelectAll `@examples` spread attrs without `renderless`; added `renderless` (matches the docs example precedent). Same fix for `Treeview.Cue` in `apps/docs` treeview `basic.vue`
- `Radio` — `RadioGroup` slot `@example` duplicated `role="radiogroup"`; `RadioRoot` slot `@example` spread attrs *and* re-bound `select` alongside `attrs.onClick` (triple-fire). Added `renderless`, dropped the redundant handler

**Checked clean:** Select/Combobox fixtures and all select/combobox docs examples (already corrected shape), Selection/Single/Group examples (pure context providers, no Atom), Presence (renderless by nature), Rating/Avatar/Image docs examples (already `renderless`).

Out of scope per issue: Select.Activator button-name (#613/#635) and the accessible-name mechanism (#610).

## Verification

- `vitest --project v0:browser` — a11y sweep + Select: 152 passed
- `pnpm typecheck` — green