### PR TITLE
fix(EmSnackbar): announce error variants assertively instead of politely

### DIFF
--- a/.changeset/emsnackbar-urgent-role-803.md
+++ b/.changeset/emsnackbar-urgent-role-803.md
@@ -1,0 +1,8 @@
+---
+'@paper/emerald': patch
+---
+
+fix(EmSnackbar): announce error variants assertively instead of politely
+
+`variant="error"` now uses `role="alert"`. Other variants stay `role="status"`.
+Pass `urgent` to override either way.

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbar.test.ts
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbar.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Context
+import EmSnackbar from './EmSnackbar.vue'
+
+// Utilities
+import { createApp, h } from 'vue'
+
+// Types
+import type { EmSnackbarProps } from './EmSnackbar.vue'
+import type { App } from 'vue'
+
+const apps: App[] = []
+
+function mount (props: EmSnackbarProps) {
+  const host = document.createElement('div')
+
+  document.body.append(host)
+
+  const app = createApp({
+    render: () => h(EmSnackbar, props, { default: () => 'Message' }),
+  })
+
+  apps.push(app)
+  app.mount(host)
+
+  return host
+}
+
+function role (host: HTMLElement) {
+  return host.querySelector('.emerald-snackbar')?.getAttribute('role')
+}
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.unmount()
+
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('emSnackbar', () => {
+  describe('urgency', () => {
+    it('should announce role=alert for variant=error', () => {
+      const host = mount({ variant: 'error' })
+
+      expect(role(host)).toBe('alert')
+    })
+
+    it('should announce role=status for variant=success', () => {
+      const host = mount({ variant: 'success' })
+
+      expect(role(host)).toBe('status')
+    })
+
+    it('should announce role=status for variant=warning', () => {
+      const host = mount({ variant: 'warning' })
+
+      expect(role(host)).toBe('status')
+    })
+
+    it('should announce role=status by default (variant=neutral)', () => {
+      const host = mount({})
+
+      expect(role(host)).toBe('status')
+    })
+
+    it('should let an explicit urgent=true override a non-error variant', () => {
+      const host = mount({ variant: 'warning', urgent: true })
+
+      expect(role(host)).toBe('alert')
+    })
+
+    it('should let an explicit urgent=false override variant=error', () => {
+      const host = mount({ variant: 'error', urgent: false })
+
+      expect(role(host)).toBe('status')
+    })
+  })
+})

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbar.vue
@@ -8,11 +8,10 @@
   export type EmSnackbarVariant = 'success' | 'error' | 'info' | 'warning' | 'neutral'
 
   /**
-   * Emerald withholds `urgent`, so every snackbar is `role="status"`. `variant` is
-   * purely visual (`data-variant`) and does not raise politeness — a `variant="error"`
-   * snackbar is still announced politely.
+   * `urgent` defaults to true for `variant="error"` and false otherwise;
+   * pass it explicitly to override the variant-derived default.
    */
-  export interface EmSnackbarProps extends Pick<SnackbarRootProps, 'id' | 'namespace'> {
+  export interface EmSnackbarProps extends Pick<SnackbarRootProps, 'id' | 'namespace' | 'urgent'> {
     variant?: EmSnackbarVariant
   }
 </script>
@@ -24,6 +23,10 @@
     id,
     namespace,
     variant = 'neutral',
+    // `= undefined` isn't a no-op here: without it, Vue's Boolean-prop casting
+    // resolves an absent `urgent` to `false` rather than `undefined`, which
+    // would permanently short-circuit the `??` fallback below.
+    urgent = undefined,
   } = defineProps<EmSnackbarProps>()
 </script>
 
@@ -33,6 +36,7 @@
     class="emerald-snackbar"
     :data-variant="variant"
     :namespace
+    :urgent="urgent ?? variant === 'error'"
   >
     <slot />
   </Snackbar.Root>


### PR DESCRIPTION
Fixes #803

## Root cause

`EmSnackbar` withholds v0's `urgent` prop entirely, and `variant` only sets `data-variant` (consumed by CSS). `urgent` is what switches `Snackbar.Root` between `role="alert"` (assertive, routed to the Portal's assertive live region) and `role="status"` (polite) — so every Emerald snackbar, including `variant="error"`, rendered `role="status"` and was announced politely by assistive tech. A destructive-failure toast looked urgent but announced like a routine status update.

## Fix

Went with the issue's option 2 (fits Emerald's variant-driven design language): `urgent` now derives from `variant` (`error` → assertive, everything else → polite), with an explicit `urgent` prop still available to override the derived default in either direction.

One non-obvious wrinkle I ran into and want to flag for review: a plain

```ts
const { urgent } = defineProps<{ urgent?: boolean }>()
```

does **not** give `urgent` the value `undefined` when the caller doesn't pass it — Vue's Boolean-prop casting resolves an absent Boolean-typed prop to `false`, not `undefined`, which permanently short-circuits `urgent ?? (variant === 'error')` (the `??` never sees `undefined`, since it's already `false`). The fix needs `urgent = undefined` explicitly in the destructure (verified empirically: this isn't a no-op — it's what tells Vue's runtime prop resolution to register an explicit `default: undefined` instead of falling through to the implicit Boolean-cast path). Left a comment on the line since it's easy to "simplify" back into the broken version.

## Test plan

- [x] Added `EmSnackbar.test.ts` (new — no test file existed) covering: `variant="error"` → `role="alert"`, `success`/`warning`/default → `role="status"`, and explicit `urgent` overriding the derived default in both directions
- [x] Reproduced the bug in isolation first (a debug harness showed `role="status"` even for `variant="error"` before the `= undefined` fix), confirmed the fix resolves it, then removed the scratch harness
- [x] `pnpm vitest run --project v0:unit --project emerald` → 4803 passed, 1 skipped
- [x] `pnpm --filter=@paper/emerald typecheck` and `pnpm eslint` clean on changed files
- [x] 100% branch/line coverage on the changed file
- [x] Added a changeset (patch bump for `@paper/emerald`)