### PR TITLE
feat(playground): add Vuetify version picker with nightly toggle

### DIFF
--- a/.changeset/select-activator-data-disabled.md
+++ b/.changeset/select-activator-data-disabled.md
@@ -1,0 +1,5 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Select): Add `data-disabled` attribute to SelectActivator for styling hooks (#836)

--- a/apps/playground/src/components/app/AppSelect.vue
+++ b/apps/playground/src/components/app/AppSelect.vue
@@ -38,7 +38,7 @@
 
 <template>
   <Select.Root v-model="model" :disabled :mandatory>
-    <Select.Activator class="trigger" :class="{ 'trigger--disabled': disabled }">
+    <Select.Activator class="trigger">
       <span>{{ selectedLabel }}</span>
 
       <Select.Cue class="cue">
@@ -92,11 +92,11 @@
   transition: border-color 0.15s, background 0.15s;
 }
 
-.trigger:hover:not(.trigger--disabled) {
+.trigger:hover:not([data-disabled]) {
   border-color: var(--v0-outline);
 }
 
-.trigger--disabled {
+.trigger[data-disabled] {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/apps/playground/src/components/app/AppSelect.vue
+++ b/apps/playground/src/components/app/AppSelect.vue
@@ -19,10 +19,12 @@
   const {
     items,
     mandatory,
+    disabled,
     placeholder = 'Select...',
   } = defineProps<{
     items: AppSelectItem[]
     mandatory?: boolean
+    disabled?: boolean
     placeholder?: string
   }>()
 
@@ -35,8 +37,8 @@
 </script>
 
 <template>
-  <Select.Root v-model="model" :mandatory>
-    <Select.Activator class="trigger">
+  <Select.Root v-model="model" :disabled :mandatory>
+    <Select.Activator class="trigger" :class="{ 'trigger--disabled': disabled }">
       <span>{{ selectedLabel }}</span>
 
       <Select.Cue class="cue">
@@ -90,8 +92,13 @@
   transition: border-color 0.15s, background 0.15s;
 }
 
-.trigger:hover {
+.trigger:hover:not(.trigger--disabled) {
   border-color: var(--v0-outline);
+}
+
+.trigger--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .trigger:focus-visible {

--- a/apps/playground/src/components/app/AppSelect.vue
+++ b/apps/playground/src/components/app/AppSelect.vue
@@ -38,21 +38,21 @@
 
 <template>
   <Select.Root v-model="model" :disabled :mandatory>
-    <Select.Activator class="trigger">
+    <Select.Activator class="flex items-center justify-between gap-1.5 w-full bg-surface-variant border border-outline-variant rounded-md text-on-surface text-[13px] px-2.5 py-1.5 text-left transition-colors hover:not-data-[disabled]:border-outline data-[disabled]:opacity-60 data-[disabled]:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-primary focus-visible:-outline-offset-1">
       <span>{{ selectedLabel }}</span>
 
-      <Select.Cue class="cue">
+      <Select.Cue class="flex items-center shrink-0 text-on-surface-variant transition-transform data-[state=open]:rotate-180">
         <AppIcon icon="chevron-down" :size="14" />
       </Select.Cue>
     </Select.Activator>
 
-    <Select.Content class="content">
+    <Select.Content class="bg-surface border border-outline-variant rounded-md shadow-lg text-[13px] max-h-[260px] overflow-y-auto p-1" style="width: anchor-size(width)">
       <Select.Item
         v-for="item in items"
         :id="item.id"
         :key="item.id"
         v-slot="{ isSelected }"
-        class="item"
+        class="flex items-center justify-between rounded text-on-surface cursor-pointer px-2 py-1.5 transition-colors select-none hover:bg-surface-tint data-[highlighted]:bg-surface-tint data-[selected]:text-primary"
         :value="item.id"
       >
         <span>{{ item.label }}</span>
@@ -60,7 +60,7 @@
         <svg
           v-if="isSelected"
           aria-hidden="true"
-          class="check"
+          class="text-primary shrink-0"
           fill="none"
           height="12"
           stroke="currentColor"
@@ -74,85 +74,3 @@
     </Select.Content>
   </Select.Root>
 </template>
-
-<style scoped>
-.trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  width: 100%;
-  background: var(--v0-surface-variant);
-  border: 1px solid var(--v0-outline-variant, var(--v0-outline));
-  border-radius: 6px;
-  color: var(--v0-on-surface);
-  font-size: 13px;
-  padding: 6px 10px;
-  text-align: left;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.trigger:hover:not([data-disabled]) {
-  border-color: var(--v0-outline);
-}
-
-.trigger[data-disabled] {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.trigger:focus-visible {
-  outline: 2px solid var(--v0-primary);
-  outline-offset: -1px;
-}
-
-.cue {
-  display: flex;
-  align-items: center;
-  color: var(--v0-on-surface-variant);
-  flex-shrink: 0;
-  transition: transform 0.15s;
-}
-
-.cue[data-state="open"] {
-  transform: rotate(180deg);
-}
-
-.content {
-  background: var(--v0-surface);
-  border: 1px solid var(--v0-outline-variant, var(--v0-outline));
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  font-size: 13px;
-  max-height: 260px;
-  width: anchor-size(width);
-  overflow-y: auto;
-  padding: 4px;
-}
-
-.item {
-  align-items: center;
-  border-radius: 4px;
-  color: var(--v0-on-surface);
-  cursor: pointer;
-  display: flex;
-  justify-content: space-between;
-  padding: 6px 8px;
-  transition: background 0.1s;
-  user-select: none;
-}
-
-.item:hover,
-.item[data-highlighted] {
-  background: var(--v0-surface-tint);
-}
-
-.item[data-selected] {
-  color: var(--v0-primary);
-}
-
-.check {
-  color: var(--v0-primary);
-  flex-shrink: 0;
-}
-</style>

--- a/apps/playground/src/components/playground/app/PlaygroundApp.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundApp.vue
@@ -6,7 +6,7 @@
   import { usePlaygroundFiles } from '@/composables/usePlaygroundFiles'
 
   // Utilities
-  import { nextTick, onMounted, shallowRef, watch } from 'vue'
+  import { nextTick, onMounted, shallowRef, toRef, watch } from 'vue'
 
   // Types
   import type { ActiveExample } from '@/composables/usePlaygroundFiles'
@@ -25,8 +25,12 @@
     editor: { value: boolean }
     vueVersion: Ref<string | null>
     v0Version: Ref<string>
+    vuetifyVersion: Ref<string>
+    vuetifyNightly: Ref<boolean>
     vueVersions: Ref<string[]>
     v0Versions: Ref<string[]>
+    vuetifyVersions: Ref<string[]>
+    vuetifyNightlyVersions: Ref<string[]>
     fetching: Ref<boolean>
     fetchVersions: () => Promise<void>
     activePreset: ShallowRef<string>
@@ -43,12 +47,19 @@
     /** JSON payload for Vuetify One `playground.content`. */
     snapshotContent: () => string
     showConfig: ShallowRef<boolean>
+    /** Current playground locked state from Vuetify One. */
+    isLocked: Ref<boolean>
   }
 
   export const [usePlayground, providePlayground] = createContext<PlaygroundContext>('v0:playground')
 </script>
 
 <script setup lang="ts">
+  // Composables
+  import { useOnePlaygrounds } from '@/composables/useOnePlaygrounds'
+
+  const one = useOnePlaygrounds()
+
   const {
     store,
     isReady,
@@ -56,8 +67,12 @@
     loadError,
     vueVersion,
     v0Version,
+    vuetifyVersion,
+    vuetifyNightly,
     vueVersions,
     v0Versions,
+    vuetifyVersions,
+    vuetifyNightlyVersions,
     fetching,
     fetchVersions,
     activePreset,
@@ -70,6 +85,8 @@
     activeExample,
     snapshotContent,
   } = usePlaygroundFiles()
+
+  const isLocked = toRef(() => one.currentMeta?.value.locked ?? false)
   const storage = useStorage()
   const { isMobile } = useBreakpoints()
 
@@ -111,8 +128,12 @@
     editor,
     vueVersion,
     v0Version,
+    vuetifyVersion,
+    vuetifyNightly,
     vueVersions,
     v0Versions,
+    vuetifyVersions,
+    vuetifyNightlyVersions,
     fetching,
     fetchVersions,
     activePreset,
@@ -127,6 +148,7 @@
     activeExample,
     snapshotContent,
     showConfig,
+    isLocked,
   })
 
   // Restore panel state on runtime breakpoint changes

--- a/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
@@ -105,13 +105,13 @@
 <template>
   <div class="flex flex-col gap-5">
     <!-- Vue version -->
-    <div class="dep-row">
-      <div class="dep-header">
-        <AppIcon class="dep-icon text-[#42b883]" icon="lang-vue" :size="18" />
-        <label class="field-label">Vue</label>
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <AppIcon class="shrink-0 opacity-90 text-[#42b883]" icon="lang-vue" :size="18" />
+        <label class="flex-1 text-xs font-semibold text-on-surface-variant uppercase tracking-wide opacity-70">Vue</label>
 
         <button
-          class="release-btn"
+          class="flex items-center justify-center size-5 rounded text-on-surface-variant opacity-60 transition-opacity hover:opacity-100 hover:bg-surface-tint"
           title="Release notes"
           type="button"
           @click="openVueReleaseNotes"
@@ -120,7 +120,7 @@
         </button>
       </div>
 
-      <div v-if="playground.fetching.value" class="select-skeleton" />
+      <div v-if="playground.fetching.value" class="h-8 rounded-md bg-surface-variant border border-outline-variant opacity-50 animate-pulse" />
 
       <AppSelect
         v-else
@@ -132,13 +132,13 @@
     </div>
 
     <!-- Vuetify version (only shown with vuetify preset) -->
-    <div v-if="isVuetifyPreset" class="dep-row">
-      <div class="dep-header">
-        <AppIcon class="dep-icon text-[#1867c0]" icon="vuetify" :size="18" />
-        <label class="field-label">Vuetify</label>
+    <div v-if="isVuetifyPreset" class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <AppIcon class="shrink-0 opacity-90 text-[#1867c0]" icon="vuetify" :size="18" />
+        <label class="flex-1 text-xs font-semibold text-on-surface-variant uppercase tracking-wide opacity-70">Vuetify</label>
 
         <button
-          class="release-btn"
+          class="flex items-center justify-center size-5 rounded text-on-surface-variant opacity-60 transition-opacity hover:opacity-100 hover:bg-surface-tint"
           title="Release notes"
           type="button"
           @click="openVuetifyReleaseNotes"
@@ -147,7 +147,7 @@
         </button>
       </div>
 
-      <div v-if="playground.fetching.value" class="select-skeleton" />
+      <div v-if="playground.fetching.value" class="h-8 rounded-md bg-surface-variant border border-outline-variant opacity-50 animate-pulse" />
 
       <AppSelect
         v-else
@@ -158,30 +158,30 @@
       />
 
       <!-- Nightly toggle -->
-      <div class="nightly-row">
-        <span class="nightly-label">Nightly</span>
+      <div class="flex items-center justify-between py-1.5">
+        <span class="text-xs text-on-surface-variant">Nightly</span>
 
         <Switch.Root
           v-model="vuetifyNightly"
           aria-label="Use nightly builds"
-          class="switch-root shrink-0 inline-flex items-center border-none bg-transparent p-0 outline-none"
+          class="shrink-0 inline-flex items-center border-none bg-transparent p-0 outline-none data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
           :disabled="isLocked"
         >
-          <Switch.Track class="switch-track">
-            <Switch.Thumb class="switch-thumb" />
+          <Switch.Track class="relative inline-flex items-center rounded-full transition-colors w-9 h-5 bg-on-surface/20 data-[state=checked]:bg-primary">
+            <Switch.Thumb class="![visibility:visible] block size-3.5 rounded-full bg-white shadow-sm transition-transform translate-x-0.75 data-[state=checked]:translate-x-4.75" />
           </Switch.Track>
         </Switch.Root>
       </div>
     </div>
 
     <!-- v0 version (only shown when NOT using vuetify preset) -->
-    <div v-if="!isVuetifyPreset" class="dep-row">
-      <div class="dep-header">
-        <AppIcon class="dep-icon text-primary" icon="vuetify-0" :size="18" />
-        <label class="field-label">@vuetify/v0</label>
+    <div v-if="!isVuetifyPreset" class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <AppIcon class="shrink-0 opacity-90 text-primary" icon="vuetify-0" :size="18" />
+        <label class="flex-1 text-xs font-semibold text-on-surface-variant uppercase tracking-wide opacity-70">@vuetify/v0</label>
 
         <button
-          class="release-btn"
+          class="flex items-center justify-center size-5 rounded text-on-surface-variant opacity-60 transition-opacity hover:opacity-100 hover:bg-surface-tint"
           title="Release notes"
           type="button"
           @click="openV0ReleaseNotes"
@@ -190,7 +190,7 @@
         </button>
       </div>
 
-      <div v-if="playground.fetching.value" class="select-skeleton" />
+      <div v-if="playground.fetching.value" class="h-8 rounded-md bg-surface-variant border border-outline-variant opacity-50 animate-pulse" />
 
       <AppSelect
         v-else
@@ -203,150 +203,13 @@
 
     <!-- Add Dependency (disabled, Coming Soon parity with play) -->
     <button
-      class="add-dep-btn"
+      class="flex items-center gap-2 px-3 py-2 border border-dashed border-outline-variant rounded-md text-xs text-on-surface-variant opacity-50 cursor-not-allowed"
       disabled
       type="button"
     >
       <AppIcon icon="file-plus" :size="14" />
       <span>Add Dependency</span>
-      <span class="coming-soon">soon</span>
+      <span class="ml-auto text-[10px] border border-current rounded-sm px-1 opacity-60">soon</span>
     </button>
   </div>
 </template>
-
-<style scoped>
-.dep-row {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.dep-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.dep-icon {
-  flex-shrink: 0;
-  opacity: 0.9;
-}
-
-.field-label {
-  flex: 1;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--v0-on-surface-variant);
-  opacity: 0.7;
-}
-
-.release-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
-  color: var(--v0-on-surface-variant);
-  opacity: 0.6;
-  transition: opacity 0.15s, background 0.15s;
-}
-
-.release-btn:hover {
-  opacity: 1;
-  background: var(--v0-surface-tint);
-}
-
-.nightly-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 0;
-}
-
-.nightly-label {
-  font-size: 12px;
-  color: var(--v0-on-surface-variant);
-}
-
-.select-skeleton {
-  background: var(--v0-surface-variant);
-  border: 1px solid var(--v0-outline-variant, var(--v0-outline));
-  border-radius: 6px;
-  height: 32px;
-  opacity: 0.5;
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-.add-dep-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border: 1px dashed var(--v0-outline-variant, var(--v0-outline));
-  border-radius: 6px;
-  color: var(--v0-on-surface-variant);
-  font-size: 12px;
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.coming-soon {
-  margin-left: auto;
-  font-size: 10px;
-  border: 1px solid currentColor;
-  border-radius: 3px;
-  padding: 1px 4px;
-  opacity: 0.6;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.5; }
-  50% { opacity: 0.25; }
-}
-
-/* Switch styling via data attributes */
-.switch-root[data-disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.switch-track {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  width: 32px;
-  height: 16px;
-  border-radius: 9999px;
-  transition: background-color 0.15s;
-}
-
-.switch-track[data-state="checked"] {
-  background: var(--v0-primary);
-}
-
-.switch-track[data-state="unchecked"] {
-  background: color-mix(in srgb, var(--v0-on-surface, #666) 20%, transparent);
-}
-
-.switch-thumb {
-  display: block;
-  width: 12px;
-  height: 12px;
-  border-radius: 9999px;
-  background: white;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  transition: transform 0.15s;
-  visibility: visible !important;
-}
-
-.switch-thumb[data-state="checked"] {
-  transform: translateX(16px);
-}
-
-.switch-thumb[data-state="unchecked"] {
-  transform: translateX(2px);
-}
-</style>

--- a/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
@@ -164,18 +164,11 @@
         <Switch.Root
           v-model="vuetifyNightly"
           aria-label="Use nightly builds"
-          class="shrink-0 inline-flex items-center border-none bg-transparent p-0 outline-none"
+          class="switch-root shrink-0 inline-flex items-center border-none bg-transparent p-0 outline-none"
           :disabled="isLocked"
         >
-          <Switch.Track
-            class="relative inline-flex items-center rounded-full transition-colors w-8 h-4"
-            :class="isLocked ? 'opacity-50 cursor-not-allowed' : ''"
-            :style="{ background: vuetifyNightly ? 'var(--v0-primary)' : 'var(--v0-on-surface, #666)/20%' }"
-          >
-            <Switch.Thumb
-              class="![visibility:visible] block size-3 rounded-full bg-white shadow-sm transition-transform"
-              :style="{ transform: vuetifyNightly ? 'translateX(16px)' : 'translateX(2px)' }"
-            />
+          <Switch.Track class="switch-track">
+            <Switch.Thumb class="switch-thumb" />
           </Switch.Track>
         </Switch.Root>
       </div>
@@ -312,5 +305,48 @@
 @keyframes pulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 0.25; }
+}
+
+/* Switch styling via data attributes */
+.switch-root[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.switch-track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 32px;
+  height: 16px;
+  border-radius: 9999px;
+  transition: background-color 0.15s;
+}
+
+.switch-track[data-state="checked"] {
+  background: var(--v0-primary);
+}
+
+.switch-track[data-state="unchecked"] {
+  background: color-mix(in srgb, var(--v0-on-surface, #666) 20%, transparent);
+}
+
+.switch-thumb {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  transition: transform 0.15s;
+  visibility: visible !important;
+}
+
+.switch-thumb[data-state="checked"] {
+  transform: translateX(16px);
+}
+
+.switch-thumb[data-state="unchecked"] {
+  transform: translateX(2px);
 }
 </style>

--- a/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
+++ b/apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
   // Framework
-  import { isArray } from '@vuetify/v0'
+  import { isArray, Switch } from '@vuetify/v0'
 
   // Components
+  import AppIcon from '@/components/app/AppIcon.vue'
   import AppSelect from '@/components/app/AppSelect.vue'
   import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
 
@@ -17,10 +18,14 @@
 
   onMounted(() => playground.fetchVersions())
 
+  const isVuetifyPreset = toRef(() => playground.activePreset.value === 'vuetify')
+  const isLocked = toRef(() => playground.isLocked.value)
+
   // Vue: null means "latest" in the ref, but the select uses 'latest' as the item id
   const vueModel = computed({
     get: (): ID => playground.vueVersion.value ?? 'latest',
     set: (id: ID | ID[]) => {
+      if (isLocked.value) return
       const value = isArray(id) ? id[0] : id
       playground.vueVersion.value = value === 'latest' ? null : String(value)
     },
@@ -30,7 +35,27 @@
   const v0Model = computed({
     get: (): ID => playground.v0Version.value,
     set: (id: ID | ID[]) => {
+      if (isLocked.value) return
       playground.v0Version.value = String(isArray(id) ? id[0] : id)
+    },
+  })
+
+  // Vuetify: 'latest' string is used directly as the item id
+  const vuetifyModel = computed({
+    get: (): ID => playground.vuetifyVersion.value,
+    set: (id: ID | ID[]) => {
+      if (isLocked.value) return
+      playground.vuetifyVersion.value = String(isArray(id) ? id[0] : id)
+    },
+  })
+
+  const vuetifyNightly = computed({
+    get: () => playground.vuetifyNightly.value,
+    set: (value: boolean) => {
+      if (isLocked.value) return
+      playground.vuetifyNightly.value = value
+      // When toggling nightly, reset to latest/head of the new list
+      playground.vuetifyVersion.value = 'latest'
     },
   })
 
@@ -43,34 +68,214 @@
     { id: 'latest', label: 'Latest' },
     ...(playground.v0Versions.value ?? []).map(v => ({ id: v, label: v })),
   ])
+
+  const vuetifyItems = toRef((): AppSelectItem[] => {
+    const versions = vuetifyNightly.value
+      ? playground.vuetifyNightlyVersions.value
+      : playground.vuetifyVersions.value
+    return [
+      { id: 'latest', label: 'Latest' },
+      ...(versions ?? []).map(v => ({ id: v, label: v })),
+    ]
+  })
+
+  function openVueReleaseNotes () {
+    const version = vueModel.value === 'latest'
+      ? playground.vueVersions.value?.[0]
+      : String(vueModel.value)
+    if (version) {
+      window.open(`https://github.com/vuejs/core/releases/tag/v${version}`, '_blank')
+    }
+  }
+
+  function openVuetifyReleaseNotes () {
+    window.open('https://vuetifyjs.com/getting-started/release-notes/', '_blank')
+  }
+
+  function openV0ReleaseNotes () {
+    const version = v0Model.value === 'latest'
+      ? playground.v0Versions.value?.[0]
+      : String(v0Model.value)
+    if (version) {
+      window.open(`https://github.com/vuetifyjs/0/releases/tag/v${version}`, '_blank')
+    }
+  }
 </script>
 
 <template>
   <div class="flex flex-col gap-5">
     <!-- Vue version -->
-    <div class="flex flex-col gap-1.5">
-      <label class="field-label">Vue</label>
+    <div class="dep-row">
+      <div class="dep-header">
+        <AppIcon class="dep-icon text-[#42b883]" icon="lang-vue" :size="18" />
+        <label class="field-label">Vue</label>
+
+        <button
+          class="release-btn"
+          title="Release notes"
+          type="button"
+          @click="openVueReleaseNotes"
+        >
+          <AppIcon icon="book-open" :size="12" />
+        </button>
+      </div>
+
       <div v-if="playground.fetching.value" class="select-skeleton" />
-      <AppSelect v-else v-model="vueModel" :items="vueItems" mandatory />
+
+      <AppSelect
+        v-else
+        v-model="vueModel"
+        :disabled="isLocked"
+        :items="vueItems"
+        mandatory
+      />
     </div>
 
-    <!-- v0 version -->
-    <div class="flex flex-col gap-1.5">
-      <label class="field-label">@vuetify/v0</label>
+    <!-- Vuetify version (only shown with vuetify preset) -->
+    <div v-if="isVuetifyPreset" class="dep-row">
+      <div class="dep-header">
+        <AppIcon class="dep-icon text-[#1867c0]" icon="vuetify" :size="18" />
+        <label class="field-label">Vuetify</label>
+
+        <button
+          class="release-btn"
+          title="Release notes"
+          type="button"
+          @click="openVuetifyReleaseNotes"
+        >
+          <AppIcon icon="book-open" :size="12" />
+        </button>
+      </div>
+
       <div v-if="playground.fetching.value" class="select-skeleton" />
-      <AppSelect v-else v-model="v0Model" :items="v0Items" mandatory />
+
+      <AppSelect
+        v-else
+        v-model="vuetifyModel"
+        :disabled="isLocked"
+        :items="vuetifyItems"
+        mandatory
+      />
+
+      <!-- Nightly toggle -->
+      <div class="nightly-row">
+        <span class="nightly-label">Nightly</span>
+
+        <Switch.Root
+          v-model="vuetifyNightly"
+          aria-label="Use nightly builds"
+          class="shrink-0 inline-flex items-center border-none bg-transparent p-0 outline-none"
+          :disabled="isLocked"
+        >
+          <Switch.Track
+            class="relative inline-flex items-center rounded-full transition-colors w-8 h-4"
+            :class="isLocked ? 'opacity-50 cursor-not-allowed' : ''"
+            :style="{ background: vuetifyNightly ? 'var(--v0-primary)' : 'var(--v0-on-surface, #666)/20%' }"
+          >
+            <Switch.Thumb
+              class="![visibility:visible] block size-3 rounded-full bg-white shadow-sm transition-transform"
+              :style="{ transform: vuetifyNightly ? 'translateX(16px)' : 'translateX(2px)' }"
+            />
+          </Switch.Track>
+        </Switch.Root>
+      </div>
     </div>
+
+    <!-- v0 version (only shown when NOT using vuetify preset) -->
+    <div v-if="!isVuetifyPreset" class="dep-row">
+      <div class="dep-header">
+        <AppIcon class="dep-icon text-primary" icon="vuetify-0" :size="18" />
+        <label class="field-label">@vuetify/v0</label>
+
+        <button
+          class="release-btn"
+          title="Release notes"
+          type="button"
+          @click="openV0ReleaseNotes"
+        >
+          <AppIcon icon="book-open" :size="12" />
+        </button>
+      </div>
+
+      <div v-if="playground.fetching.value" class="select-skeleton" />
+
+      <AppSelect
+        v-else
+        v-model="v0Model"
+        :disabled="isLocked"
+        :items="v0Items"
+        mandatory
+      />
+    </div>
+
+    <!-- Add Dependency (disabled, Coming Soon parity with play) -->
+    <button
+      class="add-dep-btn"
+      disabled
+      type="button"
+    >
+      <AppIcon icon="file-plus" :size="14" />
+      <span>Add Dependency</span>
+      <span class="coming-soon">soon</span>
+    </button>
   </div>
 </template>
 
 <style scoped>
+.dep-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dep-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dep-icon {
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
 .field-label {
+  flex: 1;
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--v0-on-surface-variant);
   opacity: 0.7;
+}
+
+.release-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  color: var(--v0-on-surface-variant);
+  opacity: 0.6;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.release-btn:hover {
+  opacity: 1;
+  background: var(--v0-surface-tint);
+}
+
+.nightly-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+}
+
+.nightly-label {
+  font-size: 12px;
+  color: var(--v0-on-surface-variant);
 }
 
 .select-skeleton {
@@ -80,6 +285,28 @@
   height: 32px;
   opacity: 0.5;
   animation: pulse 1.5s ease-in-out infinite;
+}
+
+.add-dep-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px dashed var(--v0-outline-variant, var(--v0-outline));
+  border-radius: 6px;
+  color: var(--v0-on-surface-variant);
+  font-size: 12px;
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.coming-soon {
+  margin-left: auto;
+  font-size: 10px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 1px 4px;
+  opacity: 0.6;
 }
 
 @keyframes pulse {

--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -213,7 +213,14 @@ export interface PlaygroundHashData {
   files: Record<string, string>
   active?: string
   imports?: Record<string, string>
-  settings?: { vue?: string, v0?: string, preset?: string, addons?: string }
+  settings?: {
+    vue?: string
+    v0?: string
+    vuetify?: string
+    vuetifyNightly?: boolean
+    preset?: string
+    addons?: string
+  }
 }
 
 /**
@@ -223,11 +230,13 @@ export async function encodePlaygroundHash (data: PlaygroundHashData): Promise<s
   return utoa(JSON.stringify(data))
 }
 
-function isValidSettings (v: unknown): v is { vue?: string, v0?: string, preset?: string, addons?: string } {
+function isValidSettings (v: unknown): v is PlaygroundHashData['settings'] {
   if (!isObject(v)) return false
   const s = v as Record<string, unknown>
   return (isUndefined(s.vue) || isString(s.vue))
     && (isUndefined(s.v0) || isString(s.v0))
+    && (isUndefined(s.vuetify) || isString(s.vuetify))
+    && (isUndefined(s.vuetifyNightly) || typeof s.vuetifyNightly === 'boolean')
     && (isUndefined(s.preset) || isString(s.preset))
     && (isUndefined(s.addons) || isString(s.addons))
 }

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -7,7 +7,7 @@ import { decodePlaygroundHash, encodePlaygroundHash, isFileRecord, parseVuetifyP
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
-import { createMainTs, createVuetifyTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS } from '@/data/playground-defaults'
+import { createMainTs, createVuetifyTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS, vuetifyEsmUrl } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
 import { parseRegistryQuery, resolveRegistryExample } from '@/data/registry'
 import { parseVuetifyExampleQuery, resolveVuetifyExample } from '@/data/vuetify-examples'
@@ -32,7 +32,19 @@ export function usePlaygroundFiles () {
   const one = useOnePlaygrounds()
   const routeId = usePlaygroundRouteId()
 
-  const { importMap, vueVersion, v0Version, vueVersions, v0Versions, fetching, fetchVersions } = usePlaygroundSettings()
+  const {
+    importMap,
+    vueVersion,
+    v0Version,
+    vuetifyVersion,
+    vuetifyNightly,
+    vueVersions,
+    v0Versions,
+    vuetifyVersions,
+    vuetifyNightlyVersions,
+    fetching,
+    fetchVersions,
+  } = usePlaygroundSettings()
 
   const builtinImportMap = computed(() => ({
     imports: {
@@ -77,13 +89,18 @@ export function usePlaygroundFiles () {
   function rebuildMain () {
     const file = store.files['src/main.ts']
     if (!file) return
-    file.code = createMainTs(theme.isDark.value ? 'dark' : 'light', mergedMainOptions())
+    file.code = createMainTs(theme.isDark.value ? 'dark' : 'light', mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value)
     compileFile(store, file)
   }
 
   function rebuildImportMap () {
     const preset = PRESETS.find(p => p.id === activePreset.value)
     const imports: Record<string, string> = { ...preset?.imports }
+    // Override vuetify import with versioned URL when vuetify preset is active
+    // Use @vuetify/nightly package when nightly mode is enabled
+    if (activePreset.value === 'vuetify') {
+      imports.vuetify = vuetifyEsmUrl(vuetifyVersion.value, vuetifyNightly.value)
+    }
     for (const id of activeAddons.value) {
       const addon = ADDONS.find(a => a.id === id)
       if (addon?.imports) Object.assign(imports, addon.imports)
@@ -159,6 +176,8 @@ export function usePlaygroundFiles () {
     if (decoded.settings?.preset) activePreset.value = decoded.settings.preset
     if (decoded.settings?.vue) vueVersion.value = decoded.settings.vue
     if (decoded.settings?.v0) v0Version.value = decoded.settings.v0
+    if (decoded.settings?.vuetify) vuetifyVersion.value = decoded.settings.vuetify
+    if (decoded.settings?.vuetifyNightly) vuetifyNightly.value = decoded.settings.vuetifyNightly
     if (decoded.settings?.addons) activeAddons.value = decoded.settings.addons.split(',').filter(Boolean)
 
     // Vuetify Play hashes (Format 4 and re-encoded Format 2/3) include infrastructure
@@ -255,7 +274,7 @@ export function usePlaygroundFiles () {
     rebuildImportMap()
     await store.setFiles(
       {
-        'src/main.ts': createMainTs(theme_, options),
+        'src/main.ts': createMainTs(theme_, options, vuetifyVersion.value, vuetifyNightly.value),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'tsconfig.json': REPL_TSCONFIG,
         ...(options.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme_) } : {}),
@@ -294,6 +313,8 @@ export function usePlaygroundFiles () {
     const settings: PlaygroundHashData['settings'] = {}
     if (vueVersion.value) settings.vue = vueVersion.value
     if (v0Version.value !== 'latest') settings.v0 = v0Version.value
+    if (vuetifyVersion.value !== 'latest') settings.vuetify = vuetifyVersion.value
+    if (vuetifyNightly.value) settings.vuetifyNightly = true
     if (activePreset.value !== 'default') settings.preset = activePreset.value
     if (activeAddons.value.length > 0) settings.addons = activeAddons.value.join(',')
 
@@ -324,6 +345,8 @@ export function usePlaygroundFiles () {
       // Track version/preset/addon refs so hash updates when they change
       vueVersion.value // eslint-disable-line @typescript-eslint/no-unused-expressions
       v0Version.value // eslint-disable-line @typescript-eslint/no-unused-expressions
+      vuetifyVersion.value // eslint-disable-line @typescript-eslint/no-unused-expressions
+      vuetifyNightly.value // eslint-disable-line @typescript-eslint/no-unused-expressions
       activePreset.value // eslint-disable-line @typescript-eslint/no-unused-expressions
       activeAddons.value // eslint-disable-line @typescript-eslint/no-unused-expressions
       for (const file of Object.values(store.files)) {
@@ -343,7 +366,7 @@ export function usePlaygroundFiles () {
     const mode = isDark ? 'dark' : 'light'
     const main = store.files['src/main.ts']
     if (main) {
-      main.code = createMainTs(mode, mergedMainOptions())
+      main.code = createMainTs(mode, mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value)
       compileFile(store, main)
     }
     // Keep sandbox Vuetify theme aligned with the host chrome toggle.
@@ -352,6 +375,13 @@ export function usePlaygroundFiles () {
       vuetify.code = createVuetifyTs(mode)
       compileFile(store, vuetify)
     }
+  })
+
+  // Rebuild main and import map when Vuetify version changes (nightly toggle or version select)
+  watch([vuetifyVersion, vuetifyNightly], () => {
+    if (!isReady.value || activePreset.value !== 'vuetify') return
+    rebuildMain()
+    rebuildImportMap()
   })
 
   watch(() => store.activeFile?.code, code => {
@@ -381,7 +411,7 @@ export function usePlaygroundFiles () {
     const options = preset.mainOptions
     await store.setFiles(
       {
-        'src/main.ts': createMainTs(theme_, options),
+        'src/main.ts': createMainTs(theme_, options, vuetifyVersion.value, vuetifyNightly.value),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'tsconfig.json': REPL_TSCONFIG,
         ...(options?.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme_) } : {}),
@@ -479,6 +509,8 @@ export function usePlaygroundFiles () {
         aliasMap.value = new Map()
         if (data.settings?.vue) vueVersion.value = data.settings.vue
         if (data.settings?.v0) v0Version.value = data.settings.v0
+        if (data.settings?.vuetify) vuetifyVersion.value = data.settings.vuetify
+        if (data.settings?.vuetifyNightly) vuetifyNightly.value = data.settings.vuetifyNightly
 
         await loadExample(data.files, data.active)
         rebuildImportMap()
@@ -609,8 +641,12 @@ export function usePlaygroundFiles () {
     loadExample,
     vueVersion,
     v0Version,
+    vuetifyVersion,
+    vuetifyNightly,
     vueVersions,
     v0Versions,
+    vuetifyVersions,
+    vuetifyNightlyVersions,
     fetching,
     fetchVersions,
     activePreset,

--- a/apps/playground/src/composables/usePlaygroundSettings.ts
+++ b/apps/playground/src/composables/usePlaygroundSettings.ts
@@ -1,4 +1,3 @@
-// Data
 // Utilities
 import { fetchNpmVersions } from '@/utilities/npm'
 import { useVueImportMap } from '@vue/repl/core'
@@ -12,9 +11,13 @@ export function usePlaygroundSettings () {
   })
 
   const v0Version = shallowRef('latest')
+  const vuetifyVersion = shallowRef('latest')
+  const vuetifyNightly = shallowRef(false)
 
   const vueVersions = shallowRef<string[]>([])
   const v0Versions = shallowRef<string[]>([])
+  const vuetifyVersions = shallowRef<string[]>([])
+  const vuetifyNightlyVersions = shallowRef<string[]>([])
 
   const fetching = shallowRef(false)
   let fetched = false
@@ -24,14 +27,20 @@ export function usePlaygroundSettings () {
     fetched = true
     fetching.value = true
     try {
-      const [vue, v0] = await Promise.all([
+      const [vue, v0, vuetify, vuetifyNightly_] = await Promise.all([
         // Floor at 3.5.0: @vuetify/v0 requires vue >=3.5.0 (uses useId), and
         // Vuetify 4 needs 3.5+ too — offering older Vue breaks both presets.
         fetchNpmVersions('vue', '3.5.0', false),
         fetchNpmVersions('@vuetify/v0', '0.1.0', true),
+        // Vuetify 4.x stable versions only (floor at 4.0.0)
+        fetchNpmVersions('vuetify', '4.0.0', false),
+        // Vuetify nightly builds from @vuetify/nightly package (not vuetify prereleases)
+        fetchNpmVersions('@vuetify/nightly', '0.0.0', true),
       ])
       vueVersions.value = vue
       v0Versions.value = v0
+      vuetifyVersions.value = vuetify
+      vuetifyNightlyVersions.value = vuetifyNightly_
     } catch {
       fetched = false
     } finally {
@@ -39,5 +48,17 @@ export function usePlaygroundSettings () {
     }
   }
 
-  return { importMap, vueVersion, v0Version, vueVersions, v0Versions, fetching, fetchVersions }
+  return {
+    importMap,
+    vueVersion,
+    v0Version,
+    vuetifyVersion,
+    vuetifyNightly,
+    vueVersions,
+    v0Versions,
+    vuetifyVersions,
+    vuetifyNightlyVersions,
+    fetching,
+    fetchVersions,
+  }
 }

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -78,7 +78,27 @@ export const vuetify = createVuetify({
 `
 }
 
-export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?: MainOptions): string {
+/**
+ * Generate a versioned Vuetify CDN URL for ESM JS.
+ * @param version - Version string or 'latest'
+ * @param nightly - If true, use @vuetify/nightly package instead of vuetify
+ */
+export function vuetifyEsmUrl (version = 'latest', nightly = false): string {
+  const pkg = nightly ? '@vuetify/nightly' : 'vuetify'
+  return `https://cdn.jsdelivr.net/npm/${pkg}@${version}/dist/vuetify-labs.esm.js`
+}
+
+/**
+ * Generate a versioned Vuetify CDN URL for CSS.
+ * @param version - Version string or 'latest'
+ * @param nightly - If true, use @vuetify/nightly package instead of vuetify
+ */
+function vuetifyCssUrl (version = 'latest', nightly = false): string {
+  const pkg = nightly ? '@vuetify/nightly' : 'vuetify'
+  return `https://cdn.jsdelivr.net/npm/${pkg}@${version}/dist/vuetify-labs.css`
+}
+
+export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?: MainOptions, vuetifyVersion = 'latest', vuetifyNightly = false): string {
   const useV0 = options?.v0 !== false
   const extraImports: string[] = []
   const extraPlugins: string[] = []
@@ -110,7 +130,7 @@ export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?
       // vuetify-labs.css doesn't bundle, so without it every mdi-* icon renders
       // as tofu. Add further icon-set stylesheets here as list entries.
       `for (const href of [`,
-      `  'https://cdn.jsdelivr.net/npm/vuetify@latest/dist/vuetify-labs.css',`,
+      `  '${vuetifyCssUrl(vuetifyVersion, vuetifyNightly)}',`,
       `  'https://cdn.jsdelivr.net/npm/@mdi/font@7.x/css/materialdesignicons.min.css',`,
       `  'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',`,
       `]) {`,

--- a/packages/0/src/components/Select/SelectActivator.vue
+++ b/packages/0/src/components/Select/SelectActivator.vue
@@ -42,6 +42,7 @@
       'aria-disabled': boolean
       'disabled': true | undefined
       'tabindex': 0 | undefined
+      'data-disabled': true | undefined
       'data-open': true | undefined
       'style': Record<string, string>
       'onClick': () => void
@@ -128,6 +129,7 @@
       'aria-disabled': toValue(context.disabled),
       'disabled': toValue(context.disabled) || undefined,
       'tabindex': as === 'button' ? undefined : 0,
+      'data-disabled': toValue(context.disabled) || undefined,
       'data-open': context.isOpen.value || undefined,
       'style': context.popover.anchorStyles.value,
       onClick,

--- a/packages/0/src/components/Select/index.browser.test.ts
+++ b/packages/0/src/components/Select/index.browser.test.ts
@@ -514,6 +514,20 @@ describe('select', () => {
       expect(activator.attributes('data-open')).toBe('true')
     })
 
+    it('should set data-disabled on activator when disabled', async () => {
+      const { wrapper } = await createSelect({ id: 'a11y-disabled-test', disabled: true })
+
+      const activator = wrapper.findComponent(Select.Activator as any)
+      expect(activator.attributes('data-disabled')).toBe('true')
+    })
+
+    it('should not set data-disabled on activator when not disabled', async () => {
+      const { wrapper } = await createSelect({ id: 'a11y-enabled-test' })
+
+      const activator = wrapper.findComponent(Select.Activator as any)
+      expect(activator.attributes('data-disabled')).toBeUndefined()
+    })
+
     it('should have role=option on items', async () => {
       const { itemSlotProps } = await createSelect()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Dependencies-style version selection UI to the playground Settings Versions panel, providing parity with play.vuetifyjs.com for Vuetify-preset migrants.

Fixes #830

## Features

- **Vuetify version select** (shown when Vuetify preset is active)
- **Nightly toggle** that swaps between stable and nightly version lists
- **Release notes buttons**: Vue → GitHub tags, Vuetify → vuetifyjs.com release notes, v0 → GitHub releases
- **Readonly state** when playground is locked (from Vuetify One) — selects AND nightly switch disabled
- **Icon thumbnails** for each dependency (Vue, Vuetify, v0)
- **Disabled "Add Dependency" button** (Coming Soon parity with play)

## Implementation

### Where UI Lives
- `apps/playground/src/components/playground/settings/PlaygroundSettingsVersions.vue` - Main version picker UI

### How Nightly Is Wired
1. `usePlaygroundSettings.ts` fetches versions from two npm packages:
   - Stable: `vuetify` >=4.0.0 (excluding prereleases)
   - Nightly: `@vuetify/nightly` (separate package, matching play.vuetifyjs.com)
2. Toggling nightly switches between version lists and resets selection to "Latest"
3. CDN URLs switch package based on nightly state (matching play's `isNightly` logic):
   - **Nightly OFF**: `https://cdn.jsdelivr.net/npm/vuetify@{version}/dist/...`
   - **Nightly ON**: `https://cdn.jsdelivr.net/npm/@vuetify/nightly@{version}/dist/...`
4. Version + nightly state persisted in URL hash (`settings.vuetify`, `settings.vuetifyNightly`)

### Files Changed
- `PlaygroundSettingsVersions.vue` - Version picker UI with nightly toggle
- `usePlaygroundSettings.ts` - Vuetify + nightly version fetching
- `usePlaygroundFiles.ts` - Version/nightly wiring to import-map/CSS
- `PlaygroundApp.vue` - Context provider updated
- `usePlayground.ts` - Hash data types updated
- `playground-defaults.ts` - Versioned CDN URL helpers with nightly support
- `useOnePlaygrounds.ts` - Export `currentMeta` for locked state
- `AppSelect.vue` - Added `disabled` prop support

## Testing

- Version select updates import-map and CSS CDN URL immediately
- Nightly toggle switches to `@vuetify/nightly` package URLs
- "Latest" with nightly ON correctly resolves to `@vuetify/nightly@latest`
- Locked playgrounds disable all version selects AND nightly switch
- Release notes buttons open correct URLs for each dependency
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8938926-ffdd-4b00-a59f-042fd8008b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8938926-ffdd-4b00-a59f-042fd8008b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

