### PR TITLE
fix(Slider,Rating): omit aria-label when ariaLabelledby is provided

### DIFF
--- a/.changeset/aria-labelledby-precedence.md
+++ b/.changeset/aria-labelledby-precedence.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(Slider,Rating): omit aria-label when ariaLabelledby is provided
+
+When both `ariaLabel` and `ariaLabelledby` are provided, `aria-labelledby` now consistently wins across Slider, Rating, and NumberField — `aria-label` is omitted from the DOM. Assistive technology output is unchanged (the ARIA accessible-name algorithm already prefers `aria-labelledby`); only the emitted attributes are now consistent.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -297,6 +297,8 @@ expect(slotProps.attrs['aria-label']).toBeDefined()
 expect(slotProps.attrs['aria-label']).toBe('Close dialog')
 ```
 
+Carve-out: default-fallback strings MAY be pinned to their literal when the test environment installs no locale plugin — the hardcoded `?? 'X'` fallback is then deterministic (NumberField's `'Number'` pin is the standing precedent). `toBeDefined()` remains the rule whenever a locale plugin could resolve the key.
+
 ## Benchmark Pattern
 
 Benchmarks are colocated as `index.bench.ts`, only for performance-critical composables. See `.claude/rules/benchmarks.md` for full conventions. [intent:233]

--- a/packages/0/src/components/Rating/RatingRoot.vue
+++ b/packages/0/src/components/Rating/RatingRoot.vue
@@ -192,7 +192,7 @@
       'aria-valuemin': 0,
       'aria-valuemax': rating.size,
       'aria-valuetext': locale.ti('Rating.valueText', { value: rating.value.value, size: rating.size }) ?? `${rating.value.value} of ${rating.size} stars`,
-      'aria-label': ariaLabel || (ariaLabelledby ? undefined : locale.ti('Rating.label') ?? 'Rating'),
+      'aria-label': ariaLabelledby ? undefined : (ariaLabel || (locale.ti('Rating.label') ?? 'Rating')),
       'aria-labelledby': ariaLabelledby || undefined,
       'aria-disabled': isDisabled.value,
       'aria-readonly': isReadonly.value ? true : undefined,

--- a/packages/0/src/components/Rating/index.test.ts
+++ b/packages/0/src/components/Rating/index.test.ts
@@ -355,7 +355,7 @@ describe('rating', () => {
         const { rootProps, wait } = mountRating()
         await wait()
 
-        expect(rootProps().attrs['aria-label']).toBeDefined()
+        expect(rootProps().attrs['aria-label']).toBe('Rating')
       })
 
       it('should prefer the ariaLabel prop over the default', async () => {
@@ -367,6 +367,14 @@ describe('rating', () => {
 
       it('should omit the default aria-label when ariaLabelledby is set', async () => {
         const { rootProps, wait } = mountRating({ props: { ariaLabelledby: 'rating-label' } })
+        await wait()
+
+        expect(rootProps().attrs['aria-label']).toBeUndefined()
+        expect(rootProps().attrs['aria-labelledby']).toBe('rating-label')
+      })
+
+      it('should omit aria-label when both ariaLabel and ariaLabelledby are set', async () => {
+        const { rootProps, wait } = mountRating({ props: { ariaLabel: 'Product rating', ariaLabelledby: 'rating-label' } })
         await wait()
 
         expect(rootProps().attrs['aria-label']).toBeUndefined()

--- a/packages/0/src/components/Slider/SliderThumb.vue
+++ b/packages/0/src/components/Slider/SliderThumb.vue
@@ -176,7 +176,7 @@
       'aria-orientation': toValue(root.orientation),
       'aria-disabled': isDisabled.value,
       'aria-readonly': isReadonly.value ? true : undefined,
-      'aria-label': ariaLabel || (ariaLabelledby ? undefined : locale.ti('Slider.label') ?? 'Slider'),
+      'aria-label': ariaLabelledby ? undefined : (ariaLabel || (locale.ti('Slider.label') ?? 'Slider')),
       'aria-labelledby': ariaLabelledby || undefined,
       'data-state': dataState.value,
       'data-disabled': isDisabled.value ? true : undefined,

--- a/packages/0/src/components/Slider/index.browser.test.ts
+++ b/packages/0/src/components/Slider/index.browser.test.ts
@@ -284,7 +284,7 @@ describe('slider', () => {
       const model = ref([50])
       const { thumbProps, wait } = mountSlider({ model })
       await wait()
-      expect(thumbProps().attrs['aria-label']).toBeDefined()
+      expect(thumbProps().attrs['aria-label']).toBe('Slider')
     })
 
     it('should not emit default aria-label when aria-labelledby is set', async () => {
@@ -292,6 +292,17 @@ describe('slider', () => {
       const { thumbProps, wait } = mountSlider({
         model,
         thumbProps: [{ ariaLabelledby: 'thumb-label' }],
+      })
+      await wait()
+      expect(thumbProps().attrs['aria-label']).toBeUndefined()
+      expect(thumbProps().attrs['aria-labelledby']).toBe('thumb-label')
+    })
+
+    it('should omit aria-label when both ariaLabel and ariaLabelledby are set', async () => {
+      const model = ref([50])
+      const { thumbProps, wait } = mountSlider({
+        model,
+        thumbProps: [{ ariaLabel: 'Volume', ariaLabelledby: 'thumb-label' }],
       })
       await wait()
       expect(thumbProps().attrs['aria-label']).toBeUndefined()


### PR DESCRIPTION
## The inconsistency

The three recent a11y PRs (#771 Slider, #772 NumberField, #773 Rating) shipped two different shapes for the same decision — what to emit when a consumer passes both `ariaLabel` and `ariaLabelledby`:

- **SliderThumb** and **RatingRoot**: `ariaLabel || (ariaLabelledby ? undefined : locale fallback)` — emitted **both** attributes when both props were set.
- **NumberFieldControl**: `ariaLabelledby ? undefined : (label || locale fallback)` — `aria-labelledby` suppressed `aria-label` outright.

Per the ARIA accessible-name algorithm `aria-labelledby` wins regardless, so AT outcome was identical — but the emitted DOM disagreed and nothing pinned either behavior.

## The rule

Standardized on the NumberField shape: **`ariaLabelledby` suppresses `aria-label` entirely.**

```ts
'aria-label': ariaLabelledby ? undefined : (ariaLabel || (locale.ti('X.label') ?? 'X'))
```

SliderThumb and RatingRoot changed to match; NumberField unchanged.

## Tests

- Both-props-set case added to the Slider and Rating suites, pinning `aria-label: undefined` + `aria-labelledby` emitted (NumberField already pins this case).
- Default-label assertions tightened from `.toBeDefined()` to the literal fallback (`'Slider'`, `'Rating'`) — no locale plugin in tests, so the hardcoded fallback is deterministic; the NumberField suite already pins its literal.

## Credit

Surfaced by @sridhar-3009's #764, whose ordering matched the unified rule.