### PR TITLE
docs(DocsAskPanel): contain panel scrolling with overscroll-contain

### DIFF
--- a/apps/docs/src/components/docs/DocsAskPanel.vue
+++ b/apps/docs/src/components/docs/DocsAskPanel.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
   // Framework
   import { isNull, useBreakpoints } from '@vuetify/v0'
-  import { IN_BROWSER } from '@vuetify/v0/constants'
 
   // Components
   import AppIcon from '@/components/app/AppIcon.vue'
@@ -17,7 +16,7 @@
   import { useSettings } from '@/composables/useSettings'
 
   // Utilities
-  import { nextTick, onScopeDispose, toRef, useTemplateRef, watch } from 'vue'
+  import { nextTick, toRef, useTemplateRef, watch } from 'vue'
 
   // Types
   import type { Message } from '@/composables/useAsk'
@@ -47,33 +46,6 @@
   const formRef = useTemplateRef<{ focus: () => void }>('form')
 
   const isDesktop = toRef(() => !breakpoints.isMobile.value)
-
-  const maximized = toRef(() => isDesktop.value && props.fullscreen === true)
-
-  function unlock () {
-    if (!IN_BROWSER) return
-
-    document.documentElement.style.overflow = ''
-    document.documentElement.style.paddingRight = ''
-  }
-
-  // Contain scrolling to the panel while maximized; the padding replaces
-  // the vanished scrollbar so the page behind doesn't shift
-  watch(maximized, locked => {
-    if (!IN_BROWSER) return
-
-    if (!locked) {
-      unlock()
-      return
-    }
-
-    const root = document.documentElement
-    const gutter = window.innerWidth - root.clientWidth
-    root.style.overflow = 'hidden'
-    root.style.paddingRight = gutter > 0 ? `${gutter}px` : ''
-  }, { immediate: true })
-
-  onScopeDispose(unlock)
 
   // Auto-scroll until response fills the viewport
   let shouldAutoScroll = true
@@ -255,7 +227,7 @@
     <Discovery.Activator
       ref="messages"
       as="div"
-      class="rounded-lg flex-1 h-full pa-4 overflow-y-auto"
+      class="rounded-lg flex-1 h-full pa-4 overflow-y-auto overscroll-contain"
       :padding="-4"
       step="ask-ai-panel"
     >

--- a/apps/docs/src/components/docs/DocsAskPanel.vue
+++ b/apps/docs/src/components/docs/DocsAskPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   // Framework
   import { isNull, useBreakpoints } from '@vuetify/v0'
+  import { IN_BROWSER } from '@vuetify/v0/constants'
 
   // Components
   import AppIcon from '@/components/app/AppIcon.vue'
@@ -16,7 +17,7 @@
   import { useSettings } from '@/composables/useSettings'
 
   // Utilities
-  import { nextTick, toRef, useTemplateRef, watch } from 'vue'
+  import { nextTick, onScopeDispose, toRef, useTemplateRef, watch } from 'vue'
 
   // Types
   import type { Message } from '@/composables/useAsk'
@@ -46,6 +47,33 @@
   const formRef = useTemplateRef<{ focus: () => void }>('form')
 
   const isDesktop = toRef(() => !breakpoints.isMobile.value)
+
+  const maximized = toRef(() => isDesktop.value && props.fullscreen === true)
+
+  function unlock () {
+    if (!IN_BROWSER) return
+
+    document.documentElement.style.overflow = ''
+    document.documentElement.style.paddingRight = ''
+  }
+
+  // Contain scrolling to the panel while maximized; the padding replaces
+  // the vanished scrollbar so the page behind doesn't shift
+  watch(maximized, locked => {
+    if (!IN_BROWSER) return
+
+    if (!locked) {
+      unlock()
+      return
+    }
+
+    const root = document.documentElement
+    const gutter = window.innerWidth - root.clientWidth
+    root.style.overflow = 'hidden'
+    root.style.paddingRight = gutter > 0 ? `${gutter}px` : ''
+  }, { immediate: true })
+
+  onScopeDispose(unlock)
 
   // Auto-scroll until response fills the viewport
   let shouldAutoScroll = true


### PR DESCRIPTION
## Description

Wheel scrolling inside the Ask AI panel chained to the page behind it. The messages scroller now carries `overscroll-contain`, so wheel input over the conversation area stays in the panel — including when the conversation doesn't overflow (Chromium honors `overscroll-behavior` on a non-overflowing scroll container).

Known accepted edges (deliberate — a JS document scroll lock was prototyped and dropped in favor of the CSS-only approach): wheel over the header/footer strips or the 16px margin while maximized, and keyboard scrolling with focus on the body, still reach the page behind.

Verified in-browser (Playwright): wheel over the messages area leaves `window.scrollY` untouched in both docked and maximized modes.