### PR TITLE
docs: OAuth-era Vuetify MCP page (tools, auth, prompts)

### DIFF
--- a/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
@@ -6,9 +6,9 @@ features:
   level: 1
 meta:
   - name: description
-    content: Set up Vuetify MCP server to give AI assistants like Claude and Cursor direct access to Vuetify component APIs and v0 headless composable docs.
+    content: Connect Claude, Cursor, and other AI assistants to Vuetify 3/4 and v0 APIs, install and upgrade docs, plus Vuetify One bins, playgrounds, and links.
   - name: keywords
-    content: MCP, Model Context Protocol, Claude, AI assistant, Vuetify API, developer tools
+    content: MCP, Model Context Protocol, Claude, AI assistant, Vuetify API, Vuetify One, OAuth, bins, playgrounds, developer tools
 related:
   - /guide/tooling/ai-tools
   - /guide/tooling/vuetify-cli
@@ -18,7 +18,9 @@ logo: vmcp
 
 # Vuetify MCP
 
-Vuetify MCP is a [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants structured access to Vuetify and v0 APIs. Unlike [llms.txt](/guide/tooling/ai-tools), MCP provides real-time, queryable documentation.
+Vuetify MCP is a [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants structured access to Vuetify 3/4 and v0 APIs, install/upgrade/breaking-change docs, and — with [Vuetify One](https://one.vuetifyjs.com) — bins, playgrounds, and links. Unlike [llms.txt](/guide/tooling/ai-tools), MCP is real-time and queryable.
+
+The hosted server is [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) (streamable HTTP). Documentation and API tools need no account; bins, playgrounds, and links prompt Vuetify One OAuth.
 
 <DocsPageFeatures :frontmatter />
 
@@ -192,65 +194,86 @@ Manual configuration for each IDE. Use the interactive setup above for automatic
 
 ## Available Tools
 
+31 tools on the hosted server. Documentation and API tools are public. Bins, playgrounds, and links prompt Vuetify One OAuth.
+
+### Documentation and API
+
+No account required.
+
 | Tool | Purpose |
 | - | - |
+| `get_vuetify_api_by_version` | Download/cache Vuetify API types by version |
+| `get_component_api_by_version` | Component API (props/slots/events) |
+| `get_directive_api_by_version` | Directive API |
+| `get_installation_guide` | Install guides (vite, nuxt, nuxt-module, laravel, cdn, cdn-esm, vitepress, vuetify0) |
+| `get_feature_guides` | List available feature docs |
+| `get_feature_guide` | A specific feature guide |
+| `get_exposed_exports` | Package exports |
+| `get_frequently_asked_questions` | FAQ |
+| `get_release_notes_by_version` | Release notes |
+| `get_vuetify_one_installation_guide` | `@vuetify/one` README |
+| `get_upgrade_guide` | Major-version upgrade guides |
+| `get_v4_breaking_changes` | Vuetify 4 breaking changes |
+| `get_vuetify0_installation_guide` | `@vuetify/v0` install guide |
+| `get_vuetify0_package_guide` | Package-specific v0 documentation |
 | `get_vuetify0_composable_list` | List all composables by category |
 | `get_vuetify0_composable_guide` | Detailed composable documentation |
 | `get_vuetify0_component_list` | List all headless components |
 | `get_vuetify0_component_guide` | Component documentation and examples |
 | `get_vuetify0_exports_list` | Package subpath exports |
-| `get_vuetify0_installation_guide` | Setup instructions |
-| `get_vuetify0_package_guide` | Package-specific documentation |
+| `get_vuetify0_skill` | `SKILL.md` patterns and anti-patterns |
+| `create_bug_report` | Prefill a GitHub issue link |
 
-> [!TIP]
-> The MCP server also includes tools for Vuetify 3/4 APIs, installation guides, and [Vuetify Bins](https://bin.vuetifyjs.com). Run `tools/list` to see all available tools.
+### Vuetify One
+
+These prompt [Vuetify One](https://one.vuetifyjs.com) OAuth when the assistant needs them. They are not configured with a pasted API key.
+
+| Tool | Purpose |
+| - | - |
+| `create_vuetify_bin` | Create a [Play bin](https://bin.vuetifyjs.com) |
+| `get_all_bins` | List your bins |
+| `update_vuetify_bin` | Update a bin |
+| `get_bin` | Fetch a bin by ID |
+| `create_vuetify_link` | Create a [vtfy.link](https://vtfy.link) short URL |
+| `get_all_links` | List your links |
+| `create_vuetify_playground` | Create a playground (Vue SFC) |
+| `get_all_playgrounds` | List your playgrounds |
+| `update_vuetify_playground` | Update a playground |
+| `get_playground` | Fetch a playground by ID |
+
+## Example Prompts
+
+- Install Vuetify 4 in a fresh Vite + Vue project the documented way
+- What's the current VBtn API (props, slots, events)?
+- Scan this repo for Vuetify 3 patterns that break in v4
+- List Vuetify0 selection composables and when to use each
+- Create a Play bin with a VDataTable example (needs One)
+- Make a vtfy.link for this playground (needs One)
 
 ## Workflow
 
-When using AI to build headless components:
+When using AI to build headless v0 components:
 
 1. **Explore** — `get_vuetify0_composable_list` to see available primitives
 2. **Learn** — `get_vuetify0_composable_guide` for detailed documentation
 3. **Reference** — `get_vuetify0_component_guide` for implementation patterns
 
+For Vuetify 3/4 work, start with `get_installation_guide`, `get_component_api_by_version`, `get_upgrade_guide`, or `get_v4_breaking_changes` instead.
+
 ## Authentication
 
-[Vuetify Bins](https://vuetifyjs.com/features/bins/) require an API key from your Vuetify account.
+Connect at [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) (streamable HTTP).
 
-### Vuetify CLI
+- **Public** — documentation and API tools need no login.
+- **Vuetify One OAuth** — bins, playgrounds, and links prompt a Vuetify One sign-in when used. Do not paste an API key to use them on the hosted server.
 
-::: code-group no-filename
+### Advanced: API key
 
-```bash pnpm
-pnpm dlx @vuetify/cli add mcp --api-key your-api-key
-```
-
-```bash npm
-npx @vuetify/cli add mcp --api-key your-api-key
-```
-
-```bash yarn
-yarn dlx @vuetify/cli add mcp --api-key your-api-key
-```
-
-```bash bun
-bunx @vuetify/cli add mcp --api-key your-api-key
-```
-
-:::
-
-### Claude Code
-
-```bash
-claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp \
-  -e VUETIFY_API_KEY=your-api-key
-```
-
-### Manual Configuration
+Local or self-hosted setups can still send a Vuetify API key. This is not the hosted happy path.
 
 ::: code-group no-filename
 
-```json Hosted (recommended)
+```json Hosted header
 {
   "mcpServers": {
     "vuetify-mcp": {
@@ -263,7 +286,7 @@ claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp \
 }
 ```
 
-```json Local
+```json Local env
 {
   "mcpServers": {
     "vuetify-mcp": {
@@ -278,6 +301,11 @@ claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp \
 ```
 
 :::
+
+```bash
+claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp \
+  -e VUETIFY_API_KEY=your-api-key
+```
 
 ## Self-Hosting
 


### PR DESCRIPTION
## Summary

Update `/guide/tooling/vuetify-mcp` for the hosted MCP server at https://mcp.vuetifyjs.com/mcp (streamable HTTP). The live page was v0-skewed (7 tools) and treated a pasted API key as the primary auth story.

**Docs-only.** This does not change the MCP server, lockfiles, marketplace listings, or `releases.md`.

## Changes

- **Lede** — Vuetify 3/4 + v0 APIs, install/upgrade/breaking-change docs, and (with Vuetify One) bins/playgrounds/links. Hosted URL is the primary connect path.
- **31 tools** — full `tools/list` from hosted 0.9.0, grouped:
  - Documentation / API (21, no account)
  - Vuetify One OAuth (10: bins, playgrounds, links)
- **Auth** — public docs need no login; bins/playgrounds/links prompt Vuetify One OAuth. API-key headers / `VUETIFY_API_KEY` kept only as a short advanced/legacy note.
- **Example prompts** — Vuetify 4 install, VBtn API, v3→v4 scan, v0 selection composables, Play bin, vtfy.link (last two marked needs One).
- Existing client install snippets unchanged (interactive `--remote`, Claude Code HTTP, Cursor/IDE `mcp.json`, Claude Desktop stdio/`mcp-remote`, CLI `add mcp` Ruler note, local/self-host).

## Test plan

- [ ] Render https://0.vuetifyjs.com/guide/tooling/vuetify-mcp (or this PR preview) — intro is not v0-only
- [ ] Confirm both tool tables (21 public + 10 One) and the 6 example prompts
- [ ] Confirm auth leads with hosted URL + OAuth, not `VUETIFY_API_KEY`
- [ ] Confirm install snippets still match the previous working commands