### PR TITLE
fix(GnDocsExample): keep the card's bottom hairline from being eaten by backdrop-filter

### DIFF
--- a/.changeset/fix-docs-example-hairline-backdrop-filter.md
+++ b/.changeset/fix-docs-example-hairline-backdrop-filter.md
@@ -1,0 +1,7 @@
+---
+"@paper/genesis": patch
+---
+
+fix(GnDocsExample): keep the card's bottom hairline from being eaten by backdrop-filter
+
+Consumers apply a `backdrop-filter` to the example's bars (the docs glass treatment), which composites that child into its own layer. The layer pixel-snaps outward and paints over the card's own `border-bottom` whenever the card's bottom edge lands below a half-pixel — so the bottom border disappeared on some examples and not others, and changing any earlier example's height reshuffled which ones broke. `GnDocsExample` now draws the hairline on the last child instead: a border on the child paints above its own filter, so it survives at any sub-pixel offset. A `-1px` margin keeps it on the row the card's border occupied, leaving the card's height and corner radii unchanged.

--- a/.changeset/fix-docs-example-peek-divider.md
+++ b/.changeset/fix-docs-example-peek-divider.md
@@ -1,0 +1,7 @@
+---
+"@paper/genesis": patch
+---
+
+fix(GnDocsExample): restore the preview/code divider in peek mode
+
+Peek examples skip the toggle bar, and the toggle bar is what carried the `border-top` separating the preview from the code pane — so a peek example rendered its preview and its code as one unbroken surface while a non-peek example on the same page showed a divider. On docs pages that interleave the two modes (peek under Usage and Recipes, expandable examples under Examples) the inconsistency reads as every other example missing a border. `GnDocsExample` now draws the divider on `.genesis-docs-example__code` itself when the root carries `data-peek`, so both modes match.

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
@@ -291,6 +291,8 @@
     border-radius: 0.5rem;
     background: var(--v0-surface, #fff);
     color: var(--v0-on-surface, #1a1c1e);
+    /* The bottom hairline is drawn by the last child instead — see below. */
+    border-bottom-color: transparent;
   }
 
   .genesis-docs-example__toggle-bar {
@@ -317,7 +319,17 @@
     border-top-right-radius: 8px;
   }
 
+  /* Draw the card's bottom hairline on the last child rather than on the card.
+     Consumers put a backdrop-filter on these bars (the docs glass treatment),
+     which composites the child into its own layer; that layer pixel-snaps
+     outward and paints over the card's own border-bottom whenever the card's
+     bottom edge lands below a half-pixel. A border on the child paints above
+     its own filter, so it survives at any sub-pixel offset. The negative
+     margin keeps it on the same row the card's border occupied, so the card's
+     height and the corner radii are unchanged. */
   .genesis-docs-example > *:nth-last-child(1 of :not(.genesis-peek)) {
+    border-bottom: 1px solid color-mix(in srgb, var(--v0-on-surface, currentcolor) 14%, transparent);
+    margin-bottom: -1px;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
   }

--- a/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
+++ b/packages/genesis/src/components/GnDocsExample/GnDocsExample.vue
@@ -305,6 +305,13 @@
     border-bottom: 1px solid color-mix(in srgb, var(--v0-on-surface, currentcolor) 14%, transparent);
   }
 
+  /* Peek mode drops the toggle bar, and with it the border-top that separates
+     the preview from the code pane. Restore the divider on the pane itself so
+     peek and non-peek examples read the same. */
+  .genesis-docs-example[data-peek] .genesis-docs-example__code {
+    border-top: 1px solid color-mix(in srgb, var(--v0-on-surface, currentcolor) 14%, transparent);
+  }
+
   .genesis-docs-example > *:first-child:not(.genesis-peek) {
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;


### PR DESCRIPTION
Two rendering fixes in `GnDocsExample`.

## The card's bottom border disappears on some examples

The docs glass treatment applies `backdrop-filter: blur(12px)` to the example's bars, which composites that child into its own layer. The layer pixel-snaps outward and paints over the card's own `border-bottom` whenever the card's bottom edge lands below a half-pixel — example heights are fractional (`487.5`, `391.5`, `283.5`), so card bottoms land on `.188` or `.688` and only the `.188` ones lose the border.

That is why it looked arbitrary, and why toggling a class on one example fixed the next and broke the one after: any height change reshuffles every later example's sub-pixel offset.

Measured on the Snackbar page (sampling the rendered pixels at each boundary): `Stacked toasts` had no bottom border at all, while `Toast notifications with undo` and `Snackbar inside a Dialog` did. With `backdrop-filter: none` the border came back, confirming the cause.

The fix draws the hairline on the last child instead of the card. A border on the child paints above its own filter, so it survives at any sub-pixel offset; a `-1px` margin keeps it on the row the card's border occupied, leaving height and corner radii unchanged. All boundaries now paint a uniform hairline on both the Snackbar and Button pages.

## Peek examples had no divider under the preview

Separately: peek mode skips the toggle bar, and the toggle bar carried the `border-top` separating the preview from the code pane — so a peek example rendered preview and code as one unbroken surface while a non-peek example on the same page showed a divider. The code pane now draws that divider when the root carries `data-peek`.