### PR TITLE
fix(playground): redirect /playgrounds/:id to /?playground=<id>

### DIFF
--- a/apps/playground/src/content/intro.md
+++ b/apps/playground/src/content/intro.md
@@ -41,6 +41,8 @@ Short links also work:
 
 Point `?registry=` at a custom origin when testing a local docs build.
 
+Saved playgrounds use `?playground=<id>` as the canonical URL. Legacy bookmarks from play.vuetifyjs.com (`/playgrounds/:id`) redirect automatically.
+
 ## Tips
 
 - `Ctrl+B` toggles the file tree sidebar — or drag the panel edge to close it

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -13,9 +13,25 @@ import pinia from './plugins/pinia'
 
 import 'virtual:uno.css'
 
+// Types
+import type { RouteRecordRaw } from 'vue-router'
+
+/**
+ * Redirect legacy `/playgrounds/:id` (play.vuetifyjs.com bookmark format)
+ * to the canonical `/?playground=<id>`, preserving any URL hash.
+ */
+const legacyPlaygroundRedirect: RouteRecordRaw = {
+  path: '/playgrounds/:id',
+  redirect: to => ({
+    path: '/',
+    query: { playground: Array.isArray(to.params.id) ? to.params.id[0] : to.params.id },
+    hash: to.hash,
+  }),
+}
+
 export const createApp = ViteSSG(
   App,
-  { routes: setupLayouts(routes) },
+  { routes: setupLayouts([...routes, legacyPlaygroundRedirect]) },
   async ({ app, initialState }) => {
     app.use(pinia)
     app.use(createIconPlugin())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Vue Router redirect for legacy play.vuetifyjs.com bookmarks.

## Problem

Bookmarks from the old Vuetify Play use `/playgrounds/:id` while v0play uses `?playground=<id>` as the canonical URL format.

## Solution

- Add a `RouteRecordRaw` redirect that maps `/playgrounds/:id` → `/?playground=<id>`
- Preserve any URL hash across the redirect (using Vue Router's built-in redirect function)
- Add a brief documentation note in the playground intro panel

## Changes

1. **`apps/playground/src/main.ts`**: Add legacy redirect route before routes are passed to ViteSSG
2. **`apps/playground/src/content/intro.md`**: Document canonical URL format

## Testing

The redirect is implemented using Vue Router's standard redirect pattern with a function that:
- Extracts the `:id` param from the legacy path
- Builds the query string with `playground=<id>`
- Preserves `to.hash` in the redirect

Fixes #827
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05ae0e14-4e7d-4148-888b-4f6d2651623a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05ae0e14-4e7d-4148-888b-4f6d2651623a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

