### PR TITLE
docs(emerald): fix Wave 4 documentation drift

### DIFF
--- a/packages/emerald/SPEC.md
+++ b/packages/emerald/SPEC.md
@@ -141,8 +141,10 @@ Dev showcase routes (Figma product examples; inventory in [FIGMA_INVENTORY.md](.
 
 ## Non-goals (current)
 
-- DatePicker / Upload / DataTable / Charts / Calendar (no finished v0 primitive or deferred)
-- Pixel-perfect Figma component-set parity for every variant (library pages limited via MCP seat; tokens + Wave 1–3 shells ship first)
+- DatePicker / Upload / DataTable / Charts (no finished v0 primitive or deferred)
+- Pixel-perfect Figma component-set parity for every variant (library pages limited via MCP seat; tokens + Wave 1–4 shells ship first)
+
+EmCalendar ships in Wave 4 as temporary DS-owned headless (APG grid keyboard + `Date`/`DateAdapter`) until a headless Calendar primitive lands in `@vuetify/v0`.
 
 ## Reference
 

--- a/packages/emerald/package.json
+++ b/packages/emerald/package.json
@@ -2,7 +2,7 @@
   "name": "@paper/emerald",
   "version": "0.0.0",
   "private": true,
-  "description": "Emerald design system — Wave 1–3 (v0-composed, Figma-tokened)",
+  "description": "Emerald design system — Wave 1–4 (v0-composed, Figma-tokened)",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes documentation drift in `@paper/emerald` so SPEC.md and package metadata match the shipped Wave 1–4 surface.

## Changes

### `packages/emerald/SPEC.md`
- Removed **Calendar** from the Non-goals list — it ships in Wave 4 as `EmCalendar`
- Updated "Wave 1–3 shells ship first" → "Wave 1–4 shells ship first"
- Added note clarifying that `EmCalendar` ships as temporary DS-owned headless (APG grid keyboard + `Date`/`DateAdapter`) until a headless Calendar primitive lands in `@vuetify/v0`

### `packages/emerald/package.json`
- Updated description from "Wave 1–3" → "Wave 1–4"

## Scope
Docs/metadata only — no changes to component source, build config, version, or `private` field.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7c41ae7-2cf1-4f07-b041-a47ea76ec8ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7c41ae7-2cf1-4f07-b041-a47ea76ec8ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

