### PR TITLE
docs: add typecheck script to gate examples

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,8 +11,6 @@
   },
   "devDependencies": {
     "@octokit/openapi-types": "catalog:",
-    "vue-tsc": "catalog:",
-    "typescript": "catalog:",
     "@resvg/resvg-js": "catalog:",
     "@shikijs/langs": "catalog:",
     "@shikijs/markdown-it": "catalog:",
@@ -31,6 +29,7 @@
     "shiki": "catalog:",
     "ts-morph": "catalog:",
     "tsx": "catalog:",
+    "typescript": "catalog:",
     "unocss": "catalog:",
     "unplugin-vue": "catalog:",
     "unplugin-vue-components": "catalog:",
@@ -41,7 +40,8 @@
     "vite-ssg": "catalog:",
     "vite-ssg-sitemap": "catalog:",
     "vue-component-meta": "catalog:",
-    "vue-router": "catalog:"
+    "vue-router": "catalog:",
+    "vue-tsc": "catalog:"
   },
   "dependencies": {
     "@js-temporal/polyfill": "catalog:",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,10 +6,13 @@
   "scripts": {
     "dev": "vite --port 8000",
     "build": "vite-ssg build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "vue-tsc --noEmit -p tsconfig.examples.json"
   },
   "devDependencies": {
     "@octokit/openapi-types": "catalog:",
+    "vue-tsc": "catalog:",
+    "typescript": "catalog:",
     "@resvg/resvg-js": "catalog:",
     "@shikijs/langs": "catalog:",
     "@shikijs/markdown-it": "catalog:",

--- a/apps/docs/src/examples/components/form/SignupForm.vue
+++ b/apps/docs/src/examples/components/form/SignupForm.vue
@@ -19,13 +19,13 @@
   const input = 'w-full px-3 py-2 rounded-lg border border-divider bg-surface text-on-surface placeholder:text-on-surface-variant/50 outline-none data-[focused]:border-primary data-[state=invalid]:border-error transition-colors'
 
   const passwordRules = [
-    (v: string) => !!v || 'Password is required',
-    (v: string) => v.length >= 8 || 'At least 8 characters',
+    (v: unknown) => !!v || 'Password is required',
+    (v: unknown) => (v as string).length >= 8 || 'At least 8 characters',
   ]
 
   // Cross-field rule — the confirm field validates against the password model
   const confirmRules = [
-    (v: string) => v === password.value || 'Passwords must match',
+    (v: unknown) => v === password.value || 'Passwords must match',
   ]
 
   function onSubmit (payload: { valid: boolean }) {
@@ -42,7 +42,7 @@
     <Input.Root
       v-model="name"
       label="Name"
-      :rules="[(v: string) => !!v || 'Name is required']"
+      :rules="[v => !!v || 'Name is required']"
       validate-on="blur lazy"
     >
       <Input.Control
@@ -62,8 +62,8 @@
       :error-messages="serverError"
       label="Email"
       :rules="[
-        (v: string) => !!v || 'Email is required',
-        (v: string) => /.+@.+\..+/.test(v) || 'Must be a valid email',
+        v => !!v || 'Email is required',
+        v => /.+@.+\..+/.test(v as string) || 'Must be a valid email',
       ]"
       type="email"
       validate-on="blur lazy"

--- a/apps/docs/src/examples/components/form/basic.vue
+++ b/apps/docs/src/examples/components/form/basic.vue
@@ -27,8 +27,8 @@
       v-model="email"
       label="Email"
       :rules="[
-        (v: string) => !!v || 'Email is required',
-        (v: string) => /.+@.+\..+/.test(v) || 'Must be a valid email',
+        v => !!v || 'Email is required',
+        v => /.+@.+\..+/.test(v as string) || 'Must be a valid email',
       ]"
       type="email"
     >
@@ -49,8 +49,8 @@
       v-model="password"
       label="Password"
       :rules="[
-        (v: string) => !!v || 'Password is required',
-        (v: string) => v.length >= 8 || 'Must be at least 8 characters',
+        v => !!v || 'Password is required',
+        v => (v as string).length >= 8 || 'Must be at least 8 characters',
       ]"
       type="password"
     >

--- a/apps/docs/src/examples/components/input/ContactForm.vue
+++ b/apps/docs/src/examples/components/input/ContactForm.vue
@@ -31,7 +31,7 @@
     <Input.Root
       v-model="name"
       label="Name"
-      :rules="[(v: string) => !!v || 'Name is required']"
+      :rules="[v => !!v || 'Name is required']"
       validate-on="blur lazy"
     >
       <Input.Control
@@ -50,8 +50,8 @@
       :error-messages="serverError"
       label="Email"
       :rules="[
-        (v: string) => !!v || 'Email is required',
-        (v: string) => /.+@.+\..+/.test(v) || 'Must be a valid email',
+        v => !!v || 'Email is required',
+        v => /.+@.+\..+/.test(v as string) || 'Must be a valid email',
       ]"
       type="email"
       validate-on="blur lazy"
@@ -70,8 +70,8 @@
       v-model="message"
       label="Message"
       :rules="[
-        (v: string) => !!v || 'Message is required',
-        (v: string) => v.length >= 10 || 'At least 10 characters',
+        v => !!v || 'Message is required',
+        v => (v as string).length >= 10 || 'At least 10 characters',
       ]"
       validate-on="blur lazy"
     >

--- a/apps/docs/src/examples/components/input/SearchInput.vue
+++ b/apps/docs/src/examples/components/input/SearchInput.vue
@@ -14,7 +14,7 @@
     v-model="query"
     label="Search fruits"
     :rules="[
-      (v: string) => v.length === 0 || v.length >= 2 || 'Type at least 2 characters',
+      v => (v as string).length === 0 || (v as string).length >= 2 || 'Type at least 2 characters',
     ]"
     validate-on="input"
   >

--- a/apps/docs/src/examples/components/input/basic.vue
+++ b/apps/docs/src/examples/components/input/basic.vue
@@ -12,8 +12,8 @@
       v-model="email"
       label="Email"
       :rules="[
-        (v: string) => !!v || 'Email is required',
-        (v: string) => /.+@.+\..+/.test(v) || 'Must be a valid email',
+        v => !!v || 'Email is required',
+        v => /.+@.+\..+/.test(v as string) || 'Must be a valid email',
       ]"
       type="email"
     >

--- a/apps/docs/src/examples/components/rating/ReviewForm.vue
+++ b/apps/docs/src/examples/components/rating/ReviewForm.vue
@@ -81,8 +81,8 @@
       v-model="comment"
       label="Review"
       :rules="[
-        (v: string) => !!v || 'A short review is required',
-        (v: string) => v.length >= 10 || 'At least 10 characters',
+        v => !!v || 'A short review is required',
+        v => (v as string).length >= 10 || 'At least 10 characters',
       ]"
       validate-on="blur lazy"
     >

--- a/apps/docs/src/examples/composables/create-selection/TrackList.vue
+++ b/apps/docs/src/examples/composables/create-selection/TrackList.vue
@@ -60,16 +60,16 @@
             class="block text-sm truncate"
             :class="ticket.isSelected.value ? 'text-primary font-medium' : 'text-on-surface'"
           >
-            {{ ticket.value.title }}
+            {{ ticket.value?.title }}
           </span>
 
           <span class="block text-xs text-on-surface-variant truncate">
-            {{ ticket.value.artist }}
+            {{ ticket.value?.artist }}
             <template v-if="toValue(ticket.disabled)"> &middot; unavailable</template>
           </span>
         </span>
 
-        <span class="text-xs tabular-nums text-on-surface-variant shrink-0">{{ ticket.value.duration }}</span>
+        <span class="text-xs tabular-nums text-on-surface-variant shrink-0">{{ ticket.value?.duration }}</span>
       </Checkbox.Root>
     </div>
   </div>

--- a/apps/docs/src/examples/composables/create-single/ThemeSwatches.vue
+++ b/apps/docs/src/examples/composables/create-single/ThemeSwatches.vue
@@ -13,15 +13,15 @@
       :class="ticket.isSelected.value
         ? 'border-primary scale-105 shadow-md'
         : 'border-transparent hover:border-divider'"
-      :style="{ backgroundColor: ticket.value.bg, color: ticket.value.fg }"
+      :style="{ backgroundColor: ticket.value?.bg, color: ticket.value?.fg }"
       @click="ticket.select()"
     >
       <span
         class="size-6 rounded-full mx-auto mb-2 block"
-        :style="{ backgroundColor: ticket.value.accent }"
+        :style="{ backgroundColor: ticket.value?.accent }"
       />
 
-      <span class="text-xs font-medium">{{ ticket.value.name }}</span>
+      <span class="text-xs font-medium">{{ ticket.value?.name }}</span>
     </button>
   </div>
 </template>

--- a/apps/docs/tsconfig.examples.json
+++ b/apps/docs/tsconfig.examples.json
@@ -1,0 +1,54 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "customConditions": ["development"],
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@vuetify/v0": ["../../packages/0/src"],
+      "@vuetify/v0/*": ["../../packages/0/src/*"],
+      "#v0": ["../../packages/0/src"],
+      "#v0/*": ["../../packages/0/src/*"]
+    },
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "target": "esnext"
+  },
+  "include": [
+    "src/examples/**/*.ts",
+    "src/examples/**/*.vue",
+    "../../packages/0/src/**/*.ts",
+    "../../packages/0/src/**/*.vue"
+  ],
+  "exclude": [
+    "../../packages/0/src/**/__tests__/*",
+    "src/examples/composables/create-data-table/**",
+    "src/examples/composables/create-data-grid/**",
+    "src/examples/composables/create-queue/**",
+    "src/examples/composables/create-progress/**",
+    "src/examples/composables/create-timeline/**",
+    "src/examples/composables/create-registry/**",
+    "src/examples/composables/create-slider/**",
+    "src/examples/composables/create-group/**",
+    "src/examples/composables/create-model/**",
+    "src/examples/composables/create-number-field/**",
+    "src/examples/composables/use-notifications/**",
+    "src/examples/composables/use-reduced-motion/**",
+    "src/examples/composables/use-rules/**",
+    "src/examples/components/image/**",
+    "src/examples/components/slider/**",
+    "src/examples/guide/building-frameworks/**"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "metrics:verify": "node scripts/verify-bench-stability.ts",
     "metrics:delta": "node scripts/report-benchmark-delta.ts",
     "skill": "node scripts/generate-skill.ts",
-    "typecheck": "pnpm --filter=\"./packages/*\" typecheck",
+    "typecheck": "pnpm --filter=\"./packages/*\" --filter=docs typecheck",
     "typecheck:0": "pnpm --filter=\"./packages/0\" typecheck",
     "typecheck:paper": "pnpm --filter=\"./packages/paper\" typecheck",
     "lint": "eslint --concurrency auto",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
       unocss:
         specifier: 'catalog:'
         version: 66.7.4(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -496,6 +499,9 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 5.1.0(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
+      vue-tsc:
+        specifier: 'catalog:'
+        version: 3.2.7(typescript@6.0.3)
 
   apps/playground:
     dependencies:
@@ -14207,7 +14213,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.19
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `vue-tsc` typecheck for docs examples to catch type errors at CI time. Previously, invalid enum values like `tone: 'success'` against `EmCalendarTone` survived `pnpm build:docs`, lint, and pre-push because Vite compiles SFCs without type checking.

## Changes

### Infrastructure
- **`apps/docs/tsconfig.examples.json`**: New tsconfig scoped to `src/examples/**` with proper path mappings for `@vuetify/v0` and `#v0` aliases
- **`apps/docs/package.json`**: Added `typecheck` script using `vue-tsc --noEmit -p tsconfig.examples.json`
- **Root `package.json`**: Extended typecheck filter to include `--filter=docs`

### Example Fixes
Fixed validation rule types in form examples:
- Changed `(v: string) => ...` to `(v: unknown) => ...` or removed annotations to match `FormValidationRule` signature
- Added optional chaining for `ticket.value?.` accesses where value could be undefined

## Excluded Examples

Some advanced composable examples are temporarily excluded from typechecking due to deeper API-level typing issues that require library-side fixes:
- `create-data-table/**`, `create-data-grid/**` - Type constraint issues with `Record<string, unknown>`
- `create-queue/**`, `create-progress/**`, `create-registry/**` - Context type mismatches
- `create-timeline/**`, `create-slider/**`, `create-model/**` - VNodeRef and registry type issues
- `use-notifications/**`, `use-reduced-motion/**`, `use-rules/**` - API typing issues
- `components/image/**`, `components/slider/**` - Template typing edge cases
- `guide/building-frameworks/**` - Advanced patterns with complex generics

These exclusions can be addressed incrementally in follow-up PRs as the underlying API types are refined.

## Testing

```bash
# Run docs typecheck
pnpm --filter=docs typecheck

# Run full typecheck (now includes docs)
pnpm typecheck
```

Closes #809
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65b11d1f-b0cd-49b9-b878-3cfad839ac8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65b11d1f-b0cd-49b9-b878-3cfad839ac8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

