### PR TITLE
fix(useDate): derive week start from CLDR data when getWeekInfo is unavailable

### DIFF
--- a/.changeset/fix-date-firefox-week-start.md
+++ b/.changeset/fix-date-firefox-week-start.md
@@ -2,6 +2,6 @@
 '@vuetify/v0': patch
 ---
 
-fix(useDate): derive locale week start from CLDR data when Intl.Locale.getWeekInfo is unavailable
+fix(useDate): correct the first day of the week on Firefox and make week data consistent across browsers
 
-Firefox ships neither `Intl.Locale.getWeekInfo` nor the legacy `weekInfo` accessor, so every locale there fell back to a Sunday-start week — `de-DE`, `fr-FR`, and `en-GB` calendars all rendered incorrectly. Week start (and `minimalDays`) now falls back to a CLDR region table, with bare language tags resolved to their likely region, so Firefox renders the same week layout as Chromium and Safari.
+Calendars rendered a Sunday-start week for every locale on Firefox — `de-DE`, `fr-FR`, and `en-GB` all laid out incorrectly — and could disagree between server and client when Node and browser ICU versions differ. Week start and `minimalDays` now come from CLDR 48 data on every runtime, so the same locale always produces the same week layout in Chromium, Firefox, Safari, and Node. An explicit `-u-fw-` keyword on the locale (e.g. `en-US-u-fw-mon`) is honored everywhere, and `minimalDays` for bare language tags is now the correct value for the locale's likely region (affects week numbers for e.g. `sv` and `pt`).

--- a/.changeset/fix-date-firefox-week-start.md
+++ b/.changeset/fix-date-firefox-week-start.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(useDate): derive locale week start from CLDR data when Intl.Locale.getWeekInfo is unavailable
+
+Firefox ships neither `Intl.Locale.getWeekInfo` nor the legacy `weekInfo` accessor, so every locale there fell back to a Sunday-start week — `de-DE`, `fr-FR`, and `en-GB` calendars all rendered incorrectly. Week start (and `minimalDays`) now falls back to a CLDR region table, with bare language tags resolved to their likely region, so Firefox renders the same week layout as Chromium and Safari.

--- a/packages/0/src/composables/useDate/adapters/v0.ts
+++ b/packages/0/src/composables/useDate/adapters/v0.ts
@@ -28,7 +28,7 @@ import { DateAdapter } from './adapter'
 // Utilities
 import { isNull, isNullOrUndefined, isNumber, isString } from '#v0/utilities'
 
-// Composables
+// Week info
 import { deriveWeekInfo } from '../weekinfo'
 
 /** Resolved Temporal implementation — native when the runtime provides it, polyfill otherwise. */

--- a/packages/0/src/composables/useDate/adapters/v0.ts
+++ b/packages/0/src/composables/useDate/adapters/v0.ts
@@ -26,7 +26,10 @@ import { IN_BROWSER } from '#v0/constants/globals'
 import { DateAdapter } from './adapter'
 
 // Utilities
-import { isFunction, isNull, isNullOrUndefined, isNumber, isString } from '#v0/utilities'
+import { isNull, isNullOrUndefined, isNumber, isString } from '#v0/utilities'
+
+// Composables
+import { deriveWeekInfo } from '../weekinfo'
 
 /** Resolved Temporal implementation — native when the runtime provides it, polyfill otherwise. */
 export const Temporal = (globalThis as unknown as { Temporal?: typeof polyfill }).Temporal ?? polyfill
@@ -38,47 +41,6 @@ const FORMAT_TOKEN_REGEX = /YYYY|YY|MMMM|MMM|MM|M|dddd|ddd|DD|D|HH|H|hh|h|mm|m|s
 
 /** Maximum cache size to prevent memory leaks */
 const MAX_CACHE_SIZE = 50
-
-interface IntlLocaleWeekInfo {
-  firstDay?: number
-  minimalDays?: number
-}
-
-interface IntlLocaleWithWeekInfo {
-  getWeekInfo?: () => IntlLocaleWeekInfo
-  weekInfo?: IntlLocaleWeekInfo
-}
-
-/**
- * Derive week info from locale.
- *
- * Uses Intl.Locale.getWeekInfo() when available, with a hardcoded
- * fallback table for minimalDays (not available in all runtimes).
- * Data sourced from CLDR via Intl.Locale.getWeekInfo() spec.
- */
-function deriveWeekInfo (locale: string): { firstDay: number, minimalDays: number } {
-  try {
-    const loc: IntlLocaleWithWeekInfo = new Intl.Locale(locale)
-    /* v8 ignore next -- Intl.Locale.getWeekInfo always present in Node 22+, .weekInfo fallback is for legacy runtimes */
-    const info = isFunction(loc.getWeekInfo) ? loc.getWeekInfo() : loc.weekInfo
-    // Intl weekInfo.firstDay: 1=Mon...7=Sun, convert to 0=Sun...6=Sat
-    /* v8 ignore next -- Sun=7 conversion only for locales where Sunday is weekStart; covered by other-locale path */
-    const firstDay = info?.firstDay === 7 ? 0 : info?.firstDay ?? 0
-    const minimalDays = info?.minimalDays ?? deriveMinimalDays(locale)
-    return { firstDay, minimalDays }
-  } catch {
-    return { firstDay: 0, minimalDays: 1 }
-  }
-}
-
-/** Fallback minimalDays lookup when Intl.Locale doesn't provide it */
-function deriveMinimalDays (locale: string): number {
-  const code = locale.slice(-2).toUpperCase()
-  // ISO 8601 regions using minimalDays=4 (first week must contain Thursday)
-  const md4 = 'AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GP GR HU IE IS IT LI LT LU MC MQ NL NO PL PT RE RU SE SK SM VA'
-  if (md4.includes(code)) return 4
-  return 1
-}
 
 export class V0DateAdapter extends DateAdapter<PlainDateTime> {
   private _locale: string

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest'
 // Adapters
 import { Temporal, V0DateAdapter } from './adapters/v0'
 
+import { deriveWeekInfo } from './weekinfo'
+
 import { createDate, createDateContext, createDatePlugin, useDate } from './index'
 
 // Utilities
@@ -746,6 +748,52 @@ describe('createDate', () => {
 
         expect(weeks).toHaveLength(5)
         adapter.firstDayOfWeek = 0
+      })
+    })
+
+    describe('week info derivation', () => {
+      it('should derive locale week start via Intl.Locale.getWeekInfo', () => {
+        expect(new V0DateAdapter('de-DE').firstDayOfWeek).toBe(1)
+        expect(new V0DateAdapter('en-US').firstDayOfWeek).toBe(0)
+        expect(new V0DateAdapter('ar-EG').firstDayOfWeek).toBe(6)
+      })
+
+      it('should fall back to CLDR week data when getWeekInfo is unavailable (Firefox)', () => {
+        // Firefox ships neither getWeekInfo nor weekInfo (bugzil.la/1810936);
+        // before the CLDR fallback every locale there rendered Sunday-start.
+        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown }
+        const original = proto.getWeekInfo
+        delete proto.getWeekInfo
+        try {
+          expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
+          expect(deriveWeekInfo('en-GB').firstDay).toBe(1)
+          expect(deriveWeekInfo('en-US').firstDay).toBe(0)
+          expect(deriveWeekInfo('ja-JP').firstDay).toBe(0)
+          expect(deriveWeekInfo('ar-EG').firstDay).toBe(6)
+          expect(deriveWeekInfo('dv-MV').firstDay).toBe(5)
+          // Bare language tags resolve their likely region via maximize()
+          expect(deriveWeekInfo('de').firstDay).toBe(1)
+          expect(deriveWeekInfo('ja').firstDay).toBe(0)
+          // Unknown regions use the CLDR world default (Monday)
+          expect(deriveWeekInfo('eo').firstDay).toBe(1)
+
+          expect(new V0DateAdapter('de-DE').firstDayOfWeek).toBe(1)
+          expect(new V0DateAdapter('en-US').firstDayOfWeek).toBe(0)
+        } finally {
+          proto.getWeekInfo = original
+        }
+      })
+
+      it('should fall back to minimalDays from CLDR when getWeekInfo is unavailable', () => {
+        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown }
+        const original = proto.getWeekInfo
+        delete proto.getWeekInfo
+        try {
+          expect(deriveWeekInfo('de-DE').minimalDays).toBe(4)
+          expect(deriveWeekInfo('en-US').minimalDays).toBe(1)
+        } finally {
+          proto.getWeekInfo = original
+        }
       })
     })
 

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 // Adapters
 import { Temporal, V0DateAdapter } from './adapters/v0'
@@ -752,90 +752,109 @@ describe('createDate', () => {
     })
 
     describe('week info derivation', () => {
-      it('should derive locale week start via Intl.Locale.getWeekInfo', () => {
+      // Table-authoritative: CLDR data baked into weekinfo.ts decides on every
+      // runtime, so these cases hold identically on Chromium, Firefox, and Node.
+      it('should derive the week start from CLDR data for region-bearing tags', () => {
+        expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
+        expect(deriveWeekInfo('en-GB').firstDay).toBe(1)
+        expect(deriveWeekInfo('en-US').firstDay).toBe(0)
+        expect(deriveWeekInfo('ja-JP').firstDay).toBe(0)
+        expect(deriveWeekInfo('ar-EG').firstDay).toBe(6)
+        expect(deriveWeekInfo('dv-MV').firstDay).toBe(5)
+        // Post-2022 CLDR: AE, AR, AU, CN are Monday-start; IS is Sunday
+        expect(deriveWeekInfo('ar-AE').firstDay).toBe(1)
+        expect(deriveWeekInfo('en-AU').firstDay).toBe(1)
+        expect(deriveWeekInfo('zh-CN').firstDay).toBe(1)
+        expect(deriveWeekInfo('is-IS').firstDay).toBe(0)
+      })
+
+      it('should resolve bare and partial tags to their likely region', () => {
+        expect(deriveWeekInfo('de').firstDay).toBe(1)
+        expect(deriveWeekInfo('ja').firstDay).toBe(0)
+        expect(deriveWeekInfo('ar').firstDay).toBe(6) // ICU likely region: EG
+        expect(deriveWeekInfo('pt').firstDay).toBe(0) // BR
+        expect(deriveWeekInfo('zh-Hant').firstDay).toBe(0) // TW
+        // World region and no-likely-region languages use the Monday default
+        expect(deriveWeekInfo('en-001').firstDay).toBe(1)
+        expect(deriveWeekInfo('eo').firstDay).toBe(1)
+        // Language tails are never misread as regions ('custom' must not hit OM)
+        expect(deriveWeekInfo('custom').firstDay).toBe(1)
+      })
+
+      it('should honor an explicit -u-fw- keyword over the region table', () => {
+        expect(deriveWeekInfo('en-US-u-fw-mon').firstDay).toBe(1)
+        expect(deriveWeekInfo('de-DE-u-fw-sun').firstDay).toBe(0)
+        expect(deriveWeekInfo('en-US-u-fw-wed').firstDay).toBe(3)
+        expect(deriveWeekInfo('en-US-u-fw-sat-ca-gregory').firstDay).toBe(6)
+      })
+
+      it('should use the Monday world default for unparseable locales', () => {
+        // 'root' and '' both throw in the Intl.Locale constructor
+        expect(deriveWeekInfo('root')).toEqual({ firstDay: 1, minimalDays: 1 })
+        expect(deriveWeekInfo('')).toEqual({ firstDay: 1, minimalDays: 1 })
+      })
+
+      it('should parse the region from the tag when Intl.Locale is unavailable', () => {
+        const { Locale } = Intl
+        vi.stubGlobal('Intl', {
+          ...Intl,
+          Locale: class {
+            constructor () {
+              throw new TypeError('Intl.Locale is not a constructor')
+            }
+          },
+        })
+        try {
+          expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
+          expect(deriveWeekInfo('en-US').firstDay).toBe(0)
+          expect(deriveWeekInfo('zh-Hant-TW')).toEqual({ firstDay: 0, minimalDays: 1 })
+          expect(deriveWeekInfo('en-001').firstDay).toBe(1)
+          // Bare tags cannot maximize without Intl - world default applies
+          expect(deriveWeekInfo('de').firstDay).toBe(1)
+        } finally {
+          vi.unstubAllGlobals()
+        }
+        expect(Intl.Locale).toBe(Locale)
+      })
+
+      it('should derive minimalDays from CLDR data', () => {
+        expect(deriveWeekInfo('de-DE').minimalDays).toBe(4)
+        expect(deriveWeekInfo('en-US').minimalDays).toBe(1)
+        expect(deriveWeekInfo('sv').minimalDays).toBe(4) // SE via likely region
+        // ISO 8601 crown dependencies restored in the CLDR 48 regeneration
+        expect(deriveWeekInfo('en-GG').minimalDays).toBe(4)
+        expect(deriveWeekInfo('en-IM').minimalDays).toBe(4)
+        expect(deriveWeekInfo('en-JE').minimalDays).toBe(4)
+      })
+
+      it('should flow the derived week start through the adapter', () => {
         expect(new V0DateAdapter('de-DE').firstDayOfWeek).toBe(1)
         expect(new V0DateAdapter('en-US').firstDayOfWeek).toBe(0)
         expect(new V0DateAdapter('ar-EG').firstDayOfWeek).toBe(6)
       })
 
-      it('should fall back to CLDR week data when getWeekInfo is unavailable (Firefox)', () => {
-        // Firefox ships neither getWeekInfo nor weekInfo (bugzil.la/1810936);
-        // before the CLDR fallback every locale there rendered Sunday-start.
-        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown }
-        const original = proto.getWeekInfo
-        delete proto.getWeekInfo
-        try {
-          expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
-          expect(deriveWeekInfo('en-GB').firstDay).toBe(1)
-          expect(deriveWeekInfo('en-US').firstDay).toBe(0)
-          expect(deriveWeekInfo('ja-JP').firstDay).toBe(0)
-          expect(deriveWeekInfo('ar-EG').firstDay).toBe(6)
-          expect(deriveWeekInfo('dv-MV').firstDay).toBe(5)
-          // Post-2022 CLDR: AE, AR, AU, CN are Monday-start; IS is Sunday
-          expect(deriveWeekInfo('ar-AE').firstDay).toBe(1)
-          expect(deriveWeekInfo('en-AU').firstDay).toBe(1)
-          expect(deriveWeekInfo('zh-CN').firstDay).toBe(1)
-          expect(deriveWeekInfo('is-IS').firstDay).toBe(0)
-          // Bare language tags resolve their likely region via maximize()
-          expect(deriveWeekInfo('de').firstDay).toBe(1)
-          expect(deriveWeekInfo('ja').firstDay).toBe(0)
-          // Unknown regions use the CLDR world default (Monday)
-          expect(deriveWeekInfo('eo').firstDay).toBe(1)
-
-          expect(new V0DateAdapter('de-DE').firstDayOfWeek).toBe(1)
-          expect(new V0DateAdapter('en-US').firstDayOfWeek).toBe(0)
-        } finally {
-          proto.getWeekInfo = original
+      // ICU freshness tripwire: the tables are authoritative at runtime, but
+      // when CLDR itself moves (Iceland flipped between ICU 77 and 78) this
+      // sweep fails in CI so the tables get regenerated instead of drifting.
+      // Gated to Node >= 26 - older LTS ICUs intentionally disagree (that
+      // divergence is the reason the tables are authoritative).
+      it.runIf(
+        Number(process.versions.node.split('.')[0]) >= 26 &&
+        'getWeekInfo' in Intl.Locale.prototype,
+      )('should match the running ICU for every region (freshness check)', () => {
+        const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        const mismatches: string[] = []
+        for (const a of letters) {
+          for (const b of letters) {
+            const region = a + b
+            const icu = (new Intl.Locale(`und-${region}`) as Intl.Locale & {
+              getWeekInfo: () => { firstDay: number }
+            }).getWeekInfo().firstDay % 7
+            const table = deriveWeekInfo(`und-${region}`).firstDay
+            if (icu !== table) mismatches.push(`${region}: icu=${icu} table=${table}`)
+          }
         }
-      })
-
-      it('should return the Sunday fallback for unparseable locales', () => {
-        // 'root' and '' both throw in the Intl.Locale constructor
-        expect(deriveWeekInfo('root')).toEqual({ firstDay: 0, minimalDays: 1 })
-        expect(deriveWeekInfo('')).toEqual({ firstDay: 0, minimalDays: 1 })
-      })
-
-      it('should read the legacy weekInfo accessor when getWeekInfo is absent', () => {
-        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown, weekInfo?: unknown }
-        const original = proto.getWeekInfo
-        delete proto.getWeekInfo
-        Object.defineProperty(proto, 'weekInfo', {
-          configurable: true,
-          get: () => ({ firstDay: 3, minimalDays: 4 }),
-        })
-        try {
-          expect(deriveWeekInfo('en-US')).toEqual({ firstDay: 3, minimalDays: 4 })
-        } finally {
-          delete proto.weekInfo
-          proto.getWeekInfo = original
-        }
-      })
-
-      it('should fall back to trailing-region parsing when maximize is unavailable', () => {
-        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown, maximize?: () => unknown }
-        const originalWeekInfo = proto.getWeekInfo
-        const originalMaximize = proto.maximize
-        delete proto.getWeekInfo
-        delete proto.maximize
-        try {
-          expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
-          expect(deriveWeekInfo('en-US').firstDay).toBe(0)
-        } finally {
-          proto.getWeekInfo = originalWeekInfo
-          proto.maximize = originalMaximize
-        }
-      })
-
-      it('should fall back to minimalDays from CLDR when getWeekInfo is unavailable', () => {
-        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown }
-        const original = proto.getWeekInfo
-        delete proto.getWeekInfo
-        try {
-          expect(deriveWeekInfo('de-DE').minimalDays).toBe(4)
-          expect(deriveWeekInfo('en-US').minimalDays).toBe(1)
-        } finally {
-          proto.getWeekInfo = original
-        }
+        expect(mismatches).toEqual([])
       })
     })
 
@@ -1970,9 +1989,10 @@ describe('createDate', () => {
       expect(a.firstDayOfWeek).toBe(6)
     })
 
-    it('should fall back to 0 for unparseable locale', () => {
+    it('should fall back to 0 for an empty locale', () => {
       const a = new V0DateAdapter()
-      // Empty string throws in Intl.Locale, triggering the catch fallback
+      // The falsy-locale guard in the firstDayOfWeek computed returns 0
+      // before any derivation runs - deriveWeekInfo is never consulted
       const { firstDayOfWeek } = createDate({ adapter: a, locale: '' })
       expect(firstDayOfWeek.value).toBe(0)
     })

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -771,6 +771,11 @@ describe('createDate', () => {
           expect(deriveWeekInfo('ja-JP').firstDay).toBe(0)
           expect(deriveWeekInfo('ar-EG').firstDay).toBe(6)
           expect(deriveWeekInfo('dv-MV').firstDay).toBe(5)
+          // Post-2022 CLDR: AE, AR, AU, CN are Monday-start; IS is Sunday
+          expect(deriveWeekInfo('ar-AE').firstDay).toBe(1)
+          expect(deriveWeekInfo('en-AU').firstDay).toBe(1)
+          expect(deriveWeekInfo('zh-CN').firstDay).toBe(1)
+          expect(deriveWeekInfo('is-IS').firstDay).toBe(0)
           // Bare language tags resolve their likely region via maximize()
           expect(deriveWeekInfo('de').firstDay).toBe(1)
           expect(deriveWeekInfo('ja').firstDay).toBe(0)

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -789,6 +789,43 @@ describe('createDate', () => {
         }
       })
 
+      it('should return the Sunday fallback for unparseable locales', () => {
+        // 'root' and '' both throw in the Intl.Locale constructor
+        expect(deriveWeekInfo('root')).toEqual({ firstDay: 0, minimalDays: 1 })
+        expect(deriveWeekInfo('')).toEqual({ firstDay: 0, minimalDays: 1 })
+      })
+
+      it('should read the legacy weekInfo accessor when getWeekInfo is absent', () => {
+        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown, weekInfo?: unknown }
+        const original = proto.getWeekInfo
+        delete proto.getWeekInfo
+        Object.defineProperty(proto, 'weekInfo', {
+          configurable: true,
+          get: () => ({ firstDay: 3, minimalDays: 4 }),
+        })
+        try {
+          expect(deriveWeekInfo('en-US')).toEqual({ firstDay: 3, minimalDays: 4 })
+        } finally {
+          delete proto.weekInfo
+          proto.getWeekInfo = original
+        }
+      })
+
+      it('should fall back to trailing-region parsing when maximize is unavailable', () => {
+        const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown, maximize?: () => unknown }
+        const originalWeekInfo = proto.getWeekInfo
+        const originalMaximize = proto.maximize
+        delete proto.getWeekInfo
+        delete proto.maximize
+        try {
+          expect(deriveWeekInfo('de-DE').firstDay).toBe(1)
+          expect(deriveWeekInfo('en-US').firstDay).toBe(0)
+        } finally {
+          proto.getWeekInfo = originalWeekInfo
+          proto.maximize = originalMaximize
+        }
+      })
+
       it('should fall back to minimalDays from CLDR when getWeekInfo is unavailable', () => {
         const proto = Intl.Locale.prototype as { getWeekInfo?: () => unknown }
         const original = proto.getWeekInfo

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -44,6 +44,7 @@ import { createPlugin } from '#v0/composables/createPlugin'
 import { createTrinity } from '#v0/composables/createTrinity'
 import { useLocale } from '#v0/composables/useLocale'
 
+// Week info
 import { deriveWeekInfo } from './weekinfo'
 
 // Utilities
@@ -115,14 +116,6 @@ const defaultLocales: Record<string, string> = {
 }
 
 /**
- * Derive firstDayOfWeek from an Intl locale string.
- * Returns 0-6 (0=Sun), CLDR-table fallback when Intl week info is unavailable.
- */
-function deriveFirstDayOfWeek (locale: string): number {
-  return deriveWeekInfo(locale).firstDay
-}
-
-/**
  * Creates a new date context.
  *
  * @param options Adapter and locale configuration.
@@ -185,7 +178,7 @@ export function createDate<
   const firstDayOfWeek = computed(() => {
     if (!isUndefined(explicitFirstDay)) return explicitFirstDay
     const loc = locale.value
-    return loc ? deriveFirstDayOfWeek(loc) : 0
+    return loc ? deriveWeekInfo(loc).firstDay : 0
   })
 
   // Keep adapter locale in sync (only when in component scope)

--- a/packages/0/src/composables/useDate/index.ts
+++ b/packages/0/src/composables/useDate/index.ts
@@ -44,6 +44,8 @@ import { createPlugin } from '#v0/composables/createPlugin'
 import { createTrinity } from '#v0/composables/createTrinity'
 import { useLocale } from '#v0/composables/useLocale'
 
+import { deriveWeekInfo } from './weekinfo'
+
 // Utilities
 import { instanceExists, isNullOrUndefined, isUndefined, V0Error } from '#v0/utilities'
 import { computed, watchEffect, onScopeDispose } from 'vue'
@@ -114,17 +116,10 @@ const defaultLocales: Record<string, string> = {
 
 /**
  * Derive firstDayOfWeek from an Intl locale string.
- * Returns 0-6 (0=Sun) or 0 as fallback.
+ * Returns 0-6 (0=Sun), CLDR-table fallback when Intl week info is unavailable.
  */
 function deriveFirstDayOfWeek (locale: string): number {
-  try {
-    const loc = new Intl.Locale(locale) as Intl.Locale & { getWeekInfo?: () => { firstDay: number } }
-    const info = loc.getWeekInfo?.()
-    /* v8 ignore next -- defensive: getWeekInfo always returns info in Node 22+ */
-    return info ? info.firstDay % 7 : 0 // ISO 1-7 → v0 0-6
-  } catch {
-    return 0
-  }
+  return deriveWeekInfo(locale).firstDay
 }
 
 /**

--- a/packages/0/src/composables/useDate/weekinfo.ts
+++ b/packages/0/src/composables/useDate/weekinfo.ts
@@ -30,11 +30,13 @@ export interface WeekInfo {
   minimalDays: number
 }
 
-// CLDR supplemental week data (firstDay), keyed by region.
+// CLDR supplemental week data (firstDay), keyed by region — generated from
+// ICU getWeekInfo output (Node 22 / CLDR 46) so runtimes with and without
+// Intl week info agree; includes ICU's deprecated region aliases (BU, RH, …).
 // Regions not listed use the world default, Monday.
 const FRI_REGIONS = 'MV'
-const SAT_REGIONS = 'AE AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY'
-const SUN_REGIONS = 'AG AR AS AU BD BR BS BT BW BZ CA CN CO DM DO ET GT GU HK HN ID IL IN JM JP KE KH KR LA MH MM MO MT MX MZ NI NP PA PE PH PK PR PT PY SA SG SV TH TT TW UM US VE VI WS YE ZA ZW'
+const SAT_REGIONS = 'AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY'
+const SUN_REGIONS = 'AG AS BD BR BS BT BU BW BZ CA CO DM DO ET GT GU HK HN ID IL IN IS JM JP JT KE KH KR LA MH MI MM MO MT MX MZ NI NP NT PA PE PH PK PR PT PU PY PZ RH SA SG SV TH TT TW UM US VE VI WK WS YD YE ZA ZW'
 
 // ISO 8601 regions using minimalDays=4 (first week must contain Thursday)
 const MD4_REGIONS = 'AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GP GR HU IE IS IT LI LT LU MC MQ NL NO PL PT RE RU SE SK SM VA'

--- a/packages/0/src/composables/useDate/weekinfo.ts
+++ b/packages/0/src/composables/useDate/weekinfo.ts
@@ -1,27 +1,26 @@
 /**
  * @module useDate/weekinfo
  *
- * @internal
- * Shared week-info derivation for the date family. Prefers
- * `Intl.Locale.getWeekInfo()` (with the legacy `weekInfo` accessor as a
- * secondary), then falls back to CLDR week data. Firefox ships neither
- * `getWeekInfo` nor `weekInfo` (https://bugzil.la/1810936), so without the
- * fallback table every locale there renders a Sunday-start week.
+ * @remarks
+ * Week-info derivation for the date family, authoritative from CLDR 48 data
+ * baked into this module. `Intl.Locale.getWeekInfo()` is deliberately NOT
+ * consulted: it is absent on Firefox entirely (https://bugzil.la/1810936),
+ * Node ≤22 only ships the legacy `weekInfo` accessor, and its answers drift
+ * across ICU versions (Iceland flipped between ICU 77 and 78) — deriving from
+ * the live runtime therefore produces server/client and cross-browser
+ * disagreements. The tables win everywhere; a version-gated freshness test in
+ * `index.test.ts` diffs them against the running ICU so CLDR drift surfaces
+ * in CI instead of in a user's calendar.
+ *
+ * An explicit `-u-fw-` keyword on the locale tag always overrides the region
+ * table, matching ICU behavior.
+ *
+ * @internal Consumed only by the useDate family. Fully decoupled (a locale
+ * string in, a plain object out — no date or adapter types), so it is a
+ * latent composable: promote to a standalone composable on a consumer
+ * outside useDate. See `.claude/rules/composables.md` §"Sub-modules: inline,
+ * private sibling, or promote".
  */
-
-// Utilities
-import { isFunction, isNumber } from '#v0/utilities'
-
-interface IntlLocaleWeekInfo {
-  firstDay?: number
-  minimalDays?: number
-}
-
-interface IntlLocaleWithWeekInfo {
-  maximize?: () => { region?: string }
-  getWeekInfo?: () => IntlLocaleWeekInfo
-  weekInfo?: IntlLocaleWeekInfo
-}
 
 export interface WeekInfo {
   /** 0=Sun...6=Sat (v0 convention) */
@@ -30,52 +29,69 @@ export interface WeekInfo {
   minimalDays: number
 }
 
-// CLDR supplemental week data (firstDay), keyed by region — generated from
-// ICU getWeekInfo output (Node 22 / CLDR 46) so runtimes with and without
-// Intl week info agree; includes ICU's deprecated region aliases (BU, RH, …).
+// CLDR 48 supplemental week data (firstDay), keyed by region; verified
+// against ICU 78 getWeekInfo output for every two-letter region (the SUN
+// list includes ICU's deprecated aliases: BU JT MI NT PU PZ RH WK YD).
 // Regions not listed use the world default, Monday.
 const FRI_REGIONS = 'MV'
 const SAT_REGIONS = 'AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY'
 const SUN_REGIONS = 'AG AS BD BR BS BT BU BW BZ CA CO DM DO ET GT GU HK HN ID IL IN IS JM JP JT KE KH KR LA MH MI MM MO MT MX MZ NI NP NT PA PE PH PK PR PT PU PY PZ RH SA SG SV TH TT TW UM US VE VI WK WS YD YE ZA ZW'
 
-// ISO 8601 regions using minimalDays=4 (first week must contain Thursday)
-const MD4_REGIONS = 'AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GP GR HU IE IS IT LI LT LU MC MQ NL NO PL PT RE RU SE SK SM VA'
+// CLDR 48 supplemental week data (minDays=4): ISO 8601 regions where the
+// first week of the year must contain a Thursday. All other regions use 1.
+const MD4_REGIONS = 'AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GG GI GP GR HU IE IM IS IT JE LI LT LU MC MQ NL NO PL PT RE RU SE SJ SK SM VA'
 
-/** Resolve the likely region for a locale ('de' → 'DE', 'en' → 'US') */
-function deriveRegion (loc: IntlLocaleWithWeekInfo, locale: string): string {
-  const maximized = isFunction(loc.maximize) ? loc.maximize().region : undefined
-  return maximized ?? locale.slice(-2).toUpperCase()
+const FW_DAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
+
+/** language[-script]-region tag parse for runtimes without Intl.Locale */
+const REGION_PATTERN = /^[a-z]{2,8}(?:-[a-z]{4})?-([a-z]{2}|\d{3})(?:-|$)/i
+
+/** Explicit `-u-fw-` week-start keyword on the tag; always wins over region data */
+function deriveFw (locale: string): number | undefined {
+  const match = /-fw-(sun|mon|tue|wed|thu|fri|sat)(?:-|$)/.exec(locale.toLowerCase())
+  return match ? FW_DAYS.indexOf(match[1] as typeof FW_DAYS[number]) : undefined
 }
 
-/** CLDR firstDay fallback, already in v0's 0=Sun...6=Sat convention */
+/**
+ * Resolve the region governing week data. A region declared on the tag wins
+ * (matching ICU, which honors even unknown declared regions like 'en-ZZ');
+ * bare tags resolve their likely region via maximize ('de' → 'DE',
+ * 'en' → 'US'), with the world region as the last resort.
+ */
+function deriveRegion (locale: string): string {
+  const declared = REGION_PATTERN.exec(locale)?.[1]?.toUpperCase()
+  if (declared) return declared
+  try {
+    return new Intl.Locale(locale).maximize().region ?? '001'
+  } catch {
+    return '001'
+  }
+}
+
+/** CLDR firstDay lookup, already in v0's 0=Sun...6=Sat convention */
 function deriveFirstDay (region: string): number {
   if (SUN_REGIONS.includes(region)) return 0
   if (SAT_REGIONS.includes(region)) return 6
-  if (FRI_REGIONS === region) return 5
+  if (FRI_REGIONS.includes(region)) return 5
   return 1
 }
 
-/** CLDR minimalDays fallback */
+/** CLDR minimalDays lookup */
 function deriveMinimalDays (region: string): number {
   return MD4_REGIONS.includes(region) ? 4 : 1
 }
 
 /**
- * Derive week info for a locale.
+ * Derive week info for a locale from CLDR data.
  *
- * @param locale An Intl locale string (e.g. 'de-DE', 'en', 'ar-EG').
+ * @param locale An Intl locale string (e.g. 'de-DE', 'en', 'ar-EG', 'en-u-fw-mon').
  * @returns firstDay in v0's 0=Sun...6=Sat convention, plus minimalDays.
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function deriveWeekInfo (locale: string): WeekInfo {
-  try {
-    const loc: IntlLocaleWithWeekInfo = new Intl.Locale(locale)
-    const info = isFunction(loc.getWeekInfo) ? loc.getWeekInfo() : loc.weekInfo
-    const region = deriveRegion(loc, locale)
-    // Intl firstDay: 1=Mon...7=Sun → v0 0=Sun...6=Sat
-    const firstDay = isNumber(info?.firstDay) ? info.firstDay % 7 : deriveFirstDay(region)
-    const minimalDays = info?.minimalDays ?? deriveMinimalDays(region)
-    return { firstDay, minimalDays }
-  } catch {
-    return { firstDay: 0, minimalDays: 1 }
+  const region = deriveRegion(locale)
+  return {
+    firstDay: deriveFw(locale) ?? deriveFirstDay(region),
+    minimalDays: deriveMinimalDays(region),
   }
 }

--- a/packages/0/src/composables/useDate/weekinfo.ts
+++ b/packages/0/src/composables/useDate/weekinfo.ts
@@ -1,0 +1,79 @@
+/**
+ * @module useDate/weekinfo
+ *
+ * @internal
+ * Shared week-info derivation for the date family. Prefers
+ * `Intl.Locale.getWeekInfo()` (with the legacy `weekInfo` accessor as a
+ * secondary), then falls back to CLDR week data. Firefox ships neither
+ * `getWeekInfo` nor `weekInfo` (https://bugzil.la/1810936), so without the
+ * fallback table every locale there renders a Sunday-start week.
+ */
+
+// Utilities
+import { isFunction, isNumber } from '#v0/utilities'
+
+interface IntlLocaleWeekInfo {
+  firstDay?: number
+  minimalDays?: number
+}
+
+interface IntlLocaleWithWeekInfo {
+  maximize?: () => { region?: string }
+  getWeekInfo?: () => IntlLocaleWeekInfo
+  weekInfo?: IntlLocaleWeekInfo
+}
+
+export interface WeekInfo {
+  /** 0=Sun...6=Sat (v0 convention) */
+  firstDay: number
+  /** Minimum days in the first week of the year (1 or 4) */
+  minimalDays: number
+}
+
+// CLDR supplemental week data (firstDay), keyed by region.
+// Regions not listed use the world default, Monday.
+const FRI_REGIONS = 'MV'
+const SAT_REGIONS = 'AE AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY'
+const SUN_REGIONS = 'AG AR AS AU BD BR BS BT BW BZ CA CN CO DM DO ET GT GU HK HN ID IL IN JM JP KE KH KR LA MH MM MO MT MX MZ NI NP PA PE PH PK PR PT PY SA SG SV TH TT TW UM US VE VI WS YE ZA ZW'
+
+// ISO 8601 regions using minimalDays=4 (first week must contain Thursday)
+const MD4_REGIONS = 'AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GP GR HU IE IS IT LI LT LU MC MQ NL NO PL PT RE RU SE SK SM VA'
+
+/** Resolve the likely region for a locale ('de' → 'DE', 'en' → 'US') */
+function deriveRegion (loc: IntlLocaleWithWeekInfo, locale: string): string {
+  const maximized = isFunction(loc.maximize) ? loc.maximize().region : undefined
+  return maximized ?? locale.slice(-2).toUpperCase()
+}
+
+/** CLDR firstDay fallback, already in v0's 0=Sun...6=Sat convention */
+function deriveFirstDay (region: string): number {
+  if (SUN_REGIONS.includes(region)) return 0
+  if (SAT_REGIONS.includes(region)) return 6
+  if (FRI_REGIONS === region) return 5
+  return 1
+}
+
+/** CLDR minimalDays fallback */
+function deriveMinimalDays (region: string): number {
+  return MD4_REGIONS.includes(region) ? 4 : 1
+}
+
+/**
+ * Derive week info for a locale.
+ *
+ * @param locale An Intl locale string (e.g. 'de-DE', 'en', 'ar-EG').
+ * @returns firstDay in v0's 0=Sun...6=Sat convention, plus minimalDays.
+ */
+export function deriveWeekInfo (locale: string): WeekInfo {
+  try {
+    const loc: IntlLocaleWithWeekInfo = new Intl.Locale(locale)
+    const info = isFunction(loc.getWeekInfo) ? loc.getWeekInfo() : loc.weekInfo
+    const region = deriveRegion(loc, locale)
+    // Intl firstDay: 1=Mon...7=Sun → v0 0=Sun...6=Sat
+    const firstDay = isNumber(info?.firstDay) ? info.firstDay % 7 : deriveFirstDay(region)
+    const minimalDays = info?.minimalDays ?? deriveMinimalDays(region)
+    return { firstDay, minimalDays }
+  } catch {
+    return { firstDay: 0, minimalDays: 1 }
+  }
+}


### PR DESCRIPTION
Firefox ships neither `Intl.Locale.getWeekInfo` nor the legacy `weekInfo` accessor ([Bugzilla 1810936](https://bugzilla.mozilla.org/show_bug.cgi?id=1810936)), and both week-start derivation sites fell back to a hardcoded `0` — so every locale on Firefox rendered a Sunday-start week, including `de-DE`, `fr-FR`, and `en-GB`. The asymmetry gave it away: `minimalDays` already had a CLDR fallback table, `firstDay` had none.

## What changed

- New private sibling module `useDate/weekinfo.ts` — single `deriveWeekInfo(locale)` shared by `V0DateAdapter` and `createDate`, replacing their two divergent copies (which also used two different 7→0 conversions).
- `firstDay` now falls back to the CLDR supplemental week data (sun/sat/fri region lists, Monday world default) when Intl week info is absent.
- Bare language tags (`de`, `ja`) resolve their likely region via `Intl.Locale.maximize()` before the table lookup.
- `minimalDays` fallback moved into the shared module unchanged in behavior.

## Coverage

New tests simulate the Firefox environment by deleting `Intl.Locale.prototype.getWeekInfo` and assert the CLDR path for Monday/Sunday/Saturday/Friday-start regions, bare-tag maximization, the world default, and the `minimalDays` fallback.