### PR TITLE
refactor(emerald): extend v0 prop interfaces across the library

### DIFF
--- a/.changeset/emerald-extends-v0-props.md
+++ b/.changeset/emerald-extends-v0-props.md
@@ -1,7 +1,9 @@
 ---
-'@paper/emerald': patch
+"@paper/emerald": patch
 ---
 
-fix(EmTextField): accept rule aliases, schemas, and reactive disabled state across the library
+fix(emerald): accept rule aliases, schemas, and reactive disabled state
 
 Emerald prop types now extend v0's, so values the runtime always accepted (rule aliases, Standard Schema validators, refs/getters for disabled and readonly) no longer fail typechecking; no prop was added or removed.
+
+`data-disabled`/`data-readonly` on Checkbox, Switch, Radio, Slider, TextField and Textarea now reflect the resolved value when a ref or getter is passed, instead of being permanently set.

--- a/.changeset/emerald-extends-v0-props.md
+++ b/.changeset/emerald-extends-v0-props.md
@@ -1,0 +1,7 @@
+---
+'@paper/emerald': patch
+---
+
+fix(EmTextField): accept rule aliases, schemas, and reactive disabled state across the library
+
+Emerald prop types now extend v0's, so values the runtime always accepted (rule aliases, Standard Schema validators, refs/getters for disabled and readonly) no longer fail typechecking; no prop was added or removed.

--- a/packages/emerald/src/components/EmAvatar/EmAvatar.vue
+++ b/packages/emerald/src/components/EmAvatar/EmAvatar.vue
@@ -2,12 +2,13 @@
   // Framework
   import { Avatar } from '@vuetify/v0'
 
+  // Types
+  import type { AvatarRootProps } from '@vuetify/v0'
+
   export type EmAvatarSize = 'sm' | 'md' | 'lg'
 
-  export interface EmAvatarProps {
+  export interface EmAvatarProps extends Pick<AvatarRootProps, 'value' | 'namespace'> {
     size?: EmAvatarSize
-    value?: unknown
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmAvatar/EmAvatarFallback.vue
+++ b/packages/emerald/src/components/EmAvatar/EmAvatarFallback.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Avatar } from '@vuetify/v0'
 
-  export interface EmAvatarFallbackProps {
-    namespace?: string
-  }
+  // Types
+  import type { AvatarFallbackProps } from '@vuetify/v0'
+
+  export interface EmAvatarFallbackProps extends Omit<AvatarFallbackProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmAvatar/EmAvatarImage.vue
+++ b/packages/emerald/src/components/EmAvatar/EmAvatarImage.vue
@@ -2,10 +2,12 @@
   // Framework
   import { Avatar } from '@vuetify/v0'
 
-  export interface EmAvatarImageProps {
+  // Types
+  import type { AvatarImageProps } from '@vuetify/v0'
+
+  export interface EmAvatarImageProps extends Pick<AvatarImageProps, 'alt' | 'namespace'> {
+    /** Required here, unlike v0 — an Emerald avatar image always has a source. */
     src: string
-    alt?: string
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbs.vue
+++ b/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbs.vue
@@ -2,13 +2,10 @@
   // Framework
   import { Breadcrumbs } from '@vuetify/v0'
 
-  export interface EmBreadcrumbsProps {
-    divider?: string
-    ellipsis?: string
-    gap?: number
-    label?: string
-    namespace?: string
-  }
+  // Types
+  import type { BreadcrumbsRootProps } from '@vuetify/v0'
+
+  export interface EmBreadcrumbsProps extends Omit<BreadcrumbsRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsDivider.vue
+++ b/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsDivider.vue
@@ -3,13 +3,9 @@
   import { Breadcrumbs } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { BreadcrumbsDividerProps } from '@vuetify/v0'
 
-  export interface EmBreadcrumbsDividerProps {
-    id?: ID
-    divider?: string
-    namespace?: string
-  }
+  export interface EmBreadcrumbsDividerProps extends Omit<BreadcrumbsDividerProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsEllipsis.vue
+++ b/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsEllipsis.vue
@@ -3,13 +3,9 @@
   import { Breadcrumbs } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { BreadcrumbsEllipsisProps } from '@vuetify/v0'
 
-  export interface EmBreadcrumbsEllipsisProps {
-    id?: ID
-    ellipsis?: string
-    namespace?: string
-  }
+  export interface EmBreadcrumbsEllipsisProps extends Omit<BreadcrumbsEllipsisProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsItem.vue
+++ b/packages/emerald/src/components/EmBreadcrumbs/EmBreadcrumbsItem.vue
@@ -3,14 +3,9 @@
   import { Breadcrumbs } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { BreadcrumbsItemProps } from '@vuetify/v0'
 
-  export interface EmBreadcrumbsItemProps {
-    id?: ID
-    value?: unknown
-    text?: string
-    namespace?: string
-  }
+  export interface EmBreadcrumbsItemProps extends Omit<BreadcrumbsItemProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmButton/EmButton.vue
+++ b/packages/emerald/src/components/EmButton/EmButton.vue
@@ -8,6 +8,11 @@
   export type EmButtonSize = 'sm' | 'md' | 'lg'
   export type EmButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'destructive'
 
+  /**
+   * Emerald withholds six of v0's button props: `readonly`, `passive`, `grace`, `value`,
+   * `groupNamespace` and `form`. Button.Group composition and form association are not
+   * part of the DS surface, and `loading` uses v0's default grace period.
+   */
   export interface EmButtonProps extends Pick<
     ButtonRootProps,
     'disabled' | 'loading' | 'ariaLabel' | 'name' | 'namespace'

--- a/packages/emerald/src/components/EmButton/EmButton.vue
+++ b/packages/emerald/src/components/EmButton/EmButton.vue
@@ -2,19 +2,18 @@
   // Framework
   import { Button } from '@vuetify/v0'
 
+  // Types
+  import type { ButtonRootProps } from '@vuetify/v0'
+
   export type EmButtonSize = 'sm' | 'md' | 'lg'
   export type EmButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'destructive'
 
-  export interface EmButtonProps {
-    disabled?: boolean
-    loading?: boolean
+  export interface EmButtonProps extends Pick<
+    ButtonRootProps,
+    'disabled' | 'loading' | 'ariaLabel' | 'name' | 'namespace'
+  > {
     size?: EmButtonSize
     variant?: EmButtonVariant
-    /** Accessible label for icon-only buttons */
-    ariaLabel?: string
-    /** Form field name — renders a hidden input when set */
-    name?: string
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmCheckbox/EmCheckbox.vue
+++ b/packages/emerald/src/components/EmCheckbox/EmCheckbox.vue
@@ -1,23 +1,24 @@
 <script lang="ts">
   // Framework
   import { Checkbox } from '@vuetify/v0'
-  // Utilities
   import { useId } from '@vuetify/v0/utilities'
 
   // Components
   import EmIcon from '../EmIcon/EmIcon.vue'
 
+  // Utilities
+  import { toValue } from 'vue'
+
+  // Types
+  import type { CheckboxRootProps } from '@vuetify/v0'
+
   export type EmCheckboxSize = 'sm' | 'md' | 'lg'
 
-  export interface EmCheckboxProps {
-    disabled?: boolean
-    indeterminate?: boolean
+  export interface EmCheckboxProps extends Pick<
+    CheckboxRootProps,
+    'disabled' | 'indeterminate' | 'name' | 'value' | 'label' | 'namespace'
+  > {
     size?: EmCheckboxSize
-    name?: string
-    value?: unknown
-    /** Accessible name when no default-slot label is rendered */
-    label?: string
-    namespace?: string
   }
 </script>
 
@@ -41,7 +42,7 @@
 </script>
 
 <template>
-  <label class="emerald-checkbox" :data-disabled="disabled || undefined" :data-size="size">
+  <label class="emerald-checkbox" :data-disabled="toValue(disabled) || undefined" :data-size="size">
     <Checkbox.Root
       v-model="model"
       :aria-labelledby="$slots.default ? id : undefined"

--- a/packages/emerald/src/components/EmDialog/EmDialog.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialog.vue
@@ -2,10 +2,10 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  export interface EmDialogProps {
-    id?: string
-    namespace?: string
-  }
+  // Types
+  import type { DialogRootProps } from '@vuetify/v0'
+
+  export interface EmDialogProps extends Omit<DialogRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogActivator.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogActivator.vue
@@ -2,14 +2,14 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  export interface EmDialogActivatorProps {
-    /**
-     * When true, Activator is a pure slot host — bind `attrs` onto your own
-     * trigger (e.g. EmButton) so you do not nest interactive elements.
-     */
-    renderless?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { DialogActivatorProps } from '@vuetify/v0'
+
+  /**
+   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
+   * trigger (e.g. EmButton) so you do not nest interactive elements.
+   */
+  export interface EmDialogActivatorProps extends Omit<DialogActivatorProps, 'as'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogActivator.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogActivator.vue
@@ -5,11 +5,13 @@
   // Types
   import type { DialogActivatorProps } from '@vuetify/v0'
 
-  /**
-   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
-   * trigger (e.g. EmButton) so you do not nest interactive elements.
-   */
-  export interface EmDialogActivatorProps extends Omit<DialogActivatorProps, 'as'> {}
+  export interface EmDialogActivatorProps extends Omit<DialogActivatorProps, 'as'> {
+    /**
+     * When true, Activator is a pure slot host — bind `attrs` onto your own
+     * trigger (e.g. EmButton) so you do not nest interactive elements.
+     */
+    renderless?: DialogActivatorProps['renderless']
+  }
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogClose.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogClose.vue
@@ -5,9 +5,10 @@
   // Components
   import EmIcon from '../EmIcon/EmIcon.vue'
 
-  export interface EmDialogCloseProps {
-    namespace?: string
-  }
+  // Types
+  import type { DialogCloseProps } from '@vuetify/v0'
+
+  export interface EmDialogCloseProps extends Omit<DialogCloseProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogContent.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogContent.vue
@@ -2,11 +2,10 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  export interface EmDialogContentProps {
-    closeOnClickOutside?: boolean
-    blocking?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { DialogContentProps } from '@vuetify/v0'
+
+  export interface EmDialogContentProps extends Omit<DialogContentProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogDescription.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogDescription.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  export interface EmDialogDescriptionProps {
-    namespace?: string
-  }
+  // Types
+  import type { DialogDescriptionProps } from '@vuetify/v0'
+
+  export interface EmDialogDescriptionProps extends Omit<DialogDescriptionProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmDialog/EmDialogTitle.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogTitle.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  export interface EmDialogTitleProps {
-    namespace?: string
-  }
+  // Types
+  import type { DialogTitleProps } from '@vuetify/v0'
+
+  export interface EmDialogTitleProps extends Omit<DialogTitleProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanel.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanel.vue
@@ -2,12 +2,10 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  export interface EmExpansionPanelProps {
-    id?: string
-    value?: unknown
-    disabled?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelRootProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelProps extends Omit<ExpansionPanelRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelActivator.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelActivator.vue
@@ -2,9 +2,10 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  export interface EmExpansionPanelActivatorProps {
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelActivatorProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelActivatorProps extends Omit<ExpansionPanelActivatorProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelContent.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelContent.vue
@@ -2,9 +2,10 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  export interface EmExpansionPanelContentProps {
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelContentProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelContentProps extends Omit<ExpansionPanelContentProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelCue.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelCue.vue
@@ -5,9 +5,10 @@
   // Components
   import EmIcon from '../EmIcon/EmIcon.vue'
 
-  export interface EmExpansionPanelCueProps {
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelCueProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelCueProps extends Omit<ExpansionPanelCueProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelGroup.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelGroup.vue
@@ -2,13 +2,10 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  export interface EmExpansionPanelGroupProps {
-    disabled?: boolean
-    enroll?: boolean
-    mandatory?: boolean | 'force'
-    multiple?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelGroupProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelGroupProps extends Omit<ExpansionPanelGroupProps, 'as' | 'renderless'> {}
 </script>
 
 <script lang="ts" setup generic="T = unknown">

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelHeader.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelHeader.vue
@@ -2,9 +2,10 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  export interface EmExpansionPanelHeaderProps {
-    namespace?: string
-  }
+  // Types
+  import type { ExpansionPanelHeaderProps } from '@vuetify/v0'
+
+  export interface EmExpansionPanelHeaderProps extends Omit<ExpansionPanelHeaderProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmList/EmList.vue
+++ b/packages/emerald/src/components/EmList/EmList.vue
@@ -9,6 +9,8 @@
     SingleRootProps,
     'namespace' | 'disabled' | 'mandatory'
   > {
+    /** Forwarded to Single.Root — master-detail lists want `'force'`. */
+    mandatory?: SingleRootProps['mandatory']
     /** Stamped on the host `<ul>`, not forwarded to Single.Root. */
     id?: string
   }

--- a/packages/emerald/src/components/EmList/EmList.vue
+++ b/packages/emerald/src/components/EmList/EmList.vue
@@ -2,12 +2,15 @@
   // Framework
   import { Single } from '@vuetify/v0'
 
-  export interface EmListProps {
+  // Types
+  import type { SingleRootProps } from '@vuetify/v0'
+
+  export interface EmListProps extends Pick<
+    SingleRootProps,
+    'namespace' | 'disabled' | 'mandatory'
+  > {
+    /** Stamped on the host `<ul>`, not forwarded to Single.Root. */
     id?: string
-    namespace?: string
-    disabled?: boolean
-    /** Forwarded to Single.Root — master-detail lists want `'force'`. */
-    mandatory?: boolean | 'force'
   }
 </script>
 

--- a/packages/emerald/src/components/EmList/EmListItem.vue
+++ b/packages/emerald/src/components/EmList/EmListItem.vue
@@ -6,12 +6,11 @@
   import { toRef } from 'vue'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { ID, SingleItemProps } from '@vuetify/v0'
 
-  export interface EmListItemProps {
+  export interface EmListItemProps extends Pick<SingleItemProps, 'disabled' | 'namespace'> {
+    /** Required here, unlike v0 — an Emerald row is always addressable. */
     value: ID
-    disabled?: boolean
-    namespace?: string
     /**
      * Host element for the row. The default `button` is the selectable row;
      * pass a non-interactive host for rows that carry their own controls

--- a/packages/emerald/src/components/EmPagination/EmPagination.vue
+++ b/packages/emerald/src/components/EmPagination/EmPagination.vue
@@ -2,13 +2,10 @@
   // Framework
   import { Pagination } from '@vuetify/v0'
 
-  export interface EmPaginationProps {
-    size?: number
-    totalVisible?: number
-    itemsPerPage?: number
-    ellipsis?: string | false
-    namespace?: string
-  }
+  // Types
+  import type { PaginationRootProps } from '@vuetify/v0'
+
+  export interface EmPaginationProps extends Omit<PaginationRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPagination/EmPaginationItem.vue
+++ b/packages/emerald/src/components/EmPagination/EmPaginationItem.vue
@@ -2,11 +2,13 @@
   // Framework
   import { Pagination } from '@vuetify/v0'
 
-  export interface EmPaginationItemProps {
-    value: number
-    disabled?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { PaginationItemProps } from '@vuetify/v0'
+
+  export interface EmPaginationItemProps extends Pick<
+    PaginationItemProps,
+    'value' | 'disabled' | 'namespace'
+  > {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPagination/EmPaginationNext.vue
+++ b/packages/emerald/src/components/EmPagination/EmPaginationNext.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Pagination } from '@vuetify/v0'
 
-  export interface EmPaginationNextProps {
-    namespace?: string
-  }
+  // Types
+  import type { PaginationNextProps } from '@vuetify/v0'
+
+  export interface EmPaginationNextProps extends Pick<PaginationNextProps, 'namespace'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPagination/EmPaginationPrev.vue
+++ b/packages/emerald/src/components/EmPagination/EmPaginationPrev.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Pagination } from '@vuetify/v0'
 
-  export interface EmPaginationPrevProps {
-    namespace?: string
-  }
+  // Types
+  import type { PaginationPrevProps } from '@vuetify/v0'
+
+  export interface EmPaginationPrevProps extends Pick<PaginationPrevProps, 'namespace'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPopover/EmPopover.vue
+++ b/packages/emerald/src/components/EmPopover/EmPopover.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Popover } from '@vuetify/v0'
 
-  export interface EmPopoverProps {
-    id?: string
-  }
+  // Types
+  import type { PopoverRootProps } from '@vuetify/v0'
+
+  export interface EmPopoverProps extends Omit<PopoverRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPopover/EmPopoverActivator.vue
+++ b/packages/emerald/src/components/EmPopover/EmPopoverActivator.vue
@@ -5,13 +5,14 @@
   // Types
   import type { PopoverActivatorProps } from '@vuetify/v0'
 
-  export interface EmPopoverActivatorProps extends Pick<PopoverActivatorProps, 'as'> {
-    /**
-     * When true, Activator is a pure slot host — bind `attrs` onto your own
-     * trigger (e.g. EmButton) so you do not nest interactive elements.
-     */
-    renderless?: boolean
-  }
+  /**
+   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
+   * trigger (e.g. EmButton) so you do not nest interactive elements.
+   */
+  export interface EmPopoverActivatorProps extends Pick<
+    PopoverActivatorProps,
+    'as' | 'renderless'
+  > {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPopover/EmPopoverActivator.vue
+++ b/packages/emerald/src/components/EmPopover/EmPopoverActivator.vue
@@ -5,14 +5,16 @@
   // Types
   import type { PopoverActivatorProps } from '@vuetify/v0'
 
-  /**
-   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
-   * trigger (e.g. EmButton) so you do not nest interactive elements.
-   */
   export interface EmPopoverActivatorProps extends Pick<
     PopoverActivatorProps,
     'as' | 'renderless'
-  > {}
+  > {
+    /**
+     * When true, Activator is a pure slot host — bind `attrs` onto your own
+     * trigger (e.g. EmButton) so you do not nest interactive elements.
+     */
+    renderless?: PopoverActivatorProps['renderless']
+  }
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPopover/EmPopoverContent.vue
+++ b/packages/emerald/src/components/EmPopover/EmPopoverContent.vue
@@ -8,7 +8,12 @@
   export interface EmPopoverContentProps extends Pick<
     PopoverContentProps,
     'positionArea' | 'positionTry'
-  > {}
+  > {
+    /** CSS position-area value @default 'bottom' */
+    positionArea?: PopoverContentProps['positionArea']
+    /** CSS position-try-fallbacks value @default 'most-width bottom' */
+    positionTry?: PopoverContentProps['positionTry']
+  }
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmPopover/EmPopoverContent.vue
+++ b/packages/emerald/src/components/EmPopover/EmPopoverContent.vue
@@ -2,12 +2,13 @@
   // Framework
   import { Popover, usePopoverContext } from '@vuetify/v0'
 
-  export interface EmPopoverContentProps {
-    /** CSS position-area value @default 'bottom' */
-    positionArea?: string
-    /** CSS position-try-fallbacks value @default 'most-width bottom' */
-    positionTry?: string
-  }
+  // Types
+  import type { PopoverContentProps } from '@vuetify/v0'
+
+  export interface EmPopoverContentProps extends Pick<
+    PopoverContentProps,
+    'positionArea' | 'positionTry'
+  > {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmProgress/EmProgress.vue
+++ b/packages/emerald/src/components/EmProgress/EmProgress.vue
@@ -6,20 +6,22 @@
   // Utilities
   import { toRef } from 'vue'
 
+  // Types
+  import type { ProgressRootProps } from '@vuetify/v0'
+
   export type EmProgressSize = 'sm' | 'md' | 'lg'
 
-  export interface EmProgressProps {
-    max?: number
+  export interface EmProgressProps extends Pick<
+    ProgressRootProps,
+    'max' | 'ariaLabel' | 'name' | 'namespace'
+  > {
+    /** Emerald-owned: v0 infers the indeterminate state from an absent model value */
     indeterminate?: boolean
     size?: EmProgressSize
     /** Show percentage text via Progress.Value */
     showValue?: boolean
     /** Visible label text (Progress.Label) */
     label?: string
-    /** Accessible name when no visible `label` is rendered */
-    ariaLabel?: string
-    name?: string
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmProgress/EmProgress.vue
+++ b/packages/emerald/src/components/EmProgress/EmProgress.vue
@@ -15,6 +15,8 @@
     ProgressRootProps,
     'max' | 'ariaLabel' | 'name' | 'namespace'
   > {
+    /** Accessible name when no visible `label` is rendered */
+    ariaLabel?: ProgressRootProps['ariaLabel']
     /** Emerald-owned: v0 infers the indeterminate state from an absent model value */
     indeterminate?: boolean
     size?: EmProgressSize

--- a/packages/emerald/src/components/EmRadio/EmRadio.vue
+++ b/packages/emerald/src/components/EmRadio/EmRadio.vue
@@ -1,20 +1,23 @@
 <script lang="ts">
   // Framework
   import { Radio } from '@vuetify/v0'
-  // Utilities
   import { useId } from '@vuetify/v0/utilities'
+
+  // Utilities
+  import { toValue } from 'vue'
+
+  // Types
+  import type { RadioRootProps } from '@vuetify/v0'
 
   export type EmRadioSize = 'sm' | 'md' | 'lg'
 
-  export interface EmRadioProps {
-    /** Value associated with this radio (required for group selection) */
+  export interface EmRadioProps extends Pick<
+    RadioRootProps,
+    'disabled' | 'label' | 'namespace' | 'groupNamespace'
+  > {
+    /** Value associated with this radio (required here, unlike v0 — group selection needs it) */
     value: unknown
-    disabled?: boolean
     size?: EmRadioSize
-    /** Accessible name when no default-slot label is rendered */
-    label?: string
-    namespace?: string
-    groupNamespace?: string
   }
 </script>
 
@@ -36,7 +39,7 @@
 </script>
 
 <template>
-  <label class="emerald-radio" :data-disabled="disabled || undefined" :data-size="size">
+  <label class="emerald-radio" :data-disabled="toValue(disabled) || undefined" :data-size="size">
     <Radio.Root
       :aria-labelledby="$slots.default ? id : undefined"
       class="emerald-radio__root"

--- a/packages/emerald/src/components/EmRadio/EmRadioGroup.vue
+++ b/packages/emerald/src/components/EmRadio/EmRadioGroup.vue
@@ -2,16 +2,13 @@
   // Framework
   import { Radio } from '@vuetify/v0'
 
-  export interface EmRadioGroupProps {
-    disabled?: boolean
-    name?: string
-    namespace?: string
-    mandatory?: boolean | 'force'
-    /** Accessible name for the radiogroup when no visible label is associated */
-    label?: string
-    /** ID of an existing element that labels the radiogroup */
-    ariaLabelledby?: string
-  }
+  // Types
+  import type { RadioGroupProps } from '@vuetify/v0'
+
+  export interface EmRadioGroupProps extends Pick<
+    RadioGroupProps,
+    'disabled' | 'name' | 'namespace' | 'mandatory' | 'label' | 'ariaLabelledby'
+  > {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSelect/EmSelect.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelect.vue
@@ -4,14 +4,10 @@
   // Utilities
   import { useId } from '@vuetify/v0/utilities'
 
-  export interface EmSelectProps {
-    id?: string
-    name?: string
-    form?: string
-    disabled?: boolean
-    multiple?: boolean
-    mandatory?: boolean | 'force'
-    namespace?: string
+  // Types
+  import type { SelectRootProps } from '@vuetify/v0'
+
+  export interface EmSelectProps extends Omit<SelectRootProps, 'as' | 'renderless'> {
     /** Visible field label associated with the activator */
     label?: string
   }

--- a/packages/emerald/src/components/EmSelect/EmSelectActivator.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectActivator.vue
@@ -5,9 +5,10 @@
   // Components
   import EmIcon from '../EmIcon/EmIcon.vue'
 
-  export interface EmSelectActivatorProps {
-    namespace?: string
-  }
+  // Types
+  import type { SelectActivatorProps } from '@vuetify/v0'
+
+  export interface EmSelectActivatorProps extends Omit<SelectActivatorProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSelect/EmSelectContent.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectContent.vue
@@ -5,6 +5,7 @@
   // Types
   import type { SelectContentProps } from '@vuetify/v0'
 
+  /** Emerald withholds `eager` — the menu stays lazy so long option lists cost nothing until opened. */
   export interface EmSelectContentProps extends Pick<SelectContentProps, 'namespace'> {}
 </script>
 

--- a/packages/emerald/src/components/EmSelect/EmSelectContent.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectContent.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Select } from '@vuetify/v0'
 
-  export interface EmSelectContentProps {
-    namespace?: string
-  }
+  // Types
+  import type { SelectContentProps } from '@vuetify/v0'
+
+  export interface EmSelectContentProps extends Pick<SelectContentProps, 'namespace'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSelect/EmSelectItem.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectItem.vue
@@ -3,12 +3,11 @@
   import { Select } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { ID, SelectItemProps } from '@vuetify/v0'
 
-  export interface EmSelectItemProps {
+  export interface EmSelectItemProps extends Pick<SelectItemProps, 'disabled' | 'namespace'> {
+    /** Required here, unlike v0 — an Emerald option is always addressable. */
     value: ID
-    disabled?: boolean
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmSelect/EmSelectPlaceholder.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectPlaceholder.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Select } from '@vuetify/v0'
 
-  export interface EmSelectPlaceholderProps {
-    namespace?: string
-  }
+  // Types
+  import type { SelectPlaceholderProps } from '@vuetify/v0'
+
+  export interface EmSelectPlaceholderProps extends Omit<SelectPlaceholderProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSelect/EmSelectValue.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectValue.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Select } from '@vuetify/v0'
 
-  export interface EmSelectValueProps {
-    namespace?: string
-  }
+  // Types
+  import type { SelectValueProps } from '@vuetify/v0'
+
+  export interface EmSelectValueProps extends Omit<SelectValueProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSlider/EmSlider.vue
+++ b/packages/emerald/src/components/EmSlider/EmSlider.vue
@@ -11,6 +11,8 @@
   export type EmSliderOrientation = NonNullable<SliderRootProps['orientation']>
 
   export interface EmSliderProps extends Omit<SliderRootProps, 'as' | 'renderless'> {
+    /** Accessible name for the slider group / default thumb */
+    label?: SliderRootProps['label']
     /** Thumb accessible name when no visible label */
     ariaLabel?: string
   }

--- a/packages/emerald/src/components/EmSlider/EmSlider.vue
+++ b/packages/emerald/src/components/EmSlider/EmSlider.vue
@@ -2,27 +2,17 @@
   // Framework
   import { Slider } from '@vuetify/v0'
 
-  export type EmSliderOrientation = 'horizontal' | 'vertical'
+  // Utilities
+  import { toValue } from 'vue'
 
-  export interface EmSliderProps {
-    disabled?: boolean
-    readonly?: boolean
-    min?: number
-    max?: number
-    step?: number
-    orientation?: EmSliderOrientation
-    name?: string
-    /** Accessible name for the slider group / default thumb */
-    label?: string
-    ariaLabelledby?: string
+  // Types
+  import type { SliderRootProps } from '@vuetify/v0'
+
+  export type EmSliderOrientation = NonNullable<SliderRootProps['orientation']>
+
+  export interface EmSliderProps extends Omit<SliderRootProps, 'as' | 'renderless'> {
     /** Thumb accessible name when no visible label */
     ariaLabel?: string
-    inverted?: boolean
-    minStepsBetweenThumbs?: number
-    crossover?: boolean
-    form?: string
-    id?: string
-    namespace?: string
   }
 </script>
 
@@ -54,9 +44,9 @@
 <template>
   <div
     class="emerald-slider"
-    :data-disabled="disabled || undefined"
+    :data-disabled="toValue(disabled) || undefined"
     :data-orientation="orientation"
-    :data-readonly="isReadonly || undefined"
+    :data-readonly="toValue(isReadonly) || undefined"
   >
     <Slider.Root
       :id

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
@@ -7,6 +7,11 @@
 
   export type EmSnackbarVariant = 'success' | 'error' | 'info' | 'warning' | 'neutral'
 
+  /**
+   * Emerald withholds `urgent`, so every snackbar is `role="status"`. `variant` is
+   * purely visual (`data-variant`) and does not raise politeness — a `variant="error"`
+   * snackbar is still announced politely.
+   */
   export interface EmSnackbarProps extends Pick<SnackbarRootProps, 'id' | 'namespace'> {
     variant?: EmSnackbarVariant
   }

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
@@ -3,13 +3,11 @@
   import { Snackbar } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { SnackbarRootProps } from '@vuetify/v0'
 
   export type EmSnackbarVariant = 'success' | 'error' | 'info' | 'warning' | 'neutral'
 
-  export interface EmSnackbarProps {
-    id?: ID
-    namespace?: string
+  export interface EmSnackbarProps extends Pick<SnackbarRootProps, 'id' | 'namespace'> {
     variant?: EmSnackbarVariant
   }
 </script>

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbarClose.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbarClose.vue
@@ -5,9 +5,10 @@
   // Components
   import EmIcon from '../EmIcon/EmIcon.vue'
 
-  export interface EmSnackbarCloseProps {
-    namespace?: string
-  }
+  // Types
+  import type { SnackbarCloseProps } from '@vuetify/v0'
+
+  export interface EmSnackbarCloseProps extends Omit<SnackbarCloseProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbarPortal.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbarPortal.vue
@@ -2,10 +2,10 @@
   // Framework
   import { Snackbar } from '@vuetify/v0'
 
-  export interface EmSnackbarPortalProps {
-    /** Teleport target. `'top-layer'` mounts into the topmost open modal; `false` renders inline. */
-    teleport?: 'top-layer' | (string & {}) | false
-  }
+  // Types
+  import type { SnackbarPortalProps } from '@vuetify/v0'
+
+  export interface EmSnackbarPortalProps extends Pick<SnackbarPortalProps, 'teleport'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbarQueue.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbarQueue.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Snackbar } from '@vuetify/v0'
 
-  export interface EmSnackbarQueueProps {
-    namespace?: string
-  }
+  // Types
+  import type { SnackbarQueueProps } from '@vuetify/v0'
+
+  export interface EmSnackbarQueueProps extends Omit<SnackbarQueueProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmStep/EmStep.vue
+++ b/packages/emerald/src/components/EmStep/EmStep.vue
@@ -2,12 +2,10 @@
   // Framework
   import { Step } from '@vuetify/v0'
 
-  export interface EmStepProps {
-    disabled?: boolean
-    enroll?: boolean
-    mandatory?: boolean | 'force'
-    namespace?: string
-  }
+  // Types
+  import type { StepRootProps } from '@vuetify/v0'
+
+  export interface EmStepProps extends StepRootProps {}
 </script>
 
 <script lang="ts" setup generic="T = unknown">

--- a/packages/emerald/src/components/EmStep/EmStep.vue
+++ b/packages/emerald/src/components/EmStep/EmStep.vue
@@ -5,7 +5,7 @@
   // Types
   import type { StepRootProps } from '@vuetify/v0'
 
-  export interface EmStepProps extends StepRootProps {}
+  export interface EmStepProps extends Omit<StepRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script lang="ts" setup generic="T = unknown">

--- a/packages/emerald/src/components/EmStep/EmStepItem.vue
+++ b/packages/emerald/src/components/EmStep/EmStepItem.vue
@@ -2,13 +2,10 @@
   // Framework
   import { Step } from '@vuetify/v0'
 
-  export interface EmStepItemProps {
-    id?: string
-    label?: string
-    value?: unknown
-    disabled?: boolean
-    namespace?: string
-  }
+  // Types
+  import type { StepItemProps } from '@vuetify/v0'
+
+  export interface EmStepItemProps extends StepItemProps {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmStep/EmStepItem.vue
+++ b/packages/emerald/src/components/EmStep/EmStepItem.vue
@@ -5,7 +5,7 @@
   // Types
   import type { StepItemProps } from '@vuetify/v0'
 
-  export interface EmStepItemProps extends StepItemProps {}
+  export interface EmStepItemProps extends Omit<StepItemProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmSwitch/EmSwitch.vue
+++ b/packages/emerald/src/components/EmSwitch/EmSwitch.vue
@@ -1,19 +1,21 @@
 <script lang="ts">
   // Framework
   import { Switch } from '@vuetify/v0'
-  // Utilities
   import { useId } from '@vuetify/v0/utilities'
+
+  // Utilities
+  import { toValue } from 'vue'
+
+  // Types
+  import type { SwitchRootProps } from '@vuetify/v0'
 
   export type EmSwitchSize = 'sm' | 'md' | 'lg'
 
-  export interface EmSwitchProps {
-    disabled?: boolean
+  export interface EmSwitchProps extends Pick<
+    SwitchRootProps,
+    'disabled' | 'name' | 'value' | 'label' | 'namespace'
+  > {
     size?: EmSwitchSize
-    name?: string
-    value?: unknown
-    /** Accessible name when no default-slot label is rendered */
-    label?: string
-    namespace?: string
   }
 </script>
 
@@ -36,7 +38,7 @@
 </script>
 
 <template>
-  <label class="emerald-switch" :data-disabled="disabled || undefined" :data-size="size">
+  <label class="emerald-switch" :data-disabled="toValue(disabled) || undefined" :data-size="size">
     <Switch.Root
       v-model="model"
       :aria-labelledby="$slots.default ? id : undefined"

--- a/packages/emerald/src/components/EmTabs/EmTabs.vue
+++ b/packages/emerald/src/components/EmTabs/EmTabs.vue
@@ -3,18 +3,14 @@
   import { Tabs } from '@vuetify/v0'
 
   // Types
-  import type { TabsActivation } from '@vuetify/v0'
+  import type { TabsOrientation, TabsRootProps } from '@vuetify/v0'
 
-  export type EmTabsOrientation = 'horizontal' | 'vertical'
+  export type EmTabsOrientation = TabsOrientation
 
-  export interface EmTabsProps {
-    disabled?: boolean
-    mandatory?: boolean | 'force'
-    circular?: boolean
-    orientation?: EmTabsOrientation
-    activation?: TabsActivation
-    namespace?: string
-  }
+  export interface EmTabsProps extends Pick<
+    TabsRootProps,
+    'disabled' | 'mandatory' | 'circular' | 'orientation' | 'activation' | 'namespace'
+  > {}
 </script>
 
 <script lang="ts" setup generic="T">

--- a/packages/emerald/src/components/EmTabs/EmTabsItem.vue
+++ b/packages/emerald/src/components/EmTabs/EmTabsItem.vue
@@ -3,12 +3,11 @@
   import { Tabs } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { ID, TabsItemProps } from '@vuetify/v0'
 
-  export interface EmTabsItemProps {
+  export interface EmTabsItemProps extends Pick<TabsItemProps, 'disabled' | 'namespace'> {
+    /** Required here, unlike v0 — an Emerald tab is always addressable. */
     value: ID
-    disabled?: boolean
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmTabs/EmTabsList.vue
+++ b/packages/emerald/src/components/EmTabs/EmTabsList.vue
@@ -2,11 +2,10 @@
   // Framework
   import { Tabs } from '@vuetify/v0'
 
-  export interface EmTabsListProps {
-    /** Accessible name for the tablist when no visible label is associated */
-    label?: string
-    namespace?: string
-  }
+  // Types
+  import type { TabsListProps } from '@vuetify/v0'
+
+  export interface EmTabsListProps extends Omit<TabsListProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmTabs/EmTabsPanel.vue
+++ b/packages/emerald/src/components/EmTabs/EmTabsPanel.vue
@@ -3,11 +3,10 @@
   import { Tabs } from '@vuetify/v0'
 
   // Types
-  import type { ID } from '@vuetify/v0'
+  import type { ID, TabsPanelProps } from '@vuetify/v0'
 
-  export interface EmTabsPanelProps {
+  export interface EmTabsPanelProps extends Pick<TabsPanelProps, 'namespace'> {
     value: ID
-    namespace?: string
   }
 </script>
 

--- a/packages/emerald/src/components/EmTextField/EmTextField.vue
+++ b/packages/emerald/src/components/EmTextField/EmTextField.vue
@@ -9,21 +9,10 @@
   // Types
   import type { InputRootProps } from '@vuetify/v0'
 
-  export interface EmTextFieldProps extends Pick<
-    InputRootProps,
-    | 'id'
-      | 'label'
-      | 'disabled'
-      | 'readonly'
-      | 'required'
-      | 'name'
-      | 'type'
-      | 'rules'
-      | 'validateOn'
-      | 'error'
-      | 'errorMessages'
-      | 'namespace'
-  > {
+  /** Emerald withholds `form` from v0's input surface; everything else tracks it. */
+  type EmTextFieldKeys = 'id' | 'label' | 'disabled' | 'readonly' | 'required' | 'name' | 'type' | 'rules' | 'validateOn' | 'error' | 'errorMessages' | 'namespace'
+
+  export interface EmTextFieldProps extends Pick<InputRootProps, EmTextFieldKeys> {
     /** Help text under the control (no named slots — props only) */
     description?: string
     placeholder?: string

--- a/packages/emerald/src/components/EmTextField/EmTextField.vue
+++ b/packages/emerald/src/components/EmTextField/EmTextField.vue
@@ -1,31 +1,33 @@
 <script lang="ts">
   // Framework
   import { Input } from '@vuetify/v0'
-  // Utilities
   import { useId } from '@vuetify/v0/utilities'
 
-  // Types
-  import type { FormValidationRule, ID, ValidateOn } from '@vuetify/v0'
+  // Utilities
+  import { toValue } from 'vue'
 
-  export interface EmTextFieldProps {
-    id?: ID
-    /** Visible label text; associated via `for`/`id` (not Root aria-label) */
-    label?: string
+  // Types
+  import type { InputRootProps } from '@vuetify/v0'
+
+  export interface EmTextFieldProps extends Pick<
+    InputRootProps,
+    | 'id'
+      | 'label'
+      | 'disabled'
+      | 'readonly'
+      | 'required'
+      | 'name'
+      | 'type'
+      | 'rules'
+      | 'validateOn'
+      | 'error'
+      | 'errorMessages'
+      | 'namespace'
+  > {
     /** Help text under the control (no named slots — props only) */
     description?: string
-    disabled?: boolean
-    readonly?: boolean
-    required?: boolean
-    name?: string
-    /** Native input type — owned by Input.Root, not Control */
-    type?: string
     placeholder?: string
     autocomplete?: string
-    rules?: FormValidationRule[]
-    validateOn?: ValidateOn
-    error?: boolean
-    errorMessages?: string | string[]
-    namespace?: string
   }
 </script>
 
@@ -60,7 +62,7 @@
     :id
     v-model="model"
     class="emerald-text-field"
-    :data-disabled="disabled || undefined"
+    :data-disabled="toValue(disabled) || undefined"
     :disabled
     :error
     :error-messages

--- a/packages/emerald/src/components/EmTextField/EmTextField.vue
+++ b/packages/emerald/src/components/EmTextField/EmTextField.vue
@@ -13,6 +13,10 @@
   type EmTextFieldKeys = 'id' | 'label' | 'disabled' | 'readonly' | 'required' | 'name' | 'type' | 'rules' | 'validateOn' | 'error' | 'errorMessages' | 'namespace'
 
   export interface EmTextFieldProps extends Pick<InputRootProps, EmTextFieldKeys> {
+    /** Visible label text; associated via `for`/`id` (not Root aria-label) */
+    label?: InputRootProps['label']
+    /** Native input type — owned by Input.Root, not Control */
+    type?: InputRootProps['type']
     /** Help text under the control (no named slots — props only) */
     description?: string
     placeholder?: string

--- a/packages/emerald/src/components/EmTextarea/EmTextarea.vue
+++ b/packages/emerald/src/components/EmTextarea/EmTextarea.vue
@@ -9,20 +9,10 @@
   // Types
   import type { InputRootProps } from '@vuetify/v0'
 
-  export interface EmTextareaProps extends Pick<
-    InputRootProps,
-    | 'id'
-      | 'label'
-      | 'disabled'
-      | 'readonly'
-      | 'required'
-      | 'name'
-      | 'rules'
-      | 'validateOn'
-      | 'error'
-      | 'errorMessages'
-      | 'namespace'
-  > {
+  /** Emerald withholds `form` and `type` from v0's input surface; everything else tracks it. */
+  type EmTextareaKeys = 'id' | 'label' | 'disabled' | 'readonly' | 'required' | 'name' | 'rules' | 'validateOn' | 'error' | 'errorMessages' | 'namespace'
+
+  export interface EmTextareaProps extends Pick<InputRootProps, EmTextareaKeys> {
     /** Help text under the control (no named slots — props only) */
     description?: string
     placeholder?: string

--- a/packages/emerald/src/components/EmTextarea/EmTextarea.vue
+++ b/packages/emerald/src/components/EmTextarea/EmTextarea.vue
@@ -13,6 +13,8 @@
   type EmTextareaKeys = 'id' | 'label' | 'disabled' | 'readonly' | 'required' | 'name' | 'rules' | 'validateOn' | 'error' | 'errorMessages' | 'namespace'
 
   export interface EmTextareaProps extends Pick<InputRootProps, EmTextareaKeys> {
+    /** Visible label text; associated via `for`/`id` (not Root aria-label) */
+    label?: InputRootProps['label']
     /** Help text under the control (no named slots — props only) */
     description?: string
     placeholder?: string

--- a/packages/emerald/src/components/EmTextarea/EmTextarea.vue
+++ b/packages/emerald/src/components/EmTextarea/EmTextarea.vue
@@ -1,28 +1,31 @@
 <script lang="ts">
   // Framework
   import { Input } from '@vuetify/v0'
-  // Utilities
   import { useId } from '@vuetify/v0/utilities'
 
-  // Types
-  import type { FormValidationRule, ID, ValidateOn } from '@vuetify/v0'
+  // Utilities
+  import { toValue } from 'vue'
 
-  export interface EmTextareaProps {
-    id?: ID
-    /** Visible label text; associated via `for`/`id` (not Root aria-label) */
-    label?: string
+  // Types
+  import type { InputRootProps } from '@vuetify/v0'
+
+  export interface EmTextareaProps extends Pick<
+    InputRootProps,
+    | 'id'
+      | 'label'
+      | 'disabled'
+      | 'readonly'
+      | 'required'
+      | 'name'
+      | 'rules'
+      | 'validateOn'
+      | 'error'
+      | 'errorMessages'
+      | 'namespace'
+  > {
     /** Help text under the control (no named slots — props only) */
     description?: string
-    disabled?: boolean
-    readonly?: boolean
-    required?: boolean
-    name?: string
     placeholder?: string
-    rules?: FormValidationRule[]
-    validateOn?: ValidateOn
-    error?: boolean
-    errorMessages?: string | string[]
-    namespace?: string
     /** Visible text rows; drives native `rows` and control min-height */
     rows?: number
   }
@@ -58,7 +61,7 @@
     :id
     v-model="model"
     class="emerald-textarea"
-    :data-disabled="disabled || undefined"
+    :data-disabled="toValue(disabled) || undefined"
     :disabled
     :error
     :error-messages

--- a/packages/emerald/src/components/EmTooltip/EmTooltip.vue
+++ b/packages/emerald/src/components/EmTooltip/EmTooltip.vue
@@ -2,15 +2,10 @@
   // Framework
   import { Tooltip } from '@vuetify/v0'
 
-  export interface EmTooltipProps {
-    namespace?: string
-    openDelay?: number
-    closeDelay?: number
-    disabled?: boolean
-    interactive?: boolean
-    positionArea?: string
-    positionTry?: string
-  }
+  // Types
+  import type { TooltipRootProps } from '@vuetify/v0'
+
+  export interface EmTooltipProps extends Omit<TooltipRootProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmTooltip/EmTooltipActivator.vue
+++ b/packages/emerald/src/components/EmTooltip/EmTooltipActivator.vue
@@ -5,14 +5,14 @@
   // Types
   import type { TooltipActivatorProps } from '@vuetify/v0'
 
-  export interface EmTooltipActivatorProps extends Pick<TooltipActivatorProps, 'as'> {
-    /**
-     * When true, Activator is a pure slot host — bind `attrs` onto your own
-     * trigger (e.g. EmButton) so you do not nest interactive elements.
-     */
-    renderless?: boolean
-    namespace?: string
-  }
+  /**
+   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
+   * trigger (e.g. EmButton) so you do not nest interactive elements.
+   */
+  export interface EmTooltipActivatorProps extends Pick<
+    TooltipActivatorProps,
+    'as' | 'renderless' | 'namespace'
+  > {}
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmTooltip/EmTooltipActivator.vue
+++ b/packages/emerald/src/components/EmTooltip/EmTooltipActivator.vue
@@ -5,14 +5,16 @@
   // Types
   import type { TooltipActivatorProps } from '@vuetify/v0'
 
-  /**
-   * `renderless` makes Activator a pure slot host — bind `attrs` onto your own
-   * trigger (e.g. EmButton) so you do not nest interactive elements.
-   */
   export interface EmTooltipActivatorProps extends Pick<
     TooltipActivatorProps,
     'as' | 'renderless' | 'namespace'
-  > {}
+  > {
+    /**
+     * When true, Activator is a pure slot host — bind `attrs` onto your own
+     * trigger (e.g. EmButton) so you do not nest interactive elements.
+     */
+    renderless?: TooltipActivatorProps['renderless']
+  }
 </script>
 
 <script setup lang="ts">

--- a/packages/emerald/src/components/EmTooltip/EmTooltipContent.vue
+++ b/packages/emerald/src/components/EmTooltip/EmTooltipContent.vue
@@ -2,9 +2,10 @@
   // Framework
   import { Tooltip } from '@vuetify/v0'
 
-  export interface EmTooltipContentProps {
-    namespace?: string
-  }
+  // Types
+  import type { TooltipContentProps } from '@vuetify/v0'
+
+  export interface EmTooltipContentProps extends Omit<TooltipContentProps, 'as' | 'renderless'> {}
 </script>
 
 <script setup lang="ts">


### PR DESCRIPTION
The extends-sweep: 56 of Emerald's 74 hand-written `Em*Props` interfaces now extend v0's exported prop types — `Omit<XRootProps, 'as' | 'renderless'>` for the 27 full mirrors (tracking v0), explicit `Pick<>` key lists for the curated subsets (frozen surface), own-fields for DS-specific props. The 18 without a v0 counterpart (EmCalendar family, EmKanban, and the seven Atom-based presentational components) are unchanged.

## Consumer-facing fixes (the drift this closes)
- `rules` on EmTextField/EmTextarea accepts rule aliases and Standard Schema validators (inherits `InputRootProps['rules']`).
- `disabled`/`readonly`/`indeterminate` accept refs and getters (`MaybeRefOrGetter`) wherever v0 declares them — and the seven `data-disabled`/`data-readonly` truthy-test sites now resolve through `toValue()`, fixing styling that would have latched permanently on a ref input.
- Hand-typed unions replaced with v0's exports (`EmTabsOrientation = TabsOrientation`; `EmSliderOrientation = NonNullable<SliderRootProps['orientation']>`).

## Surface proof
Runtime prop surface diffed from the built bundle across **all 90 components** at every phase: identical — zero props added, removed, or renamed. The seven `toValue` wraps are the only non-declaration lines in the 57-file diff. Emerald + dev-app typecheck, emerald build, lint, and the full non-browser suite (4869) all green.

## Notes for review
- `as`/`renderless` are deliberately excluded from every mirror: Emerald never forwards them, and inheriting them would have added lying props to 27 surfaces (the SFC compiler treats unresolved extends members as fallthrough attrs — discovered the hard way: `Omit<X, keyof AtomProps>` typechecks but breaks the build; literal key unions resolve).
- Emerald-specific JSDoc that inheritance erased is restored via indexed-access own-fields (`label?: InputRootProps['label']`), keeping the drift pin.
- **A11y gap documented, not fixed** (out of scope for a type sweep): EmSnackbar withholds v0's `urgent`, so every snackbar — including `variant="error"` — announces as `role="status"`/polite. Follow-up issue filed.
- Process note: typecheck alone is insufficient for this class of change — the SFC build and the runtime-props diff each caught a failure typecheck passed.