### PR TITLE
fix(Progress): clear stale segment values when flipping to indeterminate

### DIFF
--- a/.changeset/progress-indeterminate-stale-state-814.md
+++ b/.changeset/progress-indeterminate-stale-state-814.md
@@ -1,6 +1,6 @@
 ---
-'@vuetify/v0': patch
-'@paper/emerald': patch
+"@vuetify/v0": patch
+"@paper/emerald": patch
 ---
 
 fix(createProgress): clear stale segment values when the model becomes indeterminate

--- a/.changeset/progress-indeterminate-stale-state-814.md
+++ b/.changeset/progress-indeterminate-stale-state-814.md
@@ -18,3 +18,9 @@ values, resetting any segment without a corresponding entry back to `min`. A
 progress bar transitioning to indeterminate now correctly reports
 `data-state="indeterminate"`, clears `aria-valuenow`/`aria-valuetext`, and sets
 `aria-busy`.
+
+Also fixes the related pin in `isIndeterminate`: an instance created with an
+initial `value` (`createProgress({ value })`) returned `false` permanently, even
+after segments registered and were cleared back to `min`. The initial value now
+only backs the zero-segment state — mirroring `total`'s fallback — so segments
+become the sole source of truth once registered.

--- a/.changeset/progress-indeterminate-stale-state-814.md
+++ b/.changeset/progress-indeterminate-stale-state-814.md
@@ -1,0 +1,20 @@
+---
+'@vuetify/v0': patch
+'@paper/emerald': patch
+---
+
+fix(createProgress): clear stale segment values when the model becomes indeterminate
+
+`Progress.Root`'s `apply()` only wrote incoming values to segments at matching
+indices, so `apply([])` — what happens when the bound model value becomes
+`undefined`, e.g. flipping `EmProgress`'s `indeterminate` prop after a value was
+already committed — left previously-registered segments untouched. The bar
+correctly ran Emerald's indeterminate sweep animation via CSS, but `data-state`
+stayed `"determinate"` and `aria-valuenow`/`aria-valuetext` kept reporting the
+stale committed value to assistive tech.
+
+`apply()` now walks every registered segment rather than only the incoming
+values, resetting any segment without a corresponding entry back to `min`. A
+progress bar transitioning to indeterminate now correctly reports
+`data-state="indeterminate"`, clears `aria-valuenow`/`aria-valuetext`, and sets
+`aria-busy`.

--- a/packages/0/src/components/Progress/index.test.ts
+++ b/packages/0/src/components/Progress/index.test.ts
@@ -320,6 +320,22 @@ describe('progress', () => {
       expect(rootProps().total).toBe(75)
       expect(rootProps().percent).toBe(75)
     })
+
+    it('should clear stale total/aria-valuenow/data-state when model value becomes undefined', async () => {
+      const model = ref(60)
+      const { wrapper, rootProps, wait } = mountProgress({ model })
+      await wait()
+      expect(rootProps().total).toBe(60)
+      expect(rootProps().attrs['aria-valuenow']).toBe(60)
+      expect(rootProps().attrs['data-state']).toBe('determinate')
+
+      await wrapper.setProps({ modelValue: undefined })
+
+      expect(rootProps().total).toBe(0)
+      expect(rootProps().attrs['aria-valuenow']).toBeUndefined()
+      expect(rootProps().attrs['data-state']).toBe('indeterminate')
+      expect(rootProps().attrs['aria-busy']).toBe(true)
+    })
   })
 
   describe('slot props', () => {

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -187,6 +187,19 @@ describe('createProgress', () => {
       val.value = 5
       expect(progress.isIndeterminate.value).toBe(false)
     })
+
+    it('should not stay pinned determinate on a value-initialized instance once segments clear', () => {
+      const progress = setup({ value: 60 })
+      expect(progress.isIndeterminate.value).toBe(false)
+
+      const val = shallowRef(60)
+      progress.register({ value: val })
+      expect(progress.isIndeterminate.value).toBe(false)
+
+      progress.apply([])
+      expect(toValue(val)).toBe(0)
+      expect(progress.isIndeterminate.value).toBe(true)
+    })
   })
 
   describe('fromValue', () => {

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -267,18 +267,18 @@ describe('createProgress', () => {
 
     it('should reset a segment without a matching incoming entry to min', () => {
       const progress = setup({ min: 0, max: 100 })
-      const val1 = shallowRef(60)
-      progress.register({ value: val1 })
+      const val = shallowRef(60)
+      progress.register({ value: val })
       progress.apply([])
-      expect(toValue(val1)).toBe(0)
+      expect(toValue(val)).toBe(0)
     })
 
     it('should skip readonly segments', () => {
       const progress = setup({ min: 0, max: 100 })
-      const readonlyVal = computed(() => 50)
-      progress.register({ value: readonlyVal })
+      const val = computed(() => 50)
+      progress.register({ value: val })
       progress.apply([80])
-      expect(toValue(readonlyVal)).toBe(50)
+      expect(toValue(val)).toBe(50)
     })
   })
 

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createProgress, createProgressContext, useProgress } from './index'
 
 // Utilities
-import { inject, provide, shallowRef, toValue } from 'vue'
+import { computed, inject, provide, shallowRef, toValue } from 'vue'
 
 // Types
 import type { ProgressOptions } from './index'
@@ -250,6 +250,22 @@ describe('createProgress', () => {
       progress.apply([30, 20])
       expect(toValue(val1)).toBe(30)
       expect(toValue(val2)).toBe(20)
+    })
+
+    it('should reset a segment without a matching incoming entry to min', () => {
+      const progress = setup({ min: 0, max: 100 })
+      const val1 = shallowRef(60)
+      progress.register({ value: val1 })
+      progress.apply([])
+      expect(toValue(val1)).toBe(0)
+    })
+
+    it('should skip readonly segments', () => {
+      const progress = setup({ min: 0, max: 100 })
+      const readonlyVal = computed(() => 50)
+      progress.register({ value: readonlyVal })
+      progress.apply([80])
+      expect(toValue(readonlyVal)).toBe(50)
     })
   })
 

--- a/packages/0/src/composables/createProgress/index.ts
+++ b/packages/0/src/composables/createProgress/index.ts
@@ -114,9 +114,10 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
   })
 
   const isIndeterminate = toRef(() => {
-    if (_hasInitialValue) return false
     const segs = segments.value
-    if (segs.length === 0) return true
+    // The initial value only backs the zero-segment state (mirroring total's
+    // fallback); once segments register they are the sole source of truth.
+    if (segs.length === 0) return !_hasInitialValue
     for (const seg of segs) {
       if ((toValue(seg.value) ?? 0) > 0) return false
     }

--- a/packages/0/src/composables/createProgress/index.ts
+++ b/packages/0/src/composables/createProgress/index.ts
@@ -157,10 +157,12 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
       return
     }
 
-    for (const [index, element] of clamped.entries()) {
-      const ticket = segments.value[index]
-      if (!ticket || !isRef(ticket.value) || isReadonly(ticket.value)) continue
-      ticket.value.value = element!
+    // incoming reflects the full desired state, so segments without a
+    // corresponding entry (e.g. apply([]) when transitioning to
+    // indeterminate) are reset to min rather than left at a stale value.
+    for (const [index, ticket] of segments.value.entries()) {
+      if (!isRef(ticket.value) || isReadonly(ticket.value)) continue
+      ticket.value.value = clamped[index] ?? min
     }
   }
 

--- a/packages/emerald/src/components/EmProgress/EmProgress.vue
+++ b/packages/emerald/src/components/EmProgress/EmProgress.vue
@@ -39,8 +39,9 @@
 
   const model = defineModel<number>()
 
-  // ProgressRoot always emits aria-labelledby="{id}-label"; when no Progress.Label is
-  // rendered that reference dangles and accname falls through to aria-label.
+  // ProgressRoot only emits aria-labelledby="{id}-label" when a Progress.Label
+  // child is mounted (gated on hasLabel); otherwise accname falls through to
+  // aria-label, which is what we provide here.
   const ariaLabel = toRef(() => label ? undefined : _ariaLabel ?? 'Progress')
 
   function onModel (value: number | number[] | undefined) {


### PR DESCRIPTION
Fixes #814

## Root cause

`EmProgress.vue` passes `:model-value="indeterminate ? undefined : model"` to `Progress.Root`. When `indeterminate` flips to `true` after a value was already committed, `ProgressRoot`'s `internal` computed collapses to `[]`, and `useProxyModel` calls `context.apply([])`.

`createProgress.apply()` only wrote incoming values to segments at matching array indices:

```ts
for (const [index, element] of clamped.entries()) {
  const ticket = segments.value[index]
  if (!ticket || !isRef(ticket.value) || isReadonly(ticket.value)) continue
  ticket.value.value = element!
}
```

`clamped.entries()` is empty when `incoming` is `[]`, so the loop body never runs — any already-registered segment keeps its old value. `isIndeterminate` derives from segment values (`> 0` means determinate), so it stayed `false`, and `ProgressRoot` kept emitting `data-state="determinate"` and the stale `aria-valuenow`/`aria-valuetext` even while Emerald's CSS sweep animation was visibly running — a real accessibility bug (AT reports a fixed value while the bar visually reads as busy/indeterminate).

## Fix

`apply()` now iterates over every registered segment instead of only the incoming array, so a segment with no corresponding entry resets to `min`:

```ts
for (const [index, ticket] of segments.value.entries()) {
  if (!isRef(ticket.value) || isReadonly(ticket.value)) continue
  ticket.value.value = clamped[index] ?? min
}
```

Since `apply()` is always called with the full desired model state (see `useProxyModel`'s `reconcile`), this is the correct general semantic — not specific to the indeterminate case — and doesn't affect any of the existing `apply` tests (single segment, multi-segment, clamping, pending-registration).

Also fixed the smaller item the issue flagged: the stale comment in `EmProgress.vue` claiming `ProgressRoot` always emits `aria-labelledby` — it's gated on `hasLabel` (`ProgressRoot.vue:144`).

## Test plan

- [x] Reproduced against the pre-fix code first: added a `v-model` test that commits a value, then transitions to `undefined` via `wrapper.setProps` — failed on `main` (`total` stayed `60` instead of resetting to `0`), passes with the fix
- [x] `pnpm vitest run --project v0:unit` → 4700 passed, 1 skipped (no change from baseline)
- [x] `pnpm --filter=@vuetify/v0 typecheck` and `pnpm --filter=@paper/emerald typecheck` clean
- [x] `pnpm eslint` clean on changed files
- [x] Added a changeset (patch bump for `@vuetify/v0` and `@paper/emerald`)