### PR TITLE
docs(Benchmarks): use a flat noise band for trend change flagging

### DIFF
--- a/apps/docs/src/components/docs/benchmark/BenchmarkGroup.vue
+++ b/apps/docs/src/components/docs/benchmark/BenchmarkGroup.vue
@@ -45,9 +45,9 @@
   })
 
   /**
-   * Benchmarks whose trend clears their own error bars, split by direction.
-   * Null when nothing in the group moved — a badge that renders "0 changes" is
-   * noise, and the collapsed header should stay quiet when there is no news.
+   * Benchmarks whose trend clears the noise band, split by direction. Null when
+   * nothing in the group moved — a badge that renders "0 changes" is noise, and
+   * the collapsed header should stay quiet when there is no news.
    */
   const changes = computed(() => {
     const map = historyByBench.value
@@ -58,7 +58,7 @@
 
     for (const bench of props.group.benchmarks) {
       const delta = map.get(bench.name)?.delta
-      if (isUndefined(delta) || !significant(delta, bench.rme)) continue
+      if (isUndefined(delta) || !significant(delta)) continue
       if (delta > 0) up++
       else down++
     }
@@ -74,7 +74,7 @@
     const parts: string[] = []
     if (c.up) parts.push(`${c.up} faster`)
     if (c.down) parts.push(`${c.down} slower`)
-    return `${parts.join(', ')} beyond measurement variance since ${since.value ?? 'the first recorded run'}`
+    return `${parts.join(', ')} beyond run-to-run noise since ${since.value ?? 'the first recorded run'}`
   })
 </script>
 

--- a/apps/docs/src/components/docs/benchmark/BenchmarkRow.vue
+++ b/apps/docs/src/components/docs/benchmark/BenchmarkRow.vue
@@ -21,10 +21,10 @@
 
   const barColor = toRef(() => TIER_BG[props.benchmark.tier])
 
-  // Colored only when the delta clears this bench's own error bars, so a row
-  // reads the same way the group header counted it.
+  // Colored only when the delta clears the noise band, so a row reads the same
+  // way the group header counted it.
   function deltaClass (delta: number): string {
-    if (!significant(delta, props.benchmark.rme)) return 'text-on-surface-variant'
+    if (!significant(delta)) return 'text-on-surface-variant'
     return delta > 0 ? 'text-success' : 'text-error'
   }
 

--- a/apps/docs/src/composables/useBenchmarkHistory.ts
+++ b/apps/docs/src/composables/useBenchmarkHistory.ts
@@ -14,27 +14,21 @@ import type { TierState } from './useBenchmarkData'
 const CURRENT_LABEL = 'current' as const
 
 /**
- * Smallest delta worth reporting, regardless of how tight a bench's error bars
- * are. `rme` measures spread *within* one run and is tiny for most benches
- * (median 0.36% across the current set), so it never catches the real source of
- * cross-version drift: snapshots are recorded on rotating hosts. Measured
- * against that set, |delta| runs p50 3.3% / p75 6.7% / p90 17.4% — a 10% floor
- * sits above the drift band and leaves roughly a quarter of groups flagged.
+ * The band a trend delta has to clear before it counts as a real change.
+ *
+ * Flat on purpose. `rme` is within-run dispersion and does not predict
+ * between-run spread — the two correlate at 0.413 — so gating on it was
+ * measured and rejected when host calibration was removed (#749). That same
+ * work measured what identical code does across runs on the fixed reference
+ * host: 42 of 433 benches spread over 10%, 9 over 20%. A 20% band is where
+ * most of what surfaces is movement rather than apparatus; it flags 16 of 95
+ * groups on the current data, against 30 at 10%.
  */
-export const NOISE_FLOOR = 10
+export const NOISE_BAND = 20
 
-/**
- * The band a delta has to clear to count as signal. `rme` is the 95% confidence
- * interval on a *single* run — comparing two runs stacks two of them, which
- * widens the band by √2.
- */
-export function noise (rme: number): number {
-  return Math.max(rme * Math.SQRT2, NOISE_FLOOR)
-}
-
-/** True when a trend delta outranks measurement variance. */
-export function significant (delta: number, rme: number): boolean {
-  return Math.abs(delta) > noise(rme)
+/** True when a trend delta is large enough to outrank run-to-run noise. */
+export function significant (delta: number): boolean {
+  return Math.abs(delta) > NOISE_BAND
 }
 
 export interface HistoryPoint {


### PR DESCRIPTION
### Description

Follow-up to #807, which shipped the group-header change badge with a noise band of `max(rme × √2, 10%)`. That band was wrong on two counts.

**`rme` should not be in the formula.** Gating on it was measured and rejected when host calibration was removed in #749 — `rme` is within-run dispersion and correlates with between-run spread at only 0.413, so it cannot predict the noise it was being asked to bound. It was also inert in practice: median `rme` across the current set is 0.36%, so the floor decided nearly every case regardless.

**10% was too low.** #749 measured what identical code does across runs on the fixed reference host: 42 of 433 benches spread over 10%, 9 over 20%. At a 10% band roughly half of what surfaced could be apparatus rather than movement. A flat 20% band brings that to about a quarter.

Flagged groups go from 30 to 16 of 95. The Trend column colors on the same test, so an opened group still agrees with its header.

Also corrects a comment and an aria-label that described snapshots as recorded on rotating hosts. They are recorded on a single fixed reference host, as the benchmarks guide already states.
