### PR TITLE
docs(Portal): use neutral div in landmark example

### DIFF
--- a/apps/docs/src/pages/components/primitives/portal.md
+++ b/apps/docs/src/pages/components/primitives/portal.md
@@ -61,7 +61,7 @@ Teleported content lands outside your app's landmark structure — `body` is not
 ```vue
 <template>
   <Portal>
-    <aside role="region" aria-label="Chat panel">...</aside>
+    <div role="region" aria-label="Chat panel">...</div>
   </Portal>
 </template>
 ```


### PR DESCRIPTION
Follow-up to #776 (merged before the review nit could be amended in). The Landmarks example paired `role="region"` with `<aside>`, which is already a `complementary` landmark on its own — a confusing pairing for an example teaching landmark choice. Swapped to a plain `<div role="region" aria-label="Chat panel">`.