### PR TITLE
docs(Portal): document landmark expectations for teleported content

### DIFF
--- a/apps/docs/src/pages/components/primitives/portal.md
+++ b/apps/docs/src/pages/components/primitives/portal.md
@@ -50,6 +50,22 @@ Portal is transparent — it adds no DOM elements, ARIA attributes, or keyboard 
 > [!TIP]
 > When teleporting interactive content (modals, menus, notifications), ensure it has proper ARIA roles, keyboard handling, and focus management. Portal handles *where* content renders, not *how* it behaves.
 
+### Landmarks
+
+Teleported content lands outside your app's landmark structure — `body` is not inside `<main>`, so audit tools flag the subtree with the axe [region](https://dequeuniversity.com/rules/axe/4.12/region) rule. Give the teleported subtree its own semantics instead of relying on the surrounding page:
+
+- `role="dialog"` — dialogs are exempt from the landmark rule
+- `role="status"` or `role="alert"` — toast and notification regions
+- `role="region"` plus `aria-label` — arbitrary overlays with no more specific role
+
+```vue
+<template>
+  <Portal>
+    <aside role="region" aria-label="Chat panel">...</aside>
+  </Portal>
+</template>
+```
+
 ## FAQ
 
 ::: faq

--- a/apps/docs/src/pages/guide/features/accessibility.md
+++ b/apps/docs/src/pages/guide/features/accessibility.md
@@ -82,6 +82,10 @@ v0 does **not** provide focus trapping. Use external solutions:
 
 v0 does **not** provide roving tabindex. This keeps the library headless - implement in your design system layer if needed for arrow key navigation between items.
 
+### Teleported Content and Landmarks
+
+Content teleported by [Portal](/components/primitives/portal) renders into `body`, outside your app's landmarks, so audit tools flag it with the axe [region](https://dequeuniversity.com/rules/axe/4.12/region) rule. v0 is headless — it won't pick a landmark role for you. Give the teleported subtree its own semantics: `role="dialog"` for modals (exempt from the landmark rule), `role="status"` or `role="alert"` for toast regions, or `role="region"` plus `aria-label` for arbitrary overlays. See the [Portal accessibility notes](/components/primitives/portal#landmarks) for an example.
+
 ## Keyboard Navigation
 
 ### What v0 Handles

--- a/packages/0/src/components/fixtures/audit.ts
+++ b/packages/0/src/components/fixtures/audit.ts
@@ -51,6 +51,22 @@ const PAGE_LEVEL_RULES = new Set([
 ])
 
 /**
+ * Findings that are inherent to a component's design, not defects — keyed
+ * `subject:rule`. The rule still runs and still reports (it stays a real
+ * finding for every other component); the note only keeps the summary from
+ * presenting an expected hit as unexplained.
+ *
+ * Portal teleports content to `<body>` — outside every landmark — by design.
+ * v0 is headless, so the teleported subtree's semantics (`role="dialog"`,
+ * `role="status"`, `role="region"` + name) are the consumer's decision,
+ * documented on the Portal docs page.
+ * https://github.com/vuetifyjs/0/issues/742
+ */
+const EXPECTED = new Map([
+  ['Portal:region', 'teleports outside landmarks by design — consumer supplies the subtree role, see the Portal docs Accessibility section'],
+])
+
+/**
  * Run axe-core over `element` and flatten the result.
  *
  * Deliberately passes no `rules` / `runOnly` option — an auditor configured
@@ -122,7 +138,9 @@ export function summarize (violations: readonly AxeViolation[]): string {
     const counted = [...new Set(hits.map(hit => hit.rule))]
       .map(rule => {
         const count = hits.filter(hit => hit.rule === rule).flatMap(hit => hit.nodes).length
-        return count > 1 ? `${rule} x${count}` : rule
+        const label = count > 1 ? `${rule} x${count}` : rule
+        const note = EXPECTED.get(`${subject}:${rule}`)
+        return note ? `${label} [expected — ${note}]` : label
       })
       .toSorted()
 


### PR DESCRIPTION
Closes #742

## Decision

Option 1 — the behavior is inherent, so document it. Portal teleports to `body` by design, which places content outside every landmark; v0 is headless, so choosing a landmark role for arbitrary teleported content is the consumer's semantic decision (`role="dialog"` is exempt from the rule, `role="status"`/`role="alert"` for toast regions, `role="region"` + `aria-label` for arbitrary overlays). No landmark-wrapper prop, no change to the default teleport target.

## Changes

- Portal docs: new **Landmarks** subsection under Accessibility — why the axe `region` rule fires and which role to give the teleported subtree, with a tiny example.
- Accessibility guide: matching **Teleported Content and Landmarks** subsection linking to the Portal notes.
- a11y sweep (`fixtures/audit.ts`): `EXPECTED` annotation map so the report labels Portal's `region` hit as expected-by-design instead of an unexplained finding — the rule keeps firing and reporting for every other component. Report now renders:

```
Portal — region [expected — teleports outside landmarks by design — consumer supplies the subtree role, see the Portal docs Accessibility section]
```