### PR TITLE
chore: rebase Select a11y/typeahead (#635) onto dev tip

### DIFF
--- a/.changeset/feat-select-aria-label-typeahead-613.md
+++ b/.changeset/feat-select-aria-label-typeahead-613.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(Select): add `aria-label` prop and printable-char typeahead to `SelectActivator` (#635)
+
+`SelectActivator` had no way to carry an accessible label when the visible label lives in a sibling element, and no typeahead for keyboard users. A new `label` prop renders as `aria-label` on the activator, and pressing a printable character while the listbox is open now jumps virtual focus to the first non-disabled item whose text starts with that character, per the ARIA Authoring Practices Listbox pattern.

--- a/packages/0/src/components/Select/SelectActivator.vue
+++ b/packages/0/src/components/Select/SelectActivator.vue
@@ -26,6 +26,8 @@
   export interface SelectActivatorProps extends AtomProps {
     /** Namespace for dependency injection */
     namespace?: string
+    /** Accessible label for the activator when no visible label is present */
+    label?: string
   }
 
   export interface SelectActivatorSlotProps {
@@ -39,6 +41,7 @@
       'aria-expanded': boolean
       'aria-haspopup': 'listbox'
       'aria-controls': string
+      'aria-label': string | undefined
       'aria-disabled': boolean
       'disabled': true | undefined
       'tabindex': 0 | undefined
@@ -61,6 +64,7 @@
     as = 'button',
     namespace = 'v0:select',
     renderless,
+    label,
   } = defineProps<SelectActivatorProps>()
 
   const context = useSelectContext(namespace)
@@ -101,6 +105,11 @@
           context.virtualFocus.onKeydown(e)
           break
         }
+        default: {
+          if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            context.virtualFocus.typeahead(e.key)
+          }
+        }
       }
     } else {
       switch (e.key) {
@@ -125,6 +134,7 @@
       'aria-expanded': context.isOpen.value,
       'aria-haspopup': 'listbox',
       'aria-controls': context.listboxId,
+      'aria-label': label || undefined,
       'aria-disabled': toValue(context.disabled),
       'disabled': toValue(context.disabled) || undefined,
       'tabindex': as === 'button' ? undefined : 0,

--- a/packages/0/src/components/Select/index.browser.test.ts
+++ b/packages/0/src/components/Select/index.browser.test.ts
@@ -433,6 +433,85 @@ describe('select', () => {
       // No selection should be made when nothing is highlighted
       expect(selected.value).toBeUndefined()
     })
+
+    it('should typeahead-highlight a matching item when a printable char is pressed while open', async () => {
+      // typeahead calls document.querySelector inside useVirtualFocus; the
+      // component must be attached to the live document for the query to resolve.
+      const container = document.createElement('div')
+      document.body.append(container)
+
+      const taItemSlotProps = ref<Record<string, any>>({})
+      let taRootSlotProps: any
+      const taItems = [
+        { value: 'Apple' },
+        { value: 'Banana' },
+        { value: 'Cherry' },
+      ]
+
+      const taWrapper = mount(
+        defineComponent({
+          setup () {
+            return { taItemSlotProps }
+          },
+          render () {
+            return h(Select.Root as any, { id: 'ta-test' }, {
+              default: (sp: any) => {
+                taRootSlotProps = sp
+                return [
+                  h(Select.Activator as any, {}, {
+                    default: (slotProps: any) => h('span', slotProps.attrs),
+                  }),
+                  h(Select.Content as any, {}, {
+                    default: () => taItems.map(item =>
+                      h(Select.Item as any, { key: item.value, value: item.value }, {
+                        default: (slotProps: any) => {
+                          this.taItemSlotProps[item.value] = slotProps
+                          return h('div', slotProps.attrs, item.value)
+                        },
+                      }),
+                    ),
+                  }),
+                ]
+              },
+            })
+          },
+        }),
+        { attachTo: container },
+      )
+
+      // Boot lazy content and register items
+      await nextTick()
+      taRootSlotProps.open()
+      await nextTick()
+      taRootSlotProps.close()
+      await nextTick()
+
+      // Open for the test
+      taRootSlotProps.open()
+      await nextTick()
+
+      const activator = taWrapper.findComponent(Select.Activator as any)
+      expect(activator.attributes('aria-expanded')).toBe('true')
+
+      await activator.trigger('keydown', { key: 'b' })
+      await nextTick()
+
+      expect(taItemSlotProps.value.Banana.isHighlighted).toBe(true)
+      expect(taItemSlotProps.value.Apple.isHighlighted).toBe(false)
+
+      taWrapper.unmount()
+      container.remove()
+    })
+
+    it('should not typeahead when select is closed', async () => {
+      const { wrapper, itemSlotProps } = await createSelect({ id: 'ta-closed-test' })
+
+      // select is closed
+      await triggerKeydown(wrapper, 'b')
+      await nextTick()
+
+      expect(itemSlotProps.value.Banana.isHighlighted).toBe(false)
+    })
   })
 
   describe('accessibility', () => {
@@ -579,6 +658,32 @@ describe('select', () => {
       })
 
       expect(itemSlotProps.value.Apple.attrs['data-id']).toBe('a')
+    })
+
+    it('should set aria-label on activator when label prop is provided', async () => {
+      const wrapper = mount(
+        defineComponent({
+          render () {
+            return h(Select.Root as any, { id: 'label-test' }, {
+              default: () => h(Select.Activator as any, { label: 'Choose a fruit' }, {
+                default: (slotProps: any) => h('span', slotProps.attrs),
+              }),
+            })
+          },
+        }),
+      )
+
+      await nextTick()
+
+      const activator = wrapper.findComponent(Select.Activator as any)
+      expect(activator.attributes('aria-label')).toBe('Choose a fruit')
+    })
+
+    it('should omit aria-label when label prop is not provided', async () => {
+      const { wrapper } = await createSelect({ id: 'no-label-test' })
+
+      const activator = wrapper.findComponent(Select.Activator as any)
+      expect(activator.attributes('aria-label')).toBeUndefined()
     })
   })
 

--- a/packages/0/src/composables/useVirtualFocus/index.test.ts
+++ b/packages/0/src/composables/useVirtualFocus/index.test.ts
@@ -848,4 +848,172 @@ describe('useVirtualFocus', () => {
       expect(control.hasAttribute('aria-activedescendant')).toBe(false)
     })
   })
+
+  describe('typeahead', () => {
+    function createTextElement (id: string, text: string): HTMLElement {
+      const el = document.createElement('div')
+      el.setAttribute('id', id)
+      el.textContent = text
+      el.scrollIntoView = vi.fn()
+      return el
+    }
+
+    it('should highlight the first item whose text starts with the given char', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+      const bananaEl = createTextElement('banana', 'Banana')
+      const cherryEl = createTextElement('cherry', 'Cherry')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl },
+        { id: 'banana', el: bananaEl },
+        { id: 'cherry', el: cherryEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('b')
+
+      expect(result!.highlightedId.value).toBe('banana')
+    })
+
+    it('should match case-insensitively', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('A')
+
+      expect(result!.highlightedId.value).toBe('apple')
+    })
+
+    it('should search from after the current highlighted position', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+      const avocadoEl = createTextElement('avocado', 'Avocado')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl },
+        { id: 'avocado', el: avocadoEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.highlight('apple')
+      result!.typeahead('a')
+
+      expect(result!.highlightedId.value).toBe('avocado')
+    })
+
+    it('should wrap around to the beginning when searching from the end', () => {
+      const avocadoEl = createTextElement('avocado', 'Avocado')
+      const bananaEl = createTextElement('banana', 'Banana')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'avocado', el: avocadoEl },
+        { id: 'banana', el: bananaEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.highlight('banana')
+      result!.typeahead('a')
+
+      expect(result!.highlightedId.value).toBe('avocado')
+    })
+
+    it('should skip disabled items', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+      const avocadoEl = createTextElement('avocado', 'Avocado')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl, disabled: true },
+        { id: 'avocado', el: avocadoEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('a')
+
+      expect(result!.highlightedId.value).toBe('avocado')
+    })
+
+    it('should do nothing when no item text matches', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('z')
+
+      expect(result!.highlightedId.value).toBeUndefined()
+    })
+
+    it('should return early and do nothing when all items are disabled', () => {
+      const appleEl = createTextElement('apple', 'Apple')
+
+      const textItems: VirtualFocusItem[] = [
+        { id: 'apple', el: appleEl, disabled: true },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('a')
+
+      expect(result!.highlightedId.value).toBeUndefined()
+    })
+
+    it('should treat item with no el as empty text (not matching)', () => {
+      const noElItem: VirtualFocusItem = { id: 'no-el' }
+      const bananaEl = createTextElement('banana', 'Banana')
+
+      const textItems: VirtualFocusItem[] = [
+        noElItem,
+        { id: 'banana', el: bananaEl },
+      ]
+
+      let result: ReturnType<typeof useVirtualFocus>
+
+      scope.run(() => {
+        result = useVirtualFocus(() => textItems, { control })
+      })
+
+      result!.typeahead('b')
+
+      expect(result!.highlightedId.value).toBe('banana')
+    })
+  })
 })

--- a/packages/0/src/composables/useVirtualFocus/index.ts
+++ b/packages/0/src/composables/useVirtualFocus/index.ts
@@ -72,6 +72,7 @@ export interface VirtualFocusReturn {
   first: () => void
   last: () => void
   onKeydown: (e: KeyboardEvent) => void
+  typeahead: (char: string) => void
 }
 
 export function useVirtualFocus (
@@ -151,6 +152,23 @@ export function useVirtualFocus (
     useEventListener(listener, 'keydown', traversal.onKeydown)
   }
 
+  function typeahead (char: string) {
+    const all = items().filter(i => !toValue(i.disabled))
+    if (all.length === 0) return
+
+    const currentIndex = all.findIndex(i => i.id === traversal.activeId.value)
+    const start = currentIndex === -1 ? 0 : (currentIndex + 1) % all.length
+
+    for (let offset = 0; offset < all.length; offset++) {
+      const item = all[(start + offset) % all.length]
+      const text = item.el ? (toValue(item.el)?.textContent?.trim() ?? '') : ''
+      if (text.toLowerCase().startsWith(char.toLowerCase())) {
+        highlight(item.id)
+        return
+      }
+    }
+  }
+
   onScopeDispose(() => {
     clear()
   })
@@ -164,5 +182,6 @@ export function useVirtualFocus (
     first: traversal.first,
     last: traversal.last,
     onKeydown: traversal.onKeydown,
+    typeahead,
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This branch carries the exact commits from PR #635 rebased onto the current `dev` tip.

## Purpose
PR #635 (Select a11y/typeahead) was 122 commits behind `dev`. This branch brings it current without force-pushing to the contributor's fork.

## Changes
Cherry-picked from #635 (authored by @sridhar-3009):
- `feat(Select): add aria-label prop and printable-char typeahead to SelectActivator`
- `test(select): add coverage for typeahead and aria-label features`
- `chore: add changeset for Select aria-label and typeahead`

## CI Note
The original PR only ran sparse checks because `pr-checks.yml` triggers only on PRs targeting `master`, not `dev`. This PR targets `dev` as well, so the same limitation applies. Consider updating `.github/workflows/pr-checks.yml` to include `dev` in the `branches` array for full CI coverage on feature PRs.

## Review
No code changes from #635. This is purely a rebase. Once merged, #635 can be closed as superseded.

Closes #610
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636167f7-56f4-4063-900a-ffa4443b1d5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636167f7-56f4-4063-900a-ffa4443b1d5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

