### PR TITLE
docs: make the AI/crawler surface discoverable

### DIFF
--- a/apps/docs/build/api-names.ts
+++ b/apps/docs/build/api-names.ts
@@ -10,8 +10,28 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '../../..')
 const COMPONENTS_DIR = resolve(ROOT, 'packages/0/src/components')
+const COMPONENTS_BARREL = resolve(COMPONENTS_DIR, 'index.ts')
 const COMPOSABLES_DIR = resolve(ROOT, 'packages/0/src/composables')
 const COMPOSABLES_BARREL = resolve(COMPOSABLES_DIR, 'index.ts')
+
+/**
+ * Read the public surface from a barrel (index.ts).
+ *
+ * Discovery must mirror the public API, not the filesystem. Every barrel line is
+ * `export * from './<dirName>'`, so this is the single source of truth for what
+ * is public — a new internal directory is excluded automatically with no
+ * blocklist to maintain.
+ */
+async function getPublicDirs (barrel: string): Promise<Set<string>> {
+  const content = await readFile(barrel, 'utf8')
+  const dirs = new Set<string>()
+
+  for (const match of content.matchAll(/export\s+\*\s+from\s+'\.\/([^']+)'/g)) {
+    dirs.add(match[1])
+  }
+
+  return dirs
+}
 
 export interface ApiNameInfo {
   name: string
@@ -53,9 +73,17 @@ export function toCamel (str: string): string {
  */
 async function getComponentNames (): Promise<ApiNameInfo[]> {
   const names: ApiNameInfo[] = []
-  const dirs = await readdir(COMPONENTS_DIR)
+  const [dirs, publicDirs] = await Promise.all([
+    readdir(COMPONENTS_DIR),
+    getPublicDirs(COMPONENTS_BARREL),
+  ])
 
   for (const dir of dirs) {
+    // Only components re-exported from the public barrel are part of the API.
+    // `components/fixtures/` holds .vue test fixtures, not components — without
+    // this it mints an orphan /api/fixtures page with no API data.
+    if (!publicDirs.has(dir)) continue
+
     const dirPath = resolve(COMPONENTS_DIR, dir)
     const entries = await readdir(dirPath).catch(() => [])
 
@@ -75,29 +103,6 @@ async function getComponentNames (): Promise<ApiNameInfo[]> {
 }
 
 /**
- * Read the public composable surface from the barrel (index.ts).
- *
- * Discovery must mirror the public API, not the filesystem. Internal-only
- * composables (e.g., createFocusTraversal, createObserver) live in their own
- * directories but are never re-exported, so they must not leak into the SSG
- * routes or nav — otherwise they mint orphan /api/:name pages with no matching
- * docs page or API data. The barrel is the single source of truth: every line
- * is `export * from './<dirName>'`. This mirrors generate-api.ts and
- * generate-api-whitelist.ts, so a new internal composable is excluded
- * automatically with no blocklist to maintain.
- */
-async function getPublicComposableDirs (): Promise<Set<string>> {
-  const content = await readFile(COMPOSABLES_BARREL, 'utf8')
-  const dirs = new Set<string>()
-
-  for (const match of content.matchAll(/export\s+\*\s+from\s+'\.\/([^']+)'/g)) {
-    dirs.add(match[1])
-  }
-
-  return dirs
-}
-
-/**
  * Discover all composable names from the packages/0/src/composables directory.
  * Only includes directories re-exported from the public barrel that have an
  * index.ts file.
@@ -106,7 +111,7 @@ async function getComposableNames (): Promise<ApiNameInfo[]> {
   const names: ApiNameInfo[] = []
   const [dirs, publicDirs] = await Promise.all([
     readdir(COMPOSABLES_DIR),
-    getPublicComposableDirs(),
+    getPublicDirs(COMPOSABLES_BARREL),
   ])
 
   for (const dir of dirs) {

--- a/apps/docs/build/generate-api-markdown.ts
+++ b/apps/docs/build/generate-api-markdown.ts
@@ -1,0 +1,178 @@
+/**
+ * Emit a markdown twin for every /api/<slug> page.
+ *
+ * The authored docs pages under src/pages already ship `.md` twins verbatim via
+ * copy-markdown, but the API reference is rendered from `virtual:api` by
+ * `pages/api/[name].vue`, so there is no source markdown to copy. Agent
+ * fetchers and AI crawlers that ask for `/api/create-form.md` would 404 on
+ * exactly the pages carrying the type signatures they need most.
+ *
+ * This renders the same ApiData the page renders, in the same resolution order,
+ * to `dist/api/<slug>.md`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getApiNames, toCamel, toPascal } from './api-names'
+
+// Types
+import type { ApiData, ComponentApi, ComposableApi } from './generate-api'
+import type { Plugin } from 'vite'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const API_CACHE_FILE = resolve(__dirname, '../node_modules/.cache/api-cache.json')
+
+const SITE = 'https://0.vuetifyjs.com'
+
+function table (heading: string, headers: string[], rows: string[][]): string[] {
+  if (rows.length === 0) return []
+
+  return [
+    heading,
+    '',
+    `| ${headers.join(' | ')} |`,
+    `|${headers.map(() => '---').join('|')}|`,
+    ...rows.map(cells => `| ${cells.join(' | ')} |`),
+    '',
+  ]
+}
+
+/** Pipes and newlines break table rows; backtick-wrapped code must stay inline. */
+function cell (value?: string): string {
+  if (!value) return '—'
+  return value.replaceAll('|', String.raw`\|`).replaceAll('\n', ' ').trim() || '—'
+}
+
+function code (value?: string): string {
+  if (!value) return '—'
+  return `\`${cell(value)}\``
+}
+
+function renderComponent (api: ComponentApi): string[] {
+  return [
+    `## ${api.name}`,
+    '',
+    ...table(
+      '### Props',
+      ['Name', 'Type', 'Default', 'Required', 'Description'],
+      api.props.map(p => [
+        code(p.name),
+        code(p.type),
+        p.default ? code(p.default) : '—',
+        p.required ? 'yes' : 'no',
+        cell(p.description),
+      ]),
+    ),
+    ...table(
+      '### Events',
+      ['Name', 'Type', 'Description'],
+      api.events.map(e => [code(e.name), code(e.type), cell(e.description)]),
+    ),
+    ...table(
+      '### Slots',
+      ['Name', 'Type', 'Description'],
+      api.slots.map(s => [code(s.name), code(s.type), cell(s.description)]),
+    ),
+  ]
+}
+
+function renderComposable (api: ComposableApi): string[] {
+  const functions = api.functions.flatMap(fn => [
+    `### ${fn.name}`,
+    '',
+    ...fn.description ? [fn.description, ''] : [],
+    '```ts',
+    fn.signature,
+    '```',
+    '',
+  ])
+
+  return [
+    ...functions.length > 0 ? ['## Functions', '', ...functions] : [],
+    ...table(
+      '## Options',
+      ['Name', 'Type', 'Default', 'Required', 'Description'],
+      api.options.map(o => [
+        code(o.name),
+        code(o.type),
+        o.default ? code(o.default) : '—',
+        o.required ? 'yes' : 'no',
+        cell(o.description),
+      ]),
+    ),
+    ...table(
+      '## Methods',
+      ['Name', 'Type', 'Description'],
+      api.methods.map(m => [code(m.name), code(m.type), cell(m.description)]),
+    ),
+    ...table(
+      '## Properties',
+      ['Name', 'Type', 'Description'],
+      api.properties.map(p => [code(p.name), code(p.type), cell(p.description)]),
+    ),
+  ]
+}
+
+export default function generateApiMarkdownPlugin (): Plugin {
+  return {
+    name: 'generate-api-markdown',
+    apply: (config, { command }) => command === 'build' && !config.build?.ssr,
+    async writeBundle (options) {
+      const outDir = options.dir || 'dist'
+
+      if (!existsSync(API_CACHE_FILE)) {
+        console.warn('[generate-api-markdown] No API cache; skipping markdown twins')
+        return
+      }
+
+      const data = JSON.parse(readFileSync(API_CACHE_FILE, 'utf8')) as ApiData
+      const names = await getApiNames()
+      let written = 0
+
+      for (const { slug } of names) {
+        // Mirror the resolution order in pages/api/[name].vue exactly, or the
+        // twin can describe a different API than the page it shadows.
+        const pascal = toPascal(slug)
+        const camel = toCamel(slug)
+
+        const componentApis = Object.entries(data.components)
+          .filter(([name]) => name === pascal || name.startsWith(`${pascal}.`))
+          .map(([, api]) => api)
+          .toSorted((a, b) => {
+            if (a.name.endsWith('Root')) return -1
+            if (b.name.endsWith('Root')) return 1
+            return a.name.localeCompare(b.name)
+          })
+
+        const composableApi = data.composables[camel] ?? null
+
+        if (componentApis.length === 0 && !composableApi) continue
+
+        const title = componentApis.length > 0 ? pascal : camel
+        const related = data.related[title] ?? []
+
+        const lines: string[] = [
+          `# ${title} API`,
+          '',
+          `> Auto-generated API reference for \`${title}\` from @vuetify/v0 (Vuetify0).`,
+          `> Source of truth: ${SITE}/api/${slug}`,
+          '',
+          ...related.length > 0
+            ? ['## Related', '', ...related.map(item => `- ${SITE}${item}`), '']
+            : [],
+          ...composableApi ? renderComposable(composableApi) : [],
+          ...componentApis.flatMap(api => renderComponent(api)),
+        ]
+
+        const dest = join(outDir, 'api', `${slug}.md`)
+        mkdirSync(dirname(dest), { recursive: true })
+        writeFileSync(dest, `${lines.join('\n').trimEnd()}\n`)
+        written++
+      }
+
+      console.log(`[generate-api-markdown] Wrote ${written} API markdown twins`)
+    },
+  }
+}

--- a/apps/docs/build/generate-faqs.ts
+++ b/apps/docs/build/generate-faqs.ts
@@ -37,12 +37,22 @@ export interface Faq {
  * FAQPage answers are plain text; leaving markdown or component tags in place
  * puts syntax into the snippet a search engine quotes.
  */
+function stripTags (value: string): string {
+  let current = value
+  let previous = ''
+  while (current !== previous) {
+    previous = current
+    current = current.replace(/<[^>]*>/g, '')
+  }
+  return current
+}
+
 function plain (markdown: string): string {
-  return markdown
-    // Fenced code blocks carry no answer prose and wreck the snippet.
-    .replaceAll(/```[\s\S]*?```/g, '')
-    // Inline components (<DocsCount ... />) render as values we cannot resolve here.
-    .replaceAll(/<[^>]+>/g, '')
+  return stripTags(
+    markdown
+      // Fenced code blocks carry no answer prose and wreck the snippet.
+      .replaceAll(/```[\s\S]*?```/g, ''),
+  )
     // Links -> their text.
     .replaceAll(/\[([^\]]+)]\([^)]*\)/g, '$1')
     .replaceAll(/[*_`]/g, '')

--- a/apps/docs/build/generate-faqs.ts
+++ b/apps/docs/build/generate-faqs.ts
@@ -1,0 +1,116 @@
+/**
+ * Provide `virtual:faqs` — extracted `::: faq` blocks keyed by route path.
+ *
+ * Feeds FAQPage JSON-LD in App.vue. Google requires FAQPage markup to mirror
+ * content visible on the page, so this parses the same authored markdown the
+ * page renders rather than maintaining a parallel list.
+ *
+ * Block shape:
+ *
+ *   ::: faq
+ *   ??? Question text
+ *
+ *   Answer paragraphs, markdown, possibly inline components.
+ *
+ *   ??? Next question
+ *   ...
+ *   :::
+ */
+
+import { readFile, glob } from 'node:fs/promises'
+import { relative } from 'node:path'
+
+// Types
+import type { Plugin } from 'vite'
+
+const VIRTUAL_MODULE_ID = 'virtual:faqs'
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`
+
+export interface Faq {
+  question: string
+  answer: string
+}
+
+/**
+ * Reduce authored markdown to the plain prose a reader sees.
+ *
+ * FAQPage answers are plain text; leaving markdown or component tags in place
+ * puts syntax into the snippet a search engine quotes.
+ */
+function plain (markdown: string): string {
+  return markdown
+    // Fenced code blocks carry no answer prose and wreck the snippet.
+    .replaceAll(/```[\s\S]*?```/g, '')
+    // Inline components (<DocsCount ... />) render as values we cannot resolve here.
+    .replaceAll(/<[^>]+>/g, '')
+    // Links -> their text.
+    .replaceAll(/\[([^\]]+)]\([^)]*\)/g, '$1')
+    .replaceAll(/[*_`]/g, '')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+}
+
+function extract (source: string): Faq[] {
+  const faqs: Faq[] = []
+
+  for (const block of source.matchAll(/^::: faq\s*$([\s\S]*?)^:::\s*$/gm)) {
+    const body = block[1]
+    // Split on `???` markers; the first chunk is any preamble before question one.
+    const chunks = body.split(/^\?\?\? +/m).slice(1)
+
+    for (const chunk of chunks) {
+      const newline = chunk.indexOf('\n')
+      if (newline === -1) continue
+
+      const question = plain(chunk.slice(0, newline))
+      const answer = plain(chunk.slice(newline))
+
+      // A question with no answer body is not a valid FAQPage entry.
+      if (!question || !answer) continue
+
+      faqs.push({ question, answer })
+    }
+  }
+
+  return faqs
+}
+
+async function getFaqs (): Promise<Record<string, Faq[]>> {
+  const result: Record<string, Faq[]> = {}
+
+  for await (const file of glob('src/pages/**/*.md')) {
+    const source = await readFile(file, 'utf8')
+    if (!source.includes('::: faq')) continue
+
+    const faqs = extract(source)
+    if (faqs.length === 0) continue
+
+    const rel = relative('src/pages', file).replaceAll('\\', '/')
+
+    let route: string
+    if (rel === 'index.md') route = '/'
+    else if (rel.endsWith('/index.md')) route = `/${rel.slice(0, -'/index.md'.length)}`
+    else route = `/${rel.slice(0, -'.md'.length)}`
+
+    result[route] = faqs
+  }
+
+  return result
+}
+
+export default function generateFaqsPlugin (): Plugin {
+  return {
+    name: 'generate-faqs',
+    resolveId (id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_VIRTUAL_MODULE_ID
+    },
+    async load (id) {
+      if (id !== RESOLVED_VIRTUAL_MODULE_ID) return
+      return `export default ${JSON.stringify(await getFaqs())}`
+    },
+  }
+}

--- a/apps/docs/build/md-routes.ts
+++ b/apps/docs/build/md-routes.ts
@@ -1,0 +1,61 @@
+/**
+ * Provide `virtual:md-routes` — a map of route path to markdown-twin URL.
+ *
+ * Every docs route that has a `.md` twin gets a `<link rel="alternate">` in
+ * App.vue so agent fetchers and AI crawlers can discover the markdown without
+ * guessing a URL. The twins already shipped; nothing advertised them.
+ *
+ * The mapping is not derivable from the route alone: `pages/composables/index.md`
+ * serves route `/composables` but copies to `/composables/index.md`, while
+ * `pages/composables/data/create-filter.md` serves `/composables/data/create-filter`
+ * and copies to that path plus `.md`. Emitting a manifest keeps App.vue from
+ * guessing and advertising links that 404.
+ *
+ * Twin producers: `copy-markdown` (authored pages) and `generate-api-markdown`
+ * (the /api reference, which renders from `virtual:api` and has no source file).
+ */
+
+import { glob } from 'node:fs/promises'
+import { relative } from 'node:path'
+
+import { getApiNames } from './api-names'
+
+// Types
+import type { Plugin } from 'vite'
+
+const VIRTUAL_MODULE_ID = 'virtual:md-routes'
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`
+
+async function getMarkdownRoutes (): Promise<Record<string, string>> {
+  const routes: Record<string, string> = {}
+
+  for await (const file of glob('src/pages/**/*.md')) {
+    const rel = relative('src/pages', file).replaceAll('\\', '/')
+
+    let route: string
+    if (rel === 'index.md') route = '/'
+    else if (rel.endsWith('/index.md')) route = `/${rel.slice(0, -'/index.md'.length)}`
+    else route = `/${rel.slice(0, -'.md'.length)}`
+
+    routes[route] = `/${rel}`
+  }
+
+  for (const { slug } of await getApiNames()) {
+    routes[`/api/${slug}`] = `/api/${slug}.md`
+  }
+
+  return routes
+}
+
+export default function mdRoutesPlugin (): Plugin {
+  return {
+    name: 'md-routes',
+    resolveId (id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_VIRTUAL_MODULE_ID
+    },
+    async load (id) {
+      if (id !== RESOLVED_VIRTUAL_MODULE_ID) return
+      return `export default ${JSON.stringify(await getMarkdownRoutes())}`
+    },
+  }
+}

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -2,3 +2,11 @@ User-agent: *
 Allow: /
 
 Sitemap: https://0.vuetifyjs.com/sitemap.xml
+
+# LLM context bundles — curated documentation for AI assistants.
+# Index:     https://0.vuetifyjs.com/llms.txt
+# Full text: https://0.vuetifyjs.com/llms-full.txt
+# Agent skill: https://0.vuetifyjs.com/SKILL.md
+# Every docs page also serves its source markdown at the same path + ".md"
+# (e.g. https://0.vuetifyjs.com/composables/data/create-filter.md), advertised
+# per-page via <link rel="alternate" type="text/markdown">.

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
   import { useHead } from '@unhead/vue'
+  import faqs from 'virtual:faqs'
+  import mdRoutes from 'virtual:md-routes'
+  import pageDates from 'virtual:page-dates'
 
   // Framework
   import { IN_BROWSER, Scrim, useBreakpoints, useStack } from '@vuetify/v0'
@@ -67,6 +70,21 @@
   const url = toRef(() => `https://0.vuetifyjs.com${route.path}`)
   const breadcrumbs = useBreadcrumbItems()
 
+  // Advertise the page's markdown twin so agent fetchers and AI crawlers can
+  // retrieve source markdown instead of scraping rendered HTML. Only emitted for
+  // routes that actually have a twin — see build/md-routes.ts.
+  const markdown = toRef(() => {
+    const twin = mdRoutes[route.path] ?? mdRoutes[route.path.replace(/\/$/, '')]
+    if (!twin) return []
+
+    return [{
+      key: 'alternate-markdown',
+      rel: 'alternate',
+      type: 'text/markdown',
+      href: `https://0.vuetifyjs.com${twin}`,
+    }]
+  })
+
   const breadcrumbScript = toRef(() => {
     if (route.path === '/') return []
 
@@ -94,15 +112,70 @@
     }]
   })
 
+  // Documentation pages are TechArticle, not bare WebSite nodes — it carries the
+  // headline and dateModified that AI answer engines use to judge freshness.
+  // `dateModified` is the page's last git commit, already collected for the
+  // freshness badge.
+  const articleScript = toRef(() => {
+    const items = breadcrumbs.value
+    if (items.length <= 1) return []
+
+    const headline = items.at(-1)?.text
+    if (!headline) return []
+
+    const dates = pageDates[route.path]
+
+    return [{
+      key: 'article-schema',
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        headline,
+        'url': url.value,
+        'isPartOf': { '@type': 'WebSite', 'name': 'Vuetify0', 'url': 'https://0.vuetifyjs.com' },
+        'about': { '@type': 'SoftwareSourceCode', 'name': '@vuetify/v0', 'programmingLanguage': 'TypeScript' },
+        'publisher': { '@type': 'Organization', 'name': 'Vuetify', 'url': 'https://vuetifyjs.com' },
+        ...dates?.updated ? { dateModified: dates.updated } : {},
+      }),
+    }]
+  })
+
+  // FAQPage markup must mirror content the reader can see, so these come from
+  // the same `::: faq` blocks the page renders — see build/generate-faqs.ts.
+  const faqScript = toRef(() => {
+    const items = faqs[route.path] ?? faqs[route.path.replace(/\/$/, '')]
+    if (!items?.length) return []
+
+    return [{
+      key: 'faq-schema',
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        'mainEntity': items.map(item => ({
+          '@type': 'Question',
+          'name': item.question,
+          'acceptedAnswer': { '@type': 'Answer', 'text': item.answer },
+        })),
+      }),
+    }]
+  })
+
   useHead({
     title: 'Vuetify0',
     titleTemplate: '%s — Vuetify0',
-    link: [
+    link: toRef(() => [
       { rel: 'preconnect', href: 'https://api.github.com' },
       { rel: 'preconnect', href: 'https://cdn.vuetifyjs.com' },
       { rel: 'dns-prefetch', href: 'https://api.npmjs.org' },
-      { key: 'canonical', rel: 'canonical', href: url },
-    ],
+      { key: 'canonical', rel: 'canonical', href: url.value },
+      // Site-wide LLM context bundles. Documented for humans on
+      // /guide/tooling/ai-tools; these make them machine-discoverable.
+      { key: 'llms', rel: 'alternate', type: 'text/plain', href: 'https://0.vuetifyjs.com/llms.txt', title: 'llms.txt' },
+      { key: 'llms-full', rel: 'alternate', type: 'text/plain', href: 'https://0.vuetifyjs.com/llms-full.txt', title: 'llms-full.txt' },
+      ...markdown.value,
+    ]),
     meta: [
       { key: 'description', name: 'description', content: 'Headless components and composables for building modern applications and design systems' },
       { key: 'og:type', property: 'og:type', content: 'website' },
@@ -132,6 +205,8 @@
         }),
       },
       ...breadcrumbScript.value,
+      ...articleScript.value,
+      ...faqScript.value,
     ]),
   })
 </script>

--- a/apps/docs/src/vite-env.d.ts
+++ b/apps/docs/src/vite-env.d.ts
@@ -30,6 +30,20 @@ declare module 'virtual:page-dates' {
   export default data
 }
 
+declare module 'virtual:faqs' {
+  // Types
+  import type { Faq } from '@build/generate-faqs'
+  /** Route path -> FAQ entries extracted from `::: faq` blocks. */
+  const faqs: Record<string, Faq[]>
+  export default faqs
+}
+
+declare module 'virtual:md-routes' {
+  /** Route path -> markdown twin URL, for `rel="alternate"` links. */
+  const routes: Record<string, string>
+  export default routes
+}
+
 declare module 'virtual:llms-stats' {
   // Types
   import type { LlmsStats } from '@build/generate-llms-full'

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -12,8 +12,10 @@ import VueRouter from 'vue-router/vite'
 import { getApiSlugs } from './build/api-names'
 import copyMarkdownPlugin from './build/copy-markdown'
 import generateApiPlugin from './build/generate-api'
+import generateApiMarkdownPlugin from './build/generate-api-markdown'
 import generateApiWhitelistPlugin from './build/generate-api-whitelist'
 import generateExamplesPlugin from './build/generate-examples'
+import generateFaqsPlugin from './build/generate-faqs'
 import generateLlmsFullPlugin from './build/generate-llms-full'
 import generateNavPlugin from './build/generate-nav'
 import { generateOgImages } from './build/generate-og-images'
@@ -23,6 +25,7 @@ import generateSearchIndexPlugin from './build/generate-search-index'
 import generateTestCountPlugin from './build/generate-test-count'
 import generateTipsPlugin from './build/generate-tips'
 import Markdown from './build/markdown'
+import mdRoutesPlugin from './build/md-routes'
 import { getSkillzSlugs } from './build/skillz-tours'
 import pkg from './package.json' with { type: 'json' }
 
@@ -54,7 +57,10 @@ export default defineConfig({
         getApiSlugs(),
         getSkillzSlugs(),
       ])
-      const filtered = paths.filter(p => !p.includes(':path'))
+      // Drop every dynamic route, not just ':path'. Concrete routes are appended
+      // below from the discovered slugs; any surviving placeholder (e.g.
+      // '/api/:name') prerenders as an empty shell and lands in the sitemap.
+      const filtered = paths.filter(p => !p.includes(':'))
       const apiRoutes = apiSlugs.map(slug => `/api/${slug}`)
       const skillzRoutes = skillzSlugs.map(slug => `/skillz/${slug}`)
       return [...filtered, ...apiRoutes, ...skillzRoutes, '/404']
@@ -90,6 +96,9 @@ export default defineConfig({
     Layouts(),
     copyMarkdownPlugin(),
     generateApiPlugin(),
+    generateApiMarkdownPlugin(),
+    mdRoutesPlugin(),
+    generateFaqsPlugin(),
     generateExamplesPlugin(),
     generateLlmsFullPlugin(),
     generateSearchIndexPlugin(),


### PR DESCRIPTION
Six fixes to how the docs site presents itself to AI crawlers, agent fetchers, and search engines. All verified against a full build.

## Orphan routes

Both were live in the sitemap.

- **`/api/:name`** — `includedRoutes` filtered `':path'`, but the API route is `/api/:name`, so the placeholder prerendered as an empty shell and got submitted to crawlers. Now filters every dynamic route; concrete ones are appended from the discovered slugs as before.
- **`/api/fixtures`** — `getComponentNames()` included any directory containing `.vue` files, and `packages/0/src/components/fixtures/` holds test fixtures. Components are now discovered from the public barrel, which is what composables already did; the shared helper serves both.

## Markdown twins

- Authored pages already shipped `.md` twins, but nothing linked them and they appeared in no sitemap, so nothing crawled them. Added a per-page `<link rel="alternate" type="text/markdown">`, driven by a build-time manifest (`virtual:md-routes`) so a twin is never advertised unless it exists. The mapping isn't derivable from the route alone — `pages/composables/index.md` serves `/composables` but copies to `/composables/index.md`.
- The `/api` reference renders from `virtual:api` and had no source markdown to copy, so the pages carrying the type signatures were exactly the ones with no twin. `generate-api-markdown` renders the same `ApiData`, in the same resolution order as `pages/api/[name].vue`, to `dist/api/<slug>.md`.

## Schema and llms.txt

- **FAQPage** on 118 pages, extracted from the `::: faq` blocks the page already renders. Parsed from the authored markdown rather than a parallel list, so the markup mirrors visible content as Google requires.
- **TechArticle** with `dateModified` sourced from the existing git-backed page dates.
- **llms.txt / llms-full.txt** are documented for humans on `/guide/tooling/ai-tools` but were machine-undiscoverable — a cold fetcher that never reaches that page can't find them. Advertised via `<link rel="alternate">` and the whole surface is described in `robots.txt`.

## Result

| | Before | After |
|---|---|---|
| Sitemap URLs | 295 + 2 orphans | 293, both orphans gone |
| Pages advertising a `.md` twin | 0 | 266 |
| API markdown twins | 0 | 111 |
| Pages with FAQPage | 0 | 118 |

Dead twin links: 0. Invalid JSON-LD blocks: 0. FAQ answers with leaked markdown or component tags: 0.

App-only change under `apps/docs` — ships no package version, so no changeset.