### PR TITLE
chore(playground): load docs examples from the registry catalog

### DIFF
--- a/apps/docs/src/components/docs/DocsExample.vue
+++ b/apps/docs/src/components/docs/DocsExample.vue
@@ -10,7 +10,11 @@
   import { useCodeHighlighter } from '@/composables/useCodeHighlighter'
   import { useExamples } from '@/composables/useExamples'
   import { useIdleCallback } from '@/composables/useIdleCallback'
-  import { usePlayground } from '@/composables/usePlayground'
+  import {
+    playgroundRegistryUrl,
+    registryRefFromExamplePath,
+    usePlayground,
+  } from '@/composables/usePlayground'
 
   // Utilities
   import { toKebab } from '@/utilities/strings'
@@ -206,6 +210,18 @@
 
   async function openAllInPlayground () {
     if (!displayFiles.value?.length) return
+    // Hash by default; short registry URLs only when VITE_PLAYGROUND_REGISTRY=1
+    // (needs live /registry/*). Entry = last .vue, matching the registry builder.
+    if (import.meta.env.VITE_PLAYGROUND_REGISTRY === '1' && !imports) {
+      const path = filePath
+        ?? [...(filePaths ?? [])].toReversed().find(p => p.endsWith('.vue'))
+        ?? filePaths?.[0]
+      const ref = path ? registryRefFromExamplePath(path) : null
+      if (ref) {
+        window.open(playgroundRegistryUrl(ref), '_blank')
+        return
+      }
+    }
     const files = displayFiles.value.map(f => ({ name: f.name, code: f.code }))
     const url = await usePlayground(files, undefined, imports)
     window.open(url, '_blank')

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -10,7 +10,11 @@
   import { useExamples } from '@/composables/useExamples'
   import { prehighlight } from '@/composables/useHighlightCode'
   import { useIdleCallback } from '@/composables/useIdleCallback'
-  import { usePlayground } from '@/composables/usePlayground'
+  import {
+    playgroundRegistryUrl,
+    registryRefFromExamplePath,
+    usePlayground,
+  } from '@/composables/usePlayground'
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
 
@@ -91,6 +95,20 @@
   })
 
   async function onPlayground (list: GnDocsExampleFile[]) {
+    // Embed source in the hash by default — works without a live /registry/*
+    // (PR #721). Opt into short registry URLs with VITE_PLAYGROUND_REGISTRY=1
+    // once the seed is deployed; entry file is the last .vue (registry contract).
+    if (import.meta.env.VITE_PLAYGROUND_REGISTRY === '1' && !props.imports) {
+      const path = props.filePath
+        ?? [...(props.filePaths ?? [])].toReversed().find(p => p.endsWith('.vue'))
+        ?? props.filePaths?.[0]
+      const ref = path ? registryRefFromExamplePath(path) : null
+      if (ref) {
+        window.open(playgroundRegistryUrl(ref), '_blank')
+        return
+      }
+    }
+
     const files = list.map(f => ({ name: f.name, code: f.code }))
     const url = await usePlayground(files, undefined, props.imports)
     window.open(url, '_blank')

--- a/apps/docs/src/composables/usePlayground.ts
+++ b/apps/docs/src/composables/usePlayground.ts
@@ -100,6 +100,10 @@ function buildPlaygroundFiles (inputFiles: PlaygroundFile[], dir?: string): Reco
   return files
 }
 
+function playgroundBase () {
+  return import.meta.env.VITE_PLAYGROUND_URL ?? 'https://v0play.vuetifyjs.com'
+}
+
 /**
  * Get editor URL for multiple files.
  * When dir is provided, files are nested under src/{dir}/.
@@ -113,8 +117,72 @@ export async function usePlayground (
   const data: PlaygroundHashData = { files }
   if (imports && Object.keys(imports).length > 0) data.imports = imports
   const hash = await encodePlaygroundHash(data)
-  const base = import.meta.env.VITE_PLAYGROUND_URL ?? 'https://v0play.vuetifyjs.com'
-  return `${base}/#${hash}`
+  return `${playgroundBase()}/#${hash}`
+}
+
+export interface PlaygroundRegistryRef {
+  /** Feature name, e.g. `dialog`. */
+  item: string
+  /** Example id, e.g. `basic`. */
+  example?: string
+  /** `components` | `composables` when known. */
+  type?: 'components' | 'composables'
+  /** Override docs registry origin. */
+  registry?: string
+}
+
+/**
+ * Short playground URL that resolves against the docs registry catalog.
+ * Smaller than a hash payload and always pulls current seed source — but
+ * requires a live `/registry/*` (docs PR #721) **and** CORS on that origin.
+ * Docs "Open in Playground" stays hash-based unless `VITE_PLAYGROUND_REGISTRY=1`.
+ *
+ * @example
+ * ```ts
+ * playgroundRegistryUrl({ item: 'dialog', example: 'basic' })
+ * // → https://v0play.vuetifyjs.com/?example=dialog/basic
+ * ```
+ */
+export function playgroundRegistryUrl (ref: PlaygroundRegistryRef): string {
+  const params = new URLSearchParams()
+  if (ref.type) {
+    params.set(
+      'example',
+      ref.example
+        ? `${ref.type}/${ref.item}/${ref.example}`
+        : `${ref.type}/${ref.item}`,
+    )
+  } else if (ref.example) {
+    params.set('example', `${ref.item}/${ref.example}`)
+  } else {
+    params.set('example', ref.item)
+  }
+  if (ref.registry) params.set('registry', ref.registry)
+  return `${playgroundBase()}/?${params}`
+}
+
+/**
+ * Map a docs example path (`/components/dialog/basic`, `composables/use-theme/…`)
+ * to a registry ref for short playground URLs.
+ */
+export function registryRefFromExamplePath (path: string): PlaygroundRegistryRef | null {
+  const clean = path.replace(/^\//, '').replace(/\.\w+$/, '')
+  const parts = clean.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  if (parts[0] !== 'components' && parts[0] !== 'composables') return null
+
+  const type = parts[0] as 'components' | 'composables'
+  const item = parts[1]!
+  if (parts.length === 2) {
+    return { type, item }
+  }
+  // Registry id: entry basename when files sit at `{type}/{name}/`, else the
+  // first subdirectory name (`components/dialog/gallery/App.vue` → `gallery`).
+  return {
+    type,
+    item,
+    example: parts[2],
+  }
 }
 
 function isFileRecord (v: unknown): v is Record<string, string> {

--- a/apps/playground/src/components/playground/app/PlaygroundApp.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundApp.vue
@@ -9,6 +9,7 @@
   import { nextTick, onMounted, shallowRef, watch } from 'vue'
 
   // Types
+  import type { RegistryExampleRef } from '@/data/registry'
   import type { ReplStore } from '@vue/repl'
   import type { Ref, ShallowRef } from 'vue'
 
@@ -31,7 +32,9 @@
     activeAddons: ShallowRef<string[]>
     toggleAddon: (id: string) => Promise<void>
     filesVersion: ShallowRef<number>
+    loadError: ShallowRef<string | undefined>
     openPlayground: (content: string) => Promise<void>
+    openRegistryExample: (ref: RegistryExampleRef, options?: { clearSearch?: boolean }) => Promise<void>
     showConfig: ShallowRef<boolean>
   }
 
@@ -39,7 +42,24 @@
 </script>
 
 <script setup lang="ts">
-  const { store, isReady, filesVersion, vueVersion, v0Version, vueVersions, v0Versions, fetching, fetchVersions, activePreset, applyPreset, activeAddons, toggleAddon, openPlayground } = usePlaygroundFiles()
+  const {
+    store,
+    isReady,
+    filesVersion,
+    loadError,
+    vueVersion,
+    v0Version,
+    vueVersions,
+    v0Versions,
+    fetching,
+    fetchVersions,
+    activePreset,
+    applyPreset,
+    activeAddons,
+    toggleAddon,
+    openPlayground,
+    openRegistryExample,
+  } = usePlaygroundFiles()
   const storage = useStorage()
   const { isMobile } = useBreakpoints()
 
@@ -90,7 +110,9 @@
     activeAddons,
     toggleAddon,
     filesVersion,
+    loadError,
     openPlayground,
+    openRegistryExample,
     showConfig,
   })
 
@@ -130,6 +152,22 @@
     class="h-screen flex flex-col overflow-hidden bg-background transition-opacity duration-150"
     :class="settled ? 'opacity-100' : 'opacity-0'"
   >
+    <div
+      v-if="loadError"
+      class="flex items-center justify-between gap-3 px-3 py-2 text-xs bg-error/10 text-error border-b border-error/20 shrink-0"
+      role="alert"
+    >
+      <span class="min-w-0 truncate">{{ loadError }}</span>
+
+      <button
+        class="shrink-0 underline opacity-80 hover:opacity-100"
+        type="button"
+        @click="loadError = undefined"
+      >
+        Dismiss
+      </button>
+    </div>
+
     <slot />
   </div>
 </template>

--- a/apps/playground/src/components/playground/app/PlaygroundMenuBar.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundMenuBar.vue
@@ -122,7 +122,7 @@
             type="button"
             @click="onOpen"
           >
-            Open...
+            Open example…
           </button>
 
           <div class="border-t border-divider my-1" />

--- a/apps/playground/src/components/playground/app/PlaygroundOpenDialog.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundOpenDialog.vue
@@ -5,8 +5,14 @@
   // Context
   import { usePlayground } from './PlaygroundApp.vue'
 
+  // Data
+  import { DEFAULT_REGISTRY, getRegistryIndex, getRegistryItem } from '@/data/registry'
+
   // Utilities
   import { computed, nextTick, onMounted, ref, shallowRef, useTemplateRef } from 'vue'
+
+  // Types
+  import type { RegistryExample, RegistryIndexEntry, RegistryItem } from '@/data/registry'
 
   interface VuetifyPlayground {
     id: string
@@ -16,43 +22,171 @@
     updatedAt: string
   }
 
+  type Tab = 'examples' | 'saved'
+
   const emit = defineEmits<{ close: [] }>()
 
   const playground = usePlayground()
-  const items = ref<VuetifyPlayground[]>([])
-  const loading = shallowRef(true)
-  const error = shallowRef<string>()
+  const tab = shallowRef<Tab>('examples')
+
+  // ── Saved playgrounds (API) ──────────────────────────────────────────
+  const saved = ref<VuetifyPlayground[]>([])
+  const savedLoading = shallowRef(false)
+  const savedError = shallowRef<string>()
+  const savedLoaded = shallowRef(false)
+
+  // ── Docs registry examples ───────────────────────────────────────────
+  const items = ref<RegistryIndexEntry[]>([])
+  const examplesLoading = shallowRef(true)
+  const examplesError = shallowRef<string>()
   const query = shallowRef('')
   const input = useTemplateRef<HTMLInputElement>('input')
+  const opening = shallowRef(false)
+  const selected = shallowRef<RegistryIndexEntry>()
+  const selectedItem = shallowRef<RegistryItem>()
+  const itemLoading = shallowRef(false)
 
   const filtered = computed(() => {
     const q = query.value.toLowerCase().trim()
     if (!q) return items.value
-    return items.value.filter(item => (item.title || '').toLowerCase().includes(q))
+    return items.value.filter(item =>
+      item.name.includes(q)
+      || item.title.toLowerCase().includes(q)
+      || item.category.toLowerCase().includes(q)
+      || item.examples.some(id => id.includes(q)),
+    )
+  })
+
+  const filteredSaved = computed(() => {
+    const q = query.value.toLowerCase().trim()
+    if (!q) return saved.value
+    return saved.value.filter(item => (item.title || '').toLowerCase().includes(q))
+  })
+
+  /** Group filtered items for scannable headers. */
+  const groups = computed(() => {
+    const order = ['components', 'plugins', 'composables', 'other'] as const
+    const buckets = new Map<string, RegistryIndexEntry[]>()
+
+    for (const item of filtered.value) {
+      let key: string
+      if (item.category === 'plugins') key = 'plugins'
+      else if (item.type === 'components') key = 'components'
+      else if (item.type === 'composables') key = 'composables'
+      else key = 'other'
+
+      const list = buckets.get(key) ?? []
+      list.push(item)
+      buckets.set(key, list)
+    }
+
+    return order
+      .filter(key => (buckets.get(key)?.length ?? 0) > 0)
+      .map(key => ({
+        key,
+        label: key === 'other' ? 'Other' : key[0]!.toUpperCase() + key.slice(1),
+        items: buckets.get(key)!,
+      }))
   })
 
   onMounted(async () => {
+    await loadExamples()
+    nextTick(() => input.value?.focus())
+  })
+
+  async function loadExamples () {
+    examplesLoading.value = true
+    examplesError.value = undefined
+    try {
+      const index = await getRegistryIndex()
+      items.value = index.items
+        .filter(item => item.examples.length > 0)
+        .toSorted((a, b) => a.title.localeCompare(b.title) || a.name.localeCompare(b.name))
+    } catch (error) {
+      examplesError.value = error instanceof Error
+        ? error.message
+        : `Failed to load registry from ${DEFAULT_REGISTRY}`
+    } finally {
+      examplesLoading.value = false
+    }
+  }
+
+  async function loadSaved () {
+    if (savedLoaded.value || savedLoading.value) return
+    savedLoading.value = true
+    savedError.value = undefined
     try {
       const res = await fetch('https://api.vuetifyjs.com/one/playgrounds', {
         credentials: 'include',
       })
 
       if (!res.ok) {
-        error.value = res.status === 401
+        savedError.value = res.status === 401
           ? 'Session expired. Please sign in again.'
           : `Failed to load playgrounds (${res.status})`
         return
       }
 
       const data = await res.json()
-      items.value = data.playgrounds ?? data
+      saved.value = data.playgrounds ?? data
+      savedLoaded.value = true
     } catch {
-      error.value = 'Failed to load playgrounds'
+      savedError.value = 'Failed to load playgrounds'
     } finally {
-      loading.value = false
-      nextTick(() => input.value?.focus())
+      savedLoading.value = false
     }
-  })
+  }
+
+  async function onTab (next: Tab) {
+    tab.value = next
+    selected.value = undefined
+    selectedItem.value = undefined
+    if (next === 'saved') await loadSaved()
+    nextTick(() => input.value?.focus())
+  }
+
+  async function onSelectFeature (entry: RegistryIndexEntry) {
+    if (selected.value?.name === entry.name && selected.value?.type === entry.type) {
+      // Single example → open immediately on second click
+      if (selectedItem.value?.examples.length === 1) {
+        await openExample(selectedItem.value.examples[0]!)
+      }
+      return
+    }
+
+    selected.value = entry
+    selectedItem.value = undefined
+    itemLoading.value = true
+    try {
+      selectedItem.value = await getRegistryItem(entry)
+      // Auto-open features that only ship one example
+      if (selectedItem.value.examples.length === 1) {
+        await openExample(selectedItem.value.examples[0]!)
+      }
+    } catch (error) {
+      examplesError.value = error instanceof Error ? error.message : String(error)
+      selected.value = undefined
+    } finally {
+      itemLoading.value = false
+    }
+  }
+
+  async function openExample (example: RegistryExample) {
+    if (!selected.value || opening.value) return
+    opening.value = true
+    try {
+      await playground.openRegistryExample({
+        item: selected.value.name,
+        type: selected.value.type,
+        example: example.id,
+      })
+      emit('close')
+    } catch (error) {
+      examplesError.value = error instanceof Error ? error.message : String(error)
+    } finally {
+      opening.value = false
+    }
+  }
 
   function formatDate (iso: string) {
     return new Date(iso).toLocaleDateString(undefined, {
@@ -62,7 +196,7 @@
     })
   }
 
-  async function open (item: VuetifyPlayground) {
+  async function openSaved (item: VuetifyPlayground) {
     let content = item.content
     if (!content) {
       const res = await fetch(`https://api.vuetifyjs.com/one/playgrounds/${item.id}`, {
@@ -93,60 +227,189 @@
       <div
         aria-labelledby="open-title"
         aria-modal="true"
-        class="relative bg-surface border border-divider rounded-lg shadow-xl w-[480px] max-h-[520px] flex flex-col overflow-hidden"
+        class="relative bg-surface border border-divider rounded-lg shadow-xl w-[560px] max-h-[560px] flex flex-col overflow-hidden"
         role="dialog"
       >
         <div class="flex items-center justify-between px-4 py-3 border-b border-divider">
           <h2 id="open-title" class="text-sm font-medium">
-            Open Playground
+            Open
           </h2>
 
           <AppCloseButton @click="$emit('close')" />
         </div>
 
-        <div v-if="!loading && !error && items.length > 0" class="px-4 py-2 border-b border-divider">
+        <!-- Tabs -->
+        <div class="flex gap-1 px-3 pt-2 border-b border-divider">
+          <button
+            class="px-3 py-1.5 text-xs rounded-t transition-colors"
+            :class="tab === 'examples'
+              ? 'text-primary border-b-2 border-primary font-medium'
+              : 'text-on-surface-variant hover:text-on-surface'"
+            type="button"
+            @click="onTab('examples')"
+          >
+            Docs examples
+          </button>
+
+          <button
+            class="px-3 py-1.5 text-xs rounded-t transition-colors"
+            :class="tab === 'saved'
+              ? 'text-primary border-b-2 border-primary font-medium'
+              : 'text-on-surface-variant hover:text-on-surface'"
+            type="button"
+            @click="onTab('saved')"
+          >
+            Saved
+          </button>
+        </div>
+
+        <div
+          v-if="(tab === 'examples' && !examplesLoading && !examplesError && items.length > 0)
+            || (tab === 'saved' && !savedLoading && !savedError && saved.length > 0)"
+          class="px-4 py-2 border-b border-divider"
+        >
           <input
             ref="input"
             v-model="query"
             class="w-full bg-transparent text-sm text-on-surface outline-none placeholder-on-surface-variant/50"
-            placeholder="Search..."
+            :placeholder="tab === 'examples' ? 'Search features…' : 'Search…'"
             type="text"
           >
         </div>
 
-        <div class="flex-1 overflow-y-auto">
-          <!-- Loading -->
-          <div v-if="loading" class="p-4 flex flex-col gap-3">
-            <div v-for="i in 4" :key="i" class="h-12 rounded bg-surface-tint animate-pulse" />
-          </div>
+        <div class="flex-1 overflow-y-auto min-h-0">
+          <!-- ── Docs examples ──────────────────────────────────────── -->
+          <template v-if="tab === 'examples'">
+            <div v-if="examplesLoading" class="p-4 flex flex-col gap-3">
+              <div v-for="i in 5" :key="i" class="h-10 rounded bg-surface-tint animate-pulse" />
+            </div>
 
-          <!-- Error -->
-          <div v-else-if="error" class="p-6 text-center">
-            <p class="text-sm text-on-surface-variant">{{ error }}</p>
-          </div>
+            <div v-else-if="examplesError" class="p-6 text-center flex flex-col gap-2">
+              <p class="text-sm text-on-surface-variant">{{ examplesError }}</p>
 
-          <!-- Empty -->
-          <div v-else-if="items.length === 0" class="p-6 text-center">
-            <p class="text-sm text-on-surface-variant">No playgrounds found</p>
-          </div>
+              <p class="text-xs text-on-surface-variant/70">
+                Origin: {{ DEFAULT_REGISTRY }}/registry
+              </p>
 
-          <!-- No matches -->
-          <div v-else-if="filtered.length === 0" class="p-6 text-center">
-            <p class="text-sm text-on-surface-variant">No matches</p>
-          </div>
+              <button
+                class="text-xs text-primary self-center mt-1"
+                type="button"
+                @click="loadExamples"
+              >
+                Retry
+              </button>
+            </div>
 
-          <!-- List -->
+            <div v-else-if="items.length === 0" class="p-6 text-center">
+              <p class="text-sm text-on-surface-variant">No examples in the registry</p>
+            </div>
+
+            <div v-else-if="filtered.length === 0" class="p-6 text-center">
+              <p class="text-sm text-on-surface-variant">No matches</p>
+            </div>
+
+            <div v-else class="flex min-h-0">
+              <!-- Feature list -->
+              <div
+                class="flex-1 overflow-y-auto border-r border-divider max-h-[380px]"
+                :class="selected ? 'max-w-[55%]' : ''"
+              >
+                <template v-for="group in groups" :key="group.key">
+                  <div class="px-4 py-1.5 text-2.5 uppercase tracking-wide text-on-surface-variant/60 sticky top-0 bg-surface">
+                    {{ group.label }}
+                  </div>
+
+                  <button
+                    v-for="entry in group.items"
+                    :key="`${entry.type}/${entry.name}`"
+                    class="w-full flex items-center justify-between px-4 py-2 text-left transition-colors border-b border-divider/60"
+                    :class="selected?.name === entry.name && selected?.type === entry.type
+                      ? 'bg-surface-tint'
+                      : 'hover:bg-surface-tint/60'"
+                    type="button"
+                    @click="onSelectFeature(entry)"
+                  >
+                    <span class="text-sm text-on-surface truncate">{{ entry.title || entry.name }}</span>
+
+                    <span class="text-xs text-on-surface-variant shrink-0 ml-3">
+                      {{ entry.examples.length }}
+                    </span>
+                  </button>
+                </template>
+              </div>
+
+              <!-- Example list for selected feature -->
+              <div
+                v-if="selected"
+                class="w-[45%] overflow-y-auto max-h-[380px] bg-surface-tint/30"
+              >
+                <div class="px-3 py-2 border-b border-divider">
+                  <div class="text-xs font-medium text-on-surface truncate">
+                    {{ selected.title || selected.name }}
+                  </div>
+
+                  <div class="text-2.5 text-on-surface-variant truncate">
+                    {{ selected.type }}/{{ selected.name }}
+                  </div>
+                </div>
+
+                <div v-if="itemLoading" class="p-3 flex flex-col gap-2">
+                  <div v-for="i in 3" :key="i" class="h-8 rounded bg-surface-tint animate-pulse" />
+                </div>
+
+                <template v-else-if="selectedItem">
+                  <button
+                    v-for="example in selectedItem.examples"
+                    :key="example.id"
+                    class="w-full px-3 py-2.5 text-left hover:bg-surface-tint transition-colors border-b border-divider/60 last:border-b-0 disabled:opacity-50"
+                    :disabled="opening"
+                    type="button"
+                    @click="openExample(example)"
+                  >
+                    <div class="text-sm text-on-surface">{{ example.title || example.id }}</div>
+
+                    <div class="text-2.5 text-on-surface-variant mt-0.5">
+                      {{ example.files.length }} file{{ example.files.length === 1 ? '' : 's' }}
+                    </div>
+                  </button>
+                </template>
+              </div>
+            </div>
+          </template>
+
+          <!-- ── Saved playgrounds ──────────────────────────────────── -->
           <template v-else>
-            <button
-              v-for="item in filtered"
-              :key="item.id"
-              class="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-surface-tint transition-colors border-b border-divider last:border-b-0"
-              type="button"
-              @click="open(item)"
-            >
-              <span class="text-sm text-on-surface truncate">{{ item.title || 'Untitled' }}</span>
-              <span class="text-xs text-on-surface-variant shrink-0 ml-4">{{ formatDate(item.updatedAt || item.createdAt) }}</span>
-            </button>
+            <div v-if="savedLoading" class="p-4 flex flex-col gap-3">
+              <div v-for="i in 4" :key="i" class="h-12 rounded bg-surface-tint animate-pulse" />
+            </div>
+
+            <div v-else-if="savedError" class="p-6 text-center">
+              <p class="text-sm text-on-surface-variant">{{ savedError }}</p>
+            </div>
+
+            <div v-else-if="saved.length === 0" class="p-6 text-center">
+              <p class="text-sm text-on-surface-variant">No playgrounds found</p>
+            </div>
+
+            <div v-else-if="filteredSaved.length === 0" class="p-6 text-center">
+              <p class="text-sm text-on-surface-variant">No matches</p>
+            </div>
+
+            <template v-else>
+              <button
+                v-for="item in filteredSaved"
+                :key="item.id"
+                class="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-surface-tint transition-colors border-b border-divider last:border-b-0"
+                type="button"
+                @click="openSaved(item)"
+              >
+                <span class="text-sm text-on-surface truncate">{{ item.title || 'Untitled' }}</span>
+
+                <span class="text-xs text-on-surface-variant shrink-0 ml-4">
+                  {{ formatDate(item.updatedAt || item.createdAt) }}
+                </span>
+              </button>
+            </template>
           </template>
         </div>
       </div>

--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -79,7 +79,7 @@ export function generateAppWrapper (entryPath: string): string {
  * Build the src/-prefixed file record that loadExample expects.
  * When dir is provided, files are nested: src/{dir}/{name}
  */
-function buildPlaygroundFiles (inputFiles: PlaygroundFile[], dir?: string): Record<string, string> {
+export function buildPlaygroundFiles (inputFiles: PlaygroundFile[], dir?: string): Record<string, string> {
   const files: Record<string, string> = {}
   const prefix = dir ? `src/${dir}` : 'src'
 

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -8,6 +8,7 @@ import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 // Data
 import { createMainTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
+import { parseRegistryQuery, resolveRegistryExample } from '@/data/registry'
 
 // Utilities
 import { compileFile, useStore } from '@vue/repl/core'
@@ -15,6 +16,7 @@ import { computed, onMounted, shallowRef, watch, watchEffect } from 'vue'
 
 // Types
 import type { PlaygroundHashData } from '@/composables/usePlayground'
+import type { RegistryExampleRef } from '@/data/registry'
 
 export function usePlaygroundFiles () {
   const theme = useTheme()
@@ -41,6 +43,8 @@ export function usePlaygroundFiles () {
 
   const isReady = shallowRef(false)
   const filesVersion = shallowRef(0)
+  /** Set when a registry deep-link or browser open fails. */
+  const loadError = shallowRef<string>()
 
   const aliasMap = shallowRef(new Map<string, string>())
   const extraImports = shallowRef<Record<string, string>>()
@@ -78,6 +82,11 @@ export function usePlaygroundFiles () {
   onMounted(async () => {
     const hash = window.location.hash.slice(1)
     const decoded = hash ? await decodePlaygroundHash(hash) : null
+    // Hash wins when present (share links are self-contained). Short registry
+    // deep-links use `?example=` / `?item=` with an empty hash.
+    const registryRef = decoded
+      ? null
+      : parseRegistryQuery(new URLSearchParams(window.location.search))
 
     if (decoded) {
       if (decoded.settings?.preset) activePreset.value = decoded.settings.preset
@@ -111,25 +120,39 @@ export function usePlaygroundFiles () {
         extraImports.value = decoded.imports
       }
       rebuildImportMap()
+    } else if (registryRef) {
+      try {
+        await openRegistryExample(registryRef, { clearSearch: true })
+      } catch (error) {
+        loadError.value = error instanceof Error ? error.message : String(error)
+        // Drop ?example= so a later hash rewrite / reload does not re-hit a
+        // broken deep-link, and so hash-only shares stay the share surface.
+        clearRegistrySearch()
+        await seedDefault()
+      }
     } else {
-      const theme_ = theme.isDark.value ? 'dark' : 'light'
-      await store.setFiles(
-        {
-          'src/main.ts': createMainTs(theme_),
-          'src/uno.config.ts': UNO_CONFIG_TS,
-          'src/App.vue': DEFAULT_APP,
-          'tsconfig.json': REPL_TSCONFIG,
-        },
-        'src/main.ts',
-      )
-      store.files['src/main.ts']!.hidden = true
-      store.files['src/uno.config.ts']!.hidden = true
-      store.files['tsconfig.json']!.hidden = true
-      store.setActive('src/App.vue')
+      await seedDefault()
     }
 
     isReady.value = true
   })
+
+  async function seedDefault () {
+    const theme_ = theme.isDark.value ? 'dark' : 'light'
+    await store.setFiles(
+      {
+        'src/main.ts': createMainTs(theme_),
+        'src/uno.config.ts': UNO_CONFIG_TS,
+        'src/App.vue': DEFAULT_APP,
+        'tsconfig.json': REPL_TSCONFIG,
+      },
+      'src/main.ts',
+    )
+    store.files['src/main.ts']!.hidden = true
+    store.files['src/uno.config.ts']!.hidden = true
+    store.files['tsconfig.json']!.hidden = true
+    store.setActive('src/App.vue')
+  }
 
   async function loadExample (files: Record<string, string>, activeFile?: string) {
     const aliases: Record<string, string> = {}
@@ -339,6 +362,7 @@ export function usePlaygroundFiles () {
       activeAddons.value = []
       extraImports.value = Object.keys(imports).length > 0 ? imports : undefined
       aliasMap.value = new Map()
+      loadError.value = undefined
 
       if (vue) vueVersion.value = vue
 
@@ -348,5 +372,56 @@ export function usePlaygroundFiles () {
     } catch { /* ignore malformed content */ }
   }
 
-  return { store, isReady, filesVersion, loadExample, vueVersion, v0Version, vueVersions, v0Versions, fetching, fetchVersions, activePreset, applyPreset, activeAddons, toggleAddon, openPlayground }
+  function clearRegistrySearch () {
+    if (typeof window === 'undefined') return
+    const url = new URL(window.location.href)
+    url.searchParams.delete('example')
+    url.searchParams.delete('item')
+    url.searchParams.delete('registry')
+    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+  }
+
+  /**
+   * Load a docs registry example into the REPL.
+   * Optionally strip `?example=` / `?item=` from the URL so the subsequent
+   * hash write is the share surface (self-contained, no registry dependency).
+   */
+  async function openRegistryExample (
+    ref: RegistryExampleRef,
+    options: { clearSearch?: boolean } = {},
+  ) {
+    loadError.value = undefined
+    const resolved = await resolveRegistryExample(ref)
+
+    activePreset.value = 'default'
+    activeAddons.value = []
+    extraImports.value = resolved.imports
+    aliasMap.value = new Map()
+
+    await loadExample(resolved.files, resolved.active)
+    rebuildImportMap()
+    filesVersion.value++
+
+    if (options.clearSearch) clearRegistrySearch()
+  }
+
+  return {
+    store,
+    isReady,
+    filesVersion,
+    loadError,
+    loadExample,
+    vueVersion,
+    v0Version,
+    vueVersions,
+    v0Versions,
+    fetching,
+    fetchVersions,
+    activePreset,
+    applyPreset,
+    activeAddons,
+    toggleAddon,
+    openPlayground,
+    openRegistryExample,
+  }
 }

--- a/apps/playground/src/content/intro.md
+++ b/apps/playground/src/content/intro.md
@@ -29,7 +29,17 @@ Theme colors work two ways: CSS custom properties (`var(--v0-primary)`) and UnoC
 
 ## Getting started
 
-Open the **examples** menu in the toolbar and load any demo — you'll get a complete, working project with files, imports, and a live preview that updates as you type. Or skip that entirely: open `App.vue` in the editor and start writing a component from scratch. The preview hot-reloads on every keystroke, so you'll see the result before you finish the thought. Either way, you're writing real Vue 3 code against the full v0 API — no stubs, no simulations.
+Use **☰ → File → Open example…** to browse every docs demo from the official registry (same catalog as `vuetify add`). Pick a feature, then an example, and the workspace loads with files and a live preview. Or skip that entirely: open `App.vue` and start from scratch — the preview hot-reloads on every keystroke.
+
+Short links also work:
+
+```
+/?example=dialog
+/?example=dialog/basic
+/?example=components/dialog/basic
+```
+
+Point `?registry=` at a custom origin when testing a local docs build.
 
 ## Tips
 

--- a/apps/playground/src/data/registry.ts
+++ b/apps/playground/src/data/registry.ts
@@ -1,0 +1,263 @@
+/**
+ * Official docs seed registry (`/registry/*`) — same catalog the CLI uses for
+ * `vuetify add`. Playground resolves short deep-links and the "Docs examples"
+ * browser against this surface.
+ */
+
+// Composables
+import { buildPlaygroundFiles } from '@/composables/usePlayground'
+
+export const DEFAULT_REGISTRY
+  = (import.meta.env.VITE_REGISTRY_URL as string | undefined)?.replace(/\/$/, '')
+    || 'https://0.vuetifyjs.com'
+
+export type RegistryItemType = 'components' | 'composables'
+
+export interface RegistryIndexEntry {
+  name: string
+  type: RegistryItemType
+  category: string
+  level: string
+  title: string
+  description: string
+  docs: string
+  examples: string[]
+}
+
+export interface RegistryIndex {
+  version: number
+  v0Version: string
+  tokens: string[]
+  items: RegistryIndexEntry[]
+}
+
+export interface RegistryFile {
+  path: string
+  name: string
+  entry: boolean
+  content: string
+}
+
+export interface RegistryExample {
+  id: string
+  title: string
+  description: string
+  dir: string
+  files: RegistryFile[]
+  dependencies: string[]
+  tokens: string[]
+  icons?: { collections: string[], classes: string[] }
+}
+
+export interface RegistryItem {
+  name: string
+  type: RegistryItemType
+  category: string
+  level: string
+  title: string
+  description: string
+  docs: string
+  examples: RegistryExample[]
+}
+
+export interface RegistryExampleRef {
+  /** Feature name, e.g. `dialog` or `use-theme`. */
+  item: string
+  /** Example id within the feature, e.g. `basic`. Defaults to basic/first. */
+  example?: string
+  /** Disambiguate when the same name exists in both trees. */
+  type?: RegistryItemType
+  /** Registry origin (docs site root). */
+  registry?: string
+}
+
+export interface ResolvedPlaygroundExample {
+  files: Record<string, string>
+  active?: string
+  imports?: Record<string, string>
+  meta: {
+    item: RegistryItem
+    example: RegistryExample
+    origin: string
+  }
+}
+
+const RE_TRAILING_SLASH = /\/$/
+const RE_SEPARATORS = /[\s_]+/g
+const RE_FACTORY_PREFIX = /^(create|use)-/
+
+function originOf (registry?: string) {
+  return (registry ?? DEFAULT_REGISTRY).replace(RE_TRAILING_SLASH, '')
+}
+
+async function getJson<T> (origin: string, path: string): Promise<T> {
+  const url = `${originOf(origin)}/registry/${path}`
+  const response = await fetch(url, { signal: AbortSignal.timeout(15_000) })
+    .catch((error: Error) => {
+      throw new Error(`Registry ${url} unreachable (${error.message})`)
+    })
+  if (!response.ok) {
+    throw new Error(`Registry ${url} responded with ${response.status}`)
+  }
+  return await response.json() as T
+}
+
+export async function getRegistryIndex (registry?: string): Promise<RegistryIndex> {
+  return getJson(originOf(registry), 'index.json')
+}
+
+export async function getRegistryItem (
+  entry: Pick<RegistryIndexEntry, 'type' | 'name'>,
+  registry?: string,
+): Promise<RegistryItem> {
+  return getJson(originOf(registry), `${entry.type}/${entry.name}.json`)
+}
+
+/**
+ * Match a user/query name to a registry index entry.
+ * Same loose matching as the CLI: exact → bare create/use strip → includes.
+ */
+function matchRegistryItem (
+  index: RegistryIndex,
+  query: string,
+  type?: RegistryItemType,
+): RegistryIndexEntry | undefined {
+  const needle = query.trim().toLowerCase().replace(RE_SEPARATORS, '-')
+  const pool = type ? index.items.filter(i => i.type === type) : index.items
+
+  const exact = pool.filter(item => item.name === needle)
+  if (exact.length === 1) return exact[0]
+  if (exact.length > 1 && type) return exact[0]
+  if (exact.length > 1) return exact[0]
+
+  const bare = pool.filter(item => item.name.replace(RE_FACTORY_PREFIX, '') === needle)
+  if (bare.length > 0) return bare[0]
+
+  return pool.find(item => item.name.includes(needle) || needle.includes(item.name))
+}
+
+function pickExample (
+  item: RegistryItem,
+  exampleId?: string,
+): RegistryExample | undefined {
+  if (item.examples.length === 0) return undefined
+  if (exampleId) {
+    return item.examples.find(e => e.id === exampleId)
+      ?? item.examples.find(e => e.id === exampleId.replace(/\.vue$/, ''))
+  }
+  return item.examples.find(e => e.id === 'basic') ?? item.examples[0]
+}
+
+/** Map registry example files into the shape `loadExample` expects. */
+function exampleToPlayground (example: RegistryExample): {
+  files: Record<string, string>
+  active?: string
+  imports?: Record<string, string>
+} {
+  const input = example.files.map(file => ({ name: file.name, code: file.content }))
+  const files = buildPlaygroundFiles(input)
+  const entry = example.files.find(file => file.entry)
+  const imports: Record<string, string> = {}
+
+  for (const dep of example.dependencies) {
+    if (dep === 'vue' || dep.startsWith('vue/') || dep === '@vuetify/v0') continue
+    imports[dep] = `https://esm.sh/${dep}`
+  }
+
+  return {
+    files,
+    active: entry ? `src/${entry.name}` : undefined,
+    imports: Object.keys(imports).length > 0 ? imports : undefined,
+  }
+}
+
+/**
+ * Parse playground search params into a registry ref.
+ *
+ * Supported:
+ * - `?example=dialog`
+ * - `?example=dialog/basic`
+ * - `?example=components/dialog/basic`
+ * - `?item=dialog&example=basic`
+ * - `?registry=https://…` (any of the above)
+ */
+export function parseRegistryQuery (params: URLSearchParams): RegistryExampleRef | null {
+  const registry = params.get('registry') ?? undefined
+  const itemParam = params.get('item')
+  const exampleParam = params.get('example')
+
+  if (itemParam) {
+    const parsed = splitItemRef(itemParam)
+    return {
+      ...parsed,
+      example: exampleParam ?? undefined,
+      registry,
+    }
+  }
+
+  if (!exampleParam) return null
+
+  const parts = exampleParam.split('/').filter(Boolean)
+  if (parts.length === 0) return null
+
+  if (parts.length === 1) {
+    return { item: parts[0]!, registry }
+  }
+
+  if (parts[0] === 'components' || parts[0] === 'composables') {
+    if (parts.length === 2) {
+      return { type: parts[0], item: parts[1]!, registry }
+    }
+    return {
+      type: parts[0],
+      item: parts[1]!,
+      example: parts.slice(2).join('/'),
+      registry,
+    }
+  }
+
+  return {
+    item: parts[0]!,
+    example: parts.slice(1).join('/'),
+    registry,
+  }
+}
+
+function splitItemRef (value: string): Pick<RegistryExampleRef, 'item' | 'type'> {
+  const parts = value.split('/').filter(Boolean)
+  if (
+    parts.length >= 2
+    && (parts[0] === 'components' || parts[0] === 'composables')
+  ) {
+    return { type: parts[0], item: parts[1]! }
+  }
+  return { item: value }
+}
+
+/** Fetch + resolve a registry example into playground files. */
+export async function resolveRegistryExample (
+  ref: RegistryExampleRef,
+): Promise<ResolvedPlaygroundExample> {
+  const origin = originOf(ref.registry)
+  const index = await getRegistryIndex(origin)
+  const entry = matchRegistryItem(index, ref.item, ref.type)
+  if (!entry) {
+    throw new Error(`Nothing in the registry matches "${ref.item}"`)
+  }
+
+  const item = await getRegistryItem(entry, origin)
+  const example = pickExample(item, ref.example)
+  if (!example) {
+    throw new Error(
+      ref.example
+        ? `"${entry.name}" has no example "${ref.example}"`
+        : `"${entry.name}" has no examples to open`,
+    )
+  }
+
+  const payload = exampleToPlayground(example)
+  return {
+    ...payload,
+    meta: { item, example, origin },
+  }
+}

--- a/apps/playground/src/vite-env.d.ts
+++ b/apps/playground/src/vite-env.d.ts
@@ -2,6 +2,15 @@
 /// <reference types="vue-router/auto" />
 /// <reference types="vite-plugin-vue-layouts-next/client" />
 
+interface ImportMetaEnv {
+  /** Docs origin that hosts `/registry/*` (default https://0.vuetifyjs.com). */
+  readonly VITE_REGISTRY_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.md' {
   // Types
   import type { ComponentOptions } from 'vue'


### PR DESCRIPTION
## Summary

Playground loads docs examples from the official `/registry/*` catalog (same seed as `vuetify add`).

- Deep-links: `?example=dialog`, `?example=dialog/basic`, `?example=components/dialog/basic`, optional `?registry=`
- File → **Open example…** browser (Docs examples | Saved)
- Docs “Open in Playground” stays **hash-based** by default; short registry URLs with `VITE_PLAYGROUND_REGISTRY=1`
- CORS on `/registry/*` (already on master via #721; branch rebased)

Depends on: #721 (merged — registry live at https://0.vuetifyjs.com/registry/index.json)

## Test plan

- [x] Rebase onto latest `master` (nginx conflict resolved — keep Allow-Headers)
- [x] Prod registry reachable + CORS `*`
- [x] Resolve `dialog` / `basic` item JSON + file list
- [x] PR Checks green after push
- [ ] Spot-check File → Open example… in a local playground if needed

## Related

- Seed: #721
- CLI: vuetifyjs/cli#27
- Docs: #794