### PR TITLE
docs: serve /REFERENCE.md and ship Grok Bot agent profile

### DIFF
--- a/apps/docs/build/copy-markdown.ts
+++ b/apps/docs/build/copy-markdown.ts
@@ -21,8 +21,9 @@ export default function copyMarkdownPlugin (): Plugin {
         copyFileSync(file, destPath)
       }
 
-      // Copy SKILL.md and every reference it links from skills/vuetify0 to
-      // dist root — a partial copy ships a skill with dead relative links
+      // Copy SKILL.md and every reference it links from skills/vuetify0.
+      // REFERENCE.md is also aliased at dist root so /REFERENCE.md matches /SKILL.md.
+      // A partial copy ships a skill with dead relative links.
       const skillBase = '../../skills/vuetify0'
       const skillSrc = join(skillBase, 'SKILL.md')
       const refsDir = join(skillBase, 'references')
@@ -34,9 +35,13 @@ export default function copyMarkdownPlugin (): Plugin {
           for (const ref of readdirSync(refsDir)) {
             if (!ref.endsWith('.md')) continue
             copyFileSync(join(refsDir, ref), join(outDir, 'references', ref))
+            // Agents fetch /REFERENCE.md as a sibling of /SKILL.md
+            if (ref === 'REFERENCE.md') {
+              copyFileSync(join(refsDir, ref), join(outDir, 'REFERENCE.md'))
+            }
           }
         }
-        console.log(`[copy-markdown] Copied ${files.length} markdown files + SKILL.md`)
+        console.log(`[copy-markdown] Copied ${files.length} markdown files + SKILL.md + REFERENCE.md`)
       } else {
         console.log(`[copy-markdown] Copied ${files.length} markdown files (SKILL.md not found)`)
       }

--- a/apps/docs/build/generate-llms-full.ts
+++ b/apps/docs/build/generate-llms-full.ts
@@ -243,7 +243,7 @@ function generateLlmsTxt (pages: PageInfo[]): string {
   }
 
   // AI Resources section
-  lines.push('## AI Resources', '', `- [SKILL.md](${BASE_URL}/SKILL.md): Compact reference with patterns, anti-patterns, and TypeScript types for AI coding assistants`, `- [Vuetify MCP](${BASE_URL}/guide/tooling/vuetify-mcp): Model Context Protocol server for structured API access`, '')
+  lines.push('## AI Resources', '', `- [SKILL.md](${BASE_URL}/SKILL.md): Compact reference with patterns, anti-patterns, and TypeScript types for AI coding assistants`, `- [REFERENCE.md](${BASE_URL}/REFERENCE.md): Detailed API examples agents load on demand`, `- [Vuetify MCP](${BASE_URL}/guide/tooling/vuetify-mcp): Model Context Protocol server for structured API access`, '')
 
   return lines.join('\n')
 }

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -10,6 +10,7 @@ meta:
   - name: keywords
     content: llms.txt, AI tools, LLM, Claude, ChatGPT, Grok, Cursor, documentation, developer experience
 related:
+  - /guide/tooling/grok-bot
   - /guide/tooling/vuetify-mcp
   - /guide/tooling/vuetify-cli
   - /introduction/getting-started
@@ -49,6 +50,8 @@ v0 provides machine-readable documentation files following the [llms.txt](https:
 > [!ASKAI] How do I configure my AI agent to consume llms-full.txt?
 
 ## Usage
+
+Need a ready-made agent persona? Copy the [Grok Bot / AI agent setup](/guide/tooling/grok-bot) profile into [Grok Bot](https://x.ai/bot) (or adapt it for Claude Code / Cursor).
 
 Install SKILL.md via [skills.sh](https://www.skills.sh) — works with Claude Code, Codex, Cursor, Grok Build, Windsurf, and [35+ agents](https://github.com/vercel-labs/skills#supported-agents):
 

--- a/apps/docs/src/pages/guide/tooling/grok-bot.md
+++ b/apps/docs/src/pages/guide/tooling/grok-bot.md
@@ -1,0 +1,92 @@
+---
+title: Grok Bot - Vuetify0 Engineer agent profile
+features:
+  label: Grok Bot
+  order: 1.5
+  level: 1
+meta:
+- name: description
+  content: Copy-paste a Grok Bot agent profile that knows Vuetify0 conventions, security primitives, composable patterns, and where to look in the docs and repo.
+- name: keywords
+  content: Grok Bot, AI agent, Vuetify0, agent profile, Cursor, Claude, SKILL.md, MCP
+related:
+  - /guide/tooling/ai-tools
+  - /guide/tooling/vuetify-mcp
+  - /introduction/getting-started
+  - /introduction/security
+---
+
+# Grok Bot / AI agent setup
+
+Spin up a seasoned **Vuetify0 Engineer** without reinventing prompts. Paste the profile below into Grok Bot (or adapt the same block for Claude Code / Cursor agent personas). The agent should default to **v0** (`@vuetify/v0`) — not Vuetify 3/4 component APIs.
+
+<DocsPageFeatures :frontmatter />
+
+## Before you paste
+
+Point the agent at v0’s AI surfaces so it can look things up instead of guessing:
+
+```bash
+npx skills add vuetifyjs/0
+```
+
+```bash
+claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
+```
+
+```bash
+grok mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
+```
+
+Canonical docs: [https://0.vuetifyjs.com](https://0.vuetifyjs.com) (start with [Security](/introduction/security) and [Getting started](/introduction/getting-started)). Broader AI tooling notes live in [AI Tools](/guide/tooling/ai-tools).
+
+## Copy-paste profile
+
+Create a new agent (or edit an existing one). Use these three fields as-is:
+
+**Name**
+
+```text
+Vuetify0 Engineer
+```
+
+**Title**
+
+```text
+Vuetify0 Engineer
+```
+
+**Description**
+
+```text
+You are a seasoned Vuetify0 Engineer for @vuetify/v0 — Vue 3 headless UI primitives and composables (unstyled, logic-first). Default to v0 APIs and patterns. Do not reach for Vuetify 3/4 (VBtn, v-model component props, theme/framework install paths) unless the user explicitly asks for classic Vuetify.
+Do not import from the `vuetify` package (or vuetify/components) unless the user explicitly asks for classic Vuetify.
+
+Primary package: @vuetify/v0. Prefer consumer imports from @vuetify/v0. In the vuetifyjs/0 monorepo, use the #v0/ path alias (never deep relative imports across packages).
+
+Always-on sources of truth (read before inventing APIs):
+- https://0.vuetifyjs.com — especially Security and fundamentals/guides
+- https://0.vuetifyjs.com/SKILL.md (or `npx skills add vuetifyjs/0`) — decision trees, anti-patterns, surface map
+- https://0.vuetifyjs.com/llms.txt and llms-full.txt for docs context
+- Vuetify MCP at https://mcp.vuetifyjs.com/mcp when available
+- Repo: https://github.com/vuetifyjs/0 — AGENTS.md and CLAUDE.md / .claude/rules/* (implementation, composables, components, docs, testing, new-feature-checklist)
+
+Working rules:
+1. STOP and check whether v0 already ships the primitive (selection, forms/validation, registry, virtualization, popover/overlay, focus, hotkeys, etc.) before hand-rolling Vue state.
+2. Prefer composable-first / create* factories; compound components when the user wants markup. Same logic, either shape.
+3. Headless by default — no style opinions in library code; examples/docs may use UnoCSS.
+4. Respect SSR and environment guards — use package globals (e.g. IN_BROWSER / SUPPORTS_*) instead of ad-hoc typeof window checks.
+5. Use existing #v0/utilities and #v0/types (isThenable, mergeDeep, ID, MaybeArray, etc.) instead of reinventing helpers.
+6. Naming: use* only for Vue composables (reactive/lifecycle); get*/is* for plain sync utilities (e.g. getActiveElement, isElement).
+7. TypeScript: zero any; unknown over any; follow existing trinity/readonly patterns in the codebase.
+8. Security: follow https://0.vuetifyjs.com/introduction/security. Never weaken library guards (mergeDeep prototype blocks, theme/CSS validation, SSR globals). App slot/prop XSS sanitization stays the consumer’s job per that page.
+9. When unsure of an API, fetch SKILL.md / MCP / docs — do not invent prop names or composable signatures.
+
+Output: concise, production-minded Vue 3 + TypeScript. Cite the v0 primitive you chose and why when there was a plausible hand-rolled alternative.
+```
+
+## Optional next steps
+
+- Add [Vuetify MCP](/guide/tooling/vuetify-mcp) to the same workspace so the agent can call `get_vuetify0_*` tools.
+- For harness tips (surface map in always-loaded context, reminder hooks, typecheck gate), see [Making Agents Actually Use v0](/guide/tooling/ai-tools#making-agents-actually-use-v0).
+- Later variants (not in this page yet): consumer-app vs monorepo contributor profiles.

--- a/apps/docs/src/pages/introduction/getting-started.md
+++ b/apps/docs/src/pages/introduction/getting-started.md
@@ -10,6 +10,8 @@ features:
   level: 1
 related:
   - /guide/essentials/using-the-docs
+  - /guide/tooling/ai-tools
+  - /guide/tooling/grok-bot
   - /composables
   - /components
 ---
@@ -479,6 +481,7 @@ Now that v0 is installed, choose your path:
 | Understand the architecture | [Components](/guide/fundamentals/components) → [Composables](/guide/fundamentals/composables) → [Core](/guide/fundamentals/core) |
 | Build production UIs now | [Theming](/guide/features/theming) → [Accessibility](/guide/features/accessibility) |
 | Build a component library | [Building Frameworks](/guide/fundamentals/building-frameworks) |
+| Set up an AI agent | [Grok Bot / AI agent setup](/guide/tooling/grok-bot) → [AI Tools](/guide/tooling/ai-tools) |
 | Explore interactively | [Playground](/playground) |
 
 > [!TIP]


### PR DESCRIPTION
Two small public-DX fixes.

## /REFERENCE.md 404
`/references/REFERENCE.md` already ships; agents fetching `/REFERENCE.md` as a sibling of `/SKILL.md` got 404. The docs build now copies `REFERENCE.md` to the dist root as well, and `llms.txt` lists the root URL.

## Grok Bot profile (#837)
Adds a copy-paste **Vuetify0 Engineer** agent profile under Guide → Tooling. Linked from [Getting started](https://0.vuetifyjs.com/introduction/getting-started) and [AI Tools](https://0.vuetifyjs.com/guide/tooling/ai-tools).

Closes #837