### PR TITLE
chore(eslint): drop the Foundational import subgroup comment

### DIFF
--- a/packages/0/src/components/Snackbar/SnackbarQueue.vue
+++ b/packages/0/src/components/Snackbar/SnackbarQueue.vue
@@ -14,7 +14,6 @@
   import { Atom } from '#v0/components/Atom'
 
   // Composables
-  // Foundational
   import { createContext } from '#v0/composables/createContext'
   import { useNotifications } from '#v0/composables/useNotifications'
 

--- a/packages/0/src/components/Theme/Theme.vue
+++ b/packages/0/src/components/Theme/Theme.vue
@@ -12,7 +12,6 @@
   import { Atom } from '#v0/components/Atom'
 
   // Composables
-  // Foundational
   import { provideContext } from '#v0/composables/createContext'
   import { useTheme } from '#v0/composables/useTheme'
 


### PR DESCRIPTION
Removes the stray `// Foundational` subgroup comments inside the `// Composables` import sections of `SnackbarQueue.vue` and `Theme/Theme.vue`.

Investigation: no ESLint rule inserts this header — it appears in neither `eslint.config.js` nor the resolved `eslint-config-vuetify` output. The comments were hand-written in the original feature commits (e6dcb424d, e601c199a) and preserved by `perfectionist/sort-imports`, which keeps comments attached to the import below them. No config change was needed.

`SnackbarRoot.vue` keeps its copy — it is being cleaned on the open #774 branch.

Verified: full `pnpm lint:fix` does not re-insert the comments and produces no other changes.