### PR TITLE
docs: fix release-notes CLI command on /releases

### DIFF
--- a/apps/docs/src/pages/releases.md
+++ b/apps/docs/src/pages/releases.md
@@ -21,6 +21,6 @@ related:
 Stay up to date with the latest releases and changes in Vuetify v0. Select a version below to view its release notes.
 
 > [!TIP]
-> Prefer the terminal? Read any release without leaving your shell with the Vuetify CLI: `npx vuetify release-notes v0`. Add `-v <version>` for a specific release (defaults to the latest).
+> Prefer the terminal? Read any release without leaving your shell with the Vuetify CLI: `npx @vuetify/cli release-notes v0`. Add `-v <version>` for a specific release (defaults to the latest).
 
 <DocsReleases />


### PR DESCRIPTION
The `/releases` tip invoked `npx vuetify release-notes v0`. The published binary is `@vuetify/cli`; `vuetify` is the wrong package name.

Aligns the tip with `apps/docs/src/pages/guide/tooling/vuetify-cli.md`, which already documents `npx @vuetify/cli release-notes v0`. Subcommand stays plural (`release-notes`); `-v <version>` still defaults to latest.