### PR TITLE
docs(Snackbar): restore stacked hover-expand queue example

### DIFF
--- a/apps/docs/src/examples/components/snackbar/queue.vue
+++ b/apps/docs/src/examples/components/snackbar/queue.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+  import { shallowRef, toRef } from 'vue'
+  import { Snackbar, useDelay, useNotifications } from '@vuetify/v0'
+  import type { NotificationSeverity } from '@vuetify/v0'
+
+  const notifications = useNotifications()
+
+  const severities: NotificationSeverity[] = ['info', 'success', 'warning', 'error']
+  const index = shallowRef(0)
+
+  const messages: Record<NotificationSeverity, string> = {
+    info: 'Deployment started for production',
+    success: 'Changes saved successfully',
+    warning: 'API rate limit at 80%',
+    error: 'Build failed — check logs',
+  }
+
+  const classes: Record<NotificationSeverity, string> = {
+    info: 'bg-info text-on-info',
+    success: 'bg-success text-on-success',
+    warning: 'bg-warning text-on-warning',
+    error: 'bg-error text-on-error',
+  }
+
+  function onShow () {
+    const severity = severities[index.value % severities.length]
+    index.value++
+    notifications.send({ subject: messages[severity], severity, timeout: 4000 })
+  }
+
+  // Stacking behavior — consumer owns this
+  const hovered = shallowRef(false)
+
+  const ITEM_H = 44
+  const GAP = 8
+  const PEEK = 16
+  const MAX_STACK = 3
+
+  const height = toRef(() => {
+    const n = Math.min(notifications.queue.values().length, MAX_STACK)
+    if (!n) return 0
+    return hovered.value
+      ? notifications.queue.values().length * ITEM_H + (notifications.queue.values().length - 1) * GAP
+      : ITEM_H + (n - 1) * PEEK
+  })
+
+  function style (i: number) {
+    if (hovered.value) {
+      return {
+        bottom: `${i * (ITEM_H + GAP)}px`,
+        left: 0,
+        right: 0,
+        transform: 'none',
+        opacity: 1,
+        pointerEvents: 'auto' as const,
+      }
+    }
+
+    if (i >= MAX_STACK) {
+      const depth = MAX_STACK - 1
+      return {
+        bottom: 0,
+        left: `${depth * 8}px`,
+        right: `${depth * 8}px`,
+        transform: `translateY(${-depth * PEEK}px) scale(${1 - depth * 0.04})`,
+        transformOrigin: 'bottom center',
+        opacity: 0,
+        pointerEvents: 'none' as const,
+        zIndex: -1,
+      }
+    }
+
+    return {
+      bottom: 0,
+      left: `${i * 8}px`,
+      right: `${i * 8}px`,
+      transform: `translateY(${-i * PEEK}px) scale(${1 - i * 0.04})`,
+      transformOrigin: 'bottom center',
+      opacity: Math.max(0, 1 - i * 0.2),
+      zIndex: MAX_STACK - i,
+      pointerEvents: i === 0 ? 'auto' as const : 'none' as const,
+    }
+  }
+
+  const delay = useDelay(opening => hovered.value = opening, {
+    openDelay: 0,
+    closeDelay: 150,
+  })
+
+  function onEnter () {
+    delay.start(true)
+  }
+
+  function onLeave () {
+    delay.start(false)
+  }
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-6 min-h-48 p-6 bg-background rounded-lg border border-divider">
+    <button
+      class="px-4 py-2 bg-primary text-on-primary rounded-md text-sm font-medium"
+      @click="onShow"
+    >
+      Show Toast
+    </button>
+
+    <p class="text-sm opacity-40">
+      Cycles through info → success → warning → error
+    </p>
+  </div>
+
+  <Snackbar.Portal
+    class="absolute bottom-4 right-4 w-72"
+    :teleport="false"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+  >
+    <Snackbar.Queue v-slot="{ items }">
+      <div
+        class="relative transition-all duration-300 ease-out"
+        :style="{ height: `${height}px` }"
+      >
+        <div
+          v-for="(item, i) in items"
+          :key="item.id"
+          class="absolute left-0 right-0 transition-all duration-300 ease-out"
+          :style="style(i)"
+        >
+          <Snackbar.Root
+            :id="item.id"
+            class="flex items-center gap-3 px-4 py-2.5 rounded-lg shadow-lg text-sm"
+            :class="classes[item.severity ?? 'info']"
+          >
+            <Snackbar.Content class="flex-1">
+              {{ item.subject }}
+            </Snackbar.Content>
+
+            <Snackbar.Close
+              v-show="hovered || i === 0"
+              class="p-1 -mr-1 opacity-70 hover:opacity-100 shrink-0"
+            >
+              <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24">
+                <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" fill="currentColor" />
+              </svg>
+            </Snackbar.Close>
+          </Snackbar.Root>
+        </div>
+      </div>
+    </Snackbar.Queue>
+  </Snackbar.Portal>
+</template>

--- a/apps/docs/src/examples/components/snackbar/queue.vue
+++ b/apps/docs/src/examples/components/snackbar/queue.vue
@@ -1,9 +1,19 @@
 <script setup lang="ts">
-  import { shallowRef, toRef } from 'vue'
-  import { Snackbar, useDelay, useNotifications } from '@vuetify/v0'
+  import { onScopeDispose, shallowRef, toRef } from 'vue'
+  import { createNotificationsContext, Snackbar, useDelay } from '@vuetify/v0'
   import type { NotificationSeverity } from '@vuetify/v0'
 
-  const notifications = useNotifications()
+  // Dedicated namespace — this surface owns its own queue instead of
+  // sharing the app-level 'v0:notifications' instance
+  const namespace = 'docs:stacked-toasts'
+  const [, provide, notifications] = createNotificationsContext({ namespace })
+
+  provide()
+
+  onScopeDispose(() => {
+    notifications.dispose()
+    notifications.queue.dispose()
+  })
 
   const severities: NotificationSeverity[] = ['info', 'success', 'warning', 'error']
   const index = shallowRef(0)
@@ -112,11 +122,12 @@
 
   <Snackbar.Portal
     class="absolute bottom-4 right-4 w-72"
+    :namespace
     :teleport="false"
     @mouseenter="onEnter"
     @mouseleave="onLeave"
   >
-    <Snackbar.Queue v-slot="{ items }">
+    <Snackbar.Queue v-slot="{ items }" :namespace>
       <div
         class="relative transition-all duration-300 ease-out"
         :style="{ height: `${height}px` }"
@@ -131,6 +142,7 @@
             :id="item.id"
             class="flex items-center gap-3 px-4 py-2.5 rounded-lg shadow-lg text-sm"
             :class="classes[item.severity ?? 'info']"
+            :namespace
           >
             <Snackbar.Content class="flex-1">
               {{ item.subject }}
@@ -139,6 +151,7 @@
             <Snackbar.Close
               v-show="hovered || i === 0"
               class="p-1 -mr-1 opacity-70 hover:opacity-100 shrink-0"
+              :namespace
             >
               <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24">
                 <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" fill="currentColor" />

--- a/apps/docs/src/pages/components/semantic/snackbar.md
+++ b/apps/docs/src/pages/components/semantic/snackbar.md
@@ -74,6 +74,18 @@ Reach for the queue whenever notifications flow through [useNotifications](/comp
 :::
 
 ::: gn-example
+/components/snackbar/queue
+
+### Stacked toasts
+
+Newer toasts collapse into a peeked stack — each card offset, scaled, and faded by depth — and fan out into a full column while the pointer rests on the surface. The stacking geometry is pure consumer CSS applied per index via `style(i)`; `Snackbar.Queue` stays layout-agnostic and only supplies items newest-first, making index 0 the front card. Container height animates between the collapsed and expanded layouts, so surrounding content never jumps.
+
+Hover intent runs through [useDelay](/composables/system/use-delay): entering the surface expands immediately, leaving collapses after a 150ms grace period so the stack doesn't flicker while the pointer crosses gaps between cards. Auto-dismiss pauses while any item is hovered or focused (WCAG 2.2.1), which you get for free from [useNotifications](/composables/plugins/use-notifications).
+
+Reach for this pattern when toasts arrive in bursts and a flat column would push content off screen; for a simple stack with per-item actions, see the undo example above.
+:::
+
+::: gn-example
 /components/snackbar/in-dialog
 
 ### Snackbar inside a Dialog

--- a/apps/docs/src/pages/components/semantic/snackbar.md
+++ b/apps/docs/src/pages/components/semantic/snackbar.md
@@ -82,6 +82,8 @@ Newer toasts collapse into a peeked stack — each card offset, scaled, and fade
 
 Hover intent runs through [useDelay](/composables/system/use-delay): entering the surface expands immediately, leaving collapses after a 150ms grace period so the stack doesn't flicker while the pointer crosses gaps between cards. Auto-dismiss pauses while any item is hovered or focused (WCAG 2.2.1), which you get for free from [useNotifications](/composables/plugins/use-notifications).
 
+The surface owns its notifications instance: `createNotificationsContext` provides a fresh context under a dedicated namespace, and every Snackbar sub-component receives that namespace so the queue stays isolated from the app-level `v0:notifications` instance. Use this pattern whenever a toast surface shouldn't mix with the rest of the app — or, as here, with other examples on the same page.
+
 Reach for this pattern when toasts arrive in bursts and a flat column would push content off screen; for a simple stack with per-item actions, see the undo example above.
 :::
 


### PR DESCRIPTION
Restores the stacked toast example (`queue.vue`) that was dropped in #382 when the Examples section was rebuilt around the multi-file toast-host demo.

The original 156-line example is back with three adaptations to current conventions:

- `absolute` instead of `fixed` on `Snackbar.Portal` — matches the sibling ToastHost example and the post-#781 positioning contract (consumer classes win)
- `useDelay` (openDelay 0 / closeDelay 150) replaces the hand-rolled `setTimeout` leave-debounce
- `toRef` instead of `computed` for the cheap container-height derivation; single-word names

Wired into `snackbar.md` as a new **Stacked toasts** example between the undo demo and the in-dialog demo, with multi-paragraph prose per the examples depth rule.

Verified in-browser against the dev server: collapsed peek geometry (scale .96/.92, −16/−32px, opacity falloff, >3 hidden), hover fan-out (container 76px→148px, cards at 0/52/104px), 150ms leave-collapse, and empty-queue collapse to zero. `pnpm repo:check` clean.