### PR TITLE
docs: clear WCAG AA contrast on AppBanner and light primary

### DIFF
--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -55,7 +55,7 @@
   <Atom
     v-if="visible"
     :as
-    class="flex items-center justify-center h-[24px] fixed inset-x-0 top-0 px-3 text-xs gap-2 text-on-primary z-1 bg-glass-primary"
+    class="flex items-center justify-center h-[24px] fixed inset-x-0 top-0 px-3 text-xs gap-2 text-on-primary z-1 bg-primary"
   >
     <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 

--- a/apps/docs/src/themes/index.ts
+++ b/apps/docs/src/themes/index.ts
@@ -20,7 +20,7 @@ export const themes = {
     icon: 'theme-light',
     dark: false,
     colors: {
-      'primary': '#7c5cf6',
+      'primary': '#7453ec',
       'secondary': '#64748b',
       'accent': '#6366f1',
       'error': '#ef4444',


### PR DESCRIPTION
Two contrast fixes in the docs light theme.

**AppBanner** used `bg-glass-primary`, which composites 70% primary over whatever page content scrolls behind the fixed 24px strip. In the light theme that put `on-primary` white at **2.72:1** — below even the 3:1 large-text floor, and variable with the backdrop. Raising the mix to 90% still only reaches 3.77:1, so the banner is now opaque `bg-primary`.

**Light `primary`** was `#7c5cf6`, which is **4.45:1** against white — under the 4.5:1 AA floor for normal text even fully opaque. That affected every `bg-primary` surface and every `text-primary` link in the light theme, not just the banner. Darkened in OKLab holding hue and chroma to `#7453ec`, which is 5.01:1.

An audit of all 18 themes turned up 26 further pairs below 4.5:1, mostly in the vendor-mimic themes (`tailwind*`, `ant-design*`, `radix*`) where the values are deliberately faithful to upstream. Not touched here.
