### PR TITLE
fix(Snackbar): stop inline position:relative from overriding portal positioning

### DIFF
--- a/.changeset/fix-snackbar-portal-position-780.md
+++ b/.changeset/fix-snackbar-portal-position-780.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(Snackbar): stop inline position:relative from overriding portal positioning (#781)
+
+Your positioning classes on `Snackbar.Portal` (`absolute`, `fixed`, …) work again — the slot style now carries only `zIndex`. A wrapper that is still `position: static` after mount gets `position: relative` applied automatically, so the stacking-context guarantee from #602 is preserved. In renderless mode, make sure the wrapper you render is positioned for the z-index to take effect.

--- a/packages/0/src/components/Snackbar/SnackbarPortal.vue
+++ b/packages/0/src/components/Snackbar/SnackbarPortal.vue
@@ -19,11 +19,17 @@
   import { Atom } from '#v0/components/Atom'
   import { Portal } from '#v0/components/Portal'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
+  import { IN_BROWSER } from '#v0/constants/globals'
+
   // Utilities
-  import { mergeProps } from 'vue'
+  import { isNull } from '#v0/utilities'
+  import { mergeProps, toRef, useTemplateRef, watch } from 'vue'
 
   // Types
-  import type { AtomProps } from '#v0/components/Atom'
+  import type { AtomExpose, AtomProps } from '#v0/components/Atom'
 
   export interface SnackbarPortalProps extends AtomProps {
     /** Teleport target. `'top-layer'` mounts into the topmost open modal; `false` renders inline. @default 'top-layer' */
@@ -33,9 +39,18 @@
   export interface SnackbarPortalSlotProps {
     /** Calculated z-index from useStack */
     zIndex: number
-    /** Attributes to bind to the portal element */
+    /**
+     * Attributes to bind to the portal element.
+     *
+     * @remarks
+     * The style carries only `zIndex` so consumer positioning (classes or
+     * styles like `absolute` / `fixed`) wins. In renderless mode the wrapper
+     * you render must be positioned (non-`static`) for the z-index to take
+     * effect — the automatic `position: relative` fallback only covers the
+     * element rendered by the non-renderless Atom.
+     */
     attrs: {
-      style: { position: 'relative', zIndex: number }
+      style: { zIndex: number }
     }
   }
 </script>
@@ -57,16 +72,32 @@
     return {
       zIndex,
       attrs: {
-        style: { position: 'relative' as const, zIndex },
+        style: { zIndex },
       },
     }
   }
+
+  const atomRef = useTemplateRef<AtomExpose>('atom')
+  const el = toRef(() => toElement(atomRef.value?.element) ?? null)
+
+  // Preserve the stacking-context guarantee from #602 without an inline
+  // `position` that would override consumer positioning classes: only a
+  // computed `static` wrapper is nudged to `relative`.
+  watch(el, value => {
+    if (!IN_BROWSER || isNull(value)) return
+
+    const element = value as HTMLElement
+
+    if (getComputedStyle(element).position === 'static') {
+      element.style.position = 'relative'
+    }
+  })
 </script>
 
 <template>
   <Portal :disabled="teleport === false" :scrim="false" :to="teleport || 'body'">
     <template #default="{ zIndex }">
-      <Atom :as :renderless v-bind="mergeProps($attrs, getSlotProps(zIndex).attrs)">
+      <Atom ref="atom" :as :renderless v-bind="mergeProps($attrs, getSlotProps(zIndex).attrs)">
         <slot v-bind="getSlotProps(zIndex)" />
       </Atom>
     </template>

--- a/packages/0/src/components/Snackbar/index.browser.test.ts
+++ b/packages/0/src/components/Snackbar/index.browser.test.ts
@@ -79,6 +79,64 @@ describe('snackbar', () => {
       // Teleported content is not in wrapper's own DOM tree
       expect(wrapper.find('.teleported').exists()).toBe(false)
     })
+
+    it('should keep consumer positioning classes on the wrapper', async () => {
+      const sheet = document.createElement('style')
+      sheet.textContent = '.snackbar-absolute { position: absolute; }'
+      document.head.append(sheet)
+
+      let slotProps: any
+
+      const wrapper = mountWithStack(Snackbar.Portal, {
+        attachTo: document.body,
+        attrs: { class: 'snackbar-absolute' },
+        props: { teleport: false },
+        slots: {
+          default: (props: any) => {
+            slotProps = props
+            return h('div', 'content')
+          },
+        },
+      })
+
+      await nextTick()
+
+      const el = wrapper.find('.snackbar-absolute').element as HTMLElement
+
+      expect(getComputedStyle(el).position).toBe('absolute')
+      // No inline position — the consumer class must win
+      expect(el.style.position).toBe('')
+      expect(el.style.zIndex).toBe(String(slotProps.zIndex))
+
+      sheet.remove()
+      wrapper.unmount()
+    })
+
+    it('should apply position relative when the wrapper is static', async () => {
+      let slotProps: any
+
+      const wrapper = mountWithStack(Snackbar.Portal, {
+        attachTo: document.body,
+        attrs: { class: 'snackbar-static' },
+        props: { teleport: false },
+        slots: {
+          default: (props: any) => {
+            slotProps = props
+            return h('div', 'content')
+          },
+        },
+      })
+
+      await nextTick()
+
+      const el = wrapper.find('.snackbar-static').element as HTMLElement
+
+      expect(getComputedStyle(el).position).toBe('relative')
+      expect(el.style.position).toBe('relative')
+      expect(el.style.zIndex).toBe(String(slotProps.zIndex))
+
+      wrapper.unmount()
+    })
   })
 
   describe('root', () => {


### PR DESCRIPTION
Closes #780

## Mechanism

#602 added `position: 'relative'` to `SnackbarPortal`'s slot-attrs **inline style**. Inline styles beat classes, so any consumer positioning class on the Portal (`absolute`, `fixed`) was silently overridden and the wrapper forced back into flow — both docs snackbar examples render their toasts in-flow in production.

## Fix

- Slot-attrs style now carries only `zIndex`; consumer positioning wins.
- The stacking-context guarantee from #602 is preserved at runtime: when the Atom's element resolves, a computed `position: static` wrapper gets `el.style.position = 'relative'` (`IN_BROWSER`-guarded watch on the exposed element ref, so it re-applies on remount). Positioned wrappers are left untouched.
- Docs examples need no changes — they start working again with this fix.

## Renderless caveat

In renderless mode consumers render their own wrapper from slot attrs; the runtime fallback only covers the non-renderless Atom. The slot-props JSDoc now documents that a static wrapper needs positioning for the z-index to apply.