### PR TITLE
refactor(emerald): extract the calendar core from EmCalendar (incubation phase 1)

### DIFF
--- a/.changeset/emcalendar-core-split.md
+++ b/.changeset/emcalendar-core-split.md
@@ -1,0 +1,7 @@
+---
+'@paper/emerald': minor
+---
+
+fix(EmCalendar): correct selection, focus, and announcement behavior; add Title `live` and component `as` support
+
+The calendar no longer silently selects today on mount without updating your model, and clearing the model now clears the selected paint. The today indicator rolls over at midnight instead of going stale. Keyboard support gains Shift+PageUp/PageDown (±1 year) and RTL-aware arrow navigation; month changes are announced to screen readers via the title's new `live` prop (default on — set `:live="false"` on a second title over the same calendar), and the initial tab stop lands on the selected day when one is visible. `EmCalendarTitle`'s `as` now accepts components as well as tag names. Internally the calendar is rebuilt on a selection-free geometry core slated for graduation to `@vuetify/v0`.

--- a/dev/src/EmeraldCalendar.vue
+++ b/dev/src/EmeraldCalendar.vue
@@ -183,7 +183,14 @@
           class="adm-calendar__mini"
           :events="visible"
         >
-          <EmCalendarTitle as="p" class="adm-calendar__mini-head" />
+          <!-- The main header's title already announces the month; both roots
+               share one cursor, so a live region here would double it up. -->
+          <EmCalendarTitle
+            as="p"
+            class="adm-calendar__mini-head"
+            :live="false"
+          />
+
           <EmCalendarMini />
         </EmCalendar>
 

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
@@ -253,6 +253,31 @@ describe('emCalendar', () => {
       expect(host.querySelector('.emerald-calendar__title')!.textContent).toBe('August 2027')
     })
 
+    it('should carry focus across an external month write', async () => {
+      const month = shallowRef(TODAY)
+      const host = mount({
+        get month () {
+          return month.value
+        },
+      })
+
+      at(host, '2026-08-22').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(at(host, '2026-08-29').tabIndex).toBe(0)
+
+      // The page moves the cursor itself — focus must follow into the new grid
+      // rather than pointing at a day that is no longer rendered.
+      month.value = new Date(2026, 10, 1)
+      await nextTick()
+
+      expect(host.querySelector('.emerald-calendar__title')!.textContent).toBe('November 2026')
+      expect(at(host, '2026-11-29').tabIndex).toBe(0)
+      expect(cells(host).filter(cell => cell.tabIndex === 0)).toHaveLength(1)
+    })
+
     it('should page when an arrow walks off the month edge', async () => {
       const host = mount()
 

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Context
+import EmCalendar from './EmCalendar.vue'
+import EmCalendarGrid from './EmCalendarGrid.vue'
+import EmCalendarTitle from './EmCalendarTitle.vue'
+
+// Utilities
+import { createApp, h, nextTick, shallowRef } from 'vue'
+
+// Types
+import type { App } from 'vue'
+
+/** 2026-08-04 — a Tuesday; August 2026 spills to six rows naturally. */
+const TODAY = new Date(2026, 7, 4)
+
+const apps: App[] = []
+
+function mount (props: Record<string, unknown> = {}) {
+  const host = document.createElement('div')
+
+  document.body.append(host)
+
+  const app = createApp({
+    render: () => h(EmCalendar, props, () => [h(EmCalendarTitle), h(EmCalendarGrid)]),
+  })
+
+  apps.push(app)
+  app.mount(host)
+
+  return host
+}
+
+function cells (host: HTMLElement) {
+  return [...host.querySelectorAll<HTMLElement>('.emerald-calendar__cell')]
+}
+
+function at (host: HTMLElement, iso: string) {
+  return host.querySelector<HTMLElement>(`[data-iso="${iso}"]`)!
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(TODAY)
+})
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.unmount()
+
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+})
+
+describe('emCalendar', () => {
+  describe('structure', () => {
+    it('should render the 42-cell matrix the DS card is sized for', () => {
+      const host = mount()
+
+      expect(cells(host)).toHaveLength(42)
+      expect(host.querySelectorAll('.emerald-calendar__week')).toHaveLength(6)
+      expect(host.querySelectorAll('[role="columnheader"]')).toHaveLength(7)
+      expect(host.querySelector('.emerald-calendar')).not.toBeNull()
+      expect(host.querySelector('[role="grid"]')).not.toBeNull()
+    })
+
+    it('should mark the spill and today', () => {
+      const host = mount()
+
+      expect(at(host, '2026-07-26').dataset.out).toBe('true')
+      expect(at(host, '2026-08-04').dataset.out).toBeUndefined()
+      expect(at(host, '2026-08-04').getAttribute('aria-current')).toBe('date')
+    })
+
+    it('should name the grid after the title', () => {
+      const host = mount()
+
+      const title = host.querySelector('.emerald-calendar__title')!
+      const grid = host.querySelector('[role="grid"]')!
+
+      expect(grid.getAttribute('aria-labelledby')).toBe(title.id)
+      expect(title.getAttribute('aria-live')).toBe('polite')
+      expect(title.textContent).toBe('August 2026')
+    })
+  })
+
+  describe('selection', () => {
+    it('should paint the bound day', () => {
+      const host = mount({ modelValue: '2026-08-11' })
+
+      expect(at(host, '2026-08-11').dataset.selected).toBe('true')
+      expect(at(host, '2026-08-11').getAttribute('aria-selected')).toBe('true')
+      expect(cells(host).filter(cell => cell.dataset.selected)).toHaveLength(1)
+    })
+
+    it('should select nothing until asked', () => {
+      const host = mount()
+
+      expect(cells(host).some(cell => cell.dataset.selected)).toBe(false)
+    })
+
+    it('should write the model back on click', async () => {
+      const selected = shallowRef<string | undefined>()
+      const host = mount({
+        get 'modelValue' () {
+          return selected.value
+        },
+        'onUpdate:modelValue': (value: string) => {
+          selected.value = value
+        },
+      })
+
+      at(host, '2026-08-11').click()
+      await nextTick()
+
+      expect(selected.value).toBe('2026-08-11')
+      expect(at(host, '2026-08-11').dataset.selected).toBe('true')
+    })
+
+    it('should clear the paint when the model is cleared', async () => {
+      const selected = shallowRef<string | undefined>('2026-08-11')
+      const host = mount({
+        get modelValue () {
+          return selected.value
+        },
+      })
+
+      expect(at(host, '2026-08-11').dataset.selected).toBe('true')
+
+      selected.value = undefined
+      await nextTick()
+
+      expect(cells(host).some(cell => cell.dataset.selected)).toBe(false)
+    })
+
+    it('should ignore clicks while disabled', async () => {
+      const selected = shallowRef<string | undefined>()
+      const host = mount({
+        'disabled': true,
+        'onUpdate:modelValue': (value: string) => {
+          selected.value = value
+        },
+      })
+
+      at(host, '2026-08-11').click()
+      await nextTick()
+
+      expect(selected.value).toBeUndefined()
+    })
+  })
+
+  describe('navigation', () => {
+    it('should page the month model without touching the selection', async () => {
+      const month = shallowRef(TODAY)
+      const selected = shallowRef<string | undefined>('2026-08-11')
+      const host = mount({
+        get 'modelValue' () {
+          return selected.value
+        },
+        get 'month' () {
+          return month.value
+        },
+        'onUpdate:month': (value: Date) => {
+          month.value = value
+        },
+      })
+
+      at(host, '2026-08-11').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(host.querySelector('.emerald-calendar__title')!.textContent).toBe('September 2026')
+      expect(month.value.getFullYear()).toBe(2026)
+      expect(month.value.getMonth()).toBe(8)
+      expect(month.value.getDate()).toBe(1)
+      expect(selected.value).toBe('2026-08-11')
+    })
+
+    it('should jump a whole year on Shift+PageDown', async () => {
+      const host = mount()
+
+      at(host, '2026-08-11').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageDown', shiftKey: true, bubbles: true }),
+      )
+      await nextTick()
+
+      expect(host.querySelector('.emerald-calendar__title')!.textContent).toBe('August 2027')
+    })
+
+    it('should page when an arrow walks off the month edge', async () => {
+      const host = mount()
+
+      at(host, '2026-08-31').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(host.querySelector('.emerald-calendar__title')!.textContent).toBe('September 2026')
+    })
+  })
+
+  describe('events', () => {
+    it('should chip events and roll the rest into the overflow row', () => {
+      const host = mount({
+        events: [
+          { date: '2026-08-11', title: 'One', time: '09:00' },
+          { date: '2026-08-11', title: 'Two', allDay: true, tone: 'primary' },
+          { date: '2026-08-11', title: 'Three' },
+        ],
+      })
+
+      const cell = at(host, '2026-08-11')
+
+      expect(cell.querySelectorAll('.emerald-calendar__event')).toHaveLength(2)
+      expect(cell.querySelector('.emerald-calendar__more')!.textContent).toBe('+1 more')
+      expect(cell.getAttribute('aria-label')).toContain('3 events')
+      expect(cell.querySelector('[data-tone="primary"]')).not.toBeNull()
+      expect(cell.querySelector('[data-allday]')).not.toBeNull()
+    })
+  })
+})

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
@@ -9,26 +9,31 @@ import EmCalendarTitle from './EmCalendarTitle.vue'
 import { createApp, h, nextTick, shallowRef } from 'vue'
 
 // Types
-import type { App } from 'vue'
+import type { EmCalendarTitleProps } from './EmCalendarTitle.vue'
+import type { App, VNode } from 'vue'
 
 /** 2026-08-04 — a Tuesday; August 2026 spills to six rows naturally. */
 const TODAY = new Date(2026, 7, 4)
 
 const apps: App[] = []
 
-function mount (props: Record<string, unknown> = {}) {
+function mountWith (title: VNode, props: Record<string, unknown> = {}) {
   const host = document.createElement('div')
 
   document.body.append(host)
 
   const app = createApp({
-    render: () => h(EmCalendar, props, () => [h(EmCalendarTitle), h(EmCalendarGrid)]),
+    render: () => h(EmCalendar, props, () => [title, h(EmCalendarGrid)]),
   })
 
   apps.push(app)
   app.mount(host)
 
   return host
+}
+
+function mount (props: Record<string, unknown> = {}) {
+  return mountWith(h(EmCalendarTitle), props)
 }
 
 function cells (host: HTMLElement) {
@@ -69,6 +74,35 @@ describe('emCalendar', () => {
       expect(at(host, '2026-07-26').dataset.out).toBe('true')
       expect(at(host, '2026-08-04').dataset.out).toBeUndefined()
       expect(at(host, '2026-08-04').getAttribute('aria-current')).toBe('date')
+    })
+
+    it('should render the title as a level-two heading by default', () => {
+      const host = mount()
+      const title = host.querySelector('.emerald-calendar__title')!
+
+      expect(title.tagName).toBe('H2')
+      expect(title.id).toBeTruthy()
+      expect(title.getAttribute('aria-live')).toBe('polite')
+      expect(title.textContent).toBe('August 2026')
+    })
+
+    it('should render the title as the requested element', () => {
+      const host = mountWith(h(EmCalendarTitle, { as: 'p', live: false }))
+      const title = host.querySelector('.emerald-calendar__title')!
+
+      expect(title.tagName).toBe('P')
+      expect(title.id).toBeTruthy()
+      expect(title.getAttribute('aria-live')).toBeNull()
+      expect(title.textContent).toBe('August 2026')
+    })
+
+    it('should reject a renderless title at the type level', () => {
+      // Renderless would drop the id the grid's aria-labelledby points at, so
+      // `as` is non-nullable even though Atom itself accepts null.
+      // @ts-expect-error — null is not assignable to EmCalendarTitleProps['as']
+      const as: EmCalendarTitleProps['as'] = null
+
+      expect(as).toBeNull()
     })
 
     it('should name the grid after the title', () => {

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.test.ts
@@ -148,6 +148,72 @@ describe('emCalendar', () => {
     })
   })
 
+  describe('roving tabindex', () => {
+    it('should give exactly one in-month cell the tab stop', () => {
+      const host = mount({ modelValue: '2026-08-11' })
+
+      const stops = cells(host).filter(cell => cell.tabIndex === 0)
+
+      expect(stops).toHaveLength(1)
+      expect(stops[0].dataset.out).toBeUndefined()
+    })
+
+    it('should park the tab stop on a visible selected day', () => {
+      const host = mount({ modelValue: '2026-08-11' })
+
+      expect(at(host, '2026-08-11').tabIndex).toBe(0)
+      expect(at(host, '2026-08-04').tabIndex).toBe(-1)
+    })
+
+    it('should fall back to today when the selection is off-month', () => {
+      const host = mount({ modelValue: '2027-03-11' })
+
+      expect(at(host, '2026-08-04').tabIndex).toBe(0)
+    })
+
+    it('should let the roving cursor outrank the selection once it moves', async () => {
+      const host = mount({ modelValue: '2026-08-11' })
+
+      at(host, '2026-08-11').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(at(host, '2026-08-18').tabIndex).toBe(0)
+      expect(at(host, '2026-08-11').tabIndex).toBe(-1)
+
+      // Paging away and back is governed by the entry rule — the day of month
+      // carries across — not by re-seeding from the selection.
+      at(host, '2026-08-18').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(at(host, '2026-09-18').tabIndex).toBe(0)
+
+      at(host, '2026-09-18').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(at(host, '2026-08-18').tabIndex).toBe(0)
+      expect(at(host, '2026-08-11').tabIndex).toBe(-1)
+    })
+
+    it('should follow the keyboard rather than a stale local copy', async () => {
+      const host = mount()
+
+      at(host, '2026-08-04').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      )
+      await nextTick()
+
+      expect(at(host, '2026-08-11').tabIndex).toBe(0)
+      expect(at(host, '2026-08-04').tabIndex).toBe(-1)
+      expect(cells(host).filter(cell => cell.tabIndex === 0)).toHaveLength(1)
+    })
+  })
+
   describe('navigation', () => {
     it('should page the month model without touching the selection', async () => {
       const month = shallowRef(TODAY)

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.vue
@@ -63,9 +63,11 @@
 
   const cursor = toRef(() => date.parse(calendar.anchor.value))
 
+  const matrix = computed(() => calendar.months.value[0].weeks.flat())
+
   // The core's cells carry geometry only; the DS shape adds the `Date` its
   // sub-components format from, and reads the spill as `inMonth`.
-  const cells = computed(() => calendar.months.value[0].weeks.flat().map(
+  const cells = computed(() => matrix.value.map(
     (cell): EmCalendarCell => ({
       date: date.parse(cell.iso),
       iso: cell.iso,
@@ -74,6 +76,15 @@
       today: cell.today,
     }),
   ))
+
+  // APG entry order is last-focused, then selected, then today — so a visible
+  // selection owns the first tab stop. Mount-time only: once the user pages or
+  // walks, the roving cursor rightly outranks the selection.
+  const initial = matrix.value.find(
+    cell => cell.iso === selected.value && !cell.outside && !cell.disabled,
+  )
+
+  if (initial) calendar.focused.value = initial.iso
 
   const schedule = computed(() => {
     const map = new Map<string, EmCalendarEvent[]>()
@@ -98,7 +109,7 @@
   function select (iso: string) {
     if (disabled) return
 
-    const cell = calendar.months.value[0].weeks.flat().find(entry => entry.iso === iso)
+    const cell = matrix.value.find(entry => entry.iso === iso)
 
     if (cell?.disabled) return
 

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
   // Framework
-  import { createSingle, isString } from '@vuetify/v0'
+  import { isString } from '@vuetify/v0'
 
+  // Composables
+  import { createCalendar } from './calendar'
   // Context
   import { EM_CALENDAR_NAMESPACE, provideEmCalendarContext } from './context'
   import { useEmCalendarDate } from './date'
@@ -10,6 +12,7 @@
   import { computed, toRef, useId, watch } from 'vue'
 
   // Types
+  import type { CalendarUnit } from './calendar'
   import type { EmCalendarCell, EmCalendarContext, EmCalendarEvent } from './context'
 
   export interface EmCalendarProps {
@@ -39,32 +42,38 @@
   const month = defineModel<Date>('month')
 
   const date = useEmCalendarDate()
-  const now = date.now()
   const title = useId()
 
-  const first = toRef(() => firstDayOfWeek ?? date.first())
-  const cursor = computed(() => date.month(month.value ?? now))
-  const label = toRef(() => date.label(cursor.value))
-  const weekdays = toRef(() => date.weekdays(first.value))
-
-  const calendar = computed(() => {
-    const start = date.days(cursor.value, -((cursor.value.getDay() - first.value + 7) % 7))
-    const anchor = cursor.value.getMonth()
-    const today = date.iso(now)
-
-    return Array.from({ length: 42 }, (_, index): EmCalendarCell => {
-      const value = date.days(start, index)
-      const iso = date.iso(value)
-
-      return {
-        date: value,
-        iso,
-        day: value.getDate(),
-        inMonth: value.getMonth() === anchor,
-        today: iso === today,
-      }
-    })
+  /**
+   * The core speaks `YYYY-MM`; the model stays a `Date` for compatibility, so
+   * the anchor is bridged in both directions — the getter feeds the core, the
+   * watch writes navigation back out.
+   */
+  const calendar = createCalendar({
+    month: () => date.iso(month.value ?? date.now()).slice(0, 7),
+    firstDayOfWeek: () => firstDayOfWeek ?? date.first(),
+    disabled: () => disabled,
+    // Emerald holds a constant card height, so the matrix never reflows.
+    fixedWeeks: true,
   })
+
+  watch(calendar.anchor, value => {
+    month.value = date.parse(value)
+  })
+
+  const cursor = toRef(() => date.parse(calendar.anchor.value))
+
+  // The core's cells carry geometry only; the DS shape adds the `Date` its
+  // sub-components format from, and reads the spill as `inMonth`.
+  const cells = computed(() => calendar.months.value[0].weeks.flat().map(
+    (cell): EmCalendarCell => ({
+      date: date.parse(cell.iso),
+      iso: cell.iso,
+      day: cell.day,
+      inMonth: !cell.outside,
+      today: cell.today,
+    }),
+  ))
 
   const schedule = computed(() => {
     const map = new Map<string, EmCalendarEvent[]>()
@@ -80,31 +89,26 @@
     return map
   })
 
-  // Days enroll on first touch rather than 42 at a time — the matrix re-slices
-  // every month, and stale tickets would outnumber live ones within a year.
-  const day = createSingle({ mandatory: 'force' })
-
-  function enroll (iso: string) {
-    if (!day.has(iso)) day.register({ id: iso, value: iso })
-  }
-
-  const initial = selected.value ?? date.iso(now)
-
-  enroll(initial)
-  day.select(initial)
-
+  /**
+   * Selection is a plain guarded write, not a registry: days are an unbounded
+   * collection, so ticketing them only ever accumulated. Nothing is selected
+   * until the model or the user says so, and the paint is one comparison — so
+   * clearing the model clears the highlight.
+   */
   function select (iso: string) {
     if (disabled) return
 
-    enroll(iso)
-    day.select(iso)
+    const cell = calendar.months.value[0].weeks.flat().find(entry => entry.iso === iso)
+
+    if (cell?.disabled) return
+
     selected.value = iso
   }
 
   function step (amount: number) {
     if (disabled) return
 
-    month.value = date.months(cursor.value, amount)
+    calendar.step(amount)
   }
 
   function prev () {
@@ -118,37 +122,39 @@
   function today () {
     if (disabled) return
 
-    month.value = date.month(now)
-    select(date.iso(now))
+    calendar.today()
+
+    select(date.iso(date.now()))
   }
 
-  watch(selected, iso => {
-    if (!iso || day.selected(iso)) return
+  function move (unit: CalendarUnit, amount: number) {
+    if (disabled) return
 
-    enroll(iso)
-    day.select(iso)
-  })
+    calendar.move(unit, amount)
+  }
 
   const context: EmCalendarContext = {
     cursor,
-    cells: calendar,
-    weekdays,
-    label,
+    cells,
+    weekdays: calendar.weekdays,
+    label: calendar.label,
     disabled: toRef(() => disabled),
     title,
     date,
     events: iso => schedule.value.get(iso) ?? [],
-    selected: iso => day.selected(iso),
+    selected: iso => selected.value === iso,
     select,
     prev,
     next,
     today,
     step,
+    focused: calendar.focused,
+    move,
   }
 
   provideEmCalendarContext(namespace, context)
 
-  defineExpose({ day })
+  defineExpose({ calendar })
 </script>
 
 <template>

--- a/packages/emerald/src/components/EmCalendar/EmCalendarGrid.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendarGrid.vue
@@ -6,7 +6,7 @@
   import { EM_CALENDAR_NAMESPACE, useEmCalendarContext } from './context'
 
   // Utilities
-  import { nextTick, shallowRef, toRef, useTemplateRef } from 'vue'
+  import { nextTick, toRef, useTemplateRef } from 'vue'
 
   // Types
   import type { CalendarUnit } from './calendar'
@@ -31,19 +31,17 @@
   const rtl = useRtl()
 
   const root = useTemplateRef<HTMLElement>('root')
-  /** Day the keyboard last walked to; null until the user drives the grid. */
-  const active = shallowRef<string | null>(null)
 
   const weeks = toRef(() => Array.from(
     { length: 6 },
     (_, index) => context.cells.value.slice(index * 7, index * 7 + 7),
   ))
 
-  // Exactly one cell holds tabindex 0 — the walked day while it stays visible,
+  // Exactly one cell holds tabindex 0 — the focused day while it stays visible,
   // then the selected day, today, and finally the first day of the month.
   const tab = toRef(() => {
     const cells = context.cells.value
-    const walked = cells.find(cell => cell.iso === active.value && cell.inMonth)
+    const walked = cells.find(cell => cell.iso === context.focused.value && cell.inMonth)
 
     if (walked) return walked.iso
 
@@ -79,11 +77,7 @@
 
     context.move(unit, amount)
 
-    const iso = context.focused.value
-
-    active.value = iso
-
-    nextTick(() => focus(iso))
+    nextTick(() => focus(context.focused.value))
   }
 
   /** Home/End stay inside the rendered row, which is the week (APG). */
@@ -96,7 +90,6 @@
     const { iso } = cells[Math.floor(index / 7) * 7 + offset]
 
     context.focused.value = iso
-    active.value = iso
 
     focus(iso)
   }
@@ -104,7 +97,6 @@
   function onSelect (cell: EmCalendarCell) {
     if (!cell.inMonth || context.disabled.value) return
 
-    active.value = cell.iso
     context.focused.value = cell.iso
 
     context.select(cell.iso)

--- a/packages/emerald/src/components/EmCalendar/EmCalendarGrid.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendarGrid.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+  // Framework
+  import { useRtl } from '@vuetify/v0'
+
   // Context
   import { EM_CALENDAR_NAMESPACE, useEmCalendarContext } from './context'
 
@@ -6,6 +9,7 @@
   import { nextTick, shallowRef, toRef, useTemplateRef } from 'vue'
 
   // Types
+  import type { CalendarUnit } from './calendar'
   import type { EmCalendarCell } from './context'
 
   export interface EmCalendarGridProps {
@@ -24,6 +28,7 @@
   } = defineProps<EmCalendarGridProps>()
 
   const context = useEmCalendarContext(namespace)
+  const rtl = useRtl()
 
   const root = useTemplateRef<HTMLElement>('root')
   /** Day the keyboard last walked to; null until the user drives the grid. */
@@ -65,31 +70,42 @@
   }
 
   /**
-   * Walks to `target`, pulling the cursor along when it lands outside the
-   * visible month. The cell is re-keyed by that re-render, so focus is re-taken
-   * once the new matrix is in the DOM.
+   * Walks from `cell`, letting the core pull the cursor along when focus lands
+   * outside the visible month. The cell is re-keyed by that re-render, so focus
+   * is re-taken once the new matrix is in the DOM.
    */
-  function go (target: Date) {
-    const cursor = context.cursor.value
-    const delta = (target.getFullYear() - cursor.getFullYear()) * 12 + (target.getMonth() - cursor.getMonth())
-    const iso = context.date.iso(target)
+  function walk (cell: EmCalendarCell, unit: CalendarUnit, amount: number) {
+    context.focused.value = cell.iso
+
+    context.move(unit, amount)
+
+    const iso = context.focused.value
 
     active.value = iso
 
-    if (delta === 0) {
-      focus(iso)
-      return
-    }
-
-    context.step(delta)
-
     nextTick(() => focus(iso))
+  }
+
+  /** Home/End stay inside the rendered row, which is the week (APG). */
+  function edge (cell: EmCalendarCell, offset: number) {
+    const cells = context.cells.value
+    const index = cells.findIndex(entry => entry.iso === cell.iso)
+
+    if (index === -1) return
+
+    const { iso } = cells[Math.floor(index / 7) * 7 + offset]
+
+    context.focused.value = iso
+    active.value = iso
+
+    focus(iso)
   }
 
   function onSelect (cell: EmCalendarCell) {
     if (!cell.inMonth || context.disabled.value) return
 
     active.value = cell.iso
+    context.focused.value = cell.iso
 
     context.select(cell.iso)
   }
@@ -97,42 +113,37 @@
   function onKeydown (event: KeyboardEvent, cell: EmCalendarCell) {
     if (context.disabled.value) return
 
-    const { date } = context
-    let target: Date | undefined
+    // Arrows follow reading order, so the horizontal pair swaps under RTL.
+    const dir = rtl.isRtl.value ? -1 : 1
 
     switch (event.key) {
       case 'ArrowLeft': {
-        target = date.days(cell.date, -1)
+        walk(cell, 'day', -dir)
         break
       }
       case 'ArrowRight': {
-        target = date.days(cell.date, 1)
+        walk(cell, 'day', dir)
         break
       }
       case 'ArrowUp': {
-        target = date.days(cell.date, -7)
+        walk(cell, 'week', -1)
         break
       }
       case 'ArrowDown': {
-        target = date.days(cell.date, 7)
+        walk(cell, 'week', 1)
         break
       }
       case 'Home':
       case 'End': {
-        const cells = context.cells.value
-        const index = cells.findIndex(entry => entry.iso === cell.iso)
-
-        if (index === -1) return
-
-        target = cells[Math.floor(index / 7) * 7 + (event.key === 'Home' ? 0 : 6)].date
+        edge(cell, event.key === 'Home' ? 0 : 6)
         break
       }
       case 'PageUp': {
-        target = date.months(cell.date, -1)
+        walk(cell, event.shiftKey ? 'year' : 'month', -1)
         break
       }
       case 'PageDown': {
-        target = date.months(cell.date, 1)
+        walk(cell, event.shiftKey ? 'year' : 'month', 1)
         break
       }
       default: { return
@@ -140,8 +151,6 @@
     }
 
     event.preventDefault()
-
-    go(target)
   }
 </script>
 

--- a/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
@@ -1,11 +1,20 @@
 <script lang="ts">
+  // Framework
+  import { Atom } from '@vuetify/v0'
+
   // Context
   import { EM_CALENDAR_NAMESPACE, useEmCalendarContext } from './context'
 
+  // Types
+  import type { AtomProps } from '@vuetify/v0'
+
   export interface EmCalendarTitleProps {
     namespace?: string
-    /** Heading level for the month label. */
-    as?: string
+    /**
+     * Heading level for the month label. Non-nullable: the grid is labelled by
+     * the id stamped on this element, and a renderless title would drop it.
+     */
+    as?: NonNullable<AtomProps['as']>
     /** Announce month changes. Turn off on a second title over the same state. */
     live?: boolean
   }
@@ -26,14 +35,14 @@
 <template>
   <!-- The grid names itself after this element, and a month change is otherwise
        a silent update for anyone not watching the cells. -->
-  <component
-    :is="as"
+  <Atom
     :id="context.title"
     :aria-live="live ? 'polite' : undefined"
+    :as
     class="emerald-calendar__title"
   >
     <slot>{{ context.label.value }}</slot>
-  </component>
+  </Atom>
 </template>
 
 <style>

--- a/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
@@ -18,7 +18,14 @@
 </script>
 
 <template>
-  <component :is="as" :id="context.title" class="emerald-calendar__title">
+  <!-- The grid names itself after this element, and a month change is otherwise
+       a silent update for anyone not watching the cells. -->
+  <component
+    :is="as"
+    :id="context.title"
+    aria-live="polite"
+    class="emerald-calendar__title"
+  >
     <slot>{{ context.label.value }}</slot>
   </component>
 </template>

--- a/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendarTitle.vue
@@ -6,13 +6,19 @@
     namespace?: string
     /** Heading level for the month label. */
     as?: string
+    /** Announce month changes. Turn off on a second title over the same state. */
+    live?: boolean
   }
 </script>
 
 <script setup lang="ts">
   defineOptions({ name: 'EmCalendarTitle' })
 
-  const { namespace = EM_CALENDAR_NAMESPACE, as = 'h2' } = defineProps<EmCalendarTitleProps>()
+  const {
+    namespace = EM_CALENDAR_NAMESPACE,
+    as = 'h2',
+    live = true,
+  } = defineProps<EmCalendarTitleProps>()
 
   const context = useEmCalendarContext(namespace)
 </script>
@@ -23,7 +29,7 @@
   <component
     :is="as"
     :id="context.title"
-    aria-live="polite"
+    :aria-live="live ? 'polite' : undefined"
     class="emerald-calendar__title"
   >
     <slot>{{ context.label.value }}</slot>

--- a/packages/emerald/src/components/EmCalendar/calendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.test.ts
@@ -426,6 +426,34 @@ describe('createCalendar', () => {
       expect(calendar.focused.value).toBe('0099-03-01')
       expect(flat(calendar).some(cell => cell.iso.startsWith('1999'))).toBe(false)
     })
+
+    it('should zero-pad the year in cell ISO strings', () => {
+      const calendar = make()
+
+      calendar.goto('0999-04')
+
+      // Unpadded years break every lexicographic compare downstream — bounds,
+      // the in-month test, and the selected-day comparison in the DS.
+      expect(flat(calendar).every(cell => /^\d{4}-\d{2}-\d{2}$/.test(cell.iso))).toBe(true)
+      expect(flat(calendar).some(cell => cell.iso === '0999-04-28')).toBe(true)
+      expect(flat(calendar).filter(cell => !cell.outside)).toHaveLength(30)
+    })
+
+    it('should keep bounds comparable for a sub-1000 year', () => {
+      const calendar = make({ min: '0999-04-10', max: '0999-04-20' })
+
+      const cells = flat(calendar)
+
+      function at (iso: string) {
+        return cells.find(cell => cell.iso === iso)!
+      }
+
+      expect(calendar.anchor.value).toBe('0999-04')
+      expect(at('0999-04-09').disabled).toBe(true)
+      expect(at('0999-04-10').disabled).toBe(false)
+      expect(at('0999-04-20').disabled).toBe(false)
+      expect(at('0999-04-21').disabled).toBe(true)
+    })
   })
 
   describe('label', () => {
@@ -500,6 +528,57 @@ describe('createCalendar', () => {
       await nextTick()
 
       expect(calendar.anchor.value).toBe('2026-09')
+    })
+  })
+
+  describe('opening inside the walls', () => {
+    it('should open on the min month when today is before the window', () => {
+      // The booking-window default: min in the future, no month given.
+      const calendar = make({ min: '2026-10-12' })
+
+      expect(calendar.anchor.value).toBe('2026-10')
+      expect(calendar.isFirst.value).toBe(true)
+      expect(calendar.focused.value).toBe('2026-10-12')
+      expect(flat(calendar).some(cell => !cell.disabled)).toBe(true)
+    })
+
+    it('should open on the max month when today is past the window', () => {
+      const calendar = make({ max: '2026-03-09' })
+
+      expect(calendar.anchor.value).toBe('2026-03')
+      expect(calendar.isLast.value).toBe(true)
+      expect(flat(calendar).some(cell => !cell.disabled)).toBe(true)
+    })
+
+    it('should clamp an out-of-range month option at construction', () => {
+      const calendar = make({ month: '2027-05', max: '2026-09-30' })
+
+      expect(calendar.anchor.value).toBe('2026-09')
+      expect(calendar.focused.value).toBe('2026-09-01')
+    })
+  })
+
+  describe('malformed input', () => {
+    it('should ignore a goto it cannot parse', () => {
+      const calendar = make()
+
+      for (const value of ['nonsense', '', '2026', 'not-a-date', '20260804']) {
+        calendar.goto(value)
+
+        expect(calendar.anchor.value).toBe('2026-08')
+        expect(calendar.focused.value).toBe('2026-08-04')
+      }
+    })
+
+    it('should ignore a malformed controlled month', async () => {
+      const month = shallowRef('2026-08')
+      const calendar = make({ month })
+
+      month.value = 'garbage'
+      await nextTick()
+
+      expect(calendar.anchor.value).toBe('2026-08')
+      expect(flat(calendar)).toHaveLength(42)
     })
   })
 

--- a/packages/emerald/src/components/EmCalendar/calendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.test.ts
@@ -440,17 +440,56 @@ describe('createCalendar', () => {
   })
 
   describe('controlled month', () => {
-    it('should follow a ref the caller owns', async () => {
+    it('should follow a ref the caller owns, carrying focus across', async () => {
       const month = shallowRef('2026-08')
       const calendar = make({ month })
 
       expect(calendar.anchor.value).toBe('2026-08')
+      expect(calendar.focused.value).toBe('2026-08-04')
 
       month.value = '2026-11'
       await nextTick()
 
+      // An external anchor move is a page, so the day of month comes along.
       expect(calendar.anchor.value).toBe('2026-11')
-      expect(calendar.focused.value).toBe('2026-11-01')
+      expect(calendar.focused.value).toBe('2026-11-04')
+    })
+
+    it('should re-snap focus rather than stranding it outside the grid', async () => {
+      const month = shallowRef('2026-08')
+      const calendar = make({ month })
+
+      calendar.goto('2026-08-22')
+      expect(calendar.focused.value).toBe('2026-08-22')
+
+      month.value = '2027-02'
+      await nextTick()
+
+      expect(calendar.focused.value).toBe('2027-02-22')
+      expect(flat(calendar).some(cell => cell.iso === calendar.focused.value)).toBe(true)
+    })
+
+    it('should clamp the carried day to a shorter target month', async () => {
+      const month = shallowRef('2026-01')
+      const calendar = make({ month })
+
+      calendar.goto('2026-01-31')
+
+      month.value = '2026-02'
+      await nextTick()
+
+      expect(calendar.focused.value).toBe('2026-02-28')
+    })
+
+    it('should not double-snap on an internal page', () => {
+      const calendar = make({ month: shallowRef('2026-08') })
+
+      calendar.goto('2026-08-22')
+      calendar.next()
+
+      // One carry, not a carry followed by an invariant re-snap to the entry day.
+      expect(calendar.anchor.value).toBe('2026-09')
+      expect(calendar.focused.value).toBe('2026-09-22')
     })
 
     it('should accept a getter and clamp it to the walls', async () => {
@@ -461,6 +500,21 @@ describe('createCalendar', () => {
       await nextTick()
 
       expect(calendar.anchor.value).toBe('2026-09')
+    })
+  })
+
+  describe('scope safety', () => {
+    it('should construct outside an effect scope without warning', () => {
+      using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const month = shallowRef('2026-08')
+      // Deliberately unscoped: no component, no effectScope.
+      const calendar = createCalendar({ month })
+
+      calendar.next()
+
+      expect(calendar.anchor.value).toBe('2026-09')
+      expect(warn).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/emerald/src/components/EmCalendar/calendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Composables
+import { createCalendar } from './calendar'
+
+// Utilities
+import { effectScope, nextTick, shallowRef } from 'vue'
+
+// Types
+import type { CalendarContext, CalendarOptions } from './calendar'
+
+/** 2026-08-04 — a Tuesday in a month that spills to six rows naturally. */
+const TODAY = new Date(2026, 7, 4)
+
+const scopes: ReturnType<typeof effectScope>[] = []
+
+/** `useTimer` registers an `onScopeDispose`, so every instance gets a scope. */
+function make (options: CalendarOptions = {}): CalendarContext {
+  const scope = effectScope()
+
+  scopes.push(scope)
+
+  return scope.run(() => createCalendar(options))!
+}
+
+function flat (calendar: CalendarContext) {
+  return calendar.months.value[0].weeks.flat()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(TODAY)
+})
+
+afterEach(() => {
+  for (const scope of scopes.splice(0)) scope.stop()
+
+  vi.useRealTimers()
+})
+
+describe('createCalendar', () => {
+  describe('anchor and paging', () => {
+    it('should anchor on the current month when uncontrolled', () => {
+      const calendar = make()
+
+      expect(calendar.anchor.value).toBe('2026-08')
+      expect(calendar.months.value).toHaveLength(1)
+      expect(calendar.months.value[0].anchor).toBe('2026-08')
+    })
+
+    it('should page whole months with next and prev', () => {
+      const calendar = make()
+
+      calendar.next()
+      expect(calendar.anchor.value).toBe('2026-09')
+
+      calendar.prev()
+      calendar.prev()
+      expect(calendar.anchor.value).toBe('2026-07')
+    })
+
+    it('should cross the year boundary when stepping', () => {
+      const calendar = make()
+
+      calendar.step(5)
+      expect(calendar.anchor.value).toBe('2027-01')
+
+      calendar.step(-13)
+      expect(calendar.anchor.value).toBe('2025-12')
+    })
+
+    it('should clamp a step to the walls rather than overshooting', () => {
+      const calendar = make({ min: '2026-06-10', max: '2026-10-20' })
+
+      calendar.step(-12)
+      expect(calendar.anchor.value).toBe('2026-06')
+
+      calendar.step(12)
+      expect(calendar.anchor.value).toBe('2026-10')
+    })
+
+    it('should flag isFirst and isLast only at the walls', () => {
+      const calendar = make({ min: '2026-07-01', max: '2026-09-30' })
+
+      expect(calendar.isFirst.value).toBe(false)
+      expect(calendar.isLast.value).toBe(false)
+
+      calendar.prev()
+      expect(calendar.isFirst.value).toBe(true)
+      expect(calendar.isLast.value).toBe(false)
+
+      calendar.step(2)
+      expect(calendar.isFirst.value).toBe(false)
+      expect(calendar.isLast.value).toBe(true)
+    })
+
+    it('should leave both flags false when unbounded', () => {
+      const calendar = make()
+
+      calendar.step(-500)
+      expect(calendar.isFirst.value).toBe(false)
+
+      calendar.step(1000)
+      expect(calendar.isLast.value).toBe(false)
+    })
+
+    it('should jump to the walls with first and last', () => {
+      const calendar = make({ min: '2026-01-15', max: '2026-12-05' })
+
+      calendar.first()
+      expect(calendar.anchor.value).toBe('2026-01')
+
+      calendar.last()
+      expect(calendar.anchor.value).toBe('2026-12')
+    })
+
+    it('should no-op first and last when unbounded', () => {
+      const calendar = make()
+
+      calendar.first()
+      expect(calendar.anchor.value).toBe('2026-08')
+
+      calendar.last()
+      expect(calendar.anchor.value).toBe('2026-08')
+    })
+  })
+
+  describe('goto', () => {
+    it('should accept a month and focus its entry day', () => {
+      const calendar = make()
+
+      calendar.goto('2027-03')
+
+      expect(calendar.anchor.value).toBe('2027-03')
+      expect(calendar.focused.value).toBe('2027-03-01')
+    })
+
+    it('should accept a day and focus it exactly', () => {
+      const calendar = make()
+
+      calendar.goto('2027-03-19')
+
+      expect(calendar.anchor.value).toBe('2027-03')
+      expect(calendar.focused.value).toBe('2027-03-19')
+    })
+
+    it('should focus today when paging back to the current month', () => {
+      const calendar = make()
+
+      calendar.goto('2027-03')
+      calendar.goto('2026-08')
+
+      expect(calendar.focused.value).toBe('2026-08-04')
+    })
+
+    it('should snap focus into the clamped month when the target is walled off', () => {
+      const calendar = make({ max: '2026-09-30' })
+
+      calendar.goto('2027-03-19')
+
+      expect(calendar.anchor.value).toBe('2026-09')
+      expect(calendar.focused.value).toBe('2026-09-01')
+    })
+  })
+
+  describe('today', () => {
+    it('should page to the current month and focus today', () => {
+      const calendar = make()
+
+      calendar.goto('2027-03')
+      calendar.today()
+
+      expect(calendar.anchor.value).toBe('2026-08')
+      expect(calendar.focused.value).toBe('2026-08-04')
+    })
+  })
+
+  describe('move', () => {
+    it('should walk the focused day without paging inside the month', () => {
+      const calendar = make()
+
+      calendar.move('day', 1)
+
+      expect(calendar.focused.value).toBe('2026-08-05')
+      expect(calendar.anchor.value).toBe('2026-08')
+    })
+
+    it('should page the anchor when focus leaves the month forwards', () => {
+      const calendar = make()
+
+      calendar.goto('2026-08-31')
+      calendar.move('day', 1)
+
+      expect(calendar.focused.value).toBe('2026-09-01')
+      expect(calendar.anchor.value).toBe('2026-09')
+    })
+
+    it('should page the anchor when focus leaves the month backwards', () => {
+      const calendar = make()
+
+      calendar.goto('2026-08-01')
+      calendar.move('day', -1)
+
+      expect(calendar.focused.value).toBe('2026-07-31')
+      expect(calendar.anchor.value).toBe('2026-07')
+    })
+
+    it('should walk by week, month, and year', () => {
+      const calendar = make()
+
+      calendar.move('week', 1)
+      expect(calendar.focused.value).toBe('2026-08-11')
+
+      calendar.move('month', 1)
+      expect(calendar.focused.value).toBe('2026-09-11')
+      expect(calendar.anchor.value).toBe('2026-09')
+
+      calendar.move('year', -1)
+      expect(calendar.focused.value).toBe('2025-09-11')
+      expect(calendar.anchor.value).toBe('2025-09')
+    })
+
+    it('should land on the wall rather than walking past it', () => {
+      const calendar = make({ min: '2026-08-02', max: '2026-08-20' })
+
+      calendar.move('year', 1)
+      expect(calendar.focused.value).toBe('2026-08-20')
+
+      calendar.move('year', -1)
+      expect(calendar.focused.value).toBe('2026-08-02')
+    })
+  })
+
+  describe('matrix', () => {
+    it('should emit four rows for a month that fills them exactly', () => {
+      const calendar = make()
+
+      calendar.goto('2026-02')
+
+      expect(calendar.months.value[0].weeks).toHaveLength(4)
+      expect(flat(calendar)[0].iso).toBe('2026-02-01')
+    })
+
+    it('should pad that month to six rows under fixedWeeks', () => {
+      const calendar = make({ fixedWeeks: true })
+
+      calendar.goto('2026-02')
+
+      const weeks = calendar.months.value[0].weeks
+      const cells = flat(calendar)
+
+      expect(weeks).toHaveLength(6)
+      expect(cells).toHaveLength(42)
+      expect(cells[0].iso).toBe('2026-02-01')
+      expect(cells[41].iso).toBe('2026-03-14')
+    })
+
+    it('should leave a natural six-row month untouched by fixedWeeks', () => {
+      const loose = make()
+      const fixed = make({ fixedWeeks: true })
+
+      expect(loose.months.value[0].weeks).toHaveLength(6)
+      expect(fixed.months.value[0].weeks).toHaveLength(6)
+      expect(flat(fixed).map(cell => cell.iso)).toEqual(flat(loose).map(cell => cell.iso))
+    })
+
+    it('should start every row on the configured week start', () => {
+      const calendar = make({ firstDayOfWeek: 1 })
+
+      // 2026-08-01 is a Saturday, so a Monday start leads with 2026-07-27.
+      expect(flat(calendar)[0].iso).toBe('2026-07-27')
+    })
+  })
+
+  describe('cells', () => {
+    it('should flag today and the surrounding spill', () => {
+      const calendar = make()
+      const cells = flat(calendar)
+
+      const today = cells.filter(cell => cell.today)
+
+      expect(today).toHaveLength(1)
+      expect(today[0].iso).toBe('2026-08-04')
+      expect(today[0].outside).toBe(false)
+      expect(today[0].day).toBe(4)
+
+      expect(cells[0].outside).toBe(true)
+      expect(cells[0].iso).toBe('2026-07-26')
+    })
+
+    it('should disable days outside min and max', () => {
+      const calendar = make({ min: '2026-08-05', max: '2026-08-20' })
+      const cells = flat(calendar)
+
+      function at (iso: string) {
+        return cells.find(cell => cell.iso === iso)!
+      }
+
+      expect(at('2026-08-04').disabled).toBe(true)
+      expect(at('2026-08-05').disabled).toBe(false)
+      expect(at('2026-08-20').disabled).toBe(false)
+      expect(at('2026-08-21').disabled).toBe(true)
+    })
+
+    it('should disable days rejected by the predicate', () => {
+      const calendar = make({ disabled: iso => iso.endsWith('-13') })
+      const cells = flat(calendar)
+
+      expect(cells.find(cell => cell.iso === '2026-08-13')!.disabled).toBe(true)
+      expect(cells.find(cell => cell.iso === '2026-08-14')!.disabled).toBe(false)
+    })
+
+    it('should disable every day when the whole calendar is disabled', () => {
+      const calendar = make({ disabled: true })
+
+      expect(flat(calendar).every(cell => cell.disabled)).toBe(true)
+    })
+
+    it('should track a reactive whole-calendar flag', async () => {
+      const disabled = shallowRef(false)
+      const calendar = make({ disabled })
+
+      expect(flat(calendar).some(cell => cell.disabled)).toBe(false)
+
+      disabled.value = true
+      await nextTick()
+
+      expect(flat(calendar).every(cell => cell.disabled)).toBe(true)
+    })
+  })
+
+  describe('weekdays', () => {
+    it('should rotate to the configured week start', () => {
+      const sunday = make()
+      const monday = make({ firstDayOfWeek: 1 })
+
+      expect(sunday.weekdays.value).toHaveLength(7)
+      expect(sunday.weekdays.value[0].long).toBe('Sunday')
+      expect(monday.weekdays.value[0].long).toBe('Monday')
+      expect(monday.weekdays.value[6].long).toBe('Sunday')
+    })
+
+    it('should carry all three widths', () => {
+      const calendar = make()
+      const [first] = calendar.weekdays.value
+
+      expect(first.short).toBe('Sun')
+      expect(first.narrow).toBe('S')
+    })
+  })
+
+  describe('label', () => {
+    it('should localize the anchor month', () => {
+      const calendar = make()
+
+      expect(calendar.label.value).toBe('August 2026')
+
+      calendar.next()
+      expect(calendar.label.value).toBe('September 2026')
+    })
+  })
+
+  describe('controlled month', () => {
+    it('should follow a ref the caller owns', async () => {
+      const month = shallowRef('2026-08')
+      const calendar = make({ month })
+
+      expect(calendar.anchor.value).toBe('2026-08')
+
+      month.value = '2026-11'
+      await nextTick()
+
+      expect(calendar.anchor.value).toBe('2026-11')
+      expect(calendar.focused.value).toBe('2026-11-01')
+    })
+
+    it('should accept a getter and clamp it to the walls', async () => {
+      const month = shallowRef('2026-08')
+      const calendar = make({ month: () => month.value, max: '2026-09-30' })
+
+      month.value = '2027-05'
+      await nextTick()
+
+      expect(calendar.anchor.value).toBe('2026-09')
+    })
+  })
+
+  describe('now', () => {
+    it('should roll the today flag over at midnight', async () => {
+      const calendar = make()
+
+      expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-04')
+
+      // The timer is armed for the next local midnight; advancing the fake
+      // clock past it re-reads the date and re-arms.
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000 + 1000)
+      await nextTick()
+
+      expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-05')
+    })
+  })
+})

--- a/packages/emerald/src/components/EmCalendar/calendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.test.ts
@@ -599,18 +599,46 @@ describe('createCalendar', () => {
 
   describe('now', () => {
     it('should roll the today flag over at midnight', async () => {
+      // Cost ceiling: `useTimer` runs an unconditional 100ms progress interval,
+      // so fake time is only ever advanced in seconds. Crossing a whole day
+      // would execute ~864k interval callbacks — CPU-bound and machine-speed
+      // dependent, which is what timed this test out on CI.
+      vi.setSystemTime(new Date(2026, 7, 4, 23, 59, 59))
+
       const calendar = make()
 
       expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-04')
 
-      // The timer is armed for the next local midnight; advancing the fake
-      // clock past it re-reads the date, and `repeat` re-arms for the one after.
-      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000 + 1000)
+      await vi.advanceTimersByTimeAsync(2000)
       await nextTick()
 
       expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-05')
 
-      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000)
+      // `repeat` re-arms off the clock as it reads at fire time, so the next
+      // tick is scheduled a full day out. Crossing it for real would cost the
+      // ~864k interval callbacks this test exists to avoid, so the re-arm is
+      // asserted directly: one-shot would have left nothing pending.
+      expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+      vi.setSystemTime(new Date(2026, 7, 5, 23, 59, 59))
+      await vi.advanceTimersByTimeAsync(2000)
+      await nextTick()
+
+      // The clock jumped but the re-armed timer is still a day of virtual time
+      // out, so the flag holds — the roll is driven by the timer, not by reads.
+      expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-05')
+    })
+
+    it('should roll again on the following midnight', async () => {
+      // The second consecutive rollover, bought at O(1) by arming a fresh
+      // calendar on the eve of it rather than traversing the day between.
+      vi.setSystemTime(new Date(2026, 7, 5, 23, 59, 59))
+
+      const calendar = make()
+
+      expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-05')
+
+      await vi.advanceTimersByTimeAsync(2000)
       await nextTick()
 
       expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-06')

--- a/packages/emerald/src/components/EmCalendar/calendar.test.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.test.ts
@@ -114,6 +114,73 @@ describe('createCalendar', () => {
       expect(calendar.anchor.value).toBe('2026-12')
     })
 
+    it('should never leave focus on a walled-off day', () => {
+      const calendar = make({ min: '2026-01-15', max: '2026-12-05' })
+
+      // The 1st of the min month is disabled, so the wall day takes focus.
+      calendar.first()
+      expect(calendar.focused.value).toBe('2026-01-15')
+
+      calendar.last()
+      expect(calendar.focused.value).toBe('2026-12-01')
+
+      calendar.step(-20)
+      expect(calendar.anchor.value).toBe('2026-01')
+      expect(calendar.focused.value).toBe('2026-01-15')
+    })
+
+    it('should pull focus back to the max wall when today overshoots it', () => {
+      const calendar = make({ max: '2026-08-02' })
+
+      calendar.last()
+
+      expect(calendar.anchor.value).toBe('2026-08')
+      expect(calendar.focused.value).toBe('2026-08-02')
+    })
+
+    it('should keep every focus landing selectable', () => {
+      const calendar = make({ min: '2026-01-15', max: '2026-12-05' })
+
+      for (const run of [() => calendar.first(), () => calendar.last(), () => calendar.step(-40)]) {
+        run()
+
+        const cell = flat(calendar).find(entry => entry.iso === calendar.focused.value)
+
+        expect(cell?.disabled).toBe(false)
+      }
+    })
+
+    it('should carry the day of month across a page', () => {
+      const calendar = make()
+
+      calendar.goto('2026-08-15')
+      calendar.next()
+
+      expect(calendar.anchor.value).toBe('2026-09')
+      expect(calendar.focused.value).toBe('2026-09-15')
+    })
+
+    it('should clamp the carried day to the target month length', () => {
+      const calendar = make()
+
+      calendar.goto('2026-01-31')
+      calendar.next()
+
+      expect(calendar.anchor.value).toBe('2026-02')
+      expect(calendar.focused.value).toBe('2026-02-28')
+    })
+
+    it('should round-trip focus when both months hold the day', () => {
+      const calendar = make()
+
+      calendar.goto('2026-08-15')
+      calendar.next()
+      calendar.prev()
+
+      expect(calendar.anchor.value).toBe('2026-08')
+      expect(calendar.focused.value).toBe('2026-08-15')
+    })
+
     it('should no-op first and last when unbounded', () => {
       const calendar = make()
 
@@ -349,6 +416,18 @@ describe('createCalendar', () => {
     })
   })
 
+  describe('early years', () => {
+    it('should not fold a two-digit year into the 1900s', () => {
+      const calendar = make()
+
+      calendar.goto('0099-03')
+
+      expect(calendar.anchor.value).toBe('0099-03')
+      expect(calendar.focused.value).toBe('0099-03-01')
+      expect(flat(calendar).some(cell => cell.iso.startsWith('1999'))).toBe(false)
+    })
+  })
+
   describe('label', () => {
     it('should localize the anchor month', () => {
       const calendar = make()
@@ -392,11 +471,16 @@ describe('createCalendar', () => {
       expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-04')
 
       // The timer is armed for the next local midnight; advancing the fake
-      // clock past it re-reads the date and re-arms.
+      // clock past it re-reads the date, and `repeat` re-arms for the one after.
       await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000 + 1000)
       await nextTick()
 
       expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-05')
+
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000)
+      await nextTick()
+
+      expect(flat(calendar).find(cell => cell.today)!.iso).toBe('2026-08-06')
     })
   })
 })

--- a/packages/emerald/src/components/EmCalendar/calendar.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.ts
@@ -128,6 +128,16 @@ function within (iso: string, anchor: string) {
 }
 
 /**
+ * `YYYY-MM` or `YYYY-MM-DD`. A structural check, not validation — it exists so
+ * an unparseable string no-ops instead of turning the anchor into `NaN`.
+ */
+const SHAPE = /^\d{4}-\d{2}(-\d{2})?$/
+
+function shaped (value: unknown): value is string {
+  return isString(value) && SHAPE.test(value)
+}
+
+/**
  * Creates the geometry and navigation state for a month calendar.
  *
  * @param options Bounds, anchor, and matrix shape.
@@ -146,8 +156,8 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
 
   const date = useEmCalendarDate()
 
-  const floor = isString(min) ? ordinal(min.slice(0, 7)) : Number.NEGATIVE_INFINITY
-  const ceiling = isString(max) ? ordinal(max.slice(0, 7)) : Number.POSITIVE_INFINITY
+  const floor = shaped(min) ? ordinal(min.slice(0, 7)) : Number.NEGATIVE_INFINITY
+  const ceiling = shaped(max) ? ordinal(max.slice(0, 7)) : Number.POSITIVE_INFINITY
 
   /** Today, re-read on a midnight tick rather than snapshotted at setup. */
   const now = shallowRef(date.iso(date.now()))
@@ -164,12 +174,14 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
     return key(clamp(ordinal(value), floor, ceiling))
   }
 
-  const anchor = shallowRef(wall(toValue(month) ?? now.value.slice(0, 7)))
+  const opening = toValue(month)
+
+  const anchor = shallowRef(wall(shaped(opening) ? opening.slice(0, 7) : now.value.slice(0, 7)))
 
   /** Focus never rests on a walled-off day. */
   function bound (iso: string) {
-    if (isString(min) && iso < min) return min
-    if (isString(max) && iso > max) return max
+    if (shaped(min) && iso < min) return min
+    if (shaped(max) && iso > max) return max
 
     return iso
   }
@@ -200,6 +212,8 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
    * below to re-snap, which is what keeps an internal page from snapping twice.
    */
   function goto (value: string) {
+    if (!shaped(value)) return
+
     const target = wall(value.slice(0, 7))
 
     focused.value = value.length > 7 && within(value, target) ? bound(value) : entry(target)
@@ -249,8 +263,8 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
     const iso = date.iso(to)
 
     // A walk that overshoots a wall lands on it rather than stopping dead.
-    if (isString(min) && iso < min) return goto(min)
-    if (isString(max) && iso > max) return goto(max)
+    if (shaped(min) && iso < min) return goto(min)
+    if (shaped(max) && iso > max) return goto(max)
 
     focused.value = iso
 
@@ -261,7 +275,7 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
 
   if (!isUndefined(month)) {
     watch(() => toValue(month), value => {
-      if (!isString(value)) return
+      if (!shaped(value)) return
 
       // Only the anchor moves; the watcher above carries focus across with it.
       anchor.value = wall(value.slice(0, 7))
@@ -277,7 +291,7 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
   }
 
   function walled (iso: string) {
-    return (isString(min) && iso < min) || (isString(max) && iso > max)
+    return (shaped(min) && iso < min) || (shaped(max) && iso > max)
   }
 
   const start = toRef(() => toValue(firstDayOfWeek) ?? date.first())
@@ -317,10 +331,10 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
     isFirst: toRef(() => ordinal(anchor.value) <= floor),
     isLast: toRef(() => ordinal(anchor.value) >= ceiling),
     first: () => {
-      if (isString(min)) goto(min.slice(0, 7))
+      if (shaped(min)) goto(min.slice(0, 7))
     },
     last: () => {
-      if (isString(max)) goto(max.slice(0, 7))
+      if (shaped(max)) goto(max.slice(0, 7))
     },
     next: () => step(1),
     prev: () => step(-1),

--- a/packages/emerald/src/components/EmCalendar/calendar.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.ts
@@ -1,0 +1,288 @@
+/**
+ * @module createCalendar
+ *
+ * @remarks
+ * Geometry and navigation for a month calendar — the minimum any calendar
+ * needs, and deliberately nothing more. Selection lives a layer up: this core
+ * has no `selected`, no `select()`, and no notion of a chosen value.
+ *
+ * Incubating inside Emerald ahead of graduation to `packages/0` as
+ * `createCalendar`; the `@see` docs link lands with that move. It is not
+ * exported from any Emerald barrel — the DS consumes it as a private core.
+ *
+ * Key features:
+ * - Visible-month anchor kept separate from the focused date, the two
+ *   mutually correcting: paging snaps focus in-month, walking focus out of the
+ *   visible month pages the anchor
+ * - `min` / `max` walls that clamp paging and gray cells
+ * - Month matrix shaped as `CalendarMonth[]` from day one, so multi-month
+ *   ranges never break the consumer contract
+ * - `now` refreshed on a midnight tick, so `today` rolls over on a page left open
+ *
+ * @example
+ * ```ts
+ * const calendar = createCalendar({ min: '2026-01-01', fixedWeeks: true })
+ *
+ * calendar.next()
+ * calendar.move('day', 1)
+ * ```
+ */
+
+// Framework
+import { clamp, IN_BROWSER, isFunction, isString, isUndefined, useTimer } from '@vuetify/v0'
+
+// Composables
+import { useEmCalendarDate } from './date'
+
+// Utilities
+import { computed, shallowRef, toRef, toValue, watch } from 'vue'
+
+// Types
+import type { EmCalendarWeekday } from './date'
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+
+/** Axes `move()` walks the focused date along. */
+export type CalendarUnit = 'day' | 'week' | 'month' | 'year'
+
+export interface CalendarCell {
+  /** `YYYY-MM-DD` — identity, key, and model currency. */
+  iso: string
+  day: number
+  /** Per-day predicate ∪ `min`/`max` ∪ whole-calendar `disabled`. */
+  disabled: boolean
+  today: boolean
+  /** Outside the anchor month — the leading and trailing spill. */
+  outside: boolean
+}
+
+export interface CalendarMonth {
+  /** `YYYY-MM`. */
+  anchor: string
+  weeks: CalendarCell[][]
+}
+
+export interface CalendarOptions {
+  /** `YYYY-MM` anchor. Uncontrolled default: the current month. */
+  month?: MaybeRefOrGetter<string>
+  /** `YYYY-MM-DD`. */
+  min?: string
+  /** `YYYY-MM-DD`. */
+  max?: string
+  /**
+   * Whole-calendar flag or a per-day predicate. Both arrive as functions at
+   * runtime, so the value is called with the day either way — a zero-argument
+   * getter simply ignores it.
+   */
+  disabled?: MaybeRefOrGetter<boolean> | ((iso: string) => boolean)
+  /** Defaults to the date engine's locale-derived value. */
+  firstDayOfWeek?: MaybeRefOrGetter<number>
+  /** Pad the matrix to a constant six rows. */
+  fixedWeeks?: boolean
+}
+
+export interface CalendarContext {
+  /** Length 1 today; shape-stable for multi-month ranges. */
+  months: ComputedRef<CalendarMonth[]>
+  weekdays: ComputedRef<EmCalendarWeekday[]>
+  /** Localized "August 2026". */
+  label: ComputedRef<string>
+  /** `YYYY-MM` of the visible month. */
+  anchor: Readonly<Ref<string>>
+  /** `YYYY-MM-DD` the roving tabindex follows. */
+  focused: Ref<string>
+  /** At the `min` wall. */
+  isFirst: Readonly<Ref<boolean>>
+  /** At the `max` wall. */
+  isLast: Readonly<Ref<boolean>>
+  /** Page to the `min` month; no-op when unbounded. */
+  first: () => void
+  /** Page to the `max` month; no-op when unbounded. */
+  last: () => void
+  next: () => void
+  prev: () => void
+  /** Page by whole months, clamped to the walls. */
+  step: (count: number) => void
+  /** Accepts `YYYY-MM` or `YYYY-MM-DD`; pages and focuses. */
+  goto: (value: string) => void
+  /** Page to the current month and focus today. Selects nothing. */
+  today: () => void
+  /** Walk the focused date, paging the anchor when it leaves the visible month. */
+  move: (unit: CalendarUnit, amount: number) => void
+}
+
+/** Months since year zero — the total order the walls clamp against. */
+function ordinal (anchor: string) {
+  const [year, month] = anchor.split('-').map(Number)
+
+  return year * 12 + month - 1
+}
+
+function key (value: number) {
+  const year = Math.floor(value / 12)
+
+  return `${String(year).padStart(4, '0')}-${String(value - year * 12 + 1).padStart(2, '0')}`
+}
+
+function within (iso: string, anchor: string) {
+  return iso.startsWith(anchor)
+}
+
+/**
+ * Creates the geometry and navigation state for a month calendar.
+ *
+ * @param options Bounds, anchor, and matrix shape.
+ * @returns The calendar context.
+ *
+ * @example
+ * ```ts
+ * const calendar = createCalendar({ month: () => anchor.value })
+ *
+ * calendar.goto('2026-08-04')
+ * calendar.months.value[0].weeks
+ * ```
+ */
+export function createCalendar (options: CalendarOptions = {}): CalendarContext {
+  const { month, min, max, disabled, firstDayOfWeek, fixedWeeks = false } = options
+
+  const date = useEmCalendarDate()
+
+  const floor = isString(min) ? ordinal(min.slice(0, 7)) : Number.NEGATIVE_INFINITY
+  const ceiling = isString(max) ? ordinal(max.slice(0, 7)) : Number.POSITIVE_INFINITY
+
+  /** Today, re-read on a midnight tick rather than snapshotted at setup. */
+  const now = shallowRef(date.iso(date.now()))
+
+  const timer = useTimer(() => {
+    now.value = date.iso(date.now())
+    timer.start()
+  }, { duration: () => date.midnight() })
+
+  if (IN_BROWSER) timer.start()
+
+  function wall (value: string) {
+    return key(clamp(ordinal(value), floor, ceiling))
+  }
+
+  const anchor = shallowRef(wall(toValue(month) ?? now.value.slice(0, 7)))
+
+  /** The day to land on when the anchor moves: today when visible, else the 1st. */
+  function entry (value: string) {
+    return within(now.value, value) ? now.value : `${value}-01`
+  }
+
+  const focused = shallowRef(entry(anchor.value))
+
+  function goto (value: string) {
+    const target = wall(value.slice(0, 7))
+
+    anchor.value = target
+    focused.value = value.length > 7 && within(value, target) ? value : entry(target)
+  }
+
+  function step (count: number) {
+    goto(key(ordinal(anchor.value) + count))
+  }
+
+  function move (unit: CalendarUnit, amount: number) {
+    const from = date.parse(focused.value)
+    let to: Date
+
+    switch (unit) {
+      case 'month': {
+        to = date.months(from, amount)
+        break
+      }
+      case 'year': {
+        to = date.years(from, amount)
+        break
+      }
+      case 'week': {
+        to = date.days(from, amount * 7)
+        break
+      }
+      default: {
+        to = date.days(from, amount)
+      }
+    }
+
+    const iso = date.iso(to)
+
+    // A walk that overshoots a wall lands on it rather than stopping dead.
+    if (isString(min) && iso < min) return goto(min)
+    if (isString(max) && iso > max) return goto(max)
+
+    focused.value = iso
+
+    const target = iso.slice(0, 7)
+
+    if (target !== anchor.value) anchor.value = target
+  }
+
+  if (!isUndefined(month)) {
+    watch(() => toValue(month), value => {
+      if (isString(value) && value !== anchor.value) goto(value)
+    })
+  }
+
+  function blocked (iso: string) {
+    // Getter and predicate are indistinguishable at runtime; a getter ignores
+    // the argument and answers for the whole calendar.
+    if (isFunction(disabled)) return (disabled as (iso: string) => boolean)(iso)
+
+    return toValue(disabled) === true
+  }
+
+  function walled (iso: string) {
+    return (isString(min) && iso < min) || (isString(max) && iso > max)
+  }
+
+  const start = toRef(() => toValue(firstDayOfWeek) ?? date.first())
+
+  const weekdays = computed(() => date.weekdays(start.value))
+
+  const months = computed((): CalendarMonth[] => {
+    const value = anchor.value
+    const cursor = date.parse(value)
+    const today = now.value
+
+    const weeks = date.weeks(cursor, start.value, fixedWeeks).map(week => week.map(
+      (day): CalendarCell => {
+        const iso = date.iso(day)
+
+        return {
+          iso,
+          day: day.getDate(),
+          disabled: walled(iso) || blocked(iso),
+          today: iso === today,
+          outside: !within(iso, value),
+        }
+      },
+    ))
+
+    return [{ anchor: value, weeks }]
+  })
+
+  const label = computed(() => date.label(date.parse(anchor.value)))
+
+  return {
+    months,
+    weekdays,
+    label,
+    anchor,
+    focused,
+    isFirst: toRef(() => ordinal(anchor.value) <= floor),
+    isLast: toRef(() => ordinal(anchor.value) >= ceiling),
+    first: () => {
+      if (isString(min)) goto(min.slice(0, 7))
+    },
+    last: () => {
+      if (isString(max)) goto(max.slice(0, 7))
+    },
+    next: () => step(1),
+    prev: () => step(-1),
+    step,
+    goto,
+    today: () => goto(now.value),
+    move,
+  }
+}

--- a/packages/emerald/src/components/EmCalendar/calendar.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.ts
@@ -152,10 +152,11 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
   /** Today, re-read on a midnight tick rather than snapshotted at setup. */
   const now = shallowRef(date.iso(date.now()))
 
+  // `repeat` re-resolves the duration after each fire, so every cycle measures
+  // afresh to the next local midnight — DST-safe, and `isActive` stays true.
   const timer = useTimer(() => {
     now.value = date.iso(date.now())
-    timer.start()
-  }, { duration: () => date.midnight() })
+  }, { duration: () => date.midnight(), repeat: true })
 
   if (IN_BROWSER) timer.start()
 
@@ -165,9 +166,17 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
 
   const anchor = shallowRef(wall(toValue(month) ?? now.value.slice(0, 7)))
 
+  /** Focus never rests on a walled-off day. */
+  function bound (iso: string) {
+    if (isString(min) && iso < min) return min
+    if (isString(max) && iso > max) return max
+
+    return iso
+  }
+
   /** The day to land on when the anchor moves: today when visible, else the 1st. */
   function entry (value: string) {
-    return within(now.value, value) ? now.value : `${value}-01`
+    return bound(within(now.value, value) ? now.value : `${value}-01`)
   }
 
   const focused = shallowRef(entry(anchor.value))
@@ -176,11 +185,20 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
     const target = wall(value.slice(0, 7))
 
     anchor.value = target
-    focused.value = value.length > 7 && within(value, target) ? value : entry(target)
+    focused.value = value.length > 7 && within(value, target) ? bound(value) : entry(target)
   }
 
+  /**
+   * Paging carries the day of month across, clamped to the target month's
+   * length — `date.months` already does that clamp (Jan 31 → Feb 28). When a
+   * wall pulls the anchor somewhere else entirely, the entry rule takes over.
+   */
   function step (count: number) {
-    goto(key(ordinal(anchor.value) + count))
+    const target = wall(key(ordinal(anchor.value) + count))
+    const shifted = date.iso(date.months(date.parse(focused.value), count))
+
+    anchor.value = target
+    focused.value = within(shifted, target) ? bound(shifted) : entry(target)
   }
 
   function move (unit: CalendarUnit, amount: number) {

--- a/packages/emerald/src/components/EmCalendar/calendar.ts
+++ b/packages/emerald/src/components/EmCalendar/calendar.ts
@@ -181,25 +181,48 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
 
   const focused = shallowRef(entry(anchor.value))
 
-  function goto (value: string) {
-    const target = wall(value.slice(0, 7))
+  /**
+   * Lands the focused day in `value`, keeping its day of month — `date.months`
+   * already clamps that to the target's length (Jan 31 → Feb 28) — then pulling
+   * it inside the walls. Falls back to the entry rule when the carried day
+   * cannot live there at all.
+   */
+  function carry (value: string) {
+    const delta = ordinal(value) - ordinal(focused.value.slice(0, 7))
+    const shifted = date.iso(date.months(date.parse(focused.value), delta))
 
-    anchor.value = target
-    focused.value = value.length > 7 && within(value, target) ? bound(value) : entry(target)
+    return within(shifted, value) ? bound(shifted) : entry(value)
   }
 
   /**
-   * Paging carries the day of month across, clamped to the target month's
-   * length — `date.months` already does that clamp (Jan 31 → Feb 28). When a
-   * wall pulls the anchor somewhere else entirely, the entry rule takes over.
+   * The anchor and the focused date correct each other, so focus is settled
+   * *before* the anchor moves — that leaves nothing for the invariant watcher
+   * below to re-snap, which is what keeps an internal page from snapping twice.
    */
+  function goto (value: string) {
+    const target = wall(value.slice(0, 7))
+
+    focused.value = value.length > 7 && within(value, target) ? bound(value) : entry(target)
+    anchor.value = target
+  }
+
   function step (count: number) {
     const target = wall(key(ordinal(anchor.value) + count))
-    const shifted = date.iso(date.months(date.parse(focused.value), count))
 
+    focused.value = carry(target)
     anchor.value = target
-    focused.value = within(shifted, target) ? bound(shifted) : entry(target)
   }
+
+  /**
+   * Whoever moves the anchor — a controlled `month` source, or a consumer
+   * writing through the model — is paging, so focus follows rather than
+   * stranding on a day the visible grid no longer renders.
+   */
+  watch(anchor, value => {
+    if (within(focused.value, value)) return
+
+    focused.value = carry(value)
+  }, { flush: 'sync' })
 
   function move (unit: CalendarUnit, amount: number) {
     const from = date.parse(focused.value)
@@ -238,7 +261,10 @@ export function createCalendar (options: CalendarOptions = {}): CalendarContext 
 
   if (!isUndefined(month)) {
     watch(() => toValue(month), value => {
-      if (isString(value) && value !== anchor.value) goto(value)
+      if (!isString(value)) return
+
+      // Only the anchor moves; the watcher above carries focus across with it.
+      anchor.value = wall(value.slice(0, 7))
     })
   }
 

--- a/packages/emerald/src/components/EmCalendar/context.ts
+++ b/packages/emerald/src/components/EmCalendar/context.ts
@@ -6,6 +6,9 @@ import type { CalendarUnit } from './calendar'
 import type { EmCalendarDate, EmCalendarWeekday } from './date'
 import type { Ref } from 'vue'
 
+/** Re-exported so `EmCalendarContext['move']` is nameable without the core. */
+export type { CalendarUnit } from './calendar'
+
 export type EmCalendarTone = 'neutral' | 'primary' | 'secondary' | 'info' | 'alert' | 'danger'
 
 export interface EmCalendarEvent {

--- a/packages/emerald/src/components/EmCalendar/context.ts
+++ b/packages/emerald/src/components/EmCalendar/context.ts
@@ -2,6 +2,7 @@
 import { createContext } from '@vuetify/v0'
 
 // Types
+import type { CalendarUnit } from './calendar'
 import type { EmCalendarDate, EmCalendarWeekday } from './date'
 import type { Ref } from 'vue'
 
@@ -45,6 +46,10 @@ export interface EmCalendarContext {
   today: () => void
   /** Move the cursor by whole months. */
   step: (amount: number) => void
+  /** The day keyboard navigation walks; drives the grid's roving tabindex. */
+  focused: Ref<string>
+  /** Walk `focused`, paging the cursor when it leaves the visible month. */
+  move: (unit: CalendarUnit, amount: number) => void
 }
 
 export const EM_CALENDAR_NAMESPACE = 'emerald:calendar'

--- a/packages/emerald/src/components/EmCalendar/date.ts
+++ b/packages/emerald/src/components/EmCalendar/date.ts
@@ -54,25 +54,38 @@ function iso (value: Date) {
   return `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`
 }
 
+/**
+ * Every `Date` in this module is built from parts here, because the two-digit
+ * year constructor folds 0-99 into the 1900s. Shifting after the fact keeps any
+ * month/day rollover the constructor already resolved.
+ */
+function build (year: number, index: number, day: number) {
+  const result = new Date(year, index, day)
+
+  if (year >= 0 && year <= 99) result.setFullYear(result.getFullYear() - 1900)
+
+  return result
+}
+
 /** Local parts, never `new Date(iso)` — that reads `YYYY-MM-DD` as UTC midnight. */
 function parse (value: string) {
   const [year, index, day] = value.split('-').map(Number)
 
-  return new Date(year, index - 1, day ?? 1)
+  return build(year, index - 1, day ?? 1)
 }
 
 function month (value: Date) {
-  return new Date(value.getFullYear(), value.getMonth(), 1)
+  return build(value.getFullYear(), value.getMonth(), 1)
 }
 
 function days (value: Date, amount: number) {
-  return new Date(value.getFullYear(), value.getMonth(), value.getDate() + amount)
+  return build(value.getFullYear(), value.getMonth(), value.getDate() + amount)
 }
 
 function months (value: Date, amount: number) {
-  const target = new Date(value.getFullYear(), value.getMonth() + amount, 1)
+  const target = build(value.getFullYear(), value.getMonth() + amount, 1)
   // Day 0 of the next month is the last day of the target one — clamps Jan 31 → Feb 28.
-  const last = new Date(target.getFullYear(), target.getMonth() + 1, 0).getDate()
+  const last = build(target.getFullYear(), target.getMonth() + 1, 0).getDate()
 
   target.setDate(Math.min(value.getDate(), last))
 
@@ -142,7 +155,7 @@ function weeks (value: Date, first: number, fixed: boolean): Date[][] {
   const anchor = month(value)
   const lead = (anchor.getDay() - first + 7) % 7
   // Day 0 of the next month is the last day of this one.
-  const length = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0).getDate()
+  const length = build(anchor.getFullYear(), anchor.getMonth() + 1, 0).getDate()
 
   return matrix(days(anchor, -lead), fixed ? 6 : Math.ceil((lead + length) / 7))
 }

--- a/packages/emerald/src/components/EmCalendar/date.ts
+++ b/packages/emerald/src/components/EmCalendar/date.ts
@@ -49,9 +49,15 @@ function pad (value: number) {
   return String(value).padStart(2, '0')
 }
 
-/** Local parts, not `toISOString()` — UTC lands on the previous day west of Greenwich. */
+/**
+ * Local parts, not `toISOString()` — UTC lands on the previous day west of
+ * Greenwich. The year pads to four digits because every comparison downstream
+ * is lexicographic: unpadded, `'999-04-28'` sorts above `'1000-01-01'`.
+ */
 function iso (value: Date) {
-  return `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`
+  const year = String(value.getFullYear()).padStart(4, '0')
+
+  return `${year}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`
 }
 
 /**

--- a/packages/emerald/src/components/EmCalendar/date.ts
+++ b/packages/emerald/src/components/EmCalendar/date.ts
@@ -9,12 +9,16 @@
 // Framework
 import { isNull, useContext } from '@vuetify/v0'
 
+// Utilities
+import { hasInjectionContext } from 'vue'
+
 // Types
 import type { DateContext } from '@vuetify/v0'
 
 export interface EmCalendarWeekday {
   long: string
   short: string
+  narrow: string
 }
 
 export interface EmCalendarDate {
@@ -22,16 +26,23 @@ export interface EmCalendarDate {
   first: () => number
   now: () => Date
   iso: (value: Date) => string
+  /** `YYYY-MM-DD` or `YYYY-MM` back to a local `Date`. */
+  parse: (value: string) => Date
   /** First of the month `value` falls in. */
   month: (value: Date) => Date
   days: (value: Date, amount: number) => Date
   months: (value: Date, amount: number) => Date
+  years: (value: Date, amount: number) => Date
   same: (value: Date, comparing: Date) => boolean
   /** "August 2026" */
   label: (value: Date) => string
   /** "Tuesday, August 4, 2026" */
   full: (value: Date) => string
   weekdays: (first: number) => EmCalendarWeekday[]
+  /** Month matrix in weeks of 7, padded to six rows when `fixed`. */
+  weeks: (value: Date, first: number, fixed: boolean) => Date[][]
+  /** Milliseconds until the next local midnight. */
+  midnight: () => number
 }
 
 function pad (value: number) {
@@ -41,6 +52,13 @@ function pad (value: number) {
 /** Local parts, not `toISOString()` — UTC lands on the previous day west of Greenwich. */
 function iso (value: Date) {
   return `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`
+}
+
+/** Local parts, never `new Date(iso)` — that reads `YYYY-MM-DD` as UTC midnight. */
+function parse (value: string) {
+  const [year, index, day] = value.split('-').map(Number)
+
+  return new Date(year, index - 1, day ?? 1)
 }
 
 function month (value: Date) {
@@ -61,8 +79,19 @@ function months (value: Date, amount: number) {
   return target
 }
 
+function years (value: Date, amount: number) {
+  return months(value, amount * 12)
+}
+
 function same (value: Date, comparing: Date) {
   return iso(value) === iso(comparing)
+}
+
+/** `days()` builds at local midnight, so the delta is the time left in the day. */
+function midnight () {
+  const value = new Date()
+
+  return days(value, 1).getTime() - value.getTime()
 }
 
 function label (value: Date) {
@@ -88,21 +117,51 @@ function weekdays (first: number): EmCalendarWeekday[] {
     return {
       long: day.toLocaleDateString(undefined, { weekday: 'long' }),
       short: day.toLocaleDateString(undefined, { weekday: 'short' }),
+      narrow: day.toLocaleDateString(undefined, { weekday: 'narrow' }),
     }
   })
+}
+
+function matrix (start: Date, rows: number): Date[][] {
+  return Array.from({ length: rows }, (_, week) => Array.from(
+    { length: 7 },
+    (_, day) => days(start, week * 7 + day),
+  ))
+}
+
+/** Continues day by day rather than repeating a week, so the spill stays real dates. */
+function fill (rows: Date[][], fixed: boolean): Date[][] {
+  const last = rows.at(-1)?.at(-1)
+
+  if (!fixed || rows.length >= 6 || !last) return rows
+
+  return [...rows, ...matrix(days(last, 1), 6 - rows.length)]
+}
+
+function weeks (value: Date, first: number, fixed: boolean): Date[][] {
+  const anchor = month(value)
+  const lead = (anchor.getDay() - first + 7) % 7
+  // Day 0 of the next month is the last day of this one.
+  const length = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0).getDate()
+
+  return matrix(days(anchor, -lead), fixed ? 6 : Math.ceil((lead + length) / 7))
 }
 
 const plain: EmCalendarDate = {
   first: () => 0,
   now: () => new Date(),
   iso,
+  parse,
   month,
   days,
   months,
+  years,
   same,
   label,
   full,
   weekdays,
+  weeks,
+  midnight,
 }
 
 /** Same seam, backed by an installed `DateAdapter`. Falls back per call if it rejects a date. */
@@ -121,13 +180,24 @@ function adapted (context: DateContext<unknown>): EmCalendarDate {
     return adapter.isNullish(input) ? fallback : adapter.format(input, format)
   }
 
+  /**
+   * `getWeekArray` and `getWeekdays` both rotate by the adapter's *own*
+   * `firstDayOfWeek`; when the root's prop overrides it, only the plain walk
+   * honours the override.
+   */
+  function rotates (first: number) {
+    return first === context.firstDayOfWeek.value
+  }
+
   return {
     first: () => context.firstDayOfWeek.value,
     now: () => new Date(),
     iso,
+    parse,
     month: value => convert(value, input => adapter.startOfMonth(input), month(value)),
     days: (value, amount) => convert(value, input => adapter.addDays(input, amount), days(value, amount)),
     months: (value, amount) => convert(value, input => adapter.addMonths(input, amount), months(value, amount)),
+    years: (value, amount) => convert(value, input => adapter.addYears(input, amount), years(value, amount)),
     same: (value, comparing) => {
       const left = adapter.date(value)
       const right = adapter.date(comparing)
@@ -138,15 +208,45 @@ function adapted (context: DateContext<unknown>): EmCalendarDate {
     },
     label: value => text(value, 'monthAndYear', label(value)),
     full: value => text(value, 'fullDateWithWeekday', full(value)),
-    weekdays,
+    weekdays: first => {
+      if (!rotates(first)) return weekdays(first)
+
+      const [long, short, narrow] = (['long', 'short', 'narrow'] as const)
+        .map(format => adapter.getWeekdays(format))
+
+      return Array.from({ length: 7 }, (_, index) => ({
+        long: long[index],
+        short: short[index],
+        narrow: narrow[index],
+      }))
+    },
+    weeks: (value, first, fixed) => {
+      if (!rotates(first)) return weeks(value, first, fixed)
+
+      const input = adapter.date(value)
+
+      if (adapter.isNullish(input)) return weeks(value, first, fixed)
+
+      // graduation: v0's adapter now takes `getWeekArray(date, fixedWeeks)`
+      // (PR #797) — drop the local `fill` once the core rides that branch.
+      return fill(
+        adapter.getWeekArray(input).map(week => week.map(day => adapter.toJsDate(day))),
+        fixed,
+      )
+    },
+    midnight,
   }
 }
 
 /**
  * Optional injection: `useDate()` throws without `createDatePlugin`, so the
- * context is read directly with a `null` default instead.
+ * context is read directly with a `null` default instead. Outside an injection
+ * context — SSR helpers, unit tests — the plain engine answers without Vue
+ * warning about a stray `inject`.
  */
 export function useEmCalendarDate (): EmCalendarDate {
+  if (!hasInjectionContext()) return plain
+
   const context = useContext<DateContext<unknown> | null>('v0:date', null)
 
   return isNull(context) ? plain : adapted(context)

--- a/packages/emerald/src/components/EmCalendar/index.ts
+++ b/packages/emerald/src/components/EmCalendar/index.ts
@@ -1,4 +1,5 @@
 export type {
+  CalendarUnit,
   EmCalendarCell,
   EmCalendarContext,
   EmCalendarEvent,

--- a/packages/emerald/vitest.config.ts
+++ b/packages/emerald/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+
+import Vue from 'unplugin-vue/rolldown'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@vuetify/v0': fileURLToPath(new URL('../0/src', import.meta.url)),
+      '@paper/emerald': fileURLToPath(new URL('src', import.meta.url)),
+      // internal
+      '#v0': fileURLToPath(new URL('../0/src', import.meta.url)),
+    },
+  },
+  plugins: [Vue()],
+  define: {
+    __DEV__: 'process.env.NODE_ENV !== \'production\'',
+    __VERSION__: '"0.0.1"',
+  },
+  test: {
+    name: 'emerald',
+    environment: 'happy-dom',
+    globals: true,
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       'packages/0',
       'packages/0/vitest.browser.config.ts',
       'packages/paper',
+      'packages/emerald',
       'apps/docs',
     ],
     globals: true,


### PR DESCRIPTION
Phase 1 of the calendar incubation plan: EmCalendar is split into an **unexported, v0-conventions core** (`calendar.ts` — geometry + navigation, selection-free, imports only `@vuetify/v0` + `vue` + the Emerald-free `date.ts` seam) and the Emerald skin consuming it. Graduation to `packages/0` becomes a file move. Contract: the approved createCalendar core spec (Rev 2.4).

## What changed
- New `createCalendar` core: month-array-shaped grid, createStep-vocabulary paging (`first/last/next/prev/step` + `isFirst/isLast`), mutually-correcting anchor/focus with day-of-month preservation and wall clamping, `fixedWeeks`, ISO-string date model (no `new Date(iso)` anywhere).
- Skin rewired with a **byte-compatible public API** (verified prop/model/slot/class/data-attr diff). `createSingle` is gone — selection is a plain model ref + guard.
- Latent bugs fixed: silent auto-select without model writeback, `watch` ignoring `undefined`, stale `now` (midnight rollover via `useTimer` repeat), missing Shift+PageUp/PageDown year jump, missing RTL arrow inversion (`useRtl`), missing `aria-live` month announcements. APG focus-entry order restored (selected day owns the initial tab stop).
- `packages/emerald` now has a registered vitest project (mirrors `packages/paper`); 57 tests.

## Verification
- emerald + dev typecheck clean; eslint clean; emerald project 57/57; full non-browser suite 4853 passed / 148 files; `@paper/emerald` build succeeds.
- QA-reviewed (3 Medium + 7 Low findings fixed in the third commit); in-browser check of the dashboard calendar page — rendering identical, two-root lockstep intact.

## Known phase-2 gaps (deliberate)
Multi-month is shape-only; `useLocale` strings not wired; `useRovingFocus` grid mode not yet adopted; adapter-path test fixture; Emerald browser-test project; external controlled-month focus re-snap (fix incoming on this branch).