### PR TITLE
chore(bench): add 1.0.3 history snapshot

### DIFF
--- a/apps/docs/src/data/metrics/1.0.3.json
+++ b/apps/docs/src/data/metrics/1.0.3.json
@@ -1,0 +1,9987 @@
+{
+  "version": "1.0.3",
+  "generatedAt": "2026-08-06T02:52:35.495Z",
+  "env": {
+    "cpu": "Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz",
+    "cores": 36,
+    "arch": "x64",
+    "platform": "linux",
+    "node": "v26.0.0",
+    "pnpm": "11.16.0",
+    "imageOs": null,
+    "imageVersion": null,
+    "ci": false,
+    "busy": 0.000832870627429206,
+    "peak": 0,
+    "governor": "performance"
+  },
+  "items": {
+    "helpers": {
+      "benchmarks": {
+        "_groups": {
+          "mergeDeep benchmarks": {
+            "shallow merge (2 objects, 5 keys each)": {
+              "name": "shallow merge (2 objects, 5 keys each)",
+              "hz": 686722,
+              "hzLabel": "686.7k ops/s",
+              "mean": 0.0014561929741383809,
+              "meanLabel": "1.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "deep nested merge (3 levels)": {
+              "name": "deep nested merge (3 levels)",
+              "hz": 343419,
+              "hzLabel": "343.4k ops/s",
+              "mean": 0.002911895556450789,
+              "meanLabel": "2.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "many sources (5 objects)": {
+              "name": "many sources (5 objects)",
+              "hz": 840003,
+              "hzLabel": "840.0k ops/s",
+              "mean": 0.0011904719477704188,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "realistic theme merge": {
+              "name": "realistic theme merge",
+              "hz": 505333,
+              "hzLabel": "505.3k ops/s",
+              "mean": 0.0019788935396865197,
+              "meanLabel": "2.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "large flat object (50 keys)": {
+              "name": "large flat object (50 keys)",
+              "hz": 59131,
+              "hzLabel": "59.1k ops/s",
+              "mean": 0.016911474227254992,
+              "meanLabel": "16.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "many sources (5 objects)",
+              "hz": 840003,
+              "hzLabel": "840.0k ops/s",
+              "mean": 0.0011904719477704188,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "large flat object (50 keys)",
+              "hz": 59131,
+              "hzLabel": "59.1k ops/s",
+              "mean": 0.016911474227254992,
+              "meanLabel": "16.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "shallow merge (2 objects, 5 keys each)": {
+          "name": "shallow merge (2 objects, 5 keys each)",
+          "hz": 686722,
+          "hzLabel": "686.7k ops/s",
+          "mean": 0.0014561929741383809,
+          "meanLabel": "1.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "deep nested merge (3 levels)": {
+          "name": "deep nested merge (3 levels)",
+          "hz": 343419,
+          "hzLabel": "343.4k ops/s",
+          "mean": 0.002911895556450789,
+          "meanLabel": "2.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "many sources (5 objects)": {
+          "name": "many sources (5 objects)",
+          "hz": 840003,
+          "hzLabel": "840.0k ops/s",
+          "mean": 0.0011904719477704188,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "realistic theme merge": {
+          "name": "realistic theme merge",
+          "hz": 505333,
+          "hzLabel": "505.3k ops/s",
+          "mean": 0.0019788935396865197,
+          "meanLabel": "2.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "large flat object (50 keys)": {
+          "name": "large flat object (50 keys)",
+          "hz": 59131,
+          "hzLabel": "59.1k ops/s",
+          "mean": 0.016911474227254992,
+          "meanLabel": "16.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "many sources (5 objects)",
+          "hz": 840003,
+          "hzLabel": "840.0k ops/s",
+          "mean": 0.0011904719477704188,
+          "meanLabel": "1.2μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "large flat object (50 keys)",
+          "hz": 59131,
+          "hzLabel": "59.1k ops/s",
+          "mean": 0.016911474227254992,
+          "meanLabel": "16.9μs",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createDataGrid": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create grid (1,000 items)": {
+              "name": "Create grid (1,000 items)",
+              "hz": 301,
+              "hzLabel": "301 ops/s",
+              "mean": 3.3175385298002324,
+              "meanLabel": "3.32ms",
+              "rme": 6.1,
+              "tier": "fast"
+            },
+            "Create grid (10,000 items)": {
+              "name": "Create grid (10,000 items)",
+              "hz": 29,
+              "hzLabel": "29 ops/s",
+              "mean": 34.3646581333344,
+              "meanLabel": "34.36ms",
+              "rme": 3.8,
+              "tier": "good"
+            },
+            "Create grid with pinned columns (1,000 items)": {
+              "name": "Create grid with pinned columns (1,000 items)",
+              "hz": 290,
+              "hzLabel": "290 ops/s",
+              "mean": 3.4489348356168295,
+              "meanLabel": "3.45ms",
+              "rme": 7.1,
+              "tier": "fast"
+            },
+            "Create grid with editable columns (1,000 items)": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 306,
+              "hzLabel": "306 ops/s",
+              "mean": 3.2689155098033713,
+              "meanLabel": "3.27ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Create grid with all options (1,000 items)": {
+              "name": "Create grid with all options (1,000 items)",
+              "hz": 300,
+              "hzLabel": "300 ops/s",
+              "mean": 3.336156179998652,
+              "meanLabel": "3.34ms",
+              "rme": 6.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 306,
+              "hzLabel": "306 ops/s",
+              "mean": 3.2689155098033713,
+              "meanLabel": "3.27ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create grid (10,000 items)",
+              "hz": 29,
+              "hzLabel": "29 ops/s",
+              "mean": 34.3646581333344,
+              "meanLabel": "34.36ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1497,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6678523484648791,
+              "meanLabel": "667.9μs",
+              "rme": 6.9,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.402660012658527,
+              "meanLabel": "6.40ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1497,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6678523484648791,
+              "meanLabel": "667.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.402660012658527,
+              "meanLabel": "6.40ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3056,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3271994833225973,
+              "meanLabel": "327.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 371,
+              "hzLabel": "371 ops/s",
+              "mean": 2.6945721612916507,
+              "meanLabel": "2.69ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 2984,
+              "hzLabel": "3.0k ops/s",
+              "mean": 0.33508481379878774,
+              "meanLabel": "335.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.751673326922733,
+              "meanLabel": "9.75ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3056,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3271994833225973,
+              "meanLabel": "327.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.751673326922733,
+              "meanLabel": "9.75ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "column layout": {
+            "Pin column (1,000 items)": {
+              "name": "Pin column (1,000 items)",
+              "hz": 16092,
+              "hzLabel": "16.1k ops/s",
+              "mean": 0.06214341685369516,
+              "meanLabel": "62.1μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Resize column (1,000 items)": {
+              "name": "Resize column (1,000 items)",
+              "hz": 13813,
+              "hzLabel": "13.8k ops/s",
+              "mean": 0.07239589836407541,
+              "meanLabel": "72.4μs",
+              "rme": 1,
+              "tier": "blazing"
+            },
+            "Resize column 10 times (1,000 items)": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5243,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.19071751716318058,
+              "meanLabel": "190.7μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Reorder column (1,000 items)": {
+              "name": "Reorder column (1,000 items)",
+              "hz": 11935,
+              "hzLabel": "11.9k ops/s",
+              "mean": 0.08378862918863068,
+              "meanLabel": "83.8μs",
+              "rme": 1.2,
+              "tier": "blazing"
+            },
+            "Reset layout (1,000 items)": {
+              "name": "Reset layout (1,000 items)",
+              "hz": 13438,
+              "hzLabel": "13.4k ops/s",
+              "mean": 0.07441711311159199,
+              "meanLabel": "74.4μs",
+              "rme": 0.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Pin column (1,000 items)",
+              "hz": 16092,
+              "hzLabel": "16.1k ops/s",
+              "mean": 0.06214341685369516,
+              "meanLabel": "62.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5243,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.19071751716318058,
+              "meanLabel": "190.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "cell editing": {
+            "Edit cell (1,000 items)": {
+              "name": "Edit cell (1,000 items)",
+              "hz": 251460,
+              "hzLabel": "251.5k ops/s",
+              "mean": 0.0039767757177058905,
+              "meanLabel": "4.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit then commit (1,000 items)": {
+              "name": "Edit then commit (1,000 items)",
+              "hz": 140477,
+              "hzLabel": "140.5k ops/s",
+              "mean": 0.007118583123355565,
+              "meanLabel": "7.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit then cancel (1,000 items)": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 253318,
+              "hzLabel": "253.3k ops/s",
+              "mean": 0.00394760219490287,
+              "meanLabel": "3.9μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Edit with validation failure (1,000 items)": {
+              "name": "Edit with validation failure (1,000 items)",
+              "hz": 140776,
+              "hzLabel": "140.8k ops/s",
+              "mean": 0.007103480529747663,
+              "meanLabel": "7.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Edit 10 cells sequentially (1,000 items)": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14644,
+              "hzLabel": "14.6k ops/s",
+              "mean": 0.06828755818130472,
+              "meanLabel": "68.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 253318,
+              "hzLabel": "253.3k ops/s",
+              "mean": 0.00394760219490287,
+              "meanLabel": "3.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14644,
+              "hzLabel": "14.6k ops/s",
+              "mean": 0.06828755818130472,
+              "meanLabel": "68.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row ordering": {
+            "Move row (1,000 items)": {
+              "name": "Move row (1,000 items)",
+              "hz": 997,
+              "hzLabel": "997 ops/s",
+              "mean": 1.0034903547107634,
+              "meanLabel": "1.00ms",
+              "rme": 4,
+              "tier": "fast"
+            },
+            "Move 10 rows (1,000 items)": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1191,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.839311323824984,
+              "meanLabel": "839.3μs",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "Reset row order (1,000 items)": {
+              "name": "Reset row order (1,000 items)",
+              "hz": 1083,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9229379372697666,
+              "meanLabel": "922.9μs",
+              "rme": 4.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1191,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.839311323824984,
+              "meanLabel": "839.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move row (1,000 items)",
+              "hz": 997,
+              "hzLabel": "997 ops/s",
+              "mean": 1.0034903547107634,
+              "meanLabel": "1.00ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "row spanning": {
+            "Compute spans (1,000 items, 1 column)": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 289,
+              "hzLabel": "289 ops/s",
+              "mean": 3.465906006896242,
+              "meanLabel": "3.47ms",
+              "rme": 5.7,
+              "tier": "fast"
+            },
+            "Compute spans (10,000 items, 1 column)": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.765739357144675,
+              "meanLabel": "35.77ms",
+              "rme": 3.7,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 289,
+              "hzLabel": "289 ops/s",
+              "mean": 3.465906006896242,
+              "meanLabel": "3.47ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.765739357144675,
+              "meanLabel": "35.77ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 413773,
+              "hzLabel": "413.8k ops/s",
+              "mean": 0.0024167819292108183,
+              "meanLabel": "2.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 418344,
+              "hzLabel": "418.3k ops/s",
+              "mean": 0.002390377708321479,
+              "meanLabel": "2.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 644405,
+              "hzLabel": "644.4k ops/s",
+              "mean": 0.0015518198713428998,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access layout.columns 100 times (1,000 items, cached)": {
+              "name": "Access layout.columns 100 times (1,000 items, cached)",
+              "hz": 561995,
+              "hzLabel": "562.0k ops/s",
+              "mean": 0.001779375860355285,
+              "meanLabel": "1.8μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access layout.pinned 100 times (1,000 items, cached)": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 556306,
+              "hzLabel": "556.3k ops/s",
+              "mean": 0.0017975710900937562,
+              "meanLabel": "1.8μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 644405,
+              "hzLabel": "644.4k ops/s",
+              "mean": 0.0015518198713428998,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 413773,
+              "hzLabel": "413.8k ops/s",
+              "mean": 0.0024167819292108183,
+              "meanLabel": "2.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1324,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7555489138964024,
+              "meanLabel": "755.5μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 139,
+              "hzLabel": "139 ops/s",
+              "mean": 7.172664085708259,
+              "meanLabel": "7.17ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (1,000 items)": {
+              "name": "Search + sort + paginate + layout (1,000 items)",
+              "hz": 1140,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.8772399964918006,
+              "meanLabel": "877.2μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (10,000 items)": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 137,
+              "hzLabel": "137 ops/s",
+              "mean": 7.273716579714412,
+              "meanLabel": "7.27ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1324,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7555489138964024,
+              "meanLabel": "755.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 137,
+              "hzLabel": "137 ops/s",
+              "mean": 7.273716579714412,
+              "meanLabel": "7.27ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create grid (1,000 items)": {
+          "name": "Create grid (1,000 items)",
+          "hz": 301,
+          "hzLabel": "301 ops/s",
+          "mean": 3.3175385298002324,
+          "meanLabel": "3.32ms",
+          "rme": 6.1,
+          "tier": "fast"
+        },
+        "Create grid (10,000 items)": {
+          "name": "Create grid (10,000 items)",
+          "hz": 29,
+          "hzLabel": "29 ops/s",
+          "mean": 34.3646581333344,
+          "meanLabel": "34.36ms",
+          "rme": 3.8,
+          "tier": "good"
+        },
+        "Create grid with pinned columns (1,000 items)": {
+          "name": "Create grid with pinned columns (1,000 items)",
+          "hz": 290,
+          "hzLabel": "290 ops/s",
+          "mean": 3.4489348356168295,
+          "meanLabel": "3.45ms",
+          "rme": 7.1,
+          "tier": "fast"
+        },
+        "Create grid with editable columns (1,000 items)": {
+          "name": "Create grid with editable columns (1,000 items)",
+          "hz": 306,
+          "hzLabel": "306 ops/s",
+          "mean": 3.2689155098033713,
+          "meanLabel": "3.27ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Create grid with all options (1,000 items)": {
+          "name": "Create grid with all options (1,000 items)",
+          "hz": 300,
+          "hzLabel": "300 ops/s",
+          "mean": 3.336156179998652,
+          "meanLabel": "3.34ms",
+          "rme": 6.5,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1497,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6678523484648791,
+          "meanLabel": "667.9μs",
+          "rme": 6.9,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.402660012658527,
+          "meanLabel": "6.40ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3056,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.3271994833225973,
+          "meanLabel": "327.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 371,
+          "hzLabel": "371 ops/s",
+          "mean": 2.6945721612916507,
+          "meanLabel": "2.69ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 2984,
+          "hzLabel": "3.0k ops/s",
+          "mean": 0.33508481379878774,
+          "meanLabel": "335.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 103,
+          "hzLabel": "103 ops/s",
+          "mean": 9.751673326922733,
+          "meanLabel": "9.75ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Pin column (1,000 items)": {
+          "name": "Pin column (1,000 items)",
+          "hz": 16092,
+          "hzLabel": "16.1k ops/s",
+          "mean": 0.06214341685369516,
+          "meanLabel": "62.1μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Resize column (1,000 items)": {
+          "name": "Resize column (1,000 items)",
+          "hz": 13813,
+          "hzLabel": "13.8k ops/s",
+          "mean": 0.07239589836407541,
+          "meanLabel": "72.4μs",
+          "rme": 1,
+          "tier": "blazing"
+        },
+        "Resize column 10 times (1,000 items)": {
+          "name": "Resize column 10 times (1,000 items)",
+          "hz": 5243,
+          "hzLabel": "5.2k ops/s",
+          "mean": 0.19071751716318058,
+          "meanLabel": "190.7μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Reorder column (1,000 items)": {
+          "name": "Reorder column (1,000 items)",
+          "hz": 11935,
+          "hzLabel": "11.9k ops/s",
+          "mean": 0.08378862918863068,
+          "meanLabel": "83.8μs",
+          "rme": 1.2,
+          "tier": "blazing"
+        },
+        "Reset layout (1,000 items)": {
+          "name": "Reset layout (1,000 items)",
+          "hz": 13438,
+          "hzLabel": "13.4k ops/s",
+          "mean": 0.07441711311159199,
+          "meanLabel": "74.4μs",
+          "rme": 0.9,
+          "tier": "blazing"
+        },
+        "Edit cell (1,000 items)": {
+          "name": "Edit cell (1,000 items)",
+          "hz": 251460,
+          "hzLabel": "251.5k ops/s",
+          "mean": 0.0039767757177058905,
+          "meanLabel": "4.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit then commit (1,000 items)": {
+          "name": "Edit then commit (1,000 items)",
+          "hz": 140477,
+          "hzLabel": "140.5k ops/s",
+          "mean": 0.007118583123355565,
+          "meanLabel": "7.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit then cancel (1,000 items)": {
+          "name": "Edit then cancel (1,000 items)",
+          "hz": 253318,
+          "hzLabel": "253.3k ops/s",
+          "mean": 0.00394760219490287,
+          "meanLabel": "3.9μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Edit with validation failure (1,000 items)": {
+          "name": "Edit with validation failure (1,000 items)",
+          "hz": 140776,
+          "hzLabel": "140.8k ops/s",
+          "mean": 0.007103480529747663,
+          "meanLabel": "7.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Edit 10 cells sequentially (1,000 items)": {
+          "name": "Edit 10 cells sequentially (1,000 items)",
+          "hz": 14644,
+          "hzLabel": "14.6k ops/s",
+          "mean": 0.06828755818130472,
+          "meanLabel": "68.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move row (1,000 items)": {
+          "name": "Move row (1,000 items)",
+          "hz": 997,
+          "hzLabel": "997 ops/s",
+          "mean": 1.0034903547107634,
+          "meanLabel": "1.00ms",
+          "rme": 4,
+          "tier": "fast"
+        },
+        "Move 10 rows (1,000 items)": {
+          "name": "Move 10 rows (1,000 items)",
+          "hz": 1191,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.839311323824984,
+          "meanLabel": "839.3μs",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "Reset row order (1,000 items)": {
+          "name": "Reset row order (1,000 items)",
+          "hz": 1083,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9229379372697666,
+          "meanLabel": "922.9μs",
+          "rme": 4.7,
+          "tier": "blazing"
+        },
+        "Compute spans (1,000 items, 1 column)": {
+          "name": "Compute spans (1,000 items, 1 column)",
+          "hz": 289,
+          "hzLabel": "289 ops/s",
+          "mean": 3.465906006896242,
+          "meanLabel": "3.47ms",
+          "rme": 5.7,
+          "tier": "fast"
+        },
+        "Compute spans (10,000 items, 1 column)": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 28,
+          "hzLabel": "28 ops/s",
+          "mean": 35.765739357144675,
+          "meanLabel": "35.77ms",
+          "rme": 3.7,
+          "tier": "good"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 413773,
+          "hzLabel": "413.8k ops/s",
+          "mean": 0.0024167819292108183,
+          "meanLabel": "2.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 418344,
+          "hzLabel": "418.3k ops/s",
+          "mean": 0.002390377708321479,
+          "meanLabel": "2.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 644405,
+          "hzLabel": "644.4k ops/s",
+          "mean": 0.0015518198713428998,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access layout.columns 100 times (1,000 items, cached)": {
+          "name": "Access layout.columns 100 times (1,000 items, cached)",
+          "hz": 561995,
+          "hzLabel": "562.0k ops/s",
+          "mean": 0.001779375860355285,
+          "meanLabel": "1.8μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access layout.pinned 100 times (1,000 items, cached)": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 556306,
+          "hzLabel": "556.3k ops/s",
+          "mean": 0.0017975710900937562,
+          "meanLabel": "1.8μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1324,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7555489138964024,
+          "meanLabel": "755.5μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 139,
+          "hzLabel": "139 ops/s",
+          "mean": 7.172664085708259,
+          "meanLabel": "7.17ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (1,000 items)": {
+          "name": "Search + sort + paginate + layout (1,000 items)",
+          "hz": 1140,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.8772399964918006,
+          "meanLabel": "877.2μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (10,000 items)": {
+          "name": "Search + sort + paginate + layout (10,000 items)",
+          "hz": 137,
+          "hzLabel": "137 ops/s",
+          "mean": 7.273716579714412,
+          "meanLabel": "7.27ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 644405,
+          "hzLabel": "644.4k ops/s",
+          "mean": 0.0015518198713428998,
+          "meanLabel": "1.6μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 28,
+          "hzLabel": "28 ops/s",
+          "mean": 35.765739357144675,
+          "meanLabel": "35.77ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createDataTable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create table (1,000 items)": {
+              "name": "Create table (1,000 items)",
+              "hz": 1154,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8662287716256901,
+              "meanLabel": "866.2μs",
+              "rme": 11.2,
+              "tier": "blazing"
+            },
+            "Create table (10,000 items)": {
+              "name": "Create table (10,000 items)",
+              "hz": 107,
+              "hzLabel": "107 ops/s",
+              "mean": 9.366713759257605,
+              "meanLabel": "9.37ms",
+              "rme": 12.8,
+              "tier": "blazing"
+            },
+            "Create table with groupBy (1,000 items)": {
+              "name": "Create table with groupBy (1,000 items)",
+              "hz": 1199,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8341802883342704,
+              "meanLabel": "834.2μs",
+              "rme": 9.4,
+              "tier": "blazing"
+            },
+            "Create table with all options (1,000 items)": {
+              "name": "Create table with all options (1,000 items)",
+              "hz": 686,
+              "hzLabel": "686 ops/s",
+              "mean": 1.4582698367336329,
+              "meanLabel": "1.46ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create table with groupBy (1,000 items)",
+              "hz": 1199,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8341802883342704,
+              "meanLabel": "834.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create table (10,000 items)",
+              "hz": 107,
+              "hzLabel": "107 ops/s",
+              "mean": 9.366713759257605,
+              "meanLabel": "9.37ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1565,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6389851570877247,
+              "meanLabel": "639.0μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.409056291139988,
+              "meanLabel": "6.41ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (1,000 items)": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1680,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5952489785713537,
+              "meanLabel": "595.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (10,000 items)": {
+              "name": "Search with custom column filter (10,000 items)",
+              "hz": 165,
+              "hzLabel": "165 ops/s",
+              "mean": 6.069698879517003,
+              "meanLabel": "6.07ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Update search 10 times (1,000 items)": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 155,
+              "hzLabel": "155 ops/s",
+              "mean": 6.461399794870372,
+              "meanLabel": "6.46ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1680,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5952489785713537,
+              "meanLabel": "595.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 155,
+              "hzLabel": "155 ops/s",
+              "mean": 6.461399794870372,
+              "meanLabel": "6.46ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3637,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.27496335129196287,
+              "meanLabel": "275.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 440,
+              "hzLabel": "440 ops/s",
+              "mean": 2.2707669321291952,
+              "meanLabel": "2.27ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3072,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.32556476432235587,
+              "meanLabel": "325.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 105,
+              "hzLabel": "105 ops/s",
+              "mean": 9.56504058490347,
+              "meanLabel": "9.57ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Multi-sort two columns (1,000 items)": {
+              "name": "Multi-sort two columns (1,000 items)",
+              "hz": 958,
+              "hzLabel": "958 ops/s",
+              "mean": 1.0434520520835577,
+              "meanLabel": "1.04ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Multi-sort two columns (10,000 items)": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.102471282610129,
+              "meanLabel": "11.10ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Toggle sort cycle 3 times (1,000 items)": {
+              "name": "Toggle sort cycle 3 times (1,000 items)",
+              "hz": 1544,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6476891943003782,
+              "meanLabel": "647.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3637,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.27496335129196287,
+              "meanLabel": "275.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.102471282610129,
+              "meanLabel": "11.10ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 776613,
+              "hzLabel": "776.6k ops/s",
+              "mean": 0.0012876433775163782,
+              "meanLabel": "1.3μs",
+              "rme": 6.5,
+              "tier": "blazing"
+            },
+            "Select all items (1,000 items)": {
+              "name": "Select all items (1,000 items)",
+              "hz": 1843,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5425350759220383,
+              "meanLabel": "542.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all items (10,000 items)": {
+              "name": "Select all items (10,000 items)",
+              "hz": 174,
+              "hzLabel": "174 ops/s",
+              "mean": 5.731100522728494,
+              "meanLabel": "5.73ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Select all with itemSelectable (1,000 items)": {
+              "name": "Select all with itemSelectable (1,000 items)",
+              "hz": 2268,
+              "hzLabel": "2.3k ops/s",
+              "mean": 0.4408607083701504,
+              "meanLabel": "440.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle all then check isAllSelected (1,000 items)": {
+              "name": "Toggle all then check isAllSelected (1,000 items)",
+              "hz": 878,
+              "hzLabel": "878 ops/s",
+              "mean": 1.1390467061507907,
+              "meanLabel": "1.14ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle 100 individual rows (1,000 items)": {
+              "name": "Toggle 100 individual rows (1,000 items)",
+              "hz": 8539,
+              "hzLabel": "8.5k ops/s",
+              "mean": 0.11711268266967625,
+              "meanLabel": "117.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 776613,
+              "hzLabel": "776.6k ops/s",
+              "mean": 0.0012876433775163782,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all items (10,000 items)",
+              "hz": 174,
+              "hzLabel": "174 ops/s",
+              "mean": 5.731100522728494,
+              "meanLabel": "5.73ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "grouping": {
+            "Compute groups (1,000 items, 8 groups)": {
+              "name": "Compute groups (1,000 items, 8 groups)",
+              "hz": 1029,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9718667067961487,
+              "meanLabel": "971.9μs",
+              "rme": 10,
+              "tier": "blazing"
+            },
+            "Compute groups (10,000 items, 8 groups)": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.766624872341747,
+              "meanLabel": "10.77ms",
+              "rme": 10,
+              "tier": "fast"
+            },
+            "Open all then close all groups (1,000 items)": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 196983,
+              "hzLabel": "197.0k ops/s",
+              "mean": 0.005076572747023875,
+              "meanLabel": "5.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Create with openAll (1,000 items)": {
+              "name": "Create with openAll (1,000 items)",
+              "hz": 694,
+              "hzLabel": "694 ops/s",
+              "mean": 1.441843809798559,
+              "meanLabel": "1.44ms",
+              "rme": 6,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 196983,
+              "hzLabel": "197.0k ops/s",
+              "mean": 0.005076572747023875,
+              "meanLabel": "5.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.766624872341747,
+              "meanLabel": "10.77ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 618213,
+              "hzLabel": "618.2k ops/s",
+              "mean": 0.0016175656293656417,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 624169,
+              "hzLabel": "624.2k ops/s",
+              "mean": 0.0016021291603227966,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 621220,
+              "hzLabel": "621.2k ops/s",
+              "mean": 0.0016097367148487963,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access total 100 times (1,000 items, cached)": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 419480,
+              "hzLabel": "419.5k ops/s",
+              "mean": 0.002383904596181564,
+              "meanLabel": "2.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 624169,
+              "hzLabel": "624.2k ops/s",
+              "mean": 0.0016021291603227966,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 419480,
+              "hzLabel": "419.5k ops/s",
+              "mean": 0.002383904596181564,
+              "meanLabel": "2.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1409,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.709954886525004,
+              "meanLabel": "710.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.751918173336113,
+              "meanLabel": "6.75ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search + multi-sort + paginate (1,000 items)": {
+              "name": "Search + multi-sort + paginate (1,000 items)",
+              "hz": 575,
+              "hzLabel": "575 ops/s",
+              "mean": 1.737659104166293,
+              "meanLabel": "1.74ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1409,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.709954886525004,
+              "meanLabel": "710.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.751918173336113,
+              "meanLabel": "6.75ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "adapter comparison": {
+            "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 378,
+              "hzLabel": "378 ops/s",
+              "mean": 2.6473061111111997,
+              "meanLabel": "2.65ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 376,
+              "hzLabel": "376 ops/s",
+              "mean": 2.6588682380955166,
+              "meanLabel": "2.66ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "ClientDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.639910881581799,
+              "meanLabel": "6.64ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 152,
+              "hzLabel": "152 ops/s",
+              "mean": 6.586058289475515,
+              "meanLabel": "6.59ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 378,
+              "hzLabel": "378 ops/s",
+              "mean": 2.6473061111111997,
+              "meanLabel": "2.65ms",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.639910881581799,
+              "meanLabel": "6.64ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create table (1,000 items)": {
+          "name": "Create table (1,000 items)",
+          "hz": 1154,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8662287716256901,
+          "meanLabel": "866.2μs",
+          "rme": 11.2,
+          "tier": "blazing"
+        },
+        "Create table (10,000 items)": {
+          "name": "Create table (10,000 items)",
+          "hz": 107,
+          "hzLabel": "107 ops/s",
+          "mean": 9.366713759257605,
+          "meanLabel": "9.37ms",
+          "rme": 12.8,
+          "tier": "blazing"
+        },
+        "Create table with groupBy (1,000 items)": {
+          "name": "Create table with groupBy (1,000 items)",
+          "hz": 1199,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8341802883342704,
+          "meanLabel": "834.2μs",
+          "rme": 9.4,
+          "tier": "blazing"
+        },
+        "Create table with all options (1,000 items)": {
+          "name": "Create table with all options (1,000 items)",
+          "hz": 686,
+          "hzLabel": "686 ops/s",
+          "mean": 1.4582698367336329,
+          "meanLabel": "1.46ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1565,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6389851570877247,
+          "meanLabel": "639.0μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.409056291139988,
+          "meanLabel": "6.41ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (1,000 items)": {
+          "name": "Search with custom column filter (1,000 items)",
+          "hz": 1680,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.5952489785713537,
+          "meanLabel": "595.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (10,000 items)": {
+          "name": "Search with custom column filter (10,000 items)",
+          "hz": 165,
+          "hzLabel": "165 ops/s",
+          "mean": 6.069698879517003,
+          "meanLabel": "6.07ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Update search 10 times (1,000 items)": {
+          "name": "Update search 10 times (1,000 items)",
+          "hz": 155,
+          "hzLabel": "155 ops/s",
+          "mean": 6.461399794870372,
+          "meanLabel": "6.46ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3637,
+          "hzLabel": "3.6k ops/s",
+          "mean": 0.27496335129196287,
+          "meanLabel": "275.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 440,
+          "hzLabel": "440 ops/s",
+          "mean": 2.2707669321291952,
+          "meanLabel": "2.27ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 3072,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.32556476432235587,
+          "meanLabel": "325.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 105,
+          "hzLabel": "105 ops/s",
+          "mean": 9.56504058490347,
+          "meanLabel": "9.57ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Multi-sort two columns (1,000 items)": {
+          "name": "Multi-sort two columns (1,000 items)",
+          "hz": 958,
+          "hzLabel": "958 ops/s",
+          "mean": 1.0434520520835577,
+          "meanLabel": "1.04ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Multi-sort two columns (10,000 items)": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 90,
+          "hzLabel": "90 ops/s",
+          "mean": 11.102471282610129,
+          "meanLabel": "11.10ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Toggle sort cycle 3 times (1,000 items)": {
+          "name": "Toggle sort cycle 3 times (1,000 items)",
+          "hz": 1544,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6476891943003782,
+          "meanLabel": "647.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 776613,
+          "hzLabel": "776.6k ops/s",
+          "mean": 0.0012876433775163782,
+          "meanLabel": "1.3μs",
+          "rme": 6.5,
+          "tier": "blazing"
+        },
+        "Select all items (1,000 items)": {
+          "name": "Select all items (1,000 items)",
+          "hz": 1843,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5425350759220383,
+          "meanLabel": "542.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all items (10,000 items)": {
+          "name": "Select all items (10,000 items)",
+          "hz": 174,
+          "hzLabel": "174 ops/s",
+          "mean": 5.731100522728494,
+          "meanLabel": "5.73ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Select all with itemSelectable (1,000 items)": {
+          "name": "Select all with itemSelectable (1,000 items)",
+          "hz": 2268,
+          "hzLabel": "2.3k ops/s",
+          "mean": 0.4408607083701504,
+          "meanLabel": "440.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle all then check isAllSelected (1,000 items)": {
+          "name": "Toggle all then check isAllSelected (1,000 items)",
+          "hz": 878,
+          "hzLabel": "878 ops/s",
+          "mean": 1.1390467061507907,
+          "meanLabel": "1.14ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle 100 individual rows (1,000 items)": {
+          "name": "Toggle 100 individual rows (1,000 items)",
+          "hz": 8539,
+          "hzLabel": "8.5k ops/s",
+          "mean": 0.11711268266967625,
+          "meanLabel": "117.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Compute groups (1,000 items, 8 groups)": {
+          "name": "Compute groups (1,000 items, 8 groups)",
+          "hz": 1029,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9718667067961487,
+          "meanLabel": "971.9μs",
+          "rme": 10,
+          "tier": "blazing"
+        },
+        "Compute groups (10,000 items, 8 groups)": {
+          "name": "Compute groups (10,000 items, 8 groups)",
+          "hz": 93,
+          "hzLabel": "93 ops/s",
+          "mean": 10.766624872341747,
+          "meanLabel": "10.77ms",
+          "rme": 10,
+          "tier": "fast"
+        },
+        "Open all then close all groups (1,000 items)": {
+          "name": "Open all then close all groups (1,000 items)",
+          "hz": 196983,
+          "hzLabel": "197.0k ops/s",
+          "mean": 0.005076572747023875,
+          "meanLabel": "5.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Create with openAll (1,000 items)": {
+          "name": "Create with openAll (1,000 items)",
+          "hz": 694,
+          "hzLabel": "694 ops/s",
+          "mean": 1.441843809798559,
+          "meanLabel": "1.44ms",
+          "rme": 6,
+          "tier": "fast"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 618213,
+          "hzLabel": "618.2k ops/s",
+          "mean": 0.0016175656293656417,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 624169,
+          "hzLabel": "624.2k ops/s",
+          "mean": 0.0016021291603227966,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 621220,
+          "hzLabel": "621.2k ops/s",
+          "mean": 0.0016097367148487963,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access total 100 times (1,000 items, cached)": {
+          "name": "Access total 100 times (1,000 items, cached)",
+          "hz": 419480,
+          "hzLabel": "419.5k ops/s",
+          "mean": 0.002383904596181564,
+          "meanLabel": "2.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1409,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.709954886525004,
+          "meanLabel": "710.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 148,
+          "hzLabel": "148 ops/s",
+          "mean": 6.751918173336113,
+          "meanLabel": "6.75ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + multi-sort + paginate (1,000 items)": {
+          "name": "Search + multi-sort + paginate (1,000 items)",
+          "hz": 575,
+          "hzLabel": "575 ops/s",
+          "mean": 1.737659104166293,
+          "meanLabel": "1.74ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+          "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+          "hz": 378,
+          "hzLabel": "378 ops/s",
+          "mean": 2.6473061111111997,
+          "meanLabel": "2.65ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+          "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+          "hz": 376,
+          "hzLabel": "376 ops/s",
+          "mean": 2.6588682380955166,
+          "meanLabel": "2.66ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "ClientDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 151,
+          "hzLabel": "151 ops/s",
+          "mean": 6.639910881581799,
+          "meanLabel": "6.64ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 152,
+          "hzLabel": "152 ops/s",
+          "mean": 6.586058289475515,
+          "meanLabel": "6.59ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Select single item (1,000 items)",
+          "hz": 776613,
+          "hzLabel": "776.6k ops/s",
+          "mean": 0.0012876433775163782,
+          "meanLabel": "1.3μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 90,
+          "hzLabel": "90 ops/s",
+          "mean": 11.102471282610129,
+          "meanLabel": "11.10ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createFilter": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty filter": {
+              "name": "Create empty filter",
+              "hz": 8082614,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.000123722355168435,
+              "meanLabel": "124ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Create filter with keys constraint": {
+              "name": "Create filter with keys constraint",
+              "hz": 7829721,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012771846893101083,
+              "meanLabel": "128ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Create filter with custom matcher": {
+              "name": "Create filter with custom matcher",
+              "hz": 7001777,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014282089635036353,
+              "meanLabel": "143ns",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty filter",
+              "hz": 8082614,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.000123722355168435,
+              "meanLabel": "124ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create filter with custom matcher",
+              "hz": 7001777,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014282089635036353,
+              "meanLabel": "143ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "primitive filtering": {
+            "Filter 1,000 string primitives with single query": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 6921272,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014448210777324487,
+              "meanLabel": "144ns",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Filter 10,000 string primitives with single query": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 6474272,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.00015445753190113283,
+              "meanLabel": "154ns",
+              "rme": 10.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 6921272,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014448210777324487,
+              "meanLabel": "144ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 6474272,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.00015445753190113283,
+              "meanLabel": "154ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "object filtering": {
+            "Filter 1,000 objects across all keys": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 6962075,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014363534669500712,
+              "meanLabel": "144ns",
+              "rme": 2.3,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with single key constraint": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 7001742,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014282160182660974,
+              "meanLabel": "143ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects across all keys": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 7090966,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001410245168253937,
+              "meanLabel": "141ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with single key constraint": {
+              "name": "Filter 10,000 objects with single key constraint",
+              "hz": 7069803,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014144666273743369,
+              "meanLabel": "141ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 7090966,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001410245168253937,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 6962075,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014363534669500712,
+              "meanLabel": "144ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "filter modes": {
+            "Filter 1,000 objects with some mode": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 6926945,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014436379119385124,
+              "meanLabel": "144ns",
+              "rme": 3.3,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with every mode": {
+              "name": "Filter 1,000 objects with every mode",
+              "hz": 7066855,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014150565966041518,
+              "meanLabel": "142ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with union mode (2 queries)": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 6985883,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014314582435527272,
+              "meanLabel": "143ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with intersection mode (2 queries)": {
+              "name": "Filter 1,000 objects with intersection mode (2 queries)",
+              "hz": 6928215,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014433731655319514,
+              "meanLabel": "144ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with some mode": {
+              "name": "Filter 10,000 objects with some mode",
+              "hz": 7072509,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014139253420468684,
+              "meanLabel": "141ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with every mode": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 7099105,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014086282865029024,
+              "meanLabel": "141ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 7099105,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014086282865029024,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 6926945,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014436379119385124,
+              "meanLabel": "144ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Access filtered 100 times (1,000 items, cached)": {
+              "name": "Access filtered 100 times (1,000 items, cached)",
+              "hz": 2135710,
+              "hzLabel": "2.1M ops/s",
+              "mean": 0.0004682284439325679,
+              "meanLabel": "468ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access filtered 100 times (10,000 items, cached)": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 2170672,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004606867231153421,
+              "meanLabel": "461ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Update query 10 times (1,000 items)": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 539128,
+              "hzLabel": "539.1k ops/s",
+              "mean": 0.001854848562855962,
+              "meanLabel": "1.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Update query 10 times (10,000 items)": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 524304,
+              "hzLabel": "524.3k ops/s",
+              "mean": 0.001907289460741283,
+              "meanLabel": "1.9μs",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 2170672,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004606867231153421,
+              "meanLabel": "461ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 524304,
+              "hzLabel": "524.3k ops/s",
+              "mean": 0.001907289460741283,
+              "meanLabel": "1.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "native comparison": {
+            "Native Array.filter 1,000 objects": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1799,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5558243233334118,
+              "meanLabel": "555.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Native Array.filter 10,000 objects": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 181,
+              "hzLabel": "181 ops/s",
+              "mean": 5.537469373626384,
+              "meanLabel": "5.54ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1799,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5558243233334118,
+              "meanLabel": "555.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 181,
+              "hzLabel": "181 ops/s",
+              "mean": 5.537469373626384,
+              "meanLabel": "5.54ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty filter": {
+          "name": "Create empty filter",
+          "hz": 8082614,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.000123722355168435,
+          "meanLabel": "124ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Create filter with keys constraint": {
+          "name": "Create filter with keys constraint",
+          "hz": 7829721,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012771846893101083,
+          "meanLabel": "128ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Create filter with custom matcher": {
+          "name": "Create filter with custom matcher",
+          "hz": 7001777,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014282089635036353,
+          "meanLabel": "143ns",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Filter 1,000 string primitives with single query": {
+          "name": "Filter 1,000 string primitives with single query",
+          "hz": 6921272,
+          "hzLabel": "6.9M ops/s",
+          "mean": 0.00014448210777324487,
+          "meanLabel": "144ns",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Filter 10,000 string primitives with single query": {
+          "name": "Filter 10,000 string primitives with single query",
+          "hz": 6474272,
+          "hzLabel": "6.5M ops/s",
+          "mean": 0.00015445753190113283,
+          "meanLabel": "154ns",
+          "rme": 10.7,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects across all keys": {
+          "name": "Filter 1,000 objects across all keys",
+          "hz": 6962075,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014363534669500712,
+          "meanLabel": "144ns",
+          "rme": 2.3,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with single key constraint": {
+          "name": "Filter 1,000 objects with single key constraint",
+          "hz": 7001742,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014282160182660974,
+          "meanLabel": "143ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects across all keys": {
+          "name": "Filter 10,000 objects across all keys",
+          "hz": 7090966,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.0001410245168253937,
+          "meanLabel": "141ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with single key constraint": {
+          "name": "Filter 10,000 objects with single key constraint",
+          "hz": 7069803,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014144666273743369,
+          "meanLabel": "141ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with some mode": {
+          "name": "Filter 1,000 objects with some mode",
+          "hz": 6926945,
+          "hzLabel": "6.9M ops/s",
+          "mean": 0.00014436379119385124,
+          "meanLabel": "144ns",
+          "rme": 3.3,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with every mode": {
+          "name": "Filter 1,000 objects with every mode",
+          "hz": 7066855,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014150565966041518,
+          "meanLabel": "142ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with union mode (2 queries)": {
+          "name": "Filter 1,000 objects with union mode (2 queries)",
+          "hz": 6985883,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014314582435527272,
+          "meanLabel": "143ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with intersection mode (2 queries)": {
+          "name": "Filter 1,000 objects with intersection mode (2 queries)",
+          "hz": 6928215,
+          "hzLabel": "6.9M ops/s",
+          "mean": 0.00014433731655319514,
+          "meanLabel": "144ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with some mode": {
+          "name": "Filter 10,000 objects with some mode",
+          "hz": 7072509,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014139253420468684,
+          "meanLabel": "141ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with every mode": {
+          "name": "Filter 10,000 objects with every mode",
+          "hz": 7099105,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014086282865029024,
+          "meanLabel": "141ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (1,000 items, cached)": {
+          "name": "Access filtered 100 times (1,000 items, cached)",
+          "hz": 2135710,
+          "hzLabel": "2.1M ops/s",
+          "mean": 0.0004682284439325679,
+          "meanLabel": "468ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (10,000 items, cached)": {
+          "name": "Access filtered 100 times (10,000 items, cached)",
+          "hz": 2170672,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004606867231153421,
+          "meanLabel": "461ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Update query 10 times (1,000 items)": {
+          "name": "Update query 10 times (1,000 items)",
+          "hz": 539128,
+          "hzLabel": "539.1k ops/s",
+          "mean": 0.001854848562855962,
+          "meanLabel": "1.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Update query 10 times (10,000 items)": {
+          "name": "Update query 10 times (10,000 items)",
+          "hz": 524304,
+          "hzLabel": "524.3k ops/s",
+          "mean": 0.001907289460741283,
+          "meanLabel": "1.9μs",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Native Array.filter 1,000 objects": {
+          "name": "Native Array.filter 1,000 objects",
+          "hz": 1799,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5558243233334118,
+          "meanLabel": "555.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Native Array.filter 10,000 objects": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 181,
+          "hzLabel": "181 ops/s",
+          "mean": 5.537469373626384,
+          "meanLabel": "5.54ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Create empty filter",
+          "hz": 8082614,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.000123722355168435,
+          "meanLabel": "124ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 181,
+          "hzLabel": "181 ops/s",
+          "mean": 5.537469373626384,
+          "meanLabel": "5.54ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createGroup": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty group": {
+              "name": "Create empty group",
+              "hz": 26839,
+              "hzLabel": "26.8k ops/s",
+              "mean": 0.03725873159454846,
+              "meanLabel": "37.3μs",
+              "rme": 9.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 437,
+              "hzLabel": "437 ops/s",
+              "mean": 2.286669543379233,
+              "meanLabel": "2.29ms",
+              "rme": 13.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.021653681810925,
+              "meanLabel": "23.02ms",
+              "rme": 3.7,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 462,
+              "hzLabel": "462 ops/s",
+              "mean": 2.1652319696991404,
+              "meanLabel": "2.17ms",
+              "rme": 11.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.406368523802875,
+              "meanLabel": "24.41ms",
+              "rme": 10,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty group",
+              "hz": 26839,
+              "hzLabel": "26.8k ops/s",
+              "mean": 0.03725873159454846,
+              "meanLabel": "37.3μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.406368523802875,
+              "meanLabel": "24.41ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1982597,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005043888211123312,
+              "meanLabel": "504ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1968830,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005079158292820976,
+              "meanLabel": "508ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1982597,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005043888211123312,
+              "meanLabel": "504ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1968830,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005079158292820976,
+              "meanLabel": "508ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 957598,
+              "hzLabel": "957.6k ops/s",
+              "mean": 0.001044279762518708,
+              "meanLabel": "1.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 956854,
+              "hzLabel": "956.9k ops/s",
+              "mean": 0.0010450912588730798,
+              "meanLabel": "1.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 549870,
+              "hzLabel": "549.9k ops/s",
+              "mean": 0.0018186117555452277,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 549820,
+              "hzLabel": "549.8k ops/s",
+              "mean": 0.0018187758220376805,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 653881,
+              "hzLabel": "653.9k ops/s",
+              "mean": 0.0015293294876116907,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 660493,
+              "hzLabel": "660.5k ops/s",
+              "mean": 0.0015140205270412622,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 957598,
+              "hzLabel": "957.6k ops/s",
+              "mean": 0.001044279762518708,
+              "meanLabel": "1.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 549820,
+              "hzLabel": "549.8k ops/s",
+              "mean": 0.0018187758220376805,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mixed state": {
+            "Mix single item (1,000 items)": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 431436,
+              "hzLabel": "431.4k ops/s",
+              "mean": 0.002317842340497571,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unmix single item (1,000 items)": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 586834,
+              "hzLabel": "586.8k ops/s",
+              "mean": 0.0017040608485409667,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 586834,
+              "hzLabel": "586.8k ops/s",
+              "mean": 0.0017040608485409667,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 431436,
+              "hzLabel": "431.4k ops/s",
+              "mean": 0.002317842340497571,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 994,
+              "hzLabel": "994 ops/s",
+              "mean": 1.0062847987914287,
+              "meanLabel": "1.01ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.710635468087585,
+              "meanLabel": "10.71ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Unselect all 1,000 items (from full)": {
+              "name": "Unselect all 1,000 items (from full)",
+              "hz": 978,
+              "hzLabel": "978 ops/s",
+              "mean": 1.0220697918361556,
+              "meanLabel": "1.02ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (none→all)": {
+              "name": "Toggle all 1,000 items (none→all)",
+              "hz": 901,
+              "hzLabel": "901 ops/s",
+              "mean": 1.1102302860317106,
+              "meanLabel": "1.11ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (all→none)": {
+              "name": "Toggle all 1,000 items (all→none)",
+              "hz": 615,
+              "hzLabel": "615 ops/s",
+              "mean": 1.6264710616879392,
+              "meanLabel": "1.63ms",
+              "rme": 5.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 994,
+              "hzLabel": "994 ops/s",
+              "mean": 1.0062847987914287,
+              "meanLabel": "1.01ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Select all 10,000 items",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.710635468087585,
+              "meanLabel": "10.71ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 599177,
+              "hzLabel": "599.2k ops/s",
+              "mean": 0.0016689563636214661,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 634512,
+              "hzLabel": "634.5k ops/s",
+              "mean": 0.001576014830244701,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access isAllSelected 100 times (partial, cached)": {
+              "name": "Access isAllSelected 100 times (partial, cached)",
+              "hz": 631998,
+              "hzLabel": "632.0k ops/s",
+              "mean": 0.001582282949378456,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access isNoneSelected 100 times (partial, cached)": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43180,
+              "hzLabel": "43.2k ops/s",
+              "mean": 0.023158914219560435,
+              "meanLabel": "23.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isMixed 100 times (partial, cached)": {
+              "name": "Access isMixed 100 times (partial, cached)",
+              "hz": 595339,
+              "hzLabel": "595.3k ops/s",
+              "mean": 0.0016797144422314885,
+              "meanLabel": "1.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 634512,
+              "hzLabel": "634.5k ops/s",
+              "mean": 0.001576014830244701,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43180,
+              "hzLabel": "43.2k ops/s",
+              "mean": 0.023158914219560435,
+              "meanLabel": "23.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty group": {
+          "name": "Create empty group",
+          "hz": 26839,
+          "hzLabel": "26.8k ops/s",
+          "mean": 0.03725873159454846,
+          "meanLabel": "37.3μs",
+          "rme": 9.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 437,
+          "hzLabel": "437 ops/s",
+          "mean": 2.286669543379233,
+          "meanLabel": "2.29ms",
+          "rme": 13.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.021653681810925,
+          "meanLabel": "23.02ms",
+          "rme": 3.7,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 462,
+          "hzLabel": "462 ops/s",
+          "mean": 2.1652319696991404,
+          "meanLabel": "2.17ms",
+          "rme": 11.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.406368523802875,
+          "meanLabel": "24.41ms",
+          "rme": 10,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1982597,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005043888211123312,
+          "meanLabel": "504ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 1968830,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005079158292820976,
+          "meanLabel": "508ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 957598,
+          "hzLabel": "957.6k ops/s",
+          "mean": 0.001044279762518708,
+          "meanLabel": "1.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 956854,
+          "hzLabel": "956.9k ops/s",
+          "mean": 0.0010450912588730798,
+          "meanLabel": "1.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 549870,
+          "hzLabel": "549.9k ops/s",
+          "mean": 0.0018186117555452277,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 549820,
+          "hzLabel": "549.8k ops/s",
+          "mean": 0.0018187758220376805,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 653881,
+          "hzLabel": "653.9k ops/s",
+          "mean": 0.0015293294876116907,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 660493,
+          "hzLabel": "660.5k ops/s",
+          "mean": 0.0015140205270412622,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Mix single item (1,000 items)": {
+          "name": "Mix single item (1,000 items)",
+          "hz": 431436,
+          "hzLabel": "431.4k ops/s",
+          "mean": 0.002317842340497571,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unmix single item (1,000 items)": {
+          "name": "Unmix single item (1,000 items)",
+          "hz": 586834,
+          "hzLabel": "586.8k ops/s",
+          "mean": 0.0017040608485409667,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 994,
+          "hzLabel": "994 ops/s",
+          "mean": 1.0062847987914287,
+          "meanLabel": "1.01ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 93,
+          "hzLabel": "93 ops/s",
+          "mean": 10.710635468087585,
+          "meanLabel": "10.71ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Unselect all 1,000 items (from full)": {
+          "name": "Unselect all 1,000 items (from full)",
+          "hz": 978,
+          "hzLabel": "978 ops/s",
+          "mean": 1.0220697918361556,
+          "meanLabel": "1.02ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (none→all)": {
+          "name": "Toggle all 1,000 items (none→all)",
+          "hz": 901,
+          "hzLabel": "901 ops/s",
+          "mean": 1.1102302860317106,
+          "meanLabel": "1.11ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (all→none)": {
+          "name": "Toggle all 1,000 items (all→none)",
+          "hz": 615,
+          "hzLabel": "615 ops/s",
+          "mean": 1.6264710616879392,
+          "meanLabel": "1.63ms",
+          "rme": 5.1,
+          "tier": "fast"
+        },
+        "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+          "hz": 599177,
+          "hzLabel": "599.2k ops/s",
+          "mean": 0.0016689563636214661,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 634512,
+          "hzLabel": "634.5k ops/s",
+          "mean": 0.001576014830244701,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access isAllSelected 100 times (partial, cached)": {
+          "name": "Access isAllSelected 100 times (partial, cached)",
+          "hz": 631998,
+          "hzLabel": "632.0k ops/s",
+          "mean": 0.001582282949378456,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access isNoneSelected 100 times (partial, cached)": {
+          "name": "Access isNoneSelected 100 times (partial, cached)",
+          "hz": 43180,
+          "hzLabel": "43.2k ops/s",
+          "mean": 0.023158914219560435,
+          "meanLabel": "23.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isMixed 100 times (partial, cached)": {
+          "name": "Access isMixed 100 times (partial, cached)",
+          "hz": 595339,
+          "hzLabel": "595.3k ops/s",
+          "mean": 0.0016797144422314885,
+          "meanLabel": "1.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1982597,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005043888211123312,
+          "meanLabel": "504ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.406368523802875,
+          "meanLabel": "24.41ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createModel": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty model": {
+              "name": "Create empty model",
+              "hz": 89337,
+              "hzLabel": "89.3k ops/s",
+              "mean": 0.011193513488004955,
+              "meanLabel": "11.2μs",
+              "rme": 10.1,
+              "tier": "fast"
+            },
+            "Register 1,000 items": {
+              "name": "Register 1,000 items",
+              "hz": 477,
+              "hzLabel": "477 ops/s",
+              "mean": 2.0977932384948073,
+              "meanLabel": "2.10ms",
+              "rme": 8.6,
+              "tier": "fast"
+            },
+            "Register 10,000 items": {
+              "name": "Register 10,000 items",
+              "hz": 47,
+              "hzLabel": "47 ops/s",
+              "mean": 21.450637416659447,
+              "meanLabel": "21.45ms",
+              "rme": 5.7,
+              "tier": "fast"
+            },
+            "Register 1,000 items (disabled)": {
+              "name": "Register 1,000 items (disabled)",
+              "hz": 1037,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9639556878613109,
+              "meanLabel": "964.0μs",
+              "rme": 9.7,
+              "tier": "blazing"
+            },
+            "Register 10,000 items (disabled)": {
+              "name": "Register 10,000 items (disabled)",
+              "hz": 91,
+              "hzLabel": "91 ops/s",
+              "mean": 10.974973521737569,
+              "meanLabel": "10.97ms",
+              "rme": 11.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty model",
+              "hz": 89337,
+              "hzLabel": "89.3k ops/s",
+              "mean": 0.011193513488004955,
+              "meanLabel": "11.2μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items",
+              "hz": 47,
+              "hzLabel": "47 ops/s",
+              "mean": 21.450637416659447,
+              "meanLabel": "21.45ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1979608,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005051504397124599,
+              "meanLabel": "505ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1972731,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005069115875907088,
+              "meanLabel": "507ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7605145,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013148992512579283,
+              "meanLabel": "131ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7620583,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.0001312235479598802,
+              "meanLabel": "131ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6222157,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016071596864647634,
+              "meanLabel": "161ns",
+              "rme": 7.3,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6517477,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.00015343360821090413,
+              "meanLabel": "153ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7620583,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.0001312235479598802,
+              "meanLabel": "131ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1972731,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005069115875907088,
+              "meanLabel": "507ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 827352,
+              "hzLabel": "827.4k ops/s",
+              "mean": 0.0012086750871020604,
+              "meanLabel": "1.2μs",
+              "rme": 3.3,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 808612,
+              "hzLabel": "808.6k ops/s",
+              "mean": 0.0012366868270778358,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 575323,
+              "hzLabel": "575.3k ops/s",
+              "mean": 0.0017381526513882643,
+              "meanLabel": "1.7μs",
+              "rme": 3,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 621546,
+              "hzLabel": "621.5k ops/s",
+              "mean": 0.001608891499608577,
+              "meanLabel": "1.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 804701,
+              "hzLabel": "804.7k ops/s",
+              "mean": 0.0012426981540887264,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 798243,
+              "hzLabel": "798.2k ops/s",
+              "mean": 0.0012527515571304282,
+              "meanLabel": "1.3μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "Select disabled item (1,000 items)": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7587811,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013179030898529114,
+              "meanLabel": "132ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7587811,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013179030898529114,
+              "meanLabel": "132ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 575323,
+              "hzLabel": "575.3k ops/s",
+              "mean": 0.0017381526513882643,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "apply operations": {
+            "Apply static value (1,000 items)": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 298093,
+              "hzLabel": "298.1k ops/s",
+              "mean": 0.003354652230478823,
+              "meanLabel": "3.4μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "Apply static value (10,000 items)": {
+              "name": "Apply static value (10,000 items)",
+              "hz": 264666,
+              "hzLabel": "264.7k ops/s",
+              "mean": 0.0037783510008082212,
+              "meanLabel": "3.8μs",
+              "rme": 3,
+              "tier": "blazing"
+            },
+            "Apply ref value (1,000 items)": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 53168,
+              "hzLabel": "53.2k ops/s",
+              "mean": 0.018808133759718366,
+              "meanLabel": "18.8μs",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "Apply undefined (1,000 items)": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 272033,
+              "hzLabel": "272.0k ops/s",
+              "mean": 0.003676027195114665,
+              "meanLabel": "3.7μs",
+              "rme": 14.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 298093,
+              "hzLabel": "298.1k ops/s",
+              "mean": 0.003354652230478823,
+              "meanLabel": "3.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 53168,
+              "hzLabel": "53.2k ops/s",
+              "mean": 0.018808133759718366,
+              "meanLabel": "18.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 1,000 then offboard 100 items": {
+              "name": "Onboard 1,000 then offboard 100 items",
+              "hz": 469,
+              "hzLabel": "469 ops/s",
+              "mean": 2.132134778723443,
+              "meanLabel": "2.13ms",
+              "rme": 5.3,
+              "tier": "fast"
+            },
+            "Onboard 10,000 then offboard 1,000 items": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.49124719047298,
+              "meanLabel": "24.49ms",
+              "rme": 14.8,
+              "tier": "fast"
+            },
+            "Reset (1,000 items)": {
+              "name": "Reset (1,000 items)",
+              "hz": 578914,
+              "hzLabel": "578.9k ops/s",
+              "mean": 0.0017273735373203396,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Reset (10,000 items)": {
+              "name": "Reset (10,000 items)",
+              "hz": 611349,
+              "hzLabel": "611.3k ops/s",
+              "mean": 0.001635726660650201,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reset (10,000 items)",
+              "hz": 611349,
+              "hzLabel": "611.3k ops/s",
+              "mean": 0.001635726660650201,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.49124719047298,
+              "meanLabel": "24.49ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 650889,
+              "hzLabel": "650.9k ops/s",
+              "mean": 0.0015363591789606796,
+              "meanLabel": "1.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+              "hz": 666493,
+              "hzLabel": "666.5k ops/s",
+              "mean": 0.001500391268352088,
+              "meanLabel": "1.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 860445,
+              "hzLabel": "860.4k ops/s",
+              "mean": 0.0011621889415351888,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 669352,
+              "hzLabel": "669.4k ops/s",
+              "mean": 0.0014939819288121872,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 860445,
+              "hzLabel": "860.4k ops/s",
+              "mean": 0.0011621889415351888,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 650889,
+              "hzLabel": "650.9k ops/s",
+              "mean": 0.0015363591789606796,
+              "meanLabel": "1.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty model": {
+          "name": "Create empty model",
+          "hz": 89337,
+          "hzLabel": "89.3k ops/s",
+          "mean": 0.011193513488004955,
+          "meanLabel": "11.2μs",
+          "rme": 10.1,
+          "tier": "fast"
+        },
+        "Register 1,000 items": {
+          "name": "Register 1,000 items",
+          "hz": 477,
+          "hzLabel": "477 ops/s",
+          "mean": 2.0977932384948073,
+          "meanLabel": "2.10ms",
+          "rme": 8.6,
+          "tier": "fast"
+        },
+        "Register 10,000 items": {
+          "name": "Register 10,000 items",
+          "hz": 47,
+          "hzLabel": "47 ops/s",
+          "mean": 21.450637416659447,
+          "meanLabel": "21.45ms",
+          "rme": 5.7,
+          "tier": "fast"
+        },
+        "Register 1,000 items (disabled)": {
+          "name": "Register 1,000 items (disabled)",
+          "hz": 1037,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9639556878613109,
+          "meanLabel": "964.0μs",
+          "rme": 9.7,
+          "tier": "blazing"
+        },
+        "Register 10,000 items (disabled)": {
+          "name": "Register 10,000 items (disabled)",
+          "hz": 91,
+          "hzLabel": "91 ops/s",
+          "mean": 10.974973521737569,
+          "meanLabel": "10.97ms",
+          "rme": 11.4,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1979608,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005051504397124599,
+          "meanLabel": "505ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 1972731,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005069115875907088,
+          "meanLabel": "507ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7605145,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.00013148992512579283,
+          "meanLabel": "131ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7620583,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.0001312235479598802,
+          "meanLabel": "131ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6222157,
+          "hzLabel": "6.2M ops/s",
+          "mean": 0.00016071596864647634,
+          "meanLabel": "161ns",
+          "rme": 7.3,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6517477,
+          "hzLabel": "6.5M ops/s",
+          "mean": 0.00015343360821090413,
+          "meanLabel": "153ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 827352,
+          "hzLabel": "827.4k ops/s",
+          "mean": 0.0012086750871020604,
+          "meanLabel": "1.2μs",
+          "rme": 3.3,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 808612,
+          "hzLabel": "808.6k ops/s",
+          "mean": 0.0012366868270778358,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 575323,
+          "hzLabel": "575.3k ops/s",
+          "mean": 0.0017381526513882643,
+          "meanLabel": "1.7μs",
+          "rme": 3,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 621546,
+          "hzLabel": "621.5k ops/s",
+          "mean": 0.001608891499608577,
+          "meanLabel": "1.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 804701,
+          "hzLabel": "804.7k ops/s",
+          "mean": 0.0012426981540887264,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 798243,
+          "hzLabel": "798.2k ops/s",
+          "mean": 0.0012527515571304282,
+          "meanLabel": "1.3μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Select disabled item (1,000 items)": {
+          "name": "Select disabled item (1,000 items)",
+          "hz": 7587811,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.00013179030898529114,
+          "meanLabel": "132ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Apply static value (1,000 items)": {
+          "name": "Apply static value (1,000 items)",
+          "hz": 298093,
+          "hzLabel": "298.1k ops/s",
+          "mean": 0.003354652230478823,
+          "meanLabel": "3.4μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Apply static value (10,000 items)": {
+          "name": "Apply static value (10,000 items)",
+          "hz": 264666,
+          "hzLabel": "264.7k ops/s",
+          "mean": 0.0037783510008082212,
+          "meanLabel": "3.8μs",
+          "rme": 3,
+          "tier": "blazing"
+        },
+        "Apply ref value (1,000 items)": {
+          "name": "Apply ref value (1,000 items)",
+          "hz": 53168,
+          "hzLabel": "53.2k ops/s",
+          "mean": 0.018808133759718366,
+          "meanLabel": "18.8μs",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Apply undefined (1,000 items)": {
+          "name": "Apply undefined (1,000 items)",
+          "hz": 272033,
+          "hzLabel": "272.0k ops/s",
+          "mean": 0.003676027195114665,
+          "meanLabel": "3.7μs",
+          "rme": 14.4,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 100 items": {
+          "name": "Onboard 1,000 then offboard 100 items",
+          "hz": 469,
+          "hzLabel": "469 ops/s",
+          "mean": 2.132134778723443,
+          "meanLabel": "2.13ms",
+          "rme": 5.3,
+          "tier": "fast"
+        },
+        "Onboard 10,000 then offboard 1,000 items": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.49124719047298,
+          "meanLabel": "24.49ms",
+          "rme": 14.8,
+          "tier": "fast"
+        },
+        "Reset (1,000 items)": {
+          "name": "Reset (1,000 items)",
+          "hz": 578914,
+          "hzLabel": "578.9k ops/s",
+          "mean": 0.0017273735373203396,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Reset (10,000 items)": {
+          "name": "Reset (10,000 items)",
+          "hz": 611349,
+          "hzLabel": "611.3k ops/s",
+          "mean": 0.001635726660650201,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+          "hz": 650889,
+          "hzLabel": "650.9k ops/s",
+          "mean": 0.0015363591789606796,
+          "meanLabel": "1.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+          "hz": 666493,
+          "hzLabel": "666.5k ops/s",
+          "mean": 0.001500391268352088,
+          "meanLabel": "1.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+          "hz": 860445,
+          "hzLabel": "860.4k ops/s",
+          "mean": 0.0011621889415351888,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+          "hz": 669352,
+          "hzLabel": "669.4k ops/s",
+          "mean": 0.0014939819288121872,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7620583,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.0001312235479598802,
+          "meanLabel": "131ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.49124719047298,
+          "meanLabel": "24.49ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createNested": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty nested": {
+              "name": "Create empty nested",
+              "hz": 15150,
+              "hzLabel": "15.1k ops/s",
+              "mean": 0.06600833768980184,
+              "meanLabel": "66.0μs",
+              "rme": 37.5,
+              "tier": "fast"
+            },
+            "Onboard 1,000 flat items": {
+              "name": "Onboard 1,000 flat items",
+              "hz": 177,
+              "hzLabel": "177 ops/s",
+              "mean": 5.658914844444209,
+              "meanLabel": "5.66ms",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 flat items": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 60.78438110000134,
+              "meanLabel": "60.78ms",
+              "rme": 3.2,
+              "tier": "good"
+            },
+            "Onboard ~1,000 tree items (depth 3)": {
+              "name": "Onboard ~1,000 tree items (depth 3)",
+              "hz": 189,
+              "hzLabel": "189 ops/s",
+              "mean": 5.291863421052633,
+              "meanLabel": "5.29ms",
+              "rme": 7.2,
+              "tier": "fast"
+            },
+            "Onboard ~10,000 tree items (depth 4)": {
+              "name": "Onboard ~10,000 tree items (depth 4)",
+              "hz": 18,
+              "hzLabel": "18 ops/s",
+              "mean": 56.2860680999991,
+              "meanLabel": "56.29ms",
+              "rme": 2.8,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Create empty nested",
+              "hz": 15150,
+              "hzLabel": "15.1k ops/s",
+              "mean": 0.06600833768980184,
+              "meanLabel": "66.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 60.78438110000134,
+              "meanLabel": "60.78ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "lookup operations": {
+            "Get by id (1,000 flat items)": {
+              "name": "Get by id (1,000 flat items)",
+              "hz": 7382013,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.0001354644098497867,
+              "meanLabel": "135ns",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 flat items)": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 7472903,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013381679572151633,
+              "meanLabel": "134ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check isLeaf (1,000 tree items)": {
+              "name": "Check isLeaf (1,000 tree items)",
+              "hz": 1656255,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0006037716681537744,
+              "meanLabel": "604ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check isLeaf (10,000 tree items)": {
+              "name": "Check isLeaf (10,000 tree items)",
+              "hz": 1668456,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005993563769633585,
+              "meanLabel": "599ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get depth (1,000 tree items)": {
+              "name": "Get depth (1,000 tree items)",
+              "hz": 575269,
+              "hzLabel": "575.3k ops/s",
+              "mean": 0.001738318566924774,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get depth (10,000 tree items)": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 453748,
+              "hzLabel": "453.7k ops/s",
+              "mean": 0.0022038640440751466,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check opened state (1,000 items)": {
+              "name": "Check opened state (1,000 items)",
+              "hz": 1983945,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005040463107355789,
+              "meanLabel": "504ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected state (1,000 items)": {
+              "name": "Check selected state (1,000 items)",
+              "hz": 1982803,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005043366293318133,
+              "meanLabel": "504ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 7472903,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013381679572151633,
+              "meanLabel": "134ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 453748,
+              "hzLabel": "453.7k ops/s",
+              "mean": 0.0022038640440751466,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "traversal operations": {
+            "Get path to deep node (1,000 tree items)": {
+              "name": "Get path to deep node (1,000 tree items)",
+              "hz": 584352,
+              "hzLabel": "584.4k ops/s",
+              "mean": 0.0017112972136674638,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get path to deep node (10,000 tree items)": {
+              "name": "Get path to deep node (10,000 tree items)",
+              "hz": 462104,
+              "hzLabel": "462.1k ops/s",
+              "mean": 0.00216401414825762,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (1,000 tree items)": {
+              "name": "Get ancestors of deep node (1,000 tree items)",
+              "hz": 567103,
+              "hzLabel": "567.1k ops/s",
+              "mean": 0.001763346934601461,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (10,000 tree items)": {
+              "name": "Get ancestors of deep node (10,000 tree items)",
+              "hz": 455702,
+              "hzLabel": "455.7k ops/s",
+              "mean": 0.0021944170137518796,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (1,000 tree items)": {
+              "name": "Get descendants of root node (1,000 tree items)",
+              "hz": 19229,
+              "hzLabel": "19.2k ops/s",
+              "mean": 0.05200398481536697,
+              "meanLabel": "52.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (10,000 tree items)": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1873,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5338929103524461,
+              "meanLabel": "533.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access roots (1,000 tree items)": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7321819,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001365780781243006,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access leaves (1,000 tree items)": {
+              "name": "Access leaves (1,000 tree items)",
+              "hz": 7236077,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013819643044641678,
+              "meanLabel": "138ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7321819,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001365780781243006,
+              "meanLabel": "137ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1873,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5338929103524461,
+              "meanLabel": "533.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open/close operations": {
+            "Open single node (1,000 tree items)": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1525129,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006556822644541533,
+              "meanLabel": "656ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open single node (10,000 tree items)": {
+              "name": "Open single node (10,000 tree items)",
+              "hz": 1502775,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.000665435581896738,
+              "meanLabel": "665ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Close single node (1,000 tree items)": {
+              "name": "Close single node (1,000 tree items)",
+              "hz": 618200,
+              "hzLabel": "618.2k ops/s",
+              "mean": 0.0016175984257726023,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle open (1,000 tree items)": {
+              "name": "Toggle open (1,000 tree items)",
+              "hz": 797035,
+              "hzLabel": "797.0k ops/s",
+              "mean": 0.0012546506080111687,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Expand all (1,000 tree items)": {
+              "name": "Expand all (1,000 tree items)",
+              "hz": 20949,
+              "hzLabel": "20.9k ops/s",
+              "mean": 0.04773401431978968,
+              "meanLabel": "47.7μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Expand all (10,000 tree items)": {
+              "name": "Expand all (10,000 tree items)",
+              "hz": 2120,
+              "hzLabel": "2.1k ops/s",
+              "mean": 0.4717624783019655,
+              "meanLabel": "471.8μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Collapse all (1,000 tree items)": {
+              "name": "Collapse all (1,000 tree items)",
+              "hz": 15885,
+              "hzLabel": "15.9k ops/s",
+              "mean": 0.06295145083724955,
+              "meanLabel": "63.0μs",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Collapse all (10,000 tree items)": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1532,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6528708407306264,
+              "meanLabel": "652.9μs",
+              "rme": 1.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1525129,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006556822644541533,
+              "meanLabel": "656ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1532,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6528708407306264,
+              "meanLabel": "652.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select leaf node (1,000 tree items)": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 71987,
+              "hzLabel": "72.0k ops/s",
+              "mean": 0.013891446129893834,
+              "meanLabel": "13.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (1,000 tree items)": {
+              "name": "Select root node with cascade (1,000 tree items)",
+              "hz": 7477,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13373993581157587,
+              "meanLabel": "133.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (10,000 tree items)": {
+              "name": "Select root node with cascade (10,000 tree items)",
+              "hz": 728,
+              "hzLabel": "728 ops/s",
+              "mean": 1.373503786301454,
+              "meanLabel": "1.37ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Unselect root node with cascade (1,000 tree items)": {
+              "name": "Unselect root node with cascade (1,000 tree items)",
+              "hz": 3367,
+              "hzLabel": "3.4k ops/s",
+              "mean": 0.29698321555814305,
+              "meanLabel": "297.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle selection (1,000 tree items)": {
+              "name": "Toggle selection (1,000 tree items)",
+              "hz": 6708,
+              "hzLabel": "6.7k ops/s",
+              "mean": 0.14908075074534272,
+              "meanLabel": "149.1μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (1,000 tree items)": {
+              "name": "Select all via selectAll (1,000 tree items)",
+              "hz": 2615,
+              "hzLabel": "2.6k ops/s",
+              "mean": 0.3824004174313663,
+              "meanLabel": "382.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (10,000 tree items)": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 250,
+              "hzLabel": "250 ops/s",
+              "mean": 4.000054032000364,
+              "meanLabel": "4.00ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 71987,
+              "hzLabel": "72.0k ops/s",
+              "mean": 0.013891446129893834,
+              "meanLabel": "13.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 250,
+              "hzLabel": "250 ops/s",
+              "mean": 4.000054032000364,
+              "meanLabel": "4.00ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single root item": {
+              "name": "Register single root item",
+              "hz": 11463,
+              "hzLabel": "11.5k ops/s",
+              "mean": 0.08723361164035215,
+              "meanLabel": "87.2μs",
+              "rme": 59.3,
+              "tier": "fast"
+            },
+            "Register item with parent (1,000 items)": {
+              "name": "Register item with parent (1,000 items)",
+              "hz": 186,
+              "hzLabel": "186 ops/s",
+              "mean": 5.386780365590527,
+              "meanLabel": "5.39ms",
+              "rme": 7.1,
+              "tier": "fast"
+            },
+            "Unregister leaf node (1,000 tree items)": {
+              "name": "Unregister leaf node (1,000 tree items)",
+              "hz": 171,
+              "hzLabel": "171 ops/s",
+              "mean": 5.842880816091502,
+              "meanLabel": "5.84ms",
+              "rme": 7.9,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (1,000 tree items)": {
+              "name": "Unregister root with cascade (1,000 tree items)",
+              "hz": 111,
+              "hzLabel": "111 ops/s",
+              "mean": 9.009631602941013,
+              "meanLabel": "9.01ms",
+              "rme": 49.7,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (10,000 tree items)": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 62.739042400001196,
+              "meanLabel": "62.74ms",
+              "rme": 1.8,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Register single root item",
+              "hz": 11463,
+              "hzLabel": "11.5k ops/s",
+              "mean": 0.08723361164035215,
+              "meanLabel": "87.2μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 62.739042400001196,
+              "meanLabel": "62.74ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 tree items": {
+              "name": "Onboard then clear 1,000 tree items",
+              "hz": 235,
+              "hzLabel": "235 ops/s",
+              "mean": 4.261370584745576,
+              "meanLabel": "4.26ms",
+              "rme": 1.8,
+              "tier": "fast"
+            },
+            "Onboard then clear 10,000 tree items": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 63.87485410000081,
+              "meanLabel": "63.87ms",
+              "rme": 18.9,
+              "tier": "good"
+            },
+            "toFlat conversion (1,000 tree items)": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2028,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.49306437931050207,
+              "meanLabel": "493.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "toFlat conversion (10,000 tree items)": {
+              "name": "toFlat conversion (10,000 tree items)",
+              "hz": 190,
+              "hzLabel": "190 ops/s",
+              "mean": 5.2553426458339345,
+              "meanLabel": "5.26ms",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2028,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.49306437931050207,
+              "meanLabel": "493.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 16,
+              "hzLabel": "16 ops/s",
+              "mean": 63.87485410000081,
+              "meanLabel": "63.87ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "selection mode comparison": {
+            "Select root - cascade mode (1,000 tree items)": {
+              "name": "Select root - cascade mode (1,000 tree items)",
+              "hz": 7455,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13414060568656336,
+              "meanLabel": "134.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root - independent mode (1,000 tree items)": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 893302,
+              "hzLabel": "893.3k ops/s",
+              "mean": 0.0011194426453758665,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select root - leaf mode (1,000 tree items)": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5328,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.18769292154636558,
+              "meanLabel": "187.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 893302,
+              "hzLabel": "893.3k ops/s",
+              "mean": 0.0011194426453758665,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5328,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.18769292154636558,
+              "meanLabel": "187.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open mode comparison": {
+            "Open 3 nodes - multiple mode (1,000 tree items)": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 577219,
+              "hzLabel": "577.2k ops/s",
+              "mean": 0.0017324438550229226,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open 3 nodes - single mode (1,000 tree items)": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 113676,
+              "hzLabel": "113.7k ops/s",
+              "mean": 0.00879690557544203,
+              "meanLabel": "8.8μs",
+              "rme": 4.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 577219,
+              "hzLabel": "577.2k ops/s",
+              "mean": 0.0017324438550229226,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 113676,
+              "hzLabel": "113.7k ops/s",
+              "mean": 0.00879690557544203,
+              "meanLabel": "8.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty nested": {
+          "name": "Create empty nested",
+          "hz": 15150,
+          "hzLabel": "15.1k ops/s",
+          "mean": 0.06600833768980184,
+          "meanLabel": "66.0μs",
+          "rme": 37.5,
+          "tier": "fast"
+        },
+        "Onboard 1,000 flat items": {
+          "name": "Onboard 1,000 flat items",
+          "hz": 177,
+          "hzLabel": "177 ops/s",
+          "mean": 5.658914844444209,
+          "meanLabel": "5.66ms",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 flat items": {
+          "name": "Onboard 10,000 flat items",
+          "hz": 16,
+          "hzLabel": "16 ops/s",
+          "mean": 60.78438110000134,
+          "meanLabel": "60.78ms",
+          "rme": 3.2,
+          "tier": "good"
+        },
+        "Onboard ~1,000 tree items (depth 3)": {
+          "name": "Onboard ~1,000 tree items (depth 3)",
+          "hz": 189,
+          "hzLabel": "189 ops/s",
+          "mean": 5.291863421052633,
+          "meanLabel": "5.29ms",
+          "rme": 7.2,
+          "tier": "fast"
+        },
+        "Onboard ~10,000 tree items (depth 4)": {
+          "name": "Onboard ~10,000 tree items (depth 4)",
+          "hz": 18,
+          "hzLabel": "18 ops/s",
+          "mean": 56.2860680999991,
+          "meanLabel": "56.29ms",
+          "rme": 2.8,
+          "tier": "good"
+        },
+        "Get by id (1,000 flat items)": {
+          "name": "Get by id (1,000 flat items)",
+          "hz": 7382013,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.0001354644098497867,
+          "meanLabel": "135ns",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 flat items)": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 7472903,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013381679572151633,
+          "meanLabel": "134ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check isLeaf (1,000 tree items)": {
+          "name": "Check isLeaf (1,000 tree items)",
+          "hz": 1656255,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0006037716681537744,
+          "meanLabel": "604ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check isLeaf (10,000 tree items)": {
+          "name": "Check isLeaf (10,000 tree items)",
+          "hz": 1668456,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005993563769633585,
+          "meanLabel": "599ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get depth (1,000 tree items)": {
+          "name": "Get depth (1,000 tree items)",
+          "hz": 575269,
+          "hzLabel": "575.3k ops/s",
+          "mean": 0.001738318566924774,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get depth (10,000 tree items)": {
+          "name": "Get depth (10,000 tree items)",
+          "hz": 453748,
+          "hzLabel": "453.7k ops/s",
+          "mean": 0.0022038640440751466,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check opened state (1,000 items)": {
+          "name": "Check opened state (1,000 items)",
+          "hz": 1983945,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005040463107355789,
+          "meanLabel": "504ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected state (1,000 items)": {
+          "name": "Check selected state (1,000 items)",
+          "hz": 1982803,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005043366293318133,
+          "meanLabel": "504ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get path to deep node (1,000 tree items)": {
+          "name": "Get path to deep node (1,000 tree items)",
+          "hz": 584352,
+          "hzLabel": "584.4k ops/s",
+          "mean": 0.0017112972136674638,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get path to deep node (10,000 tree items)": {
+          "name": "Get path to deep node (10,000 tree items)",
+          "hz": 462104,
+          "hzLabel": "462.1k ops/s",
+          "mean": 0.00216401414825762,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (1,000 tree items)": {
+          "name": "Get ancestors of deep node (1,000 tree items)",
+          "hz": 567103,
+          "hzLabel": "567.1k ops/s",
+          "mean": 0.001763346934601461,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (10,000 tree items)": {
+          "name": "Get ancestors of deep node (10,000 tree items)",
+          "hz": 455702,
+          "hzLabel": "455.7k ops/s",
+          "mean": 0.0021944170137518796,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (1,000 tree items)": {
+          "name": "Get descendants of root node (1,000 tree items)",
+          "hz": 19229,
+          "hzLabel": "19.2k ops/s",
+          "mean": 0.05200398481536697,
+          "meanLabel": "52.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (10,000 tree items)": {
+          "name": "Get descendants of root node (10,000 tree items)",
+          "hz": 1873,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5338929103524461,
+          "meanLabel": "533.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access roots (1,000 tree items)": {
+          "name": "Access roots (1,000 tree items)",
+          "hz": 7321819,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001365780781243006,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access leaves (1,000 tree items)": {
+          "name": "Access leaves (1,000 tree items)",
+          "hz": 7236077,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013819643044641678,
+          "meanLabel": "138ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Open single node (1,000 tree items)": {
+          "name": "Open single node (1,000 tree items)",
+          "hz": 1525129,
+          "hzLabel": "1.5M ops/s",
+          "mean": 0.0006556822644541533,
+          "meanLabel": "656ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open single node (10,000 tree items)": {
+          "name": "Open single node (10,000 tree items)",
+          "hz": 1502775,
+          "hzLabel": "1.5M ops/s",
+          "mean": 0.000665435581896738,
+          "meanLabel": "665ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Close single node (1,000 tree items)": {
+          "name": "Close single node (1,000 tree items)",
+          "hz": 618200,
+          "hzLabel": "618.2k ops/s",
+          "mean": 0.0016175984257726023,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle open (1,000 tree items)": {
+          "name": "Toggle open (1,000 tree items)",
+          "hz": 797035,
+          "hzLabel": "797.0k ops/s",
+          "mean": 0.0012546506080111687,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Expand all (1,000 tree items)": {
+          "name": "Expand all (1,000 tree items)",
+          "hz": 20949,
+          "hzLabel": "20.9k ops/s",
+          "mean": 0.04773401431978968,
+          "meanLabel": "47.7μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Expand all (10,000 tree items)": {
+          "name": "Expand all (10,000 tree items)",
+          "hz": 2120,
+          "hzLabel": "2.1k ops/s",
+          "mean": 0.4717624783019655,
+          "meanLabel": "471.8μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Collapse all (1,000 tree items)": {
+          "name": "Collapse all (1,000 tree items)",
+          "hz": 15885,
+          "hzLabel": "15.9k ops/s",
+          "mean": 0.06295145083724955,
+          "meanLabel": "63.0μs",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Collapse all (10,000 tree items)": {
+          "name": "Collapse all (10,000 tree items)",
+          "hz": 1532,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6528708407306264,
+          "meanLabel": "652.9μs",
+          "rme": 1.3,
+          "tier": "blazing"
+        },
+        "Select leaf node (1,000 tree items)": {
+          "name": "Select leaf node (1,000 tree items)",
+          "hz": 71987,
+          "hzLabel": "72.0k ops/s",
+          "mean": 0.013891446129893834,
+          "meanLabel": "13.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (1,000 tree items)": {
+          "name": "Select root node with cascade (1,000 tree items)",
+          "hz": 7477,
+          "hzLabel": "7.5k ops/s",
+          "mean": 0.13373993581157587,
+          "meanLabel": "133.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (10,000 tree items)": {
+          "name": "Select root node with cascade (10,000 tree items)",
+          "hz": 728,
+          "hzLabel": "728 ops/s",
+          "mean": 1.373503786301454,
+          "meanLabel": "1.37ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Unselect root node with cascade (1,000 tree items)": {
+          "name": "Unselect root node with cascade (1,000 tree items)",
+          "hz": 3367,
+          "hzLabel": "3.4k ops/s",
+          "mean": 0.29698321555814305,
+          "meanLabel": "297.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle selection (1,000 tree items)": {
+          "name": "Toggle selection (1,000 tree items)",
+          "hz": 6708,
+          "hzLabel": "6.7k ops/s",
+          "mean": 0.14908075074534272,
+          "meanLabel": "149.1μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (1,000 tree items)": {
+          "name": "Select all via selectAll (1,000 tree items)",
+          "hz": 2615,
+          "hzLabel": "2.6k ops/s",
+          "mean": 0.3824004174313663,
+          "meanLabel": "382.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (10,000 tree items)": {
+          "name": "Select all via selectAll (10,000 tree items)",
+          "hz": 250,
+          "hzLabel": "250 ops/s",
+          "mean": 4.000054032000364,
+          "meanLabel": "4.00ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single root item": {
+          "name": "Register single root item",
+          "hz": 11463,
+          "hzLabel": "11.5k ops/s",
+          "mean": 0.08723361164035215,
+          "meanLabel": "87.2μs",
+          "rme": 59.3,
+          "tier": "fast"
+        },
+        "Register item with parent (1,000 items)": {
+          "name": "Register item with parent (1,000 items)",
+          "hz": 186,
+          "hzLabel": "186 ops/s",
+          "mean": 5.386780365590527,
+          "meanLabel": "5.39ms",
+          "rme": 7.1,
+          "tier": "fast"
+        },
+        "Unregister leaf node (1,000 tree items)": {
+          "name": "Unregister leaf node (1,000 tree items)",
+          "hz": 171,
+          "hzLabel": "171 ops/s",
+          "mean": 5.842880816091502,
+          "meanLabel": "5.84ms",
+          "rme": 7.9,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (1,000 tree items)": {
+          "name": "Unregister root with cascade (1,000 tree items)",
+          "hz": 111,
+          "hzLabel": "111 ops/s",
+          "mean": 9.009631602941013,
+          "meanLabel": "9.01ms",
+          "rme": 49.7,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (10,000 tree items)": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 16,
+          "hzLabel": "16 ops/s",
+          "mean": 62.739042400001196,
+          "meanLabel": "62.74ms",
+          "rme": 1.8,
+          "tier": "good"
+        },
+        "Onboard then clear 1,000 tree items": {
+          "name": "Onboard then clear 1,000 tree items",
+          "hz": 235,
+          "hzLabel": "235 ops/s",
+          "mean": 4.261370584745576,
+          "meanLabel": "4.26ms",
+          "rme": 1.8,
+          "tier": "fast"
+        },
+        "Onboard then clear 10,000 tree items": {
+          "name": "Onboard then clear 10,000 tree items",
+          "hz": 16,
+          "hzLabel": "16 ops/s",
+          "mean": 63.87485410000081,
+          "meanLabel": "63.87ms",
+          "rme": 18.9,
+          "tier": "good"
+        },
+        "toFlat conversion (1,000 tree items)": {
+          "name": "toFlat conversion (1,000 tree items)",
+          "hz": 2028,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.49306437931050207,
+          "meanLabel": "493.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "toFlat conversion (10,000 tree items)": {
+          "name": "toFlat conversion (10,000 tree items)",
+          "hz": 190,
+          "hzLabel": "190 ops/s",
+          "mean": 5.2553426458339345,
+          "meanLabel": "5.26ms",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Select root - cascade mode (1,000 tree items)": {
+          "name": "Select root - cascade mode (1,000 tree items)",
+          "hz": 7455,
+          "hzLabel": "7.5k ops/s",
+          "mean": 0.13414060568656336,
+          "meanLabel": "134.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root - independent mode (1,000 tree items)": {
+          "name": "Select root - independent mode (1,000 tree items)",
+          "hz": 893302,
+          "hzLabel": "893.3k ops/s",
+          "mean": 0.0011194426453758665,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select root - leaf mode (1,000 tree items)": {
+          "name": "Select root - leaf mode (1,000 tree items)",
+          "hz": 5328,
+          "hzLabel": "5.3k ops/s",
+          "mean": 0.18769292154636558,
+          "meanLabel": "187.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - multiple mode (1,000 tree items)": {
+          "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+          "hz": 577219,
+          "hzLabel": "577.2k ops/s",
+          "mean": 0.0017324438550229226,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - single mode (1,000 tree items)": {
+          "name": "Open 3 nodes - single mode (1,000 tree items)",
+          "hz": 113676,
+          "hzLabel": "113.7k ops/s",
+          "mean": 0.00879690557544203,
+          "meanLabel": "8.8μs",
+          "rme": 4.5,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 7472903,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013381679572151633,
+          "meanLabel": "134ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard then clear 10,000 tree items",
+          "hz": 16,
+          "hzLabel": "16 ops/s",
+          "mean": 63.87485410000081,
+          "meanLabel": "63.87ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty registry": {
+              "name": "Create empty registry",
+              "hz": 275686,
+              "hzLabel": "275.7k ops/s",
+              "mean": 0.0036273192037314154,
+              "meanLabel": "3.6μs",
+              "rme": 11.8,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 2742,
+              "hzLabel": "2.7k ops/s",
+              "mean": 0.3647002501823444,
+              "meanLabel": "364.7μs",
+              "rme": 8.7,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 183,
+              "hzLabel": "183 ops/s",
+              "mean": 5.467435228260881,
+              "meanLabel": "5.47ms",
+              "rme": 14.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty registry",
+              "hz": 275686,
+              "hzLabel": "275.7k ops/s",
+              "mean": 0.0036273192037314154,
+              "meanLabel": "3.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 183,
+              "hzLabel": "183 ops/s",
+              "mean": 5.467435228260881,
+              "meanLabel": "5.47ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7450660,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013421630566956062,
+              "meanLabel": "134ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7717246,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012957989739350703,
+              "meanLabel": "130ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Lookup by index (1,000 items)": {
+              "name": "Lookup by index (1,000 items)",
+              "hz": 7441057,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013438951692075097,
+              "meanLabel": "134ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Lookup by index (10,000 items)": {
+              "name": "Lookup by index (10,000 items)",
+              "hz": 7549724,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013245517663998353,
+              "meanLabel": "132ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6345538,
+              "hzLabel": "6.3M ops/s",
+              "mean": 0.00015759105941779374,
+              "meanLabel": "158ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6495949,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.000153942105465998,
+              "meanLabel": "154ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (1,000 items)": {
+              "name": "Check has (1,000 items)",
+              "hz": 7705496,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012977749731442667,
+              "meanLabel": "130ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (10,000 items)": {
+              "name": "Check has (10,000 items)",
+              "hz": 7695047,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012995372790377773,
+              "meanLabel": "130ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7717246,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012957989739350703,
+              "meanLabel": "130ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6345538,
+              "hzLabel": "6.3M ops/s",
+              "mean": 0.00015759105941779374,
+              "meanLabel": "158ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 1716230,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005826724844354969,
+              "meanLabel": "583ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 1676331,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005965409811397439,
+              "meanLabel": "597ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Register single item": {
+              "name": "Register single item",
+              "hz": 247462,
+              "hzLabel": "247.5k ops/s",
+              "mean": 0.004041018142998814,
+              "meanLabel": "4.0μs",
+              "rme": 11.3,
+              "tier": "blazing"
+            },
+            "Register then unregister single item": {
+              "name": "Register then unregister single item",
+              "hz": 228201,
+              "hzLabel": "228.2k ops/s",
+              "mean": 0.004382109782804793,
+              "meanLabel": "4.4μs",
+              "rme": 10.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 1716230,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005826724844354969,
+              "meanLabel": "583ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register then unregister single item",
+              "hz": 228201,
+              "hzLabel": "228.2k ops/s",
+              "mean": 0.004382109782804793,
+              "meanLabel": "4.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 items": {
+              "name": "Onboard then clear 1,000 items",
+              "hz": 3887,
+              "hzLabel": "3.9k ops/s",
+              "mean": 0.25725330658429746,
+              "meanLabel": "257.3μs",
+              "rme": 0.9,
+              "tier": "blazing"
+            },
+            "Onboard then clear 10,000 items": {
+              "name": "Onboard then clear 10,000 items",
+              "hz": 281,
+              "hzLabel": "281 ops/s",
+              "mean": 3.5612917872340986,
+              "meanLabel": "3.56ms",
+              "rme": 3,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 1,000 items": {
+              "name": "Onboard then reindex 1,000 items",
+              "hz": 2075,
+              "hzLabel": "2.1k ops/s",
+              "mean": 0.4818808073217293,
+              "meanLabel": "481.9μs",
+              "rme": 12.5,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 10,000 items": {
+              "name": "Onboard then reindex 10,000 items",
+              "hz": 145,
+              "hzLabel": "145 ops/s",
+              "mean": 6.899900150685126,
+              "meanLabel": "6.90ms",
+              "rme": 10.3,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 then offboard 500 items": {
+              "name": "Onboard 1,000 then offboard 500 items",
+              "hz": 1599,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6252224462500362,
+              "meanLabel": "625.2μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 then offboard 5,000 items": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 118,
+              "hzLabel": "118 ops/s",
+              "mean": 8.504566449999947,
+              "meanLabel": "8.50ms",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 5454,
+              "hzLabel": "5.5k ops/s",
+              "mean": 0.18335660836084883,
+              "meanLabel": "183.4μs",
+              "rme": 9.5,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 314,
+              "hzLabel": "314 ops/s",
+              "mean": 3.179979949367085,
+              "meanLabel": "3.18ms",
+              "rme": 9.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 5454,
+              "hzLabel": "5.5k ops/s",
+              "mean": 0.18335660836084883,
+              "meanLabel": "183.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 118,
+              "hzLabel": "118 ops/s",
+              "mean": 8.504566449999947,
+              "meanLabel": "8.50ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access keys 100 times (1,000 items, cached)": {
+              "name": "Access keys 100 times (1,000 items, cached)",
+              "hz": 789062,
+              "hzLabel": "789.1k ops/s",
+              "mean": 0.001267327002626047,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, cached)": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 784961,
+              "hzLabel": "785.0k ops/s",
+              "mean": 0.0012739483592911138,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, cached)": {
+              "name": "Access values 100 times (1,000 items, cached)",
+              "hz": 721168,
+              "hzLabel": "721.2k ops/s",
+              "mean": 0.0013866388368882216,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, cached)": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 761822,
+              "hzLabel": "761.8k ops/s",
+              "mean": 0.0013126421771932583,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, cached)": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 823937,
+              "hzLabel": "823.9k ops/s",
+              "mean": 0.001213684502958959,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, cached)": {
+              "name": "Access entries 100 times (10,000 items, cached)",
+              "hz": 812711,
+              "hzLabel": "812.7k ops/s",
+              "mean": 0.0012304497657247082,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 823937,
+              "hzLabel": "823.9k ops/s",
+              "mean": 0.001213684502958959,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access values 100 times (1,000 items, cached)",
+              "hz": 721168,
+              "hzLabel": "721.2k ops/s",
+              "mean": 0.0013866388368882216,
+              "meanLabel": "1.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reactive access": {
+            "Access keys 100 times (1,000 items, reactive)": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 717990,
+              "hzLabel": "718.0k ops/s",
+              "mean": 0.0013927761089219907,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, reactive)": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 732813,
+              "hzLabel": "732.8k ops/s",
+              "mean": 0.0013646039731702363,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, reactive)": {
+              "name": "Access values 100 times (1,000 items, reactive)",
+              "hz": 683720,
+              "hzLabel": "683.7k ops/s",
+              "mean": 0.0014625864635097094,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, reactive)": {
+              "name": "Access values 100 times (10,000 items, reactive)",
+              "hz": 681822,
+              "hzLabel": "681.8k ops/s",
+              "mean": 0.001466658055452966,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, reactive)": {
+              "name": "Access entries 100 times (1,000 items, reactive)",
+              "hz": 717607,
+              "hzLabel": "717.6k ops/s",
+              "mean": 0.0013935199161618165,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, reactive)": {
+              "name": "Access entries 100 times (10,000 items, reactive)",
+              "hz": 730055,
+              "hzLabel": "730.1k ops/s",
+              "mean": 0.0013697605745379424,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (1,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 226071,
+              "hzLabel": "226.1k ops/s",
+              "mean": 0.004423390689677309,
+              "meanLabel": "4.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (10,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 220174,
+              "hzLabel": "220.2k ops/s",
+              "mean": 0.0045418558970937795,
+              "meanLabel": "4.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 732813,
+              "hzLabel": "732.8k ops/s",
+              "mean": 0.0013646039731702363,
+              "meanLabel": "1.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 220174,
+              "hzLabel": "220.2k ops/s",
+              "mean": 0.0045418558970937795,
+              "meanLabel": "4.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "seek operations": {
+            "Seek first (1,000 items)": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7328325,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001364568292916252,
+              "meanLabel": "136ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek first (10,000 items)": {
+              "name": "Seek first (10,000 items)",
+              "hz": 7165169,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013956405528411822,
+              "meanLabel": "140ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Seek last (1,000 items)": {
+              "name": "Seek last (1,000 items)",
+              "hz": 7209930,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013869759687037492,
+              "meanLabel": "139ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Seek last (10,000 items)": {
+              "name": "Seek last (10,000 items)",
+              "hz": 7289153,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013719015238254024,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (1,000 items)": {
+              "name": "Seek with predicate (1,000 items)",
+              "hz": 804041,
+              "hzLabel": "804.0k ops/s",
+              "mean": 0.0012437173854103522,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (10,000 items)": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 23592,
+              "hzLabel": "23.6k ops/s",
+              "mean": 0.04238639433760054,
+              "meanLabel": "42.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7328325,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001364568292916252,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 23592,
+              "hzLabel": "23.6k ops/s",
+              "mean": 0.04238639433760054,
+              "meanLabel": "42.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty registry": {
+          "name": "Create empty registry",
+          "hz": 275686,
+          "hzLabel": "275.7k ops/s",
+          "mean": 0.0036273192037314154,
+          "meanLabel": "3.6μs",
+          "rme": 11.8,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 2742,
+          "hzLabel": "2.7k ops/s",
+          "mean": 0.3647002501823444,
+          "meanLabel": "364.7μs",
+          "rme": 8.7,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 183,
+          "hzLabel": "183 ops/s",
+          "mean": 5.467435228260881,
+          "meanLabel": "5.47ms",
+          "rme": 14.4,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7450660,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013421630566956062,
+          "meanLabel": "134ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7717246,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012957989739350703,
+          "meanLabel": "130ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Lookup by index (1,000 items)": {
+          "name": "Lookup by index (1,000 items)",
+          "hz": 7441057,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013438951692075097,
+          "meanLabel": "134ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Lookup by index (10,000 items)": {
+          "name": "Lookup by index (10,000 items)",
+          "hz": 7549724,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013245517663998353,
+          "meanLabel": "132ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6345538,
+          "hzLabel": "6.3M ops/s",
+          "mean": 0.00015759105941779374,
+          "meanLabel": "158ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6495949,
+          "hzLabel": "6.5M ops/s",
+          "mean": 0.000153942105465998,
+          "meanLabel": "154ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (1,000 items)": {
+          "name": "Check has (1,000 items)",
+          "hz": 7705496,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012977749731442667,
+          "meanLabel": "130ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (10,000 items)": {
+          "name": "Check has (10,000 items)",
+          "hz": 7695047,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012995372790377773,
+          "meanLabel": "130ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 1716230,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005826724844354969,
+          "meanLabel": "583ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 1676331,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005965409811397439,
+          "meanLabel": "597ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Register single item": {
+          "name": "Register single item",
+          "hz": 247462,
+          "hzLabel": "247.5k ops/s",
+          "mean": 0.004041018142998814,
+          "meanLabel": "4.0μs",
+          "rme": 11.3,
+          "tier": "blazing"
+        },
+        "Register then unregister single item": {
+          "name": "Register then unregister single item",
+          "hz": 228201,
+          "hzLabel": "228.2k ops/s",
+          "mean": 0.004382109782804793,
+          "meanLabel": "4.4μs",
+          "rme": 10.2,
+          "tier": "blazing"
+        },
+        "Onboard then clear 1,000 items": {
+          "name": "Onboard then clear 1,000 items",
+          "hz": 3887,
+          "hzLabel": "3.9k ops/s",
+          "mean": 0.25725330658429746,
+          "meanLabel": "257.3μs",
+          "rme": 0.9,
+          "tier": "blazing"
+        },
+        "Onboard then clear 10,000 items": {
+          "name": "Onboard then clear 10,000 items",
+          "hz": 281,
+          "hzLabel": "281 ops/s",
+          "mean": 3.5612917872340986,
+          "meanLabel": "3.56ms",
+          "rme": 3,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 1,000 items": {
+          "name": "Onboard then reindex 1,000 items",
+          "hz": 2075,
+          "hzLabel": "2.1k ops/s",
+          "mean": 0.4818808073217293,
+          "meanLabel": "481.9μs",
+          "rme": 12.5,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 10,000 items": {
+          "name": "Onboard then reindex 10,000 items",
+          "hz": 145,
+          "hzLabel": "145 ops/s",
+          "mean": 6.899900150685126,
+          "meanLabel": "6.90ms",
+          "rme": 10.3,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 500 items": {
+          "name": "Onboard 1,000 then offboard 500 items",
+          "hz": 1599,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6252224462500362,
+          "meanLabel": "625.2μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 then offboard 5,000 items": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 118,
+          "hzLabel": "118 ops/s",
+          "mean": 8.504566449999947,
+          "meanLabel": "8.50ms",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 5454,
+          "hzLabel": "5.5k ops/s",
+          "mean": 0.18335660836084883,
+          "meanLabel": "183.4μs",
+          "rme": 9.5,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 314,
+          "hzLabel": "314 ops/s",
+          "mean": 3.179979949367085,
+          "meanLabel": "3.18ms",
+          "rme": 9.6,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, cached)": {
+          "name": "Access keys 100 times (1,000 items, cached)",
+          "hz": 789062,
+          "hzLabel": "789.1k ops/s",
+          "mean": 0.001267327002626047,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, cached)": {
+          "name": "Access keys 100 times (10,000 items, cached)",
+          "hz": 784961,
+          "hzLabel": "785.0k ops/s",
+          "mean": 0.0012739483592911138,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, cached)": {
+          "name": "Access values 100 times (1,000 items, cached)",
+          "hz": 721168,
+          "hzLabel": "721.2k ops/s",
+          "mean": 0.0013866388368882216,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, cached)": {
+          "name": "Access values 100 times (10,000 items, cached)",
+          "hz": 761822,
+          "hzLabel": "761.8k ops/s",
+          "mean": 0.0013126421771932583,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, cached)": {
+          "name": "Access entries 100 times (1,000 items, cached)",
+          "hz": 823937,
+          "hzLabel": "823.9k ops/s",
+          "mean": 0.001213684502958959,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, cached)": {
+          "name": "Access entries 100 times (10,000 items, cached)",
+          "hz": 812711,
+          "hzLabel": "812.7k ops/s",
+          "mean": 0.0012304497657247082,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, reactive)": {
+          "name": "Access keys 100 times (1,000 items, reactive)",
+          "hz": 717990,
+          "hzLabel": "718.0k ops/s",
+          "mean": 0.0013927761089219907,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, reactive)": {
+          "name": "Access keys 100 times (10,000 items, reactive)",
+          "hz": 732813,
+          "hzLabel": "732.8k ops/s",
+          "mean": 0.0013646039731702363,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, reactive)": {
+          "name": "Access values 100 times (1,000 items, reactive)",
+          "hz": 683720,
+          "hzLabel": "683.7k ops/s",
+          "mean": 0.0014625864635097094,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, reactive)": {
+          "name": "Access values 100 times (10,000 items, reactive)",
+          "hz": 681822,
+          "hzLabel": "681.8k ops/s",
+          "mean": 0.001466658055452966,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, reactive)": {
+          "name": "Access entries 100 times (1,000 items, reactive)",
+          "hz": 717607,
+          "hzLabel": "717.6k ops/s",
+          "mean": 0.0013935199161618165,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, reactive)": {
+          "name": "Access entries 100 times (10,000 items, reactive)",
+          "hz": 730055,
+          "hzLabel": "730.1k ops/s",
+          "mean": 0.0013697605745379424,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (1,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+          "hz": 226071,
+          "hzLabel": "226.1k ops/s",
+          "mean": 0.004423390689677309,
+          "meanLabel": "4.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (10,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+          "hz": 220174,
+          "hzLabel": "220.2k ops/s",
+          "mean": 0.0045418558970937795,
+          "meanLabel": "4.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek first (1,000 items)": {
+          "name": "Seek first (1,000 items)",
+          "hz": 7328325,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001364568292916252,
+          "meanLabel": "136ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek first (10,000 items)": {
+          "name": "Seek first (10,000 items)",
+          "hz": 7165169,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013956405528411822,
+          "meanLabel": "140ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Seek last (1,000 items)": {
+          "name": "Seek last (1,000 items)",
+          "hz": 7209930,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013869759687037492,
+          "meanLabel": "139ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Seek last (10,000 items)": {
+          "name": "Seek last (10,000 items)",
+          "hz": 7289153,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013719015238254024,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (1,000 items)": {
+          "name": "Seek with predicate (1,000 items)",
+          "hz": 804041,
+          "hzLabel": "804.0k ops/s",
+          "mean": 0.0012437173854103522,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (10,000 items)": {
+          "name": "Seek with predicate (10,000 items)",
+          "hz": 23592,
+          "hzLabel": "23.6k ops/s",
+          "mean": 0.04238639433760054,
+          "meanLabel": "42.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7717246,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012957989739350703,
+          "meanLabel": "130ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 118,
+          "hzLabel": "118 ops/s",
+          "mean": 8.504566449999947,
+          "meanLabel": "8.50ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createSelection": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty selection": {
+              "name": "Create empty selection",
+              "hz": 46306,
+              "hzLabel": "46.3k ops/s",
+              "mean": 0.021595617975957368,
+              "meanLabel": "21.6μs",
+              "rme": 11.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 672,
+              "hzLabel": "672 ops/s",
+              "mean": 1.4882538452387788,
+              "meanLabel": "1.49ms",
+              "rme": 11,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 65,
+              "hzLabel": "65 ops/s",
+              "mean": 15.287443911763736,
+              "meanLabel": "15.29ms",
+              "rme": 8.4,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (enroll)": {
+              "name": "Onboard 1,000 items (enroll)",
+              "hz": 493,
+              "hzLabel": "493 ops/s",
+              "mean": 2.0281474453429853,
+              "meanLabel": "2.03ms",
+              "rme": 7.5,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (enroll)": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 24.003378428572823,
+              "meanLabel": "24.00ms",
+              "rme": 11,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory: force)": {
+              "name": "Onboard 1,000 items (mandatory: force)",
+              "hz": 603,
+              "hzLabel": "603 ops/s",
+              "mean": 1.6580571390716174,
+              "meanLabel": "1.66ms",
+              "rme": 8.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory: force)": {
+              "name": "Onboard 10,000 items (mandatory: force)",
+              "hz": 54,
+              "hzLabel": "54 ops/s",
+              "mean": 18.502755785715376,
+              "meanLabel": "18.50ms",
+              "rme": 7.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty selection",
+              "hz": 46306,
+              "hzLabel": "46.3k ops/s",
+              "mean": 0.021595617975957368,
+              "meanLabel": "21.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 24.003378428572823,
+              "meanLabel": "24.00ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1988521,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.000502886437259747,
+              "meanLabel": "503ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1929365,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005183052038990028,
+              "meanLabel": "518ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1988521,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.000502886437259747,
+              "meanLabel": "503ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1929365,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005183052038990028,
+              "meanLabel": "518ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1731519,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005775277236334528,
+              "meanLabel": "578ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 1718042,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005820577924629782,
+              "meanLabel": "582ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 792820,
+              "hzLabel": "792.8k ops/s",
+              "mean": 0.0012613202484005029,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 774607,
+              "hzLabel": "774.6k ops/s",
+              "mean": 0.00129097740534188,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 906543,
+              "hzLabel": "906.5k ops/s",
+              "mean": 0.0011030919602448422,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 911887,
+              "hzLabel": "911.9k ops/s",
+              "mean": 0.0010966267458356945,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1731519,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005775277236334528,
+              "meanLabel": "578ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 774607,
+              "hzLabel": "774.6k ops/s",
+              "mean": 0.00129097740534188,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mandatory enforcement": {
+            "Select with mandatory (1,000 items)": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 848376,
+              "hzLabel": "848.4k ops/s",
+              "mean": 0.0011787227644236326,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect blocked by mandatory (1,000 items)": {
+              "name": "Unselect blocked by mandatory (1,000 items)",
+              "hz": 653036,
+              "hzLabel": "653.0k ops/s",
+              "mean": 0.0015313096276704061,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Mandate on empty (1,000 items)": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 462830,
+              "hzLabel": "462.8k ops/s",
+              "mean": 0.002160619684871827,
+              "meanLabel": "2.2μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 848376,
+              "hzLabel": "848.4k ops/s",
+              "mean": 0.0011787227644236326,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 462830,
+              "hzLabel": "462.8k ops/s",
+              "mean": 0.002160619684871827,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1598,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6256416162497771,
+              "meanLabel": "625.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 146,
+              "hzLabel": "146 ops/s",
+              "mean": 6.83431097297344,
+              "meanLabel": "6.83ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Select then unselect all 1,000 items": {
+              "name": "Select then unselect all 1,000 items",
+              "hz": 918,
+              "hzLabel": "918 ops/s",
+              "mean": 1.0894952113286787,
+              "meanLabel": "1.09ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Reset selection (1,000 items)": {
+              "name": "Reset selection (1,000 items)",
+              "hz": 449,
+              "hzLabel": "449 ops/s",
+              "mean": 2.225769693332259,
+              "meanLabel": "2.23ms",
+              "rme": 9.6,
+              "tier": "fast"
+            },
+            "Reset selection (10,000 items)": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.696864521738302,
+              "meanLabel": "22.70ms",
+              "rme": 6.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 1598,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6256416162497771,
+              "meanLabel": "625.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.696864521738302,
+              "meanLabel": "22.70ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+              "hz": 620999,
+              "hzLabel": "621.0k ops/s",
+              "mean": 0.0016103082254524126,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 620861,
+              "hzLabel": "620.9k ops/s",
+              "mean": 0.0016106666183817319,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 589908,
+              "hzLabel": "589.9k ops/s",
+              "mean": 0.001695180075534605,
+              "meanLabel": "1.7μs",
+              "rme": 5.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 631891,
+              "hzLabel": "631.9k ops/s",
+              "mean": 0.0015825508789741253,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 624469,
+              "hzLabel": "624.5k ops/s",
+              "mean": 0.001601361106211614,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 621578,
+              "hzLabel": "621.6k ops/s",
+              "mean": 0.0016088096045131278,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 631891,
+              "hzLabel": "631.9k ops/s",
+              "mean": 0.0015825508789741253,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 589908,
+              "hzLabel": "589.9k ops/s",
+              "mean": 0.001695180075534605,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty selection": {
+          "name": "Create empty selection",
+          "hz": 46306,
+          "hzLabel": "46.3k ops/s",
+          "mean": 0.021595617975957368,
+          "meanLabel": "21.6μs",
+          "rme": 11.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 672,
+          "hzLabel": "672 ops/s",
+          "mean": 1.4882538452387788,
+          "meanLabel": "1.49ms",
+          "rme": 11,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 65,
+          "hzLabel": "65 ops/s",
+          "mean": 15.287443911763736,
+          "meanLabel": "15.29ms",
+          "rme": 8.4,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (enroll)": {
+          "name": "Onboard 1,000 items (enroll)",
+          "hz": 493,
+          "hzLabel": "493 ops/s",
+          "mean": 2.0281474453429853,
+          "meanLabel": "2.03ms",
+          "rme": 7.5,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (enroll)": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 24.003378428572823,
+          "meanLabel": "24.00ms",
+          "rme": 11,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory: force)": {
+          "name": "Onboard 1,000 items (mandatory: force)",
+          "hz": 603,
+          "hzLabel": "603 ops/s",
+          "mean": 1.6580571390716174,
+          "meanLabel": "1.66ms",
+          "rme": 8.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory: force)": {
+          "name": "Onboard 10,000 items (mandatory: force)",
+          "hz": 54,
+          "hzLabel": "54 ops/s",
+          "mean": 18.502755785715376,
+          "meanLabel": "18.50ms",
+          "rme": 7.4,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1988521,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.000502886437259747,
+          "meanLabel": "503ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 1929365,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005183052038990028,
+          "meanLabel": "518ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 1731519,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005775277236334528,
+          "meanLabel": "578ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 1718042,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005820577924629782,
+          "meanLabel": "582ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 792820,
+          "hzLabel": "792.8k ops/s",
+          "mean": 0.0012613202484005029,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 774607,
+          "hzLabel": "774.6k ops/s",
+          "mean": 0.00129097740534188,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 906543,
+          "hzLabel": "906.5k ops/s",
+          "mean": 0.0011030919602448422,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 911887,
+          "hzLabel": "911.9k ops/s",
+          "mean": 0.0010966267458356945,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select with mandatory (1,000 items)": {
+          "name": "Select with mandatory (1,000 items)",
+          "hz": 848376,
+          "hzLabel": "848.4k ops/s",
+          "mean": 0.0011787227644236326,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect blocked by mandatory (1,000 items)": {
+          "name": "Unselect blocked by mandatory (1,000 items)",
+          "hz": 653036,
+          "hzLabel": "653.0k ops/s",
+          "mean": 0.0015313096276704061,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Mandate on empty (1,000 items)": {
+          "name": "Mandate on empty (1,000 items)",
+          "hz": 462830,
+          "hzLabel": "462.8k ops/s",
+          "mean": 0.002160619684871827,
+          "meanLabel": "2.2μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1598,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6256416162497771,
+          "meanLabel": "625.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 146,
+          "hzLabel": "146 ops/s",
+          "mean": 6.83431097297344,
+          "meanLabel": "6.83ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Select then unselect all 1,000 items": {
+          "name": "Select then unselect all 1,000 items",
+          "hz": 918,
+          "hzLabel": "918 ops/s",
+          "mean": 1.0894952113286787,
+          "meanLabel": "1.09ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Reset selection (1,000 items)": {
+          "name": "Reset selection (1,000 items)",
+          "hz": 449,
+          "hzLabel": "449 ops/s",
+          "mean": 2.225769693332259,
+          "meanLabel": "2.23ms",
+          "rme": 9.6,
+          "tier": "fast"
+        },
+        "Reset selection (10,000 items)": {
+          "name": "Reset selection (10,000 items)",
+          "hz": 44,
+          "hzLabel": "44 ops/s",
+          "mean": 22.696864521738302,
+          "meanLabel": "22.70ms",
+          "rme": 6.3,
+          "tier": "fast"
+        },
+        "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+          "hz": 620999,
+          "hzLabel": "621.0k ops/s",
+          "mean": 0.0016103082254524126,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 620861,
+          "hzLabel": "620.9k ops/s",
+          "mean": 0.0016106666183817319,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 589908,
+          "hzLabel": "589.9k ops/s",
+          "mean": 0.001695180075534605,
+          "meanLabel": "1.7μs",
+          "rme": 5.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+          "hz": 631891,
+          "hzLabel": "631.9k ops/s",
+          "mean": 0.0015825508789741253,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 624469,
+          "hzLabel": "624.5k ops/s",
+          "mean": 0.001601361106211614,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 621578,
+          "hzLabel": "621.6k ops/s",
+          "mean": 0.0016088096045131278,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1988521,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.000502886437259747,
+          "meanLabel": "503ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 24.003378428572823,
+          "meanLabel": "24.00ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSingle": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty single": {
+              "name": "Create empty single",
+              "hz": 34781,
+              "hzLabel": "34.8k ops/s",
+              "mean": 0.02875133172348944,
+              "meanLabel": "28.8μs",
+              "rme": 9.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 699,
+              "hzLabel": "699 ops/s",
+              "mean": 1.4300590423726685,
+              "meanLabel": "1.43ms",
+              "rme": 10,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 63,
+              "hzLabel": "63 ops/s",
+              "mean": 15.831745343743023,
+              "meanLabel": "15.83ms",
+              "rme": 10.4,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 705,
+              "hzLabel": "705 ops/s",
+              "mean": 1.4179660113308732,
+              "meanLabel": "1.42ms",
+              "rme": 9.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 62,
+              "hzLabel": "62 ops/s",
+              "mean": 16.221359096773554,
+              "meanLabel": "16.22ms",
+              "rme": 13.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty single",
+              "hz": 34781,
+              "hzLabel": "34.8k ops/s",
+              "mean": 0.02875133172348944,
+              "meanLabel": "28.8μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 62,
+              "hzLabel": "62 ops/s",
+              "mean": 16.221359096773554,
+              "meanLabel": "16.22ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1976407,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005059686158184738,
+              "meanLabel": "506ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1957100,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005109602043797029,
+              "meanLabel": "511ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 1976407,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005059686158184738,
+              "meanLabel": "506ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 1957100,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005109602043797029,
+              "meanLabel": "511ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 820467,
+              "hzLabel": "820.5k ops/s",
+              "mean": 0.0012188183964031978,
+              "meanLabel": "1.2μs",
+              "rme": 3,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 847250,
+              "hzLabel": "847.2k ops/s",
+              "mean": 0.0011802896524152388,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 605381,
+              "hzLabel": "605.4k ops/s",
+              "mean": 0.0016518527144361937,
+              "meanLabel": "1.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 586535,
+              "hzLabel": "586.5k ops/s",
+              "mean": 0.0017049287681671697,
+              "meanLabel": "1.7μs",
+              "rme": 2.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 770195,
+              "hzLabel": "770.2k ops/s",
+              "mean": 0.0012983723726915095,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 777484,
+              "hzLabel": "777.5k ops/s",
+              "mean": 0.001286200605567634,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (10,000 items)",
+              "hz": 847250,
+              "hzLabel": "847.2k ops/s",
+              "mean": 0.0011802896524152388,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 586535,
+              "hzLabel": "586.5k ops/s",
+              "mean": 0.0017049287681671697,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6490,
+              "hzLabel": "6.5k ops/s",
+              "mean": 0.1540800653107465,
+              "meanLabel": "154.1μs",
+              "rme": 4.7,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (10,000 items, cached)": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 6151,
+              "hzLabel": "6.2k ops/s",
+              "mean": 0.16257567750337343,
+              "meanLabel": "162.6μs",
+              "rme": 5.8,
+              "tier": "blazing"
+            },
+            "Access selectedItem 100 times (1,000 items, cached)": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 320188,
+              "hzLabel": "320.2k ops/s",
+              "mean": 0.0031231634529917023,
+              "meanLabel": "3.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 278398,
+              "hzLabel": "278.4k ops/s",
+              "mean": 0.0035919759553800614,
+              "meanLabel": "3.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 262937,
+              "hzLabel": "262.9k ops/s",
+              "mean": 0.0038031913226967773,
+              "meanLabel": "3.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 320188,
+              "hzLabel": "320.2k ops/s",
+              "mean": 0.0031231634529917023,
+              "meanLabel": "3.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 6151,
+              "hzLabel": "6.2k ops/s",
+              "mean": 0.16257567750337343,
+              "meanLabel": "162.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty single": {
+          "name": "Create empty single",
+          "hz": 34781,
+          "hzLabel": "34.8k ops/s",
+          "mean": 0.02875133172348944,
+          "meanLabel": "28.8μs",
+          "rme": 9.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 699,
+          "hzLabel": "699 ops/s",
+          "mean": 1.4300590423726685,
+          "meanLabel": "1.43ms",
+          "rme": 10,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 63,
+          "hzLabel": "63 ops/s",
+          "mean": 15.831745343743023,
+          "meanLabel": "15.83ms",
+          "rme": 10.4,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 705,
+          "hzLabel": "705 ops/s",
+          "mean": 1.4179660113308732,
+          "meanLabel": "1.42ms",
+          "rme": 9.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 62,
+          "hzLabel": "62 ops/s",
+          "mean": 16.221359096773554,
+          "meanLabel": "16.22ms",
+          "rme": 13.3,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1976407,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005059686158184738,
+          "meanLabel": "506ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 1957100,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005109602043797029,
+          "meanLabel": "511ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 820467,
+          "hzLabel": "820.5k ops/s",
+          "mean": 0.0012188183964031978,
+          "meanLabel": "1.2μs",
+          "rme": 3,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 847250,
+          "hzLabel": "847.2k ops/s",
+          "mean": 0.0011802896524152388,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 605381,
+          "hzLabel": "605.4k ops/s",
+          "mean": 0.0016518527144361937,
+          "meanLabel": "1.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 586535,
+          "hzLabel": "586.5k ops/s",
+          "mean": 0.0017049287681671697,
+          "meanLabel": "1.7μs",
+          "rme": 2.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 770195,
+          "hzLabel": "770.2k ops/s",
+          "mean": 0.0012983723726915095,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 777484,
+          "hzLabel": "777.5k ops/s",
+          "mean": 0.001286200605567634,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6490,
+          "hzLabel": "6.5k ops/s",
+          "mean": 0.1540800653107465,
+          "meanLabel": "154.1μs",
+          "rme": 4.7,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (10,000 items, cached)": {
+          "name": "Access selectedId 100 times (10,000 items, cached)",
+          "hz": 6151,
+          "hzLabel": "6.2k ops/s",
+          "mean": 0.16257567750337343,
+          "meanLabel": "162.6μs",
+          "rme": 5.8,
+          "tier": "blazing"
+        },
+        "Access selectedItem 100 times (1,000 items, cached)": {
+          "name": "Access selectedItem 100 times (1,000 items, cached)",
+          "hz": 320188,
+          "hzLabel": "320.2k ops/s",
+          "mean": 0.0031231634529917023,
+          "meanLabel": "3.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 278398,
+          "hzLabel": "278.4k ops/s",
+          "mean": 0.0035919759553800614,
+          "meanLabel": "3.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 262937,
+          "hzLabel": "262.9k ops/s",
+          "mean": 0.0038031913226967773,
+          "meanLabel": "3.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (1,000 items)",
+          "hz": 1976407,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005059686158184738,
+          "meanLabel": "506ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 62,
+          "hzLabel": "62 ops/s",
+          "mean": 16.221359096773554,
+          "meanLabel": "16.22ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSortable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty sortable": {
+              "name": "Create empty sortable",
+              "hz": 32661,
+              "hzLabel": "32.7k ops/s",
+              "mean": 0.030617191659837194,
+              "meanLabel": "30.6μs",
+              "rme": 50.6,
+              "tier": "fast"
+            },
+            "Create empty sortable (disabled)": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 48345,
+              "hzLabel": "48.3k ops/s",
+              "mean": 0.020684842758491695,
+              "meanLabel": "20.7μs",
+              "rme": 8.7,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 48345,
+              "hzLabel": "48.3k ops/s",
+              "mean": 0.020684842758491695,
+              "meanLabel": "20.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create empty sortable",
+              "hz": 32661,
+              "hzLabel": "32.7k ops/s",
+              "mean": 0.030617191659837194,
+              "meanLabel": "30.6μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7429775,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013459358101083405,
+              "meanLabel": "135ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7350477,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013604559674583957,
+              "meanLabel": "136ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Values snapshot (10,000 items)": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7013958,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014257284557605516,
+              "meanLabel": "143ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7429775,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013459358101083405,
+              "meanLabel": "135ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7013958,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014257284557605516,
+              "meanLabel": "143ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "move operations": {
+            "Move first to last (1,000 items)": {
+              "name": "Move first to last (1,000 items)",
+              "hz": 5885,
+              "hzLabel": "5.9k ops/s",
+              "mean": 0.16993161163377143,
+              "meanLabel": "169.9μs",
+              "rme": 12.5,
+              "tier": "blazing"
+            },
+            "Move first to last (10,000 items)": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 430,
+              "hzLabel": "430 ops/s",
+              "mean": 2.3278705860461044,
+              "meanLabel": "2.33ms",
+              "rme": 14.8,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (1,000 items)": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 228412,
+              "hzLabel": "228.4k ops/s",
+              "mean": 0.00437805923350435,
+              "meanLabel": "4.4μs",
+              "rme": 8.7,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (10,000 items)": {
+              "name": "Move mid by 1 (10,000 items)",
+              "hz": 29214,
+              "hzLabel": "29.2k ops/s",
+              "mean": 0.03422984241525066,
+              "meanLabel": "34.2μs",
+              "rme": 1.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 228412,
+              "hzLabel": "228.4k ops/s",
+              "mean": 0.00437805923350435,
+              "meanLabel": "4.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 430,
+              "hzLabel": "430 ops/s",
+              "mean": 2.3278705860461044,
+              "meanLabel": "2.33ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "swap operations": {
+            "Swap two tickets (1,000 items)": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7985,
+              "hzLabel": "8.0k ops/s",
+              "mean": 0.12523363210617608,
+              "meanLabel": "125.2μs",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "Swap two tickets (10,000 items)": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 454,
+              "hzLabel": "454 ops/s",
+              "mean": 2.2048110528620852,
+              "meanLabel": "2.20ms",
+              "rme": 7.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7985,
+              "hzLabel": "8.0k ops/s",
+              "mean": 0.12523363210617608,
+              "meanLabel": "125.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 454,
+              "hzLabel": "454 ops/s",
+              "mean": 2.2048110528620852,
+              "meanLabel": "2.20ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reorder operations": {
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2278,
+              "hzLabel": "2.3k ops/s",
+              "mean": 0.43904194117536405,
+              "meanLabel": "439.0μs",
+              "rme": 12,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.414406512819905,
+              "meanLabel": "6.41ms",
+              "rme": 9.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2278,
+              "hzLabel": "2.3k ops/s",
+              "mean": 0.43904194117536405,
+              "meanLabel": "439.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.414406512819905,
+              "meanLabel": "6.41ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 100 items": {
+              "name": "Onboard 100 items",
+              "hz": 4511,
+              "hzLabel": "4.5k ops/s",
+              "mean": 0.2217015221631945,
+              "meanLabel": "221.7μs",
+              "rme": 6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 485,
+              "hzLabel": "485 ops/s",
+              "mean": 2.0626302469141375,
+              "meanLabel": "2.06ms",
+              "rme": 5.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.8851633181859,
+              "meanLabel": "22.89ms",
+              "rme": 6,
+              "tier": "fast"
+            },
+            "Register then move to mid (1,000 items)": {
+              "name": "Register then move to mid (1,000 items)",
+              "hz": 467,
+              "hzLabel": "467 ops/s",
+              "mean": 2.1416711666669523,
+              "meanLabel": "2.14ms",
+              "rme": 5.6,
+              "tier": "fast"
+            },
+            "Register then move to mid (10,000 items)": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.5111795238003,
+              "meanLabel": "24.51ms",
+              "rme": 13,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Onboard 100 items",
+              "hz": 4511,
+              "hzLabel": "4.5k ops/s",
+              "mean": 0.2217015221631945,
+              "meanLabel": "221.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.5111795238003,
+              "meanLabel": "24.51ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "events overhead": {
+            "Move with no listeners (1,000 items)": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 246038,
+              "hzLabel": "246.0k ops/s",
+              "mean": 0.004064413314988935,
+              "meanLabel": "4.1μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Move with listener attached (1,000 items)": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 244399,
+              "hzLabel": "244.4k ops/s",
+              "mean": 0.004091674378056021,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Move with no listeners (10,000 items)": {
+              "name": "Move with no listeners (10,000 items)",
+              "hz": 29496,
+              "hzLabel": "29.5k ops/s",
+              "mean": 0.0339033754404505,
+              "meanLabel": "33.9μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Move with listener attached (10,000 items)": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29405,
+              "hzLabel": "29.4k ops/s",
+              "mean": 0.03400728415972022,
+              "meanLabel": "34.0μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 246038,
+              "hzLabel": "246.0k ops/s",
+              "mean": 0.004064413314988935,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29405,
+              "hzLabel": "29.4k ops/s",
+              "mean": 0.03400728415972022,
+              "meanLabel": "34.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty sortable": {
+          "name": "Create empty sortable",
+          "hz": 32661,
+          "hzLabel": "32.7k ops/s",
+          "mean": 0.030617191659837194,
+          "meanLabel": "30.6μs",
+          "rme": 50.6,
+          "tier": "fast"
+        },
+        "Create empty sortable (disabled)": {
+          "name": "Create empty sortable (disabled)",
+          "hz": 48345,
+          "hzLabel": "48.3k ops/s",
+          "mean": 0.020684842758491695,
+          "meanLabel": "20.7μs",
+          "rme": 8.7,
+          "tier": "fast"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7429775,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013459358101083405,
+          "meanLabel": "135ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7350477,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013604559674583957,
+          "meanLabel": "136ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Values snapshot (10,000 items)": {
+          "name": "Values snapshot (10,000 items)",
+          "hz": 7013958,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014257284557605516,
+          "meanLabel": "143ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Move first to last (1,000 items)": {
+          "name": "Move first to last (1,000 items)",
+          "hz": 5885,
+          "hzLabel": "5.9k ops/s",
+          "mean": 0.16993161163377143,
+          "meanLabel": "169.9μs",
+          "rme": 12.5,
+          "tier": "blazing"
+        },
+        "Move first to last (10,000 items)": {
+          "name": "Move first to last (10,000 items)",
+          "hz": 430,
+          "hzLabel": "430 ops/s",
+          "mean": 2.3278705860461044,
+          "meanLabel": "2.33ms",
+          "rme": 14.8,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (1,000 items)": {
+          "name": "Move mid by 1 (1,000 items)",
+          "hz": 228412,
+          "hzLabel": "228.4k ops/s",
+          "mean": 0.00437805923350435,
+          "meanLabel": "4.4μs",
+          "rme": 8.7,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (10,000 items)": {
+          "name": "Move mid by 1 (10,000 items)",
+          "hz": 29214,
+          "hzLabel": "29.2k ops/s",
+          "mean": 0.03422984241525066,
+          "meanLabel": "34.2μs",
+          "rme": 1.8,
+          "tier": "blazing"
+        },
+        "Swap two tickets (1,000 items)": {
+          "name": "Swap two tickets (1,000 items)",
+          "hz": 7985,
+          "hzLabel": "8.0k ops/s",
+          "mean": 0.12523363210617608,
+          "meanLabel": "125.2μs",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "Swap two tickets (10,000 items)": {
+          "name": "Swap two tickets (10,000 items)",
+          "hz": 454,
+          "hzLabel": "454 ops/s",
+          "mean": 2.2048110528620852,
+          "meanLabel": "2.20ms",
+          "rme": 7.2,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 2278,
+          "hzLabel": "2.3k ops/s",
+          "mean": 0.43904194117536405,
+          "meanLabel": "439.0μs",
+          "rme": 12,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.414406512819905,
+          "meanLabel": "6.41ms",
+          "rme": 9.2,
+          "tier": "blazing"
+        },
+        "Onboard 100 items": {
+          "name": "Onboard 100 items",
+          "hz": 4511,
+          "hzLabel": "4.5k ops/s",
+          "mean": 0.2217015221631945,
+          "meanLabel": "221.7μs",
+          "rme": 6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 485,
+          "hzLabel": "485 ops/s",
+          "mean": 2.0626302469141375,
+          "meanLabel": "2.06ms",
+          "rme": 5.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 44,
+          "hzLabel": "44 ops/s",
+          "mean": 22.8851633181859,
+          "meanLabel": "22.89ms",
+          "rme": 6,
+          "tier": "fast"
+        },
+        "Register then move to mid (1,000 items)": {
+          "name": "Register then move to mid (1,000 items)",
+          "hz": 467,
+          "hzLabel": "467 ops/s",
+          "mean": 2.1416711666669523,
+          "meanLabel": "2.14ms",
+          "rme": 5.6,
+          "tier": "fast"
+        },
+        "Register then move to mid (10,000 items)": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.5111795238003,
+          "meanLabel": "24.51ms",
+          "rme": 13,
+          "tier": "fast"
+        },
+        "Move with no listeners (1,000 items)": {
+          "name": "Move with no listeners (1,000 items)",
+          "hz": 246038,
+          "hzLabel": "246.0k ops/s",
+          "mean": 0.004064413314988935,
+          "meanLabel": "4.1μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Move with listener attached (1,000 items)": {
+          "name": "Move with listener attached (1,000 items)",
+          "hz": 244399,
+          "hzLabel": "244.4k ops/s",
+          "mean": 0.004091674378056021,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move with no listeners (10,000 items)": {
+          "name": "Move with no listeners (10,000 items)",
+          "hz": 29496,
+          "hzLabel": "29.5k ops/s",
+          "mean": 0.0339033754404505,
+          "meanLabel": "33.9μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Move with listener attached (10,000 items)": {
+          "name": "Move with listener attached (10,000 items)",
+          "hz": 29405,
+          "hzLabel": "29.4k ops/s",
+          "mean": 0.03400728415972022,
+          "meanLabel": "34.0μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7429775,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013459358101083405,
+          "meanLabel": "135ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.5111795238003,
+          "meanLabel": "24.51ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createStep": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty step": {
+              "name": "Create empty step",
+              "hz": 27595,
+              "hzLabel": "27.6k ops/s",
+              "mean": 0.0362382440933234,
+              "meanLabel": "36.2μs",
+              "rme": 5.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 729,
+              "hzLabel": "729 ops/s",
+              "mean": 1.3710754794510376,
+              "meanLabel": "1.37ms",
+              "rme": 9.5,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 65,
+              "hzLabel": "65 ops/s",
+              "mean": 15.342930212128328,
+              "meanLabel": "15.34ms",
+              "rme": 8.3,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (circular)": {
+              "name": "Onboard 1,000 items (circular)",
+              "hz": 705,
+              "hzLabel": "705 ops/s",
+              "mean": 1.4189554844188461,
+              "meanLabel": "1.42ms",
+              "rme": 10.4,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 682,
+              "hzLabel": "682 ops/s",
+              "mean": 1.466614363634313,
+              "meanLabel": "1.47ms",
+              "rme": 9.8,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty step",
+              "hz": 27595,
+              "hzLabel": "27.6k ops/s",
+              "mean": 0.0362382440933234,
+              "meanLabel": "36.2μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 65,
+              "hzLabel": "65 ops/s",
+              "mean": 15.342930212128328,
+              "meanLabel": "15.34ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation operations (linear)": {
+            "next() from mid-point (1,000 items)": {
+              "name": "next() from mid-point (1,000 items)",
+              "hz": 113747,
+              "hzLabel": "113.7k ops/s",
+              "mean": 0.00879144192430119,
+              "meanLabel": "8.8μs",
+              "rme": 4.8,
+              "tier": "blazing"
+            },
+            "next() from mid-point (10,000 items)": {
+              "name": "next() from mid-point (10,000 items)",
+              "hz": 120953,
+              "hzLabel": "121.0k ops/s",
+              "mean": 0.008267693420585035,
+              "meanLabel": "8.3μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (1,000 items)": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 119455,
+              "hzLabel": "119.5k ops/s",
+              "mean": 0.008371381479511079,
+              "meanLabel": "8.4μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (10,000 items)": {
+              "name": "prev() from mid-point (10,000 items)",
+              "hz": 113614,
+              "hzLabel": "113.6k ops/s",
+              "mean": 0.008801735472895207,
+              "meanLabel": "8.8μs",
+              "rme": 6.8,
+              "tier": "blazing"
+            },
+            "first() (1,000 items)": {
+              "name": "first() (1,000 items)",
+              "hz": 387650,
+              "hzLabel": "387.6k ops/s",
+              "mean": 0.002579648631437664,
+              "meanLabel": "2.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "last() (1,000 items)": {
+              "name": "last() (1,000 items)",
+              "hz": 381394,
+              "hzLabel": "381.4k ops/s",
+              "mean": 0.0026219599681036724,
+              "meanLabel": "2.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "step(+5) from mid-point (1,000 items)": {
+              "name": "step(+5) from mid-point (1,000 items)",
+              "hz": 116015,
+              "hzLabel": "116.0k ops/s",
+              "mean": 0.008619582867961648,
+              "meanLabel": "8.6μs",
+              "rme": 5.1,
+              "tier": "blazing"
+            },
+            "step(+50) from mid-point (1,000 items)": {
+              "name": "step(+50) from mid-point (1,000 items)",
+              "hz": 120962,
+              "hzLabel": "121.0k ops/s",
+              "mean": 0.008267072419362026,
+              "meanLabel": "8.3μs",
+              "rme": 2.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "first() (1,000 items)",
+              "hz": 387650,
+              "hzLabel": "387.6k ops/s",
+              "mean": 0.002579648631437664,
+              "meanLabel": "2.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "prev() from mid-point (10,000 items)",
+              "hz": 113614,
+              "hzLabel": "113.6k ops/s",
+              "mean": 0.008801735472895207,
+              "meanLabel": "8.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "navigation operations (circular)": {
+            "next() from mid-point circular (1,000 items)": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 117773,
+              "hzLabel": "117.8k ops/s",
+              "mean": 0.008490925212613323,
+              "meanLabel": "8.5μs",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "next() wrapping past end circular (1,000 items)": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 147822,
+              "hzLabel": "147.8k ops/s",
+              "mean": 0.0067649048990739424,
+              "meanLabel": "6.8μs",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "prev() wrapping past start circular (1,000 items)": {
+              "name": "prev() wrapping past start circular (1,000 items)",
+              "hz": 149233,
+              "hzLabel": "149.2k ops/s",
+              "mean": 0.00670092625000757,
+              "meanLabel": "6.7μs",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "prev() wrapping past start circular (1,000 items)",
+              "hz": 149233,
+              "hzLabel": "149.2k ops/s",
+              "mean": 0.00670092625000757,
+              "meanLabel": "6.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 117773,
+              "hzLabel": "117.8k ops/s",
+              "mean": 0.008490925212613323,
+              "meanLabel": "8.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "boundary conditions": {
+            "next() at last item — no-op (1,000 items)": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 250593,
+              "hzLabel": "250.6k ops/s",
+              "mean": 0.0039905417208717445,
+              "meanLabel": "4.0μs",
+              "rme": 4.5,
+              "tier": "blazing"
+            },
+            "prev() at first item — no-op (1,000 items)": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 270510,
+              "hzLabel": "270.5k ops/s",
+              "mean": 0.003696716419230501,
+              "meanLabel": "3.7μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 270510,
+              "hzLabel": "270.5k ops/s",
+              "mean": 0.003696716419230501,
+              "meanLabel": "3.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 250593,
+              "hzLabel": "250.6k ops/s",
+              "mean": 0.0039905417208717445,
+              "meanLabel": "4.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 278401,
+              "hzLabel": "278.4k ops/s",
+              "mean": 0.003591947536315153,
+              "meanLabel": "3.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (10,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (10,000 items, cached)",
+              "hz": 278221,
+              "hzLabel": "278.2k ops/s",
+              "mean": 0.003594266485059425,
+              "meanLabel": "3.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6066,
+              "hzLabel": "6.1k ops/s",
+              "mean": 0.1648607227166051,
+              "meanLabel": "164.9μs",
+              "rme": 6.3,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 271022,
+              "hzLabel": "271.0k ops/s",
+              "mean": 0.0036897403236484947,
+              "meanLabel": "3.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 278401,
+              "hzLabel": "278.4k ops/s",
+              "mean": 0.003591947536315153,
+              "meanLabel": "3.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6066,
+              "hzLabel": "6.1k ops/s",
+              "mean": 0.1648607227166051,
+              "meanLabel": "164.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty step": {
+          "name": "Create empty step",
+          "hz": 27595,
+          "hzLabel": "27.6k ops/s",
+          "mean": 0.0362382440933234,
+          "meanLabel": "36.2μs",
+          "rme": 5.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 729,
+          "hzLabel": "729 ops/s",
+          "mean": 1.3710754794510376,
+          "meanLabel": "1.37ms",
+          "rme": 9.5,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 65,
+          "hzLabel": "65 ops/s",
+          "mean": 15.342930212128328,
+          "meanLabel": "15.34ms",
+          "rme": 8.3,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (circular)": {
+          "name": "Onboard 1,000 items (circular)",
+          "hz": 705,
+          "hzLabel": "705 ops/s",
+          "mean": 1.4189554844188461,
+          "meanLabel": "1.42ms",
+          "rme": 10.4,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 682,
+          "hzLabel": "682 ops/s",
+          "mean": 1.466614363634313,
+          "meanLabel": "1.47ms",
+          "rme": 9.8,
+          "tier": "fast"
+        },
+        "next() from mid-point (1,000 items)": {
+          "name": "next() from mid-point (1,000 items)",
+          "hz": 113747,
+          "hzLabel": "113.7k ops/s",
+          "mean": 0.00879144192430119,
+          "meanLabel": "8.8μs",
+          "rme": 4.8,
+          "tier": "blazing"
+        },
+        "next() from mid-point (10,000 items)": {
+          "name": "next() from mid-point (10,000 items)",
+          "hz": 120953,
+          "hzLabel": "121.0k ops/s",
+          "mean": 0.008267693420585035,
+          "meanLabel": "8.3μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (1,000 items)": {
+          "name": "prev() from mid-point (1,000 items)",
+          "hz": 119455,
+          "hzLabel": "119.5k ops/s",
+          "mean": 0.008371381479511079,
+          "meanLabel": "8.4μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (10,000 items)": {
+          "name": "prev() from mid-point (10,000 items)",
+          "hz": 113614,
+          "hzLabel": "113.6k ops/s",
+          "mean": 0.008801735472895207,
+          "meanLabel": "8.8μs",
+          "rme": 6.8,
+          "tier": "blazing"
+        },
+        "first() (1,000 items)": {
+          "name": "first() (1,000 items)",
+          "hz": 387650,
+          "hzLabel": "387.6k ops/s",
+          "mean": 0.002579648631437664,
+          "meanLabel": "2.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "last() (1,000 items)": {
+          "name": "last() (1,000 items)",
+          "hz": 381394,
+          "hzLabel": "381.4k ops/s",
+          "mean": 0.0026219599681036724,
+          "meanLabel": "2.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "step(+5) from mid-point (1,000 items)": {
+          "name": "step(+5) from mid-point (1,000 items)",
+          "hz": 116015,
+          "hzLabel": "116.0k ops/s",
+          "mean": 0.008619582867961648,
+          "meanLabel": "8.6μs",
+          "rme": 5.1,
+          "tier": "blazing"
+        },
+        "step(+50) from mid-point (1,000 items)": {
+          "name": "step(+50) from mid-point (1,000 items)",
+          "hz": 120962,
+          "hzLabel": "121.0k ops/s",
+          "mean": 0.008267072419362026,
+          "meanLabel": "8.3μs",
+          "rme": 2.7,
+          "tier": "blazing"
+        },
+        "next() from mid-point circular (1,000 items)": {
+          "name": "next() from mid-point circular (1,000 items)",
+          "hz": 117773,
+          "hzLabel": "117.8k ops/s",
+          "mean": 0.008490925212613323,
+          "meanLabel": "8.5μs",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "next() wrapping past end circular (1,000 items)": {
+          "name": "next() wrapping past end circular (1,000 items)",
+          "hz": 147822,
+          "hzLabel": "147.8k ops/s",
+          "mean": 0.0067649048990739424,
+          "meanLabel": "6.8μs",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "prev() wrapping past start circular (1,000 items)": {
+          "name": "prev() wrapping past start circular (1,000 items)",
+          "hz": 149233,
+          "hzLabel": "149.2k ops/s",
+          "mean": 0.00670092625000757,
+          "meanLabel": "6.7μs",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "next() at last item — no-op (1,000 items)": {
+          "name": "next() at last item — no-op (1,000 items)",
+          "hz": 250593,
+          "hzLabel": "250.6k ops/s",
+          "mean": 0.0039905417208717445,
+          "meanLabel": "4.0μs",
+          "rme": 4.5,
+          "tier": "blazing"
+        },
+        "prev() at first item — no-op (1,000 items)": {
+          "name": "prev() at first item — no-op (1,000 items)",
+          "hz": 270510,
+          "hzLabel": "270.5k ops/s",
+          "mean": 0.003696716419230501,
+          "meanLabel": "3.7μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 278401,
+          "hzLabel": "278.4k ops/s",
+          "mean": 0.003591947536315153,
+          "meanLabel": "3.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (10,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (10,000 items, cached)",
+          "hz": 278221,
+          "hzLabel": "278.2k ops/s",
+          "mean": 0.003594266485059425,
+          "meanLabel": "3.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6066,
+          "hzLabel": "6.1k ops/s",
+          "mean": 0.1648607227166051,
+          "meanLabel": "164.9μs",
+          "rme": 6.3,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 271022,
+          "hzLabel": "271.0k ops/s",
+          "mean": 0.0036897403236484947,
+          "meanLabel": "3.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "first() (1,000 items)",
+          "hz": 387650,
+          "hzLabel": "387.6k ops/s",
+          "mean": 0.002579648631437664,
+          "meanLabel": "2.6μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 65,
+          "hzLabel": "65 ops/s",
+          "mean": 15.342930212128328,
+          "meanLabel": "15.34ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createTokens": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create tokens (~100 tokens)": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6224,
+              "hzLabel": "6.2k ops/s",
+              "mean": 0.1606798168378731,
+              "meanLabel": "160.7μs",
+              "rme": 8.6,
+              "tier": "fast"
+            },
+            "Create tokens (1,000 tokens)": {
+              "name": "Create tokens (1,000 tokens)",
+              "hz": 839,
+              "hzLabel": "839 ops/s",
+              "mean": 1.1917790309513554,
+              "meanLabel": "1.19ms",
+              "rme": 5.9,
+              "tier": "fast"
+            },
+            "Create tokens (10,000 tokens)": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 68,
+              "hzLabel": "68 ops/s",
+              "mean": 14.613706857142304,
+              "meanLabel": "14.61ms",
+              "rme": 6.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6224,
+              "hzLabel": "6.2k ops/s",
+              "mean": 0.1606798168378731,
+              "meanLabel": "160.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 68,
+              "hzLabel": "68 ops/s",
+              "mean": 14.613706857142304,
+              "meanLabel": "14.61ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Resolve primitive token": {
+              "name": "Resolve primitive token",
+              "hz": 4026858,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00024833260073854147,
+              "meanLabel": "248ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve nested path (3 levels)": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 3998359,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002501026160806945,
+              "meanLabel": "250ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve deep nested path (5 levels)": {
+              "name": "Resolve deep nested path (5 levels)",
+              "hz": 4034242,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00024787806382800195,
+              "meanLabel": "248ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve by id (1,000 tokens)": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 4074300,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.0002454409103739083,
+              "meanLabel": "245ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve by id (10,000 tokens)": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 4020997,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002486945499535241,
+              "meanLabel": "249ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 4074300,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.0002454409103739083,
+              "meanLabel": "245ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 3998359,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002501026160806945,
+              "meanLabel": "250ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "alias resolution": {
+            "Resolve single alias": {
+              "name": "Resolve single alias",
+              "hz": 4066107,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024593551329409415,
+              "meanLabel": "246ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve chained alias (2 levels)": {
+              "name": "Resolve chained alias (2 levels)",
+              "hz": 4058209,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.0002464141279350411,
+              "meanLabel": "246ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve component alias reference": {
+              "name": "Resolve component alias reference",
+              "hz": 4032807,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00024796623840858684,
+              "meanLabel": "248ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (1,000 tokens)": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 4087765,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024463246867838934,
+              "meanLabel": "245ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve alias (10,000 tokens)": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 4028359,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002482400555190093,
+              "meanLabel": "248ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 4087765,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024463246867838934,
+              "meanLabel": "245ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 4028359,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002482400555190093,
+              "meanLabel": "248ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch resolution": {
+            "Resolve 5 different paths sequentially": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1333771,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007497538820241042,
+              "meanLabel": "750ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve 100 paths (20 unique, repeated)": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 80639,
+              "hzLabel": "80.6k ops/s",
+              "mean": 0.01240087767868144,
+              "meanLabel": "12.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1333771,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007497538820241042,
+              "meanLabel": "750ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 80639,
+              "hzLabel": "80.6k ops/s",
+              "mean": 0.01240087767868144,
+              "meanLabel": "12.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access token 100 times (fixture, cached)": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 87889,
+              "hzLabel": "87.9k ops/s",
+              "mean": 0.011378027011116851,
+              "meanLabel": "11.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access token 100 times (1,000 tokens, cached)": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 90328,
+              "hzLabel": "90.3k ops/s",
+              "mean": 0.01107070311081146,
+              "meanLabel": "11.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access token 100 times (10,000 tokens, cached)": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 90128,
+              "hzLabel": "90.1k ops/s",
+              "mean": 0.01109535103427422,
+              "meanLabel": "11.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 90328,
+              "hzLabel": "90.3k ops/s",
+              "mean": 0.01107070311081146,
+              "meanLabel": "11.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 87889,
+              "hzLabel": "87.9k ops/s",
+              "mean": 0.011378027011116851,
+              "meanLabel": "11.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create tokens (~100 tokens)": {
+          "name": "Create tokens (~100 tokens)",
+          "hz": 6224,
+          "hzLabel": "6.2k ops/s",
+          "mean": 0.1606798168378731,
+          "meanLabel": "160.7μs",
+          "rme": 8.6,
+          "tier": "fast"
+        },
+        "Create tokens (1,000 tokens)": {
+          "name": "Create tokens (1,000 tokens)",
+          "hz": 839,
+          "hzLabel": "839 ops/s",
+          "mean": 1.1917790309513554,
+          "meanLabel": "1.19ms",
+          "rme": 5.9,
+          "tier": "fast"
+        },
+        "Create tokens (10,000 tokens)": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 68,
+          "hzLabel": "68 ops/s",
+          "mean": 14.613706857142304,
+          "meanLabel": "14.61ms",
+          "rme": 6.1,
+          "tier": "fast"
+        },
+        "Resolve primitive token": {
+          "name": "Resolve primitive token",
+          "hz": 4026858,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00024833260073854147,
+          "meanLabel": "248ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve nested path (3 levels)": {
+          "name": "Resolve nested path (3 levels)",
+          "hz": 3998359,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002501026160806945,
+          "meanLabel": "250ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve deep nested path (5 levels)": {
+          "name": "Resolve deep nested path (5 levels)",
+          "hz": 4034242,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00024787806382800195,
+          "meanLabel": "248ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve by id (1,000 tokens)": {
+          "name": "Resolve by id (1,000 tokens)",
+          "hz": 4074300,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.0002454409103739083,
+          "meanLabel": "245ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve by id (10,000 tokens)": {
+          "name": "Resolve by id (10,000 tokens)",
+          "hz": 4020997,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002486945499535241,
+          "meanLabel": "249ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve single alias": {
+          "name": "Resolve single alias",
+          "hz": 4066107,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.00024593551329409415,
+          "meanLabel": "246ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve chained alias (2 levels)": {
+          "name": "Resolve chained alias (2 levels)",
+          "hz": 4058209,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.0002464141279350411,
+          "meanLabel": "246ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve component alias reference": {
+          "name": "Resolve component alias reference",
+          "hz": 4032807,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00024796623840858684,
+          "meanLabel": "248ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (1,000 tokens)": {
+          "name": "Resolve alias (1,000 tokens)",
+          "hz": 4087765,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.00024463246867838934,
+          "meanLabel": "245ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve alias (10,000 tokens)": {
+          "name": "Resolve alias (10,000 tokens)",
+          "hz": 4028359,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002482400555190093,
+          "meanLabel": "248ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve 5 different paths sequentially": {
+          "name": "Resolve 5 different paths sequentially",
+          "hz": 1333771,
+          "hzLabel": "1.3M ops/s",
+          "mean": 0.0007497538820241042,
+          "meanLabel": "750ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve 100 paths (20 unique, repeated)": {
+          "name": "Resolve 100 paths (20 unique, repeated)",
+          "hz": 80639,
+          "hzLabel": "80.6k ops/s",
+          "mean": 0.01240087767868144,
+          "meanLabel": "12.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (fixture, cached)": {
+          "name": "Access token 100 times (fixture, cached)",
+          "hz": 87889,
+          "hzLabel": "87.9k ops/s",
+          "mean": 0.011378027011116851,
+          "meanLabel": "11.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (1,000 tokens, cached)": {
+          "name": "Access token 100 times (1,000 tokens, cached)",
+          "hz": 90328,
+          "hzLabel": "90.3k ops/s",
+          "mean": 0.01107070311081146,
+          "meanLabel": "11.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (10,000 tokens, cached)": {
+          "name": "Access token 100 times (10,000 tokens, cached)",
+          "hz": 90128,
+          "hzLabel": "90.1k ops/s",
+          "mean": 0.01109535103427422,
+          "meanLabel": "11.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Resolve alias (1,000 tokens)",
+          "hz": 4087765,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.00024463246867838934,
+          "meanLabel": "245ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 68,
+          "hzLabel": "68 ops/s",
+          "mean": 14.613706857142304,
+          "meanLabel": "14.61ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createVirtual": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create virtual (1,000 items)": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8715,
+              "hzLabel": "8.7k ops/s",
+              "mean": 0.114743156494235,
+              "meanLabel": "114.7μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Create virtual (10,000 items)": {
+              "name": "Create virtual (10,000 items)",
+              "hz": 967,
+              "hzLabel": "967 ops/s",
+              "mean": 1.0341941301646203,
+              "meanLabel": "1.03ms",
+              "rme": 4.3,
+              "tier": "blazing"
+            },
+            "Create virtual (100,000 items)": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.701489872336289,
+              "meanLabel": "10.70ms",
+              "rme": 8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8715,
+              "hzLabel": "8.7k ops/s",
+              "mean": 0.114743156494235,
+              "meanLabel": "114.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.701489872336289,
+              "meanLabel": "10.70ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scroll operations": {
+            "Scroll to start position (1,000 items)": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 464744,
+              "hzLabel": "464.7k ops/s",
+              "mean": 0.002151721684490383,
+              "meanLabel": "2.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Scroll to start position (10,000 items)": {
+              "name": "Scroll to start position (10,000 items)",
+              "hz": 452810,
+              "hzLabel": "452.8k ops/s",
+              "mean": 0.00220843086313308,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (1,000 items)": {
+              "name": "Scroll to middle position (1,000 items)",
+              "hz": 446646,
+              "hzLabel": "446.6k ops/s",
+              "mean": 0.0022389099649528744,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (10,000 items)": {
+              "name": "Scroll to middle position (10,000 items)",
+              "hz": 445609,
+              "hzLabel": "445.6k ops/s",
+              "mean": 0.00224411759601676,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (1,000 items)": {
+              "name": "Scroll to end position (1,000 items)",
+              "hz": 447318,
+              "hzLabel": "447.3k ops/s",
+              "mean": 0.002235545452941,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (10,000 items)": {
+              "name": "Scroll to end position (10,000 items)",
+              "hz": 442945,
+              "hzLabel": "442.9k ops/s",
+              "mean": 0.0022576142960929724,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (1,000 items)": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4809,
+              "hzLabel": "4.8k ops/s",
+              "mean": 0.20792728357678744,
+              "meanLabel": "207.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (10,000 items)": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4826,
+              "hzLabel": "4.8k ops/s",
+              "mean": 0.20719657746468578,
+              "meanLabel": "207.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 464744,
+              "hzLabel": "464.7k ops/s",
+              "mean": 0.002151721684490383,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4809,
+              "hzLabel": "4.8k ops/s",
+              "mean": 0.20792728357678744,
+              "meanLabel": "207.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "resize operations": {
+            "Resize single item (1,000 items)": {
+              "name": "Resize single item (1,000 items)",
+              "hz": 1108081,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000902461047082571,
+              "meanLabel": "902ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize single item (10,000 items)": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1123275,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000890254101348156,
+              "meanLabel": "890ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (1,000 items)": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 12721,
+              "hzLabel": "12.7k ops/s",
+              "mean": 0.07861215374997468,
+              "meanLabel": "78.6μs",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (10,000 items)": {
+              "name": "Resize 100 items sequentially (10,000 items)",
+              "hz": 13278,
+              "hzLabel": "13.3k ops/s",
+              "mean": 0.07531008358423441,
+              "meanLabel": "75.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize with variable heights (1,000 items)": {
+              "name": "Resize with variable heights (1,000 items)",
+              "hz": 13059,
+              "hzLabel": "13.1k ops/s",
+              "mean": 0.07657471730463473,
+              "meanLabel": "76.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1123275,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000890254101348156,
+              "meanLabel": "890ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 12721,
+              "hzLabel": "12.7k ops/s",
+              "mean": 0.07861215374997468,
+              "meanLabel": "78.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scrollTo operations": {
+            "ScrollTo start (1,000 items)": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 439656,
+              "hzLabel": "439.7k ops/s",
+              "mean": 0.002274505718102018,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo start (10,000 items)": {
+              "name": "ScrollTo start (10,000 items)",
+              "hz": 437522,
+              "hzLabel": "437.5k ops/s",
+              "mean": 0.0022855979421399965,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (1,000 items)": {
+              "name": "ScrollTo middle (1,000 items)",
+              "hz": 422661,
+              "hzLabel": "422.7k ops/s",
+              "mean": 0.0023659632945817635,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (10,000 items)": {
+              "name": "ScrollTo middle (10,000 items)",
+              "hz": 420656,
+              "hzLabel": "420.7k ops/s",
+              "mean": 0.002377240115417655,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (1,000 items)": {
+              "name": "ScrollTo end (1,000 items)",
+              "hz": 425257,
+              "hzLabel": "425.3k ops/s",
+              "mean": 0.0023515200937898892,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (10,000 items)": {
+              "name": "ScrollTo end (10,000 items)",
+              "hz": 423778,
+              "hzLabel": "423.8k ops/s",
+              "mean": 0.0023597282160952994,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo 5 positions (10,000 items)": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 84895,
+              "hzLabel": "84.9k ops/s",
+              "mean": 0.01177927516007095,
+              "meanLabel": "11.8μs",
+              "rme": 1.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 439656,
+              "hzLabel": "439.7k ops/s",
+              "mean": 0.002274505718102018,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 84895,
+              "hzLabel": "84.9k ops/s",
+              "mean": 0.01177927516007095,
+              "meanLabel": "11.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 1067236,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000936999437821631,
+              "meanLabel": "937ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1065829,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009382368388719648,
+              "meanLabel": "938ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (1,000 items, cached)": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 51754,
+              "hzLabel": "51.8k ops/s",
+              "mean": 0.01932208354570918,
+              "meanLabel": "19.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (10,000 items, cached)": {
+              "name": "Access offset 100 times (10,000 items, cached)",
+              "hz": 51902,
+              "hzLabel": "51.9k ops/s",
+              "mean": 0.01926711937864491,
+              "meanLabel": "19.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (1,000 items, cached)": {
+              "name": "Access size 100 times (1,000 items, cached)",
+              "hz": 51892,
+              "hzLabel": "51.9k ops/s",
+              "mean": 0.019270917752231793,
+              "meanLabel": "19.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (10,000 items, cached)": {
+              "name": "Access size 100 times (10,000 items, cached)",
+              "hz": 51949,
+              "hzLabel": "51.9k ops/s",
+              "mean": 0.019249814514158595,
+              "meanLabel": "19.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 1067236,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000936999437821631,
+              "meanLabel": "937ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 51754,
+              "hzLabel": "51.8k ops/s",
+              "mean": 0.01932208354570918,
+              "meanLabel": "19.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create virtual (1,000 items)": {
+          "name": "Create virtual (1,000 items)",
+          "hz": 8715,
+          "hzLabel": "8.7k ops/s",
+          "mean": 0.114743156494235,
+          "meanLabel": "114.7μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Create virtual (10,000 items)": {
+          "name": "Create virtual (10,000 items)",
+          "hz": 967,
+          "hzLabel": "967 ops/s",
+          "mean": 1.0341941301646203,
+          "meanLabel": "1.03ms",
+          "rme": 4.3,
+          "tier": "blazing"
+        },
+        "Create virtual (100,000 items)": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 93,
+          "hzLabel": "93 ops/s",
+          "mean": 10.701489872336289,
+          "meanLabel": "10.70ms",
+          "rme": 8,
+          "tier": "blazing"
+        },
+        "Scroll to start position (1,000 items)": {
+          "name": "Scroll to start position (1,000 items)",
+          "hz": 464744,
+          "hzLabel": "464.7k ops/s",
+          "mean": 0.002151721684490383,
+          "meanLabel": "2.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Scroll to start position (10,000 items)": {
+          "name": "Scroll to start position (10,000 items)",
+          "hz": 452810,
+          "hzLabel": "452.8k ops/s",
+          "mean": 0.00220843086313308,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (1,000 items)": {
+          "name": "Scroll to middle position (1,000 items)",
+          "hz": 446646,
+          "hzLabel": "446.6k ops/s",
+          "mean": 0.0022389099649528744,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (10,000 items)": {
+          "name": "Scroll to middle position (10,000 items)",
+          "hz": 445609,
+          "hzLabel": "445.6k ops/s",
+          "mean": 0.00224411759601676,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (1,000 items)": {
+          "name": "Scroll to end position (1,000 items)",
+          "hz": 447318,
+          "hzLabel": "447.3k ops/s",
+          "mean": 0.002235545452941,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (10,000 items)": {
+          "name": "Scroll to end position (10,000 items)",
+          "hz": 442945,
+          "hzLabel": "442.9k ops/s",
+          "mean": 0.0022576142960929724,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (1,000 items)": {
+          "name": "Process 100 scroll events (1,000 items)",
+          "hz": 4809,
+          "hzLabel": "4.8k ops/s",
+          "mean": 0.20792728357678744,
+          "meanLabel": "207.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (10,000 items)": {
+          "name": "Process 100 scroll events (10,000 items)",
+          "hz": 4826,
+          "hzLabel": "4.8k ops/s",
+          "mean": 0.20719657746468578,
+          "meanLabel": "207.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resize single item (1,000 items)": {
+          "name": "Resize single item (1,000 items)",
+          "hz": 1108081,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000902461047082571,
+          "meanLabel": "902ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize single item (10,000 items)": {
+          "name": "Resize single item (10,000 items)",
+          "hz": 1123275,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000890254101348156,
+          "meanLabel": "890ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (1,000 items)": {
+          "name": "Resize 100 items sequentially (1,000 items)",
+          "hz": 12721,
+          "hzLabel": "12.7k ops/s",
+          "mean": 0.07861215374997468,
+          "meanLabel": "78.6μs",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (10,000 items)": {
+          "name": "Resize 100 items sequentially (10,000 items)",
+          "hz": 13278,
+          "hzLabel": "13.3k ops/s",
+          "mean": 0.07531008358423441,
+          "meanLabel": "75.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize with variable heights (1,000 items)": {
+          "name": "Resize with variable heights (1,000 items)",
+          "hz": 13059,
+          "hzLabel": "13.1k ops/s",
+          "mean": 0.07657471730463473,
+          "meanLabel": "76.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "ScrollTo start (1,000 items)": {
+          "name": "ScrollTo start (1,000 items)",
+          "hz": 439656,
+          "hzLabel": "439.7k ops/s",
+          "mean": 0.002274505718102018,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo start (10,000 items)": {
+          "name": "ScrollTo start (10,000 items)",
+          "hz": 437522,
+          "hzLabel": "437.5k ops/s",
+          "mean": 0.0022855979421399965,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (1,000 items)": {
+          "name": "ScrollTo middle (1,000 items)",
+          "hz": 422661,
+          "hzLabel": "422.7k ops/s",
+          "mean": 0.0023659632945817635,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (10,000 items)": {
+          "name": "ScrollTo middle (10,000 items)",
+          "hz": 420656,
+          "hzLabel": "420.7k ops/s",
+          "mean": 0.002377240115417655,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (1,000 items)": {
+          "name": "ScrollTo end (1,000 items)",
+          "hz": 425257,
+          "hzLabel": "425.3k ops/s",
+          "mean": 0.0023515200937898892,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (10,000 items)": {
+          "name": "ScrollTo end (10,000 items)",
+          "hz": 423778,
+          "hzLabel": "423.8k ops/s",
+          "mean": 0.0023597282160952994,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo 5 positions (10,000 items)": {
+          "name": "ScrollTo 5 positions (10,000 items)",
+          "hz": 84895,
+          "hzLabel": "84.9k ops/s",
+          "mean": 0.01177927516007095,
+          "meanLabel": "11.8μs",
+          "rme": 1.3,
+          "tier": "blazing"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 1067236,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000936999437821631,
+          "meanLabel": "937ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1065829,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009382368388719648,
+          "meanLabel": "938ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (1,000 items, cached)": {
+          "name": "Access offset 100 times (1,000 items, cached)",
+          "hz": 51754,
+          "hzLabel": "51.8k ops/s",
+          "mean": 0.01932208354570918,
+          "meanLabel": "19.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (10,000 items, cached)": {
+          "name": "Access offset 100 times (10,000 items, cached)",
+          "hz": 51902,
+          "hzLabel": "51.9k ops/s",
+          "mean": 0.01926711937864491,
+          "meanLabel": "19.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (1,000 items, cached)": {
+          "name": "Access size 100 times (1,000 items, cached)",
+          "hz": 51892,
+          "hzLabel": "51.9k ops/s",
+          "mean": 0.019270917752231793,
+          "meanLabel": "19.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (10,000 items, cached)": {
+          "name": "Access size 100 times (10,000 items, cached)",
+          "hz": 51949,
+          "hzLabel": "51.9k ops/s",
+          "mean": 0.019249814514158595,
+          "meanLabel": "19.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Resize single item (10,000 items)",
+          "hz": 1123275,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000890254101348156,
+          "meanLabel": "890ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 93,
+          "hzLabel": "93 ops/s",
+          "mean": 10.701489872336289,
+          "meanLabel": "10.70ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "useDate": {
+      "benchmarks": {
+        "_groups": {
+          "construction": {
+            "create date from null (now)": {
+              "name": "create date from null (now)",
+              "hz": 702987,
+              "hzLabel": "703.0k ops/s",
+              "mean": 0.0014225005405663245,
+              "meanLabel": "1.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "create date from ISO string": {
+              "name": "create date from ISO string",
+              "hz": 1506631,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006637325518264512,
+              "meanLabel": "664ns",
+              "rme": 19.5,
+              "tier": "blazing"
+            },
+            "create date from timestamp": {
+              "name": "create date from timestamp",
+              "hz": 683216,
+              "hzLabel": "683.2k ops/s",
+              "mean": 0.0014636663439810784,
+              "meanLabel": "1.5μs",
+              "rme": 12.5,
+              "tier": "blazing"
+            },
+            "create 1000 dates": {
+              "name": "create 1000 dates",
+              "hz": 1962,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.5096535274955489,
+              "meanLabel": "509.7μs",
+              "rme": 19.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "create date from ISO string",
+              "hz": 1506631,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006637325518264512,
+              "meanLabel": "664ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "create 1000 dates",
+              "hz": 1962,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.5096535274955489,
+              "meanLabel": "509.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "formatting": {
+            "format fullDate": {
+              "name": "format fullDate",
+              "hz": 532763,
+              "hzLabel": "532.8k ops/s",
+              "mean": 0.0018770084464942267,
+              "meanLabel": "1.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format shortDate": {
+              "name": "format shortDate",
+              "hz": 510572,
+              "hzLabel": "510.6k ops/s",
+              "mean": 0.0019585889668280805,
+              "meanLabel": "2.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "format 1000 dates": {
+              "name": "format 1000 dates",
+              "hz": 569,
+              "hzLabel": "569 ops/s",
+              "mean": 1.756319554384569,
+              "meanLabel": "1.76ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "format fullDate",
+              "hz": 532763,
+              "hzLabel": "532.8k ops/s",
+              "mean": 0.0018770084464942267,
+              "meanLabel": "1.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "format 1000 dates",
+              "hz": 569,
+              "hzLabel": "569 ops/s",
+              "mean": 1.756319554384569,
+              "meanLabel": "1.76ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation": {
+            "startOfDay": {
+              "name": "startOfDay",
+              "hz": 1102069,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009073839374837243,
+              "meanLabel": "907ns",
+              "rme": 10.2,
+              "tier": "blazing"
+            },
+            "startOfWeek": {
+              "name": "startOfWeek",
+              "hz": 488805,
+              "hzLabel": "488.8k ops/s",
+              "mean": 0.002045807043434469,
+              "meanLabel": "2.0μs",
+              "rme": 19.9,
+              "tier": "blazing"
+            },
+            "startOfMonth": {
+              "name": "startOfMonth",
+              "hz": 594646,
+              "hzLabel": "594.6k ops/s",
+              "mean": 0.001681671530022352,
+              "meanLabel": "1.7μs",
+              "rme": 15.7,
+              "tier": "blazing"
+            },
+            "getWeekArray": {
+              "name": "getWeekArray",
+              "hz": 17454,
+              "hzLabel": "17.5k ops/s",
+              "mean": 0.057291968721746966,
+              "meanLabel": "57.3μs",
+              "rme": 33.9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "startOfDay",
+              "hz": 1102069,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009073839374837243,
+              "meanLabel": "907ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "getWeekArray",
+              "hz": 17454,
+              "hzLabel": "17.5k ops/s",
+              "mean": 0.057291968721746966,
+              "meanLabel": "57.3μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "arithmetic": {
+            "addDays": {
+              "name": "addDays",
+              "hz": 747010,
+              "hzLabel": "747.0k ops/s",
+              "mean": 0.001338670290920634,
+              "meanLabel": "1.3μs",
+              "rme": 29.1,
+              "tier": "blazing"
+            },
+            "addMonths": {
+              "name": "addMonths",
+              "hz": 940700,
+              "hzLabel": "940.7k ops/s",
+              "mean": 0.0010630381864956831,
+              "meanLabel": "1.1μs",
+              "rme": 8.1,
+              "tier": "blazing"
+            },
+            "chain 10 additions": {
+              "name": "chain 10 additions",
+              "hz": 87657,
+              "hzLabel": "87.7k ops/s",
+              "mean": 0.011408142274132676,
+              "meanLabel": "11.4μs",
+              "rme": 36.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "addMonths",
+              "hz": 940700,
+              "hzLabel": "940.7k ops/s",
+              "mean": 0.0010630381864956831,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "chain 10 additions",
+              "hz": 87657,
+              "hzLabel": "87.7k ops/s",
+              "mean": 0.011408142274132676,
+              "meanLabel": "11.4μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "comparison": {
+            "isAfter": {
+              "name": "isAfter",
+              "hz": 1261774,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007925350403269244,
+              "meanLabel": "793ns",
+              "rme": 31,
+              "tier": "blazing"
+            },
+            "isSameDay": {
+              "name": "isSameDay",
+              "hz": 710196,
+              "hzLabel": "710.2k ops/s",
+              "mean": 0.0014080623938893012,
+              "meanLabel": "1.4μs",
+              "rme": 39.4,
+              "tier": "blazing"
+            },
+            "compare 1000 pairs": {
+              "name": "compare 1000 pairs",
+              "hz": 1449,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6901535889650052,
+              "meanLabel": "690.2μs",
+              "rme": 51.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "isAfter",
+              "hz": 1261774,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007925350403269244,
+              "meanLabel": "793ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "compare 1000 pairs",
+              "hz": 1449,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6901535889650052,
+              "meanLabel": "690.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "getters/setters": {
+            "get components": {
+              "name": "get components",
+              "hz": 5627278,
+              "hzLabel": "5.6M ops/s",
+              "mean": 0.00017770579637773522,
+              "meanLabel": "178ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "set components": {
+              "name": "set components",
+              "hz": 380052,
+              "hzLabel": "380.1k ops/s",
+              "mean": 0.002631220469771747,
+              "meanLabel": "2.6μs",
+              "rme": 21.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "get components",
+              "hz": 5627278,
+              "hzLabel": "5.6M ops/s",
+              "mean": 0.00017770579637773522,
+              "meanLabel": "178ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "set components",
+              "hz": 380052,
+              "hzLabel": "380.1k ops/s",
+              "mean": 0.002631220469771747,
+              "meanLabel": "2.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "locale switching": {
+            "locale change + reformat": {
+              "name": "locale change + reformat",
+              "hz": 18046,
+              "hzLabel": "18.0k ops/s",
+              "mean": 0.055413667109944255,
+              "meanLabel": "55.4μs",
+              "rme": 2.6,
+              "tier": "fast"
+            },
+            "toggle locale 10 times": {
+              "name": "toggle locale 10 times",
+              "hz": 1422,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7031460294937859,
+              "meanLabel": "703.1μs",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "cache eviction (60 unique formats)": {
+              "name": "cache eviction (60 unique formats)",
+              "hz": 13361,
+              "hzLabel": "13.4k ops/s",
+              "mean": 0.07484676455648494,
+              "meanLabel": "74.8μs",
+              "rme": 0.7,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "locale change + reformat",
+              "hz": 18046,
+              "hzLabel": "18.0k ops/s",
+              "mean": 0.055413667109944255,
+              "meanLabel": "55.4μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "toggle locale 10 times",
+              "hz": 1422,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7031460294937859,
+              "meanLabel": "703.1μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          }
+        },
+        "create date from null (now)": {
+          "name": "create date from null (now)",
+          "hz": 702987,
+          "hzLabel": "703.0k ops/s",
+          "mean": 0.0014225005405663245,
+          "meanLabel": "1.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "create date from ISO string": {
+          "name": "create date from ISO string",
+          "hz": 1506631,
+          "hzLabel": "1.5M ops/s",
+          "mean": 0.0006637325518264512,
+          "meanLabel": "664ns",
+          "rme": 19.5,
+          "tier": "blazing"
+        },
+        "create date from timestamp": {
+          "name": "create date from timestamp",
+          "hz": 683216,
+          "hzLabel": "683.2k ops/s",
+          "mean": 0.0014636663439810784,
+          "meanLabel": "1.5μs",
+          "rme": 12.5,
+          "tier": "blazing"
+        },
+        "create 1000 dates": {
+          "name": "create 1000 dates",
+          "hz": 1962,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.5096535274955489,
+          "meanLabel": "509.7μs",
+          "rme": 19.7,
+          "tier": "blazing"
+        },
+        "format fullDate": {
+          "name": "format fullDate",
+          "hz": 532763,
+          "hzLabel": "532.8k ops/s",
+          "mean": 0.0018770084464942267,
+          "meanLabel": "1.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format shortDate": {
+          "name": "format shortDate",
+          "hz": 510572,
+          "hzLabel": "510.6k ops/s",
+          "mean": 0.0019585889668280805,
+          "meanLabel": "2.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "format 1000 dates": {
+          "name": "format 1000 dates",
+          "hz": 569,
+          "hzLabel": "569 ops/s",
+          "mean": 1.756319554384569,
+          "meanLabel": "1.76ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "startOfDay": {
+          "name": "startOfDay",
+          "hz": 1102069,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009073839374837243,
+          "meanLabel": "907ns",
+          "rme": 10.2,
+          "tier": "blazing"
+        },
+        "startOfWeek": {
+          "name": "startOfWeek",
+          "hz": 488805,
+          "hzLabel": "488.8k ops/s",
+          "mean": 0.002045807043434469,
+          "meanLabel": "2.0μs",
+          "rme": 19.9,
+          "tier": "blazing"
+        },
+        "startOfMonth": {
+          "name": "startOfMonth",
+          "hz": 594646,
+          "hzLabel": "594.6k ops/s",
+          "mean": 0.001681671530022352,
+          "meanLabel": "1.7μs",
+          "rme": 15.7,
+          "tier": "blazing"
+        },
+        "getWeekArray": {
+          "name": "getWeekArray",
+          "hz": 17454,
+          "hzLabel": "17.5k ops/s",
+          "mean": 0.057291968721746966,
+          "meanLabel": "57.3μs",
+          "rme": 33.9,
+          "tier": "fast"
+        },
+        "addDays": {
+          "name": "addDays",
+          "hz": 747010,
+          "hzLabel": "747.0k ops/s",
+          "mean": 0.001338670290920634,
+          "meanLabel": "1.3μs",
+          "rme": 29.1,
+          "tier": "blazing"
+        },
+        "addMonths": {
+          "name": "addMonths",
+          "hz": 940700,
+          "hzLabel": "940.7k ops/s",
+          "mean": 0.0010630381864956831,
+          "meanLabel": "1.1μs",
+          "rme": 8.1,
+          "tier": "blazing"
+        },
+        "chain 10 additions": {
+          "name": "chain 10 additions",
+          "hz": 87657,
+          "hzLabel": "87.7k ops/s",
+          "mean": 0.011408142274132676,
+          "meanLabel": "11.4μs",
+          "rme": 36.2,
+          "tier": "fast"
+        },
+        "isAfter": {
+          "name": "isAfter",
+          "hz": 1261774,
+          "hzLabel": "1.3M ops/s",
+          "mean": 0.0007925350403269244,
+          "meanLabel": "793ns",
+          "rme": 31,
+          "tier": "blazing"
+        },
+        "isSameDay": {
+          "name": "isSameDay",
+          "hz": 710196,
+          "hzLabel": "710.2k ops/s",
+          "mean": 0.0014080623938893012,
+          "meanLabel": "1.4μs",
+          "rme": 39.4,
+          "tier": "blazing"
+        },
+        "compare 1000 pairs": {
+          "name": "compare 1000 pairs",
+          "hz": 1449,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.6901535889650052,
+          "meanLabel": "690.2μs",
+          "rme": 51.8,
+          "tier": "blazing"
+        },
+        "get components": {
+          "name": "get components",
+          "hz": 5627278,
+          "hzLabel": "5.6M ops/s",
+          "mean": 0.00017770579637773522,
+          "meanLabel": "178ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "set components": {
+          "name": "set components",
+          "hz": 380052,
+          "hzLabel": "380.1k ops/s",
+          "mean": 0.002631220469771747,
+          "meanLabel": "2.6μs",
+          "rme": 21.6,
+          "tier": "blazing"
+        },
+        "locale change + reformat": {
+          "name": "locale change + reformat",
+          "hz": 18046,
+          "hzLabel": "18.0k ops/s",
+          "mean": 0.055413667109944255,
+          "meanLabel": "55.4μs",
+          "rme": 2.6,
+          "tier": "fast"
+        },
+        "toggle locale 10 times": {
+          "name": "toggle locale 10 times",
+          "hz": 1422,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.7031460294937859,
+          "meanLabel": "703.1μs",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "cache eviction (60 unique formats)": {
+          "name": "cache eviction (60 unique formats)",
+          "hz": 13361,
+          "hzLabel": "13.4k ops/s",
+          "mean": 0.07484676455648494,
+          "meanLabel": "74.8μs",
+          "rme": 0.7,
+          "tier": "fast"
+        },
+        "_fastest": {
+          "name": "get components",
+          "hz": 5627278,
+          "hzLabel": "5.6M ops/s",
+          "mean": 0.00017770579637773522,
+          "meanLabel": "178ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "format 1000 dates",
+          "hz": 569,
+          "hzLabel": "569 ops/s",
+          "mean": 1.756319554384569,
+          "meanLabel": "1.76ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "useProxyRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty proxy": {
+              "name": "Create empty proxy",
+              "hz": 110933,
+              "hzLabel": "110.9k ops/s",
+              "mean": 0.009014428146396584,
+              "meanLabel": "9.0μs",
+              "rme": 14.2,
+              "tier": "blazing"
+            },
+            "Create proxy (1,000 items)": {
+              "name": "Create proxy (1,000 items)",
+              "hz": 2243,
+              "hzLabel": "2.2k ops/s",
+              "mean": 0.4457781007133653,
+              "meanLabel": "445.8μs",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "Create proxy (10,000 items)": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 180,
+              "hzLabel": "180 ops/s",
+              "mean": 5.569822199998695,
+              "meanLabel": "5.57ms",
+              "rme": 9.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty proxy",
+              "hz": 110933,
+              "hzLabel": "110.9k ops/s",
+              "mean": 0.009014428146396584,
+              "meanLabel": "9.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 180,
+              "hzLabel": "180 ops/s",
+              "mean": 5.569822199998695,
+              "meanLabel": "5.57ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "registry.keys() (1,000 items)": {
+              "name": "registry.keys() (1,000 items)",
+              "hz": 7267089,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013760667613281765,
+              "meanLabel": "138ns",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "proxy.keys (1,000 items)": {
+              "name": "proxy.keys (1,000 items)",
+              "hz": 2727631,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.0003666185709881544,
+              "meanLabel": "367ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.keys() (10,000 items)": {
+              "name": "registry.keys() (10,000 items)",
+              "hz": 7272998,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013749488971611385,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.keys (10,000 items)": {
+              "name": "proxy.keys (10,000 items)",
+              "hz": 2732884,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.0003659137754144121,
+              "meanLabel": "366ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.values() (1,000 items)": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7289222,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013718885994469044,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.values (1,000 items)": {
+              "name": "proxy.values (1,000 items)",
+              "hz": 2747793,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.0003639283993021274,
+              "meanLabel": "364ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.values() (10,000 items)": {
+              "name": "registry.values() (10,000 items)",
+              "hz": 7218259,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013853756056663992,
+              "meanLabel": "139ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.values (10,000 items)": {
+              "name": "proxy.values (10,000 items)",
+              "hz": 2736092,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.0003654847837721149,
+              "meanLabel": "365ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.entries() (1,000 items)": {
+              "name": "registry.entries() (1,000 items)",
+              "hz": 7239228,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001381362759880567,
+              "meanLabel": "138ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.entries (1,000 items)": {
+              "name": "proxy.entries (1,000 items)",
+              "hz": 2747379,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.000363983310651115,
+              "meanLabel": "364ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.entries() (10,000 items)": {
+              "name": "registry.entries() (10,000 items)",
+              "hz": 7129741,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001402575462059306,
+              "meanLabel": "140ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.entries (10,000 items)": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 2717334,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.0003680078010403408,
+              "meanLabel": "368ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "proxy.size (1,000 items)": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 2701158,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.00037021158466589546,
+              "meanLabel": "370ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "proxy.size (10,000 items)": {
+              "name": "proxy.size (10,000 items)",
+              "hz": 2740229,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.00036493300708634053,
+              "meanLabel": "365ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7289222,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013718885994469044,
+              "meanLabel": "137ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 2701158,
+              "hzLabel": "2.7M ops/s",
+              "mean": 0.00037021158466589546,
+              "meanLabel": "370ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single item (1,000 items)": {
+              "name": "Register single item (1,000 items)",
+              "hz": 138915,
+              "hzLabel": "138.9k ops/s",
+              "mean": 0.007198629070818855,
+              "meanLabel": "7.2μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Register single item (10,000 items)": {
+              "name": "Register single item (10,000 items)",
+              "hz": 21699,
+              "hzLabel": "21.7k ops/s",
+              "mean": 0.046084817343948675,
+              "meanLabel": "46.1μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Unregister single item (1,000 items)": {
+              "name": "Unregister single item (1,000 items)",
+              "hz": 2185,
+              "hzLabel": "2.2k ops/s",
+              "mean": 0.4575933092406909,
+              "meanLabel": "457.6μs",
+              "rme": 10.9,
+              "tier": "blazing"
+            },
+            "Unregister single item (10,000 items)": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 160,
+              "hzLabel": "160 ops/s",
+              "mean": 6.262083149999671,
+              "meanLabel": "6.26ms",
+              "rme": 12.7,
+              "tier": "blazing"
+            },
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 569962,
+              "hzLabel": "570.0k ops/s",
+              "mean": 0.0017545041494098285,
+              "meanLabel": "1.8μs",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 47513,
+              "hzLabel": "47.5k ops/s",
+              "mean": 0.021046721693659953,
+              "meanLabel": "21.0μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 569962,
+              "hzLabel": "570.0k ops/s",
+              "mean": 0.0017545041494098285,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 160,
+              "hzLabel": "160 ops/s",
+              "mean": 6.262083149999671,
+              "meanLabel": "6.26ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "bulk registration": {
+            "Onboard 1,000 items (proxy attached)": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1733,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5769473287199582,
+              "meanLabel": "576.9μs",
+              "rme": 10.1,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items (proxy attached)": {
+              "name": "Onboard 10,000 items (proxy attached)",
+              "hz": 127,
+              "hzLabel": "127 ops/s",
+              "mean": 7.894945124998685,
+              "meanLabel": "7.89ms",
+              "rme": 12,
+              "tier": "blazing"
+            },
+            "Register 1,000 items one-by-one (proxy attached)": {
+              "name": "Register 1,000 items one-by-one (proxy attached)",
+              "hz": 1486,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6729872032303851,
+              "meanLabel": "673.0μs",
+              "rme": 9,
+              "tier": "blazing"
+            },
+            "Register 10,000 items one-by-one (proxy attached)": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 120,
+              "hzLabel": "120 ops/s",
+              "mean": 8.346250783334835,
+              "meanLabel": "8.35ms",
+              "rme": 13.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1733,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5769473287199582,
+              "meanLabel": "576.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 120,
+              "hzLabel": "120 ops/s",
+              "mean": 8.346250783334835,
+              "meanLabel": "8.35ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty proxy": {
+          "name": "Create empty proxy",
+          "hz": 110933,
+          "hzLabel": "110.9k ops/s",
+          "mean": 0.009014428146396584,
+          "meanLabel": "9.0μs",
+          "rme": 14.2,
+          "tier": "blazing"
+        },
+        "Create proxy (1,000 items)": {
+          "name": "Create proxy (1,000 items)",
+          "hz": 2243,
+          "hzLabel": "2.2k ops/s",
+          "mean": 0.4457781007133653,
+          "meanLabel": "445.8μs",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Create proxy (10,000 items)": {
+          "name": "Create proxy (10,000 items)",
+          "hz": 180,
+          "hzLabel": "180 ops/s",
+          "mean": 5.569822199998695,
+          "meanLabel": "5.57ms",
+          "rme": 9.9,
+          "tier": "blazing"
+        },
+        "registry.keys() (1,000 items)": {
+          "name": "registry.keys() (1,000 items)",
+          "hz": 7267089,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013760667613281765,
+          "meanLabel": "138ns",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "proxy.keys (1,000 items)": {
+          "name": "proxy.keys (1,000 items)",
+          "hz": 2727631,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.0003666185709881544,
+          "meanLabel": "367ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.keys() (10,000 items)": {
+          "name": "registry.keys() (10,000 items)",
+          "hz": 7272998,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013749488971611385,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.keys (10,000 items)": {
+          "name": "proxy.keys (10,000 items)",
+          "hz": 2732884,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.0003659137754144121,
+          "meanLabel": "366ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.values() (1,000 items)": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7289222,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013718885994469044,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.values (1,000 items)": {
+          "name": "proxy.values (1,000 items)",
+          "hz": 2747793,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.0003639283993021274,
+          "meanLabel": "364ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.values() (10,000 items)": {
+          "name": "registry.values() (10,000 items)",
+          "hz": 7218259,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013853756056663992,
+          "meanLabel": "139ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.values (10,000 items)": {
+          "name": "proxy.values (10,000 items)",
+          "hz": 2736092,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.0003654847837721149,
+          "meanLabel": "365ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.entries() (1,000 items)": {
+          "name": "registry.entries() (1,000 items)",
+          "hz": 7239228,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.0001381362759880567,
+          "meanLabel": "138ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.entries (1,000 items)": {
+          "name": "proxy.entries (1,000 items)",
+          "hz": 2747379,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.000363983310651115,
+          "meanLabel": "364ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.entries() (10,000 items)": {
+          "name": "registry.entries() (10,000 items)",
+          "hz": 7129741,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.0001402575462059306,
+          "meanLabel": "140ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.entries (10,000 items)": {
+          "name": "proxy.entries (10,000 items)",
+          "hz": 2717334,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.0003680078010403408,
+          "meanLabel": "368ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "proxy.size (1,000 items)": {
+          "name": "proxy.size (1,000 items)",
+          "hz": 2701158,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.00037021158466589546,
+          "meanLabel": "370ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "proxy.size (10,000 items)": {
+          "name": "proxy.size (10,000 items)",
+          "hz": 2740229,
+          "hzLabel": "2.7M ops/s",
+          "mean": 0.00036493300708634053,
+          "meanLabel": "365ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single item (1,000 items)": {
+          "name": "Register single item (1,000 items)",
+          "hz": 138915,
+          "hzLabel": "138.9k ops/s",
+          "mean": 0.007198629070818855,
+          "meanLabel": "7.2μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Register single item (10,000 items)": {
+          "name": "Register single item (10,000 items)",
+          "hz": 21699,
+          "hzLabel": "21.7k ops/s",
+          "mean": 0.046084817343948675,
+          "meanLabel": "46.1μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Unregister single item (1,000 items)": {
+          "name": "Unregister single item (1,000 items)",
+          "hz": 2185,
+          "hzLabel": "2.2k ops/s",
+          "mean": 0.4575933092406909,
+          "meanLabel": "457.6μs",
+          "rme": 10.9,
+          "tier": "blazing"
+        },
+        "Unregister single item (10,000 items)": {
+          "name": "Unregister single item (10,000 items)",
+          "hz": 160,
+          "hzLabel": "160 ops/s",
+          "mean": 6.262083149999671,
+          "meanLabel": "6.26ms",
+          "rme": 12.7,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 569962,
+          "hzLabel": "570.0k ops/s",
+          "mean": 0.0017545041494098285,
+          "meanLabel": "1.8μs",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 47513,
+          "hzLabel": "47.5k ops/s",
+          "mean": 0.021046721693659953,
+          "meanLabel": "21.0μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items (proxy attached)": {
+          "name": "Onboard 1,000 items (proxy attached)",
+          "hz": 1733,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.5769473287199582,
+          "meanLabel": "576.9μs",
+          "rme": 10.1,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items (proxy attached)": {
+          "name": "Onboard 10,000 items (proxy attached)",
+          "hz": 127,
+          "hzLabel": "127 ops/s",
+          "mean": 7.894945124998685,
+          "meanLabel": "7.89ms",
+          "rme": 12,
+          "tier": "blazing"
+        },
+        "Register 1,000 items one-by-one (proxy attached)": {
+          "name": "Register 1,000 items one-by-one (proxy attached)",
+          "hz": 1486,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6729872032303851,
+          "meanLabel": "673.0μs",
+          "rme": 9,
+          "tier": "blazing"
+        },
+        "Register 10,000 items one-by-one (proxy attached)": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 120,
+          "hzLabel": "120 ops/s",
+          "mean": 8.346250783334835,
+          "meanLabel": "8.35ms",
+          "rme": 13.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7289222,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013718885994469044,
+          "meanLabel": "137ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 120,
+          "hzLabel": "120 ops/s",
+          "mean": 8.346250783334835,
+          "meanLabel": "8.35ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fills the only gap in the published 1.0.x benchmark history. `generate-metrics-history.ts --print-missing` reported `1.0.3`; it now reports clean.

## Provenance

Measured on the fixed reference host per `.claude/rules/benchmarks.md` § Reference host — not on a CI runner.

| | |
|---|---|
| CPU | Intel i9-7980XE @ 2.60GHz (18C/36T) |
| Node | v26.0.0 (matches `.nvmrc`) |
| governor | `performance` (held via `/usr/local/sbin/v0-governor`, restored after) |
| `busy` / `peak` | 0.08% / 0% — uncontended |
| scope | 433 benches across 16 files |

Host, Node and governor match the committed 1.0.0 / 1.0.1 / 1.0.2 snapshots exactly, so the series stays comparable end to end.

## Notes for review

- `metrics:history` measures **median of 1**, unlike the median-of-3 behind `benchmarks.json`. That is the script's designed backfill behaviour, but it means per-bench figures here carry more run-to-run noise than the live artifact — read at **feature** level, and treat the nine documented unstable benches (`createNested`, `useDate`, `createSortable`, `createRegistry`) as uninformative.
- `apps/docs/public/benchmarks.json` is **not** touched by this PR.
- `pnpm metrics:check` passes.
- Renders as a binary diff because `.gitattributes` marks these artifacts `linguist-generated` by design.