### PR TITLE
fix(useDragDrop): anchor the drop indicator to the slot, not the approach

### DIFF
--- a/.changeset/dragdrop-indicator-anchor.md
+++ b/.changeset/dragdrop-indicator-anchor.md
@@ -2,6 +2,8 @@
 '@vuetify/v0': patch
 ---
 
-fix(useDragDrop): anchor the drop indicator to the slot, not the pointer's approach
+fix(useDragDrop): anchor the drop indicator to the slot and suppress no-op slots
 
 An interior drop slot now always renders against the end edge of the rect above it. Previously the same slot anchored to the rect above or the rect below depending on which side the pointer approached from, so the indicator visibly jumped across the gap mid-drag — dragging a card down a column drew the line at the top of the next card instead of walking edge to edge.
+
+A drag over its own zone also no longer proposes the two slots flanking the dragged element's current position: dropping in either puts it straight back where it sits, so the indicator stays hidden there — grabbing the first card and nudging the pointer above it no longer draws a line over its own head — and a drop on a suppressed slot resolves `position.index` to the element's current slot instead of `0`.

--- a/.changeset/dragdrop-indicator-anchor.md
+++ b/.changeset/dragdrop-indicator-anchor.md
@@ -1,0 +1,7 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(useDragDrop): anchor the drop indicator to the slot, not the pointer's approach
+
+An interior drop slot now always renders against the end edge of the rect above it. Previously the same slot anchored to the rect above or the rect below depending on which side the pointer approached from, so the indicator visibly jumped across the gap mid-drag — dragging a card down a column drew the line at the top of the next card instead of walking edge to edge.

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -206,7 +206,7 @@ Every consumer-facing state field is a reactive ref <AppSuccessIcon />. Reads in
 | `ticket.el` | `Readonly<Ref<HTMLElement \| null>>` | Mounts / unmounts (registry element-ref pattern) |
 | `zone.isOver` | `Readonly<Ref<boolean>>` | The active drag's `over` field equals this zone's id |
 | `zone.willAccept` | `Readonly<Ref<boolean>>` | An active drag matches this zone's `accept` policy |
-| `zone.indicator` | `Readonly<Ref<DropIndicator \| null>>` | While over an oriented zone, computes the index/edge/rect of the resolved drop position |
+| `zone.indicator` | `Readonly<Ref<DropIndicator \| null>>` | While over an oriented zone, computes the index/edge/rect of the resolved drop slot. `null` over an unoriented or empty zone — and over the two slots flanking the dragged element's own position in its home zone, which are stays, not moves |
 | `zone.el` | `Readonly<Ref<HTMLElement \| null>>` | Mounts / unmounts (registry element-ref pattern) |
 
 [^drag-via-usage]: Read this to branch keyboard-only behaviors like focus restoration.
@@ -336,7 +336,7 @@ Native HTML5 DnD has terrible mobile support, an ugly default ghost element you 
 
 ??? When does `position.index` get set?
 
-Only when the over-zone declares `orientation`. Without orientation, the zone is opaque — drops fire with `position.pointer` only. With orientation, the composable measures child rects and resolves an index. Empty oriented zones default `index` to `0` (the only sensible drop position when there's nothing to splice between).
+Only when the over-zone declares `orientation`. Without orientation, the zone is opaque — drops fire with `position.pointer` only. With orientation, the composable measures child rects and resolves an index. Empty oriented zones default `index` to `0` (the only sensible drop position when there's nothing to splice between). The indicator is also `null` over the two slots flanking the dragged element's own position in its home zone — dropping there changes nothing, so no slot is proposed and the drop resolves `index` to the element's current position.
 
 ??? How do I pick the right `Z` parameter?
 

--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -937,7 +937,7 @@ describe('resolveDropPosition', () => {
     zoneEl.remove()
   })
 
-  it('should resolve gap-after when coord lies in gap closer to a.end', async () => {
+  it('should resolve a gap coordinate into the slot after the rect above', async () => {
     const adapter = new CaptureAdapter()
     const cardEl = makeFocusableEl('rdp-gap-1')
     const zoneEl = document.createElement('div')
@@ -959,7 +959,7 @@ describe('resolveDropPosition', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // y=60 lies in gap (50,100), closer to a.end=50; mid=75, 60 < 75 → 'after a'
+    // y=60 lies in the gap (50,100): past a's midpoint, short of b's → slot 1, anchored after a
     adapter.emit.move({ x: 50, y: 60 })
     expect(zone.indicator.value?.edge).toBe('after')
     expect(zone.indicator.value?.index).toBe(1)
@@ -969,7 +969,7 @@ describe('resolveDropPosition', () => {
     zoneEl.remove()
   })
 
-  it('should resolve gap-before when coord lies in gap closer to b.start', async () => {
+  it('should keep an interior slot anchored to the rect above it from either approach', async () => {
     const adapter = new CaptureAdapter()
     const cardEl = makeFocusableEl('rdp-gap-2')
     const zoneEl = document.createElement('div')
@@ -991,10 +991,22 @@ describe('resolveDropPosition', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // y=90 lies in gap (50,100), mid=75, 90 > 75 → 'before b'
-    adapter.emit.move({ x: 50, y: 90 })
-    expect(zone.indicator.value?.edge).toBe('before')
-    expect(zone.indicator.value?.index).toBe(1)
+    // Slot 1 is one place however the pointer arrives: a's bottom half, the
+    // gap on either side of its midpoint, and b's upper half all anchor the
+    // indicator to a's end edge. An indicator that flips its anchor to b.top
+    // as the pointer crosses the gap draws the same slot at two positions.
+    for (const y of [30, 60, 90, 120]) {
+      adapter.emit.move({ x: 50, y })
+      expect(zone.indicator.value?.edge).toBe('after')
+      expect(zone.indicator.value?.index).toBe(1)
+      expect(zone.indicator.value?.rect.bottom).toBe(50)
+    }
+
+    // Past b's midpoint the slot is 2, anchored to b's end edge.
+    adapter.emit.move({ x: 50, y: 130 })
+    expect(zone.indicator.value?.edge).toBe('after')
+    expect(zone.indicator.value?.index).toBe(2)
+    expect(zone.indicator.value?.rect.bottom).toBe(150)
 
     document.elementFromPoint = realFromPoint
     cardEl.remove()

--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -991,10 +991,8 @@ describe('resolveDropPosition', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // Slot 1 is one place however the pointer arrives: a's bottom half, the
-    // gap on either side of its midpoint, and b's upper half all anchor the
-    // indicator to a's end edge. An indicator that flips its anchor to b.top
-    // as the pointer crosses the gap draws the same slot at two positions.
+    // Slot 1 anchors to a's end edge from every approach: a's bottom half,
+    // both sides of the gap, and b's upper half.
     for (const y of [30, 60, 90, 120]) {
       adapter.emit.move({ x: 50, y })
       expect(zone.indicator.value?.edge).toBe('after')
@@ -1022,8 +1020,7 @@ describe('resolveDropPosition', () => {
 })
 
 describe('no-op slot suppression', () => {
-  // A zone whose children a/b carry stacked rects, with the draggable element
-  // living inside one of them — the same-zone drag shape EmKanban produces.
+  // Stacked children a/b with the draggable inside one of them.
   function board (host: 'a' | 'b' | null) {
     const zoneEl = document.createElement('div')
     const a = document.createElement('div')
@@ -1054,8 +1051,7 @@ describe('no-op slot suppression', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // Slot 0 (above the dragged first child) and slot 1 (right below it) both
-    // drop the element back where it sits — no indicator anywhere from above
+    // Slots 0 and 1 flank the dragged first child — no indicator from above
     // the zone through b's upper half.
     for (const y of [-10, 20, 60, 90, 120]) {
       adapter.emit.move({ x: 50, y })
@@ -1086,7 +1082,7 @@ describe('no-op slot suppression', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // Below the dragged last child: slot 2 flanks its own position.
+    // Slot 2 flanks the dragged last child.
     adapter.emit.move({ x: 50, y: 200 })
     expect(zone.indicator.value).toBeNull()
 
@@ -1130,9 +1126,8 @@ describe('no-op slot suppression', () => {
 
   it('should not suppress in an enclosing zone that is not the element\'s home', async () => {
     const adapter = new CaptureAdapter()
-    // A board zone whose single child wraps a column zone, with the card
-    // registered inside the column — the board contains the card but is not
-    // its home, so none of the board's slots may be suppressed.
+    // The board zone contains the card but the column zone is its home —
+    // none of the board's slots may be suppressed.
     const boardEl = document.createElement('div')
     const wrapper = document.createElement('div')
     const columnEl = document.createElement('div')
@@ -1181,8 +1176,7 @@ describe('no-op slot suppression', () => {
     const realFromPoint = document.elementFromPoint.bind(document)
     document.elementFromPoint = () => zoneEl
 
-    // Drop just below the dragged last child — the suppressed slot. Resolving
-    // it to 0 would teleport the element to the top of its own list.
+    // A drop on the suppressed slot must stay, not resolve to index 0.
     adapter.emit.move({ x: 50, y: 160 })
     adapter.emit.drop()
     document.elementFromPoint = realFromPoint

--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -1014,6 +1014,143 @@ describe('resolveDropPosition', () => {
   })
 })
 
+describe('no-op slot suppression', () => {
+  // A zone whose children a/b carry stacked rects, with the draggable element
+  // living inside one of them — the same-zone drag shape EmKanban produces.
+  function board (host: 'a' | 'b' | null) {
+    const zoneEl = document.createElement('div')
+    const a = document.createElement('div')
+    const b = document.createElement('div')
+    const cardEl = makeFocusableEl('noop-card')
+    zoneEl.append(a, b)
+    if (host) (host === 'a' ? a : b).append(cardEl)
+    else document.body.append(cardEl)
+    document.body.append(zoneEl)
+
+    a.getBoundingClientRect = () => makeRect(0, 0, 100, 50)
+    b.getBoundingClientRect = () => makeRect(0, 100, 100, 50)
+
+    return { zoneEl, a, b, cardEl }
+  }
+
+  it('should not propose the slots flanking the dragged element in its own zone', async () => {
+    const adapter = new CaptureAdapter()
+    const { zoneEl, cardEl } = board('a')
+
+    const dnd = useDragDrop({ adapters: [adapter] })
+    const ticket = dnd.draggables.register({ el: shallowRef(cardEl), type: 'a', value: null })
+    const zone = dnd.zones.register({ el: shallowRef(zoneEl), orientation: 'vertical' })
+
+    await nextTick()
+
+    adapter.emit.start(ticket, { x: 50, y: 20 }, 'pointer')
+    const realFromPoint = document.elementFromPoint.bind(document)
+    document.elementFromPoint = () => zoneEl
+
+    // Slot 0 (above the dragged first child) and slot 1 (right below it) both
+    // drop the element back where it sits — no indicator anywhere from above
+    // the zone through b's upper half.
+    for (const y of [-10, 20, 60, 90, 120]) {
+      adapter.emit.move({ x: 50, y })
+      expect(zone.indicator.value).toBeNull()
+    }
+
+    // Past b's midpoint the drop is a real move: slot 2, anchored after b.
+    adapter.emit.move({ x: 50, y: 130 })
+    expect(zone.indicator.value?.index).toBe(2)
+    expect(zone.indicator.value?.edge).toBe('after')
+
+    document.elementFromPoint = realFromPoint
+    cardEl.remove()
+    zoneEl.remove()
+  })
+
+  it('should not propose the slot below the dragged last child', async () => {
+    const adapter = new CaptureAdapter()
+    const { zoneEl, cardEl } = board('b')
+
+    const dnd = useDragDrop({ adapters: [adapter] })
+    const ticket = dnd.draggables.register({ el: shallowRef(cardEl), type: 'a', value: null })
+    const zone = dnd.zones.register({ el: shallowRef(zoneEl), orientation: 'vertical' })
+
+    await nextTick()
+
+    adapter.emit.start(ticket, { x: 50, y: 120 }, 'pointer')
+    const realFromPoint = document.elementFromPoint.bind(document)
+    document.elementFromPoint = () => zoneEl
+
+    // Below the dragged last child: slot 2 flanks its own position.
+    adapter.emit.move({ x: 50, y: 200 })
+    expect(zone.indicator.value).toBeNull()
+
+    // Above a's midpoint the drop is a real move: slot 0.
+    adapter.emit.move({ x: 50, y: 10 })
+    expect(zone.indicator.value?.index).toBe(0)
+    expect(zone.indicator.value?.edge).toBe('before')
+
+    document.elementFromPoint = realFromPoint
+    cardEl.remove()
+    zoneEl.remove()
+  })
+
+  it('should propose every slot for a drag that started in another zone', async () => {
+    const adapter = new CaptureAdapter()
+    const { zoneEl, cardEl } = board(null)
+
+    const dnd = useDragDrop({ adapters: [adapter] })
+    const ticket = dnd.draggables.register({ el: shallowRef(cardEl), type: 'a', value: null })
+    const zone = dnd.zones.register({ el: shallowRef(zoneEl), orientation: 'vertical' })
+
+    await nextTick()
+
+    adapter.emit.start(ticket, { x: 50, y: 20 }, 'pointer')
+    const realFromPoint = document.elementFromPoint.bind(document)
+    document.elementFromPoint = () => zoneEl
+
+    adapter.emit.move({ x: 50, y: 10 })
+    expect(zone.indicator.value?.index).toBe(0)
+
+    adapter.emit.move({ x: 50, y: 60 })
+    expect(zone.indicator.value?.index).toBe(1)
+
+    adapter.emit.move({ x: 50, y: 200 })
+    expect(zone.indicator.value?.index).toBe(2)
+
+    document.elementFromPoint = realFromPoint
+    cardEl.remove()
+    zoneEl.remove()
+  })
+
+  it('should resolve a suppressed drop to the element\'s own slot, not zero', async () => {
+    const adapter = new CaptureAdapter()
+    const { zoneEl, cardEl } = board('b')
+
+    const onDrop = vi.fn()
+    const dnd = useDragDrop({ adapters: [adapter] })
+    const ticket = dnd.draggables.register({ el: shallowRef(cardEl), type: 'a', value: null })
+    dnd.zones.register({ el: shallowRef(zoneEl), orientation: 'vertical', onDrop })
+
+    await nextTick()
+
+    adapter.emit.start(ticket, { x: 50, y: 120 }, 'pointer')
+    const realFromPoint = document.elementFromPoint.bind(document)
+    document.elementFromPoint = () => zoneEl
+
+    // Drop just below the dragged last child — the suppressed slot. Resolving
+    // it to 0 would teleport the element to the top of its own list.
+    adapter.emit.move({ x: 50, y: 160 })
+    adapter.emit.drop()
+    document.elementFromPoint = realFromPoint
+
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(onDrop.mock.calls[0][1].index).toBe(1)
+    expect(onDrop.mock.calls[0][1].indicator).toBeUndefined()
+
+    cardEl.remove()
+    zoneEl.remove()
+  })
+})
+
 describe('safeAccept edge cases', () => {
   it('should reject when accept predicate returns a thenable', () => {
     using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/packages/0/src/composables/useDragDrop/index.test.ts
+++ b/packages/0/src/composables/useDragDrop/index.test.ts
@@ -1008,6 +1008,13 @@ describe('resolveDropPosition', () => {
     expect(zone.indicator.value?.index).toBe(2)
     expect(zone.indicator.value?.rect.bottom).toBe(150)
 
+    // Exactly on a midpoint counts as past it — a's mid is 25, b's is 125.
+    adapter.emit.move({ x: 50, y: 25 })
+    expect(zone.indicator.value?.index).toBe(1)
+
+    adapter.emit.move({ x: 50, y: 125 })
+    expect(zone.indicator.value?.index).toBe(2)
+
     document.elementFromPoint = realFromPoint
     cardEl.remove()
     zoneEl.remove()
@@ -1119,6 +1126,44 @@ describe('no-op slot suppression', () => {
     document.elementFromPoint = realFromPoint
     cardEl.remove()
     zoneEl.remove()
+  })
+
+  it('should not suppress in an enclosing zone that is not the element\'s home', async () => {
+    const adapter = new CaptureAdapter()
+    // A board zone whose single child wraps a column zone, with the card
+    // registered inside the column — the board contains the card but is not
+    // its home, so none of the board's slots may be suppressed.
+    const boardEl = document.createElement('div')
+    const wrapper = document.createElement('div')
+    const columnEl = document.createElement('div')
+    const cardEl = makeFocusableEl('noop-nested-card')
+    columnEl.append(cardEl)
+    wrapper.append(columnEl)
+    boardEl.append(wrapper)
+    document.body.append(boardEl)
+
+    wrapper.getBoundingClientRect = () => makeRect(0, 0, 100, 50)
+
+    const dnd = useDragDrop({ adapters: [adapter] })
+    const ticket = dnd.draggables.register({ el: shallowRef(cardEl), type: 'a', value: null })
+    const board = dnd.zones.register({ el: shallowRef(boardEl), orientation: 'vertical' })
+    dnd.zones.register({ el: shallowRef(columnEl), orientation: 'vertical' })
+
+    await nextTick()
+
+    adapter.emit.start(ticket, { x: 50, y: 20 }, 'pointer')
+    const realFromPoint = document.elementFromPoint.bind(document)
+    document.elementFromPoint = () => boardEl
+
+    adapter.emit.move({ x: 50, y: 10 })
+    expect(board.indicator.value?.index).toBe(0)
+
+    adapter.emit.move({ x: 50, y: 40 })
+    expect(board.indicator.value?.index).toBe(1)
+
+    document.elementFromPoint = realFromPoint
+    cardEl.remove()
+    boardEl.remove()
   })
 
   it('should resolve a suppressed drop to the element\'s own slot, not zero', async () => {

--- a/packages/0/src/composables/useDragDrop/index.ts
+++ b/packages/0/src/composables/useDragDrop/index.ts
@@ -105,8 +105,11 @@ export interface DropIndicator {
 }
 
 /**
- * Position passed to drop hooks. `index` and `indicator` are populated for
- * oriented zones; unoriented zones receive only the pointer location.
+ * Position passed to drop hooks. `index` is populated for oriented zones;
+ * unoriented zones receive only the pointer location. `indicator` rides along
+ * except when no slot was proposed: an empty zone resolves `index` to `0`,
+ * and a drop on one of the slots flanking the dragged element's own position
+ * in its home zone resolves `index` to that position — a stay, not a move.
  *
  * @example
  * ```ts
@@ -384,6 +387,12 @@ export interface DragDropContext<Z extends DragType = DragType> {
  * Pure math for resolving where in an oriented zone a pointer would drop.
  * Internal — consumers rely on the `position.index` / `position.indicator`
  * fields delivered to `onDrop`.
+ *
+ * Assumes rects ascend along the orientation axis, which is what reading a
+ * zone's children in DOM order yields for a normal flow. A reversed layout
+ * (`column-reverse`, a horizontal zone under RTL) violates that and resolves
+ * arbitrary slots — it always has; the slot index must stay the child's DOM
+ * index for consumers to splice by, so sorting here is not the fix.
  */
 function resolveDropPosition (
   point: { x: number, y: number },
@@ -620,6 +629,15 @@ export function useDragDrop<Z extends DragType = DragType> (
     const source = toValue(_draggables.get(id)?.el)
 
     if (!zoneEl || !source) return -1
+
+    // Ownership means the *nearest* registered zone, not any enclosing one —
+    // a board zone wrapping column zones contains every card but is home to
+    // none of them, and claiming one would suppress two of its column slots.
+    for (let el = source.parentElement; el; el = el.parentElement) {
+      if (!nodes.has(el)) continue
+      if (el !== zoneEl) return -1
+      break
+    }
 
     return Array.from(zoneEl.children).findIndex(child => child.contains(source))
   }

--- a/packages/0/src/composables/useDragDrop/index.ts
+++ b/packages/0/src/composables/useDragDrop/index.ts
@@ -398,36 +398,27 @@ function resolveDropPosition (
 
   const coord = point[axis]
 
-  if (coord < rects[0][start]) {
-    return { index: 0, edge: 'before', rect: rects[0] }
-  }
+  // The slot: before the first rect whose midpoint the pointer has not yet
+  // crossed. Gaps need no case of their own — a coordinate in the gap after
+  // rect `i` is past `i`'s midpoint and short of `i + 1`'s, so it lands in
+  // slot `i + 1`.
+  let index = rects.length
 
-  const last = rects.at(-1)!
-  if (coord > last[end]) {
-    return { index: rects.length, edge: 'after', rect: last }
-  }
-
-  for (const [index, rect] of rects.entries()) {
-    if (coord >= rect[start] && coord <= rect[end]) {
-      const mid = rect[start] + (rect[end] - rect[start]) / 2
-      if (coord < mid) {
-        return { index, edge: 'before', rect }
-      }
-      return { index: index + 1, edge: 'after', rect }
+  for (const [at, rect] of rects.entries()) {
+    if (coord < rect[start] + (rect[end] - rect[start]) / 2) {
+      index = at
+      break
     }
   }
 
-  for (let index = 0; index < rects.length - 1; index++) {
-    const a = rects[index]
-    const b = rects[index + 1]
-    if (coord > a[end] && coord < b[start]) {
-      const mid = (a[end] + b[start]) / 2
-      if (coord <= mid) return { index: index + 1, edge: 'after', rect: a }
-      return { index: index + 1, edge: 'before', rect: b }
-    }
-  }
-
-  return { index: rects.length, edge: 'after', rect: last }
+  // The anchor is a function of the slot alone: an interior boundary always
+  // renders at the end edge of the rect above it. Deriving it from the pointer
+  // instead — the rect above when approached from one side, the rect below
+  // from the other — draws the same slot at two different anchors, and the
+  // indicator visibly twitches across the gap as the pointer crosses it.
+  return index === 0
+    ? { index, edge: 'before', rect: rects[0] }
+    : { index, edge: 'after', rect: rects[index - 1] }
 }
 
 /**

--- a/packages/0/src/composables/useDragDrop/index.ts
+++ b/packages/0/src/composables/useDragDrop/index.ts
@@ -106,10 +106,9 @@ export interface DropIndicator {
 
 /**
  * Position passed to drop hooks. `index` is populated for oriented zones;
- * unoriented zones receive only the pointer location. `indicator` rides along
- * except when no slot was proposed: an empty zone resolves `index` to `0`,
- * and a drop on one of the slots flanking the dragged element's own position
- * in its home zone resolves `index` to that position — a stay, not a move.
+ * unoriented zones receive only the pointer location. `indicator` is absent
+ * when no slot was proposed: an empty zone resolves `index` to `0`, a drop on
+ * a slot flanking the drag's own position resolves to that position (a stay).
  *
  * @example
  * ```ts
@@ -388,11 +387,9 @@ export interface DragDropContext<Z extends DragType = DragType> {
  * Internal — consumers rely on the `position.index` / `position.indicator`
  * fields delivered to `onDrop`.
  *
- * Assumes rects ascend along the orientation axis, which is what reading a
- * zone's children in DOM order yields for a normal flow. A reversed layout
- * (`column-reverse`, a horizontal zone under RTL) violates that and resolves
- * arbitrary slots — it always has; the slot index must stay the child's DOM
- * index for consumers to splice by, so sorting here is not the fix.
+ * Assumes rects ascend along the axis (DOM order in normal flow). Reversed
+ * layouts resolve arbitrary slots — always have — and sorting is not the fix:
+ * the slot must stay the child's DOM index for consumers to splice by.
  */
 function resolveDropPosition (
   point: { x: number, y: number },
@@ -407,10 +404,8 @@ function resolveDropPosition (
 
   const coord = point[axis]
 
-  // The slot: before the first rect whose midpoint the pointer has not yet
-  // crossed. Gaps need no case of their own — a coordinate in the gap after
-  // rect `i` is past `i`'s midpoint and short of `i + 1`'s, so it lands in
-  // slot `i + 1`.
+  // The slot before the first uncrossed midpoint; a gap coordinate is already
+  // past the previous rect's midpoint, so gaps need no case of their own.
   let index = rects.length
 
   for (const [at, rect] of rects.entries()) {
@@ -420,11 +415,8 @@ function resolveDropPosition (
     }
   }
 
-  // The anchor is a function of the slot alone: an interior boundary always
-  // renders at the end edge of the rect above it. Deriving it from the pointer
-  // instead — the rect above when approached from one side, the rect below
-  // from the other — draws the same slot at two different anchors, and the
-  // indicator visibly twitches across the gap as the pointer crosses it.
+  // Anchored by slot, not by approach — otherwise the same slot draws at two
+  // anchors and the indicator twitches across the gap.
   return index === 0
     ? { index, edge: 'before', rect: rects[0] }
     : { index, edge: 'after', rect: rects[index - 1] }
@@ -582,11 +574,8 @@ export function useDragDrop<Z extends DragType = DragType> (
 
         if (!resolved) return null
 
-        // A drag over its own zone: the two slots flanking the element's
-        // current position are not moves — dropping in either puts it straight
-        // back where it sits. No indicator for them; grabbing the first card
-        // and nudging the pointer above it must not draw a line over its own
-        // head as if that were somewhere it could go.
+        // The slots flanking a same-zone drag's own position are stays, not
+        // moves — no indicator for them.
         const from = home(el.value, active.value.id)
 
         if (from !== -1 && (resolved.index === from || resolved.index === from + 1)) return null
@@ -621,18 +610,14 @@ export function useDragDrop<Z extends DragType = DragType> (
     return null
   }
 
-  // The dragged element's slot among a zone's children, -1 when the drag did
-  // not start in this zone. The slots flanking that position drop the element
-  // right back where it sits, so the indicator and the drop resolution both
-  // treat them as "stay put" rather than as moves.
+  // The dragged element's slot among a zone's children, -1 when the zone is
+  // not its home. Home means the nearest registered zone — a board zone
+  // wrapping column zones contains every card but is home to none of them.
   function home (zoneEl: HTMLElement | null | undefined, id: ID): number {
     const source = toValue(_draggables.get(id)?.el)
 
     if (!zoneEl || !source) return -1
 
-    // Ownership means the *nearest* registered zone, not any enclosing one —
-    // a board zone wrapping column zones contains every card but is home to
-    // none of them, and claiming one would suppress two of its column slots.
     for (let el = source.parentElement; el; el = el.parentElement) {
       if (!nodes.has(el)) continue
       if (el !== zoneEl) return -1
@@ -651,10 +636,8 @@ export function useDragDrop<Z extends DragType = DragType> (
         out.index = resolved.index
         out.indicator = resolved
       } else {
-        // No slot proposed: either the zone is empty — index 0 lets consumers
-        // splice without a fallback — or the pointer sits on the dragged
-        // element's own flanked slots, which resolve to its current position
-        // so the drop is a stay, not a move to the top.
+        // No slot proposed: a suppressed same-zone drop resolves to its own
+        // position (a stay, not a move to the top); an empty zone splices at 0.
         const from = home(toValue(zone.el), drag.id)
         out.index = from === -1 ? 0 : from
       }

--- a/packages/0/src/composables/useDragDrop/index.ts
+++ b/packages/0/src/composables/useDragDrop/index.ts
@@ -568,7 +568,21 @@ export function useDragDrop<Z extends DragType = DragType> (
 
       const indicator = computed<DropIndicator | null>(() => {
         if (!registration.orientation || !isOver.value || !active.value) return null
-        return resolveDropPosition(active.value.current, rects.value, registration.orientation)
+
+        const resolved = resolveDropPosition(active.value.current, rects.value, registration.orientation)
+
+        if (!resolved) return null
+
+        // A drag over its own zone: the two slots flanking the element's
+        // current position are not moves — dropping in either puts it straight
+        // back where it sits. No indicator for them; grabbing the first card
+        // and nudging the pointer above it must not draw a line over its own
+        // head as if that were somewhere it could go.
+        const from = home(el.value, active.value.id)
+
+        if (from !== -1 && (resolved.index === from || resolved.index === from + 1)) return null
+
+        return resolved
       })
 
       const input = {
@@ -598,6 +612,18 @@ export function useDragDrop<Z extends DragType = DragType> (
     return null
   }
 
+  // The dragged element's slot among a zone's children, -1 when the drag did
+  // not start in this zone. The slots flanking that position drop the element
+  // right back where it sits, so the indicator and the drop resolution both
+  // treat them as "stay put" rather than as moves.
+  function home (zoneEl: HTMLElement | null | undefined, id: ID): number {
+    const source = toValue(_draggables.get(id)?.el)
+
+    if (!zoneEl || !source) return -1
+
+    return Array.from(zoneEl.children).findIndex(child => child.contains(source))
+  }
+
   function position (zoneId: ID, drag: ActiveDrag<Z>): DropPosition {
     const zone = _zones.get(zoneId)
     const out: DropPosition = { pointer: drag.current }
@@ -607,8 +633,12 @@ export function useDragDrop<Z extends DragType = DragType> (
         out.index = resolved.index
         out.indicator = resolved
       } else {
-        // Empty zone — index 0 lets consumers splice without a fallback.
-        out.index = 0
+        // No slot proposed: either the zone is empty — index 0 lets consumers
+        // splice without a fallback — or the pointer sits on the dragged
+        // element's own flanked slots, which resolve to its current position
+        // so the drop is a stay, not a move to the top.
+        const from = home(toValue(zone.el), drag.id)
+        out.index = from === -1 ? 0 : from
       }
     }
     return out


### PR DESCRIPTION
## What

Two related indicator problems in oriented zones:

1. **Anchor flip.** `resolveDropPosition` derived the indicator's `edge`/`rect` from which side the pointer approached: the same interior slot anchored to the rect above (`after a`) when entered from above the gap's midpoint, and to the rect below (`before b`) when entered from beneath it or from the next rect's upper half. The two anchors sit a gap apart, so the indicator visibly jumped as the pointer crossed — dragging a card down a kanban column drew the line at the *top of the next card* instead of walking edge to edge.

2. **No-op slots.** A drag over its own zone proposed the two slots flanking the dragged element's current position — grab the first card, nudge the pointer above it, and a line was drawn over its own head even though dropping there changes nothing. Worse, when a consumer suppressed rendering for those, `position()`'s null-indicator fallback resolved the drop to index `0`, teleporting the element to the top of its own list.

## How

- The slot index is resolved by a single midpoint scan (identical indices to the previous logic: a rect's upper half is its own slot, the lower half and the following gap are the next), and the anchor is now a function of the slot alone — an interior boundary always renders at the end edge of the rect above it. `edge: 'before'` remains only for slot 0.
- A new `home()` helper locates the dragged element among a zone's children. When the drag originates in the zone, the indicator returns `null` for the two slots flanking its position, and `position()` resolves a null-indicator drop to the element's current slot (falling back to `0` only for a genuinely empty zone).

Consumers are unaffected structurally: `index` values are unchanged for real moves, and `edge`/`rect` keep their contract (`before` → line at `rect.top`, `after` → line at `rect.bottom`).

## Testing

- Anchor-stability invariant: slot 1 reports `after a` from a's lower half, both sides of the gap, and b's upper half; slot 2 reports `after b` past b's midpoint.
- Suppression suite: first child dragged above itself → no indicator; last child dragged below itself → no indicator; cross-zone drags propose every slot; a drop on a suppressed slot resolves to the element's own index, not `0`.
- Full `useDragDrop` suite: 101 passing.