### PR TITLE
fix(useDate): add a fixedWeeks mode to getWeekArray

### DIFF
--- a/.changeset/date-weekarray-fixed-weeks.md
+++ b/.changeset/date-weekarray-fixed-weeks.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(useDate): add a fixedWeeks mode to getWeekArray
+
+`getWeekArray(date, fixedWeeks?)` can now pad the month matrix to a constant 6 rows (42 cells), so calendar grids keep a stable height across months instead of jumping between 4, 5, and 6 rows. Padding continues day-by-day into the next month; months that naturally span 6 rows are unchanged. Default behavior without the flag is identical to before.

--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -170,7 +170,7 @@ abstract class DateAdapter<T> {
 
   // Calendar Utilities
   abstract getWeekdays (weekdayFormat?: 'long' | 'short' | 'narrow'): string[]
-  abstract getWeekArray (date: T): T[][]
+  abstract getWeekArray (date: T, fixedWeeks?: boolean): T[][]
   abstract getMonthArray (date: T): T[]
   abstract getYearRange (start: T, end: T): T[]
   abstract getNextMonth (date: T): T
@@ -371,7 +371,7 @@ The following example builds a complete, interactive date surface from adapter c
 
 ### Interactive month calendar
 
-A navigable month grid with click-to-select, built entirely from the adapter. `useCalendar.ts` calls `useDate()` once and owns all the date math: `getWeekArray()` produces the 2D week grid, `getWeekdays('narrow')` drives the column headers, `getPreviousMonth()` and `getNextMonth()` handle navigation, and `isSameDay()` / `isSameMonth()` power the today ring, the selected fill, and the greyed-out overflow cells. The grid renders as many week rows as the month spans — four to six — straight from `getWeekArray()`, so every in-month day stays visible and the calendar never truncates a long month or borrows days from the wrong neighbouring week.
+A navigable month grid with click-to-select, built entirely from the adapter. `useCalendar.ts` calls `useDate()` once and owns all the date math: `getWeekArray()` produces the 2D week grid, `getWeekdays('narrow')` drives the column headers, `getPreviousMonth()` and `getNextMonth()` handle navigation, and `isSameDay()` / `isSameMonth()` power the today ring, the selected fill, and the greyed-out overflow cells. The grid renders as many week rows as the month spans — four to six — straight from `getWeekArray()`, so every in-month day stays visible and the calendar never truncates a long month or borrows days from the wrong neighbouring week. When a constant grid height matters more than a compact one — stacked month views, or any layout where row-count jumps cause reflow — pass `getWeekArray(date, true)` and the matrix pads trailing weeks into the next month up to a fixed six rows (42 cells).
 
 The composable precomputes each `weeks` cell into a flat `{ date, day, today, selected, outside }` record, so `CalendarGrid.vue` renders the surface from plain props — `weekdays`, `weeks`, `monthYear`, plus the `prev`, `next`, `today`, and `select` callbacks — without ever touching the adapter directly. The entry instantiates the calendar once and reads `selectedLabel` and `locale` for the summary panel. This is the structural half of the adapter interface — building and navigating grids — rather than the formatting presets shown in the Usage example above.
 

--- a/packages/0/src/composables/useDate/adapters/adapter.ts
+++ b/packages/0/src/composables/useDate/adapters/adapter.ts
@@ -137,7 +137,12 @@ export abstract class DateAdapter<T = Temporal.PlainDateTime> {
   // ============================================
 
   abstract getWeekdays (weekdayFormat?: 'long' | 'short' | 'narrow'): string[]
-  abstract getWeekArray (date: T): T[][]
+  /**
+   * Weeks-of-7 matrix for the month containing `date`, spilling into adjacent
+   * months at the edges. With `fixedWeeks`, trailing weeks pad the matrix to a
+   * constant 6 rows (42 cells) so calendar grids keep a stable height.
+   */
+  abstract getWeekArray (date: T, fixedWeeks?: boolean): T[][]
   /** Get array of months in a year (12 dates, one for each month) */
   abstract getMonthArray (date: T): T[]
   /** Get array of years between start and end dates */

--- a/packages/0/src/composables/useDate/adapters/v0.ts
+++ b/packages/0/src/composables/useDate/adapters/v0.ts
@@ -686,7 +686,7 @@ export class V0DateAdapter extends DateAdapter<PlainDateTime> {
     return weekdays
   }
 
-  getWeekArray (date: PlainDateTime): PlainDateTime[][] {
+  getWeekArray (date: PlainDateTime, fixedWeeks = false): PlainDateTime[][] {
     const weeks: PlainDateTime[][] = []
     const monthStart = this.startOfMonth(date)
     const monthEnd = this.endOfMonth(date)
@@ -694,7 +694,10 @@ export class V0DateAdapter extends DateAdapter<PlainDateTime> {
     let current = this.startOfWeek(monthStart)
     const end = this.endOfWeek(monthEnd)
 
-    while (Temporal.PlainDateTime.compare(current, end) <= 0) {
+    while (
+      Temporal.PlainDateTime.compare(current, end) <= 0 ||
+      (fixedWeeks && weeks.length < 6)
+    ) {
       const week: PlainDateTime[] = []
 
       for (let i = 0; i < 7; i++) {

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -469,6 +469,35 @@ describe('createDate', () => {
         }
       })
 
+      it('should pad to 6 weeks with fixedWeeks', () => {
+        // Feb 2026 starts on a Sunday and has 28 days - exactly 4 natural rows
+        const february = adapter.date('2026-02-15T12:00:00')!
+        expect(adapter.getWeekArray(february)).toHaveLength(4)
+
+        const fixed = adapter.getWeekArray(february, true)
+        expect(fixed).toHaveLength(6)
+        for (const week of fixed) {
+          expect(week).toHaveLength(7)
+        }
+        // Padding continues day-by-day into the next month
+        expect(fixed[4]![0]!.month).toBe(3)
+        expect(fixed[4]![0]!.day).toBe(1)
+        expect(fixed[5]![6]!.day).toBe(14)
+
+        // A natural 5-row month pads by one week
+        const june = adapter.date('2026-06-15T12:00:00')!
+        expect(adapter.getWeekArray(june)).toHaveLength(5)
+        expect(adapter.getWeekArray(june, true)).toHaveLength(6)
+      })
+
+      it('should leave natural 6-week months unchanged with fixedWeeks', () => {
+        // Aug 2026 (Sunday start) spans 6 rows naturally
+        const august = adapter.date('2026-08-15T12:00:00')!
+        const natural = adapter.getWeekArray(august)
+        expect(natural).toHaveLength(6)
+        expect(adapter.getWeekArray(august, true)).toEqual(natural)
+      })
+
       it.each([
         ['2025-01-07T23:30:00', '2025-01-07T10:00:00', 0],
         ['2025-01-08T09:30:00', '2025-01-07T10:00:00', 0],

--- a/packages/0/src/composables/useDate/index.test.ts
+++ b/packages/0/src/composables/useDate/index.test.ts
@@ -490,6 +490,22 @@ describe('createDate', () => {
         expect(adapter.getWeekArray(june, true)).toHaveLength(6)
       })
 
+      it('should pad to 6 weeks with fixedWeeks under a Monday week start', () => {
+        const a = new V0DateAdapter()
+        a.firstDayOfWeek = 1
+        // Feb 2026 spans 5 rows Monday-start (vs 4 Sunday-start)
+        const february = a.date('2026-02-15T12:00:00')!
+        expect(a.getWeekArray(february)).toHaveLength(5)
+
+        const fixed = a.getWeekArray(february, true)
+        expect(fixed).toHaveLength(6)
+        // Continuity: padding continues day-by-day from the last natural cell
+        const flat = fixed.flat()
+        for (let index = 1; index < flat.length; index++) {
+          expect(a.getDiff(flat[index]!, flat[index - 1]!, 'days')).toBe(1)
+        }
+      })
+
       it('should leave natural 6-week months unchanged with fixedWeeks', () => {
         // Aug 2026 (Sunday start) spans 6 rows naturally
         const august = adapter.date('2026-08-15T12:00:00')!


### PR DESCRIPTION
`getWeekArray` emits 4, 5, or 6 rows depending on the month (Feb 2026 with a Sunday start is exactly 4), so any calendar grid built on it changes height between months — the single most likely reason a consumer reimplements the geometry instead of using the adapter. Every surveyed date-picker library offers a fixed-6-row option (Reka's `fixedWeeks`, Melt, Zag, Corvu, react-day-picker).

## What changed

- `getWeekArray(date, fixedWeeks?)` — new optional flag on the `DateAdapter` contract and the `V0DateAdapter` implementation. When set, trailing weeks pad day-by-day into the next month up to a constant 6 rows (42 cells).
- Months that naturally span 6 rows are unchanged; default behavior without the flag is byte-identical to before.

## Coverage

Tests cover a natural 4-row month padding to 6 (Feb 2026, including the padded cells' dates), a 5-row month padding by one week, and a natural 6-row month being returned unchanged with the flag set.

Groundwork for the upcoming `createCalendar` core, which consumes this from the incubating EmCalendar refactor.