### PR TITLE
docs: move tooltip delays into createTooltipPlugin options

### DIFF
--- a/apps/docs/src/components/app/AppTooltip.vue
+++ b/apps/docs/src/components/app/AppTooltip.vue
@@ -10,12 +10,14 @@
   // openDelay/closeDelay/positionArea/disabled forward to Tooltip.Root; their
   // types come from TooltipRootProps so this wrapper can't drift. `disabled` is
   // a declared prop (not a fall-through attr) so a caller's `:disabled` is not
-  // clobbered by Tooltip.Activator's mergeProps.
+  // clobbered by Tooltip.Activator's mergeProps. openDelay/closeDelay carry no
+  // defaults on purpose — undefined lets Tooltip.Root fall back to the region
+  // delays from createTooltipPlugin, so timing is configured in one place.
   const {
     text,
     as = 'button',
-    openDelay = 500,
-    closeDelay = 200,
+    openDelay,
+    closeDelay,
     positionArea = 'top',
     disabled = false,
   } = defineProps<{

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -22,7 +22,7 @@ export default function zero (app: App) {
   app.use(createBreakpointsPlugin({ mobileBreakpoint: 768 }))
   app.use(createStoragePlugin())
   app.use(createStackPlugin())
-  app.use(createTooltipPlugin())
+  app.use(createTooltipPlugin({ openDelay: 500, closeDelay: 200 }))
   app.use(createDiscoveryPlugin())
 
   app.use(


### PR DESCRIPTION
`AppTooltip` hard-coded `openDelay: 500` / `closeDelay: 200` as component defaults, so every `Tooltip.Root` it rendered received explicit props and the region delays held by `createTooltipPlugin` were never consulted — changing the plugin config had no effect anywhere in the docs.

Drops the wrapper defaults (`undefined` now forwards, letting `Tooltip.Root` fall back to the region) and passes the same values to `createTooltipPlugin` so the region owns the timing in one place.

Behavior is unchanged: 507 ms open, 208 ms close, and warmup still hands a neighboring tooltip an `instant-open` within the skip window. Setting the plugin to 900 ms temporarily moved the appbar tooltip to 910 ms, confirming the region is now the source of truth.

`BenchmarkRow.vue` keeps its per-instance `:open-delay="300"` / `:close-delay="100"` override — that one is deliberate.