### PR TITLE
chore(bench): add 1.0.4 history snapshot

### DIFF
--- a/apps/docs/src/data/metrics/1.0.4.json
+++ b/apps/docs/src/data/metrics/1.0.4.json
@@ -1,0 +1,9987 @@
+{
+  "version": "1.0.4",
+  "generatedAt": "2026-08-14T16:25:47.801Z",
+  "env": {
+    "cpu": "Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz",
+    "cores": 36,
+    "arch": "x64",
+    "platform": "linux",
+    "node": "v26.0.0",
+    "pnpm": null,
+    "imageOs": null,
+    "imageVersion": null,
+    "ci": false,
+    "busy": 0.000555247084952804,
+    "peak": 0.009900990099009901,
+    "governor": "performance"
+  },
+  "items": {
+    "helpers": {
+      "benchmarks": {
+        "_groups": {
+          "mergeDeep benchmarks": {
+            "shallow merge (2 objects, 5 keys each)": {
+              "name": "shallow merge (2 objects, 5 keys each)",
+              "hz": 671084,
+              "hzLabel": "671.1k ops/s",
+              "mean": 0.0014901264223813552,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "deep nested merge (3 levels)": {
+              "name": "deep nested merge (3 levels)",
+              "hz": 341642,
+              "hzLabel": "341.6k ops/s",
+              "mean": 0.0029270376591568124,
+              "meanLabel": "2.9μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "many sources (5 objects)": {
+              "name": "many sources (5 objects)",
+              "hz": 831710,
+              "hzLabel": "831.7k ops/s",
+              "mean": 0.0012023427901704993,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "realistic theme merge": {
+              "name": "realistic theme merge",
+              "hz": 496688,
+              "hzLabel": "496.7k ops/s",
+              "mean": 0.0020133349856537777,
+              "meanLabel": "2.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "large flat object (50 keys)": {
+              "name": "large flat object (50 keys)",
+              "hz": 60171,
+              "hzLabel": "60.2k ops/s",
+              "mean": 0.016619426743539577,
+              "meanLabel": "16.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "many sources (5 objects)",
+              "hz": 831710,
+              "hzLabel": "831.7k ops/s",
+              "mean": 0.0012023427901704993,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "large flat object (50 keys)",
+              "hz": 60171,
+              "hzLabel": "60.2k ops/s",
+              "mean": 0.016619426743539577,
+              "meanLabel": "16.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "shallow merge (2 objects, 5 keys each)": {
+          "name": "shallow merge (2 objects, 5 keys each)",
+          "hz": 671084,
+          "hzLabel": "671.1k ops/s",
+          "mean": 0.0014901264223813552,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "deep nested merge (3 levels)": {
+          "name": "deep nested merge (3 levels)",
+          "hz": 341642,
+          "hzLabel": "341.6k ops/s",
+          "mean": 0.0029270376591568124,
+          "meanLabel": "2.9μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "many sources (5 objects)": {
+          "name": "many sources (5 objects)",
+          "hz": 831710,
+          "hzLabel": "831.7k ops/s",
+          "mean": 0.0012023427901704993,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "realistic theme merge": {
+          "name": "realistic theme merge",
+          "hz": 496688,
+          "hzLabel": "496.7k ops/s",
+          "mean": 0.0020133349856537777,
+          "meanLabel": "2.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "large flat object (50 keys)": {
+          "name": "large flat object (50 keys)",
+          "hz": 60171,
+          "hzLabel": "60.2k ops/s",
+          "mean": 0.016619426743539577,
+          "meanLabel": "16.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "many sources (5 objects)",
+          "hz": 831710,
+          "hzLabel": "831.7k ops/s",
+          "mean": 0.0012023427901704993,
+          "meanLabel": "1.2μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "large flat object (50 keys)",
+          "hz": 60171,
+          "hzLabel": "60.2k ops/s",
+          "mean": 0.016619426743539577,
+          "meanLabel": "16.6μs",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createDataTable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create table (1,000 items)": {
+              "name": "Create table (1,000 items)",
+              "hz": 1210,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8264259558095584,
+              "meanLabel": "826.4μs",
+              "rme": 8.5,
+              "tier": "blazing"
+            },
+            "Create table (10,000 items)": {
+              "name": "Create table (10,000 items)",
+              "hz": 106,
+              "hzLabel": "106 ops/s",
+              "mean": 9.423470537038089,
+              "meanLabel": "9.42ms",
+              "rme": 12.6,
+              "tier": "blazing"
+            },
+            "Create table with groupBy (1,000 items)": {
+              "name": "Create table with groupBy (1,000 items)",
+              "hz": 1176,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8500141116749895,
+              "meanLabel": "850.0μs",
+              "rme": 9.6,
+              "tier": "blazing"
+            },
+            "Create table with all options (1,000 items)": {
+              "name": "Create table with all options (1,000 items)",
+              "hz": 679,
+              "hzLabel": "679 ops/s",
+              "mean": 1.4717096705888466,
+              "meanLabel": "1.47ms",
+              "rme": 6.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create table (1,000 items)",
+              "hz": 1210,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8264259558095584,
+              "meanLabel": "826.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create table (10,000 items)",
+              "hz": 106,
+              "hzLabel": "106 ops/s",
+              "mean": 9.423470537038089,
+              "meanLabel": "9.42ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1535,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6515282981767996,
+              "meanLabel": "651.5μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 152,
+              "hzLabel": "152 ops/s",
+              "mean": 6.5613979350634875,
+              "meanLabel": "6.56ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (1,000 items)": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1617,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6182917713228143,
+              "meanLabel": "618.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (10,000 items)": {
+              "name": "Search with custom column filter (10,000 items)",
+              "hz": 162,
+              "hzLabel": "162 ops/s",
+              "mean": 6.16208120731803,
+              "meanLabel": "6.16ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Update search 10 times (1,000 items)": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.616578013156724,
+              "meanLabel": "6.62ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1617,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6182917713228143,
+              "meanLabel": "618.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.616578013156724,
+              "meanLabel": "6.62ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3647,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.2742180509870658,
+              "meanLabel": "274.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 444,
+              "hzLabel": "444 ops/s",
+              "mean": 2.2536107792786737,
+              "meanLabel": "2.25ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 2970,
+              "hzLabel": "3.0k ops/s",
+              "mean": 0.33667953364764314,
+              "meanLabel": "336.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 102,
+              "hzLabel": "102 ops/s",
+              "mean": 9.822704529409142,
+              "meanLabel": "9.82ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Multi-sort two columns (1,000 items)": {
+              "name": "Multi-sort two columns (1,000 items)",
+              "hz": 950,
+              "hzLabel": "950 ops/s",
+              "mean": 1.053160972631855,
+              "meanLabel": "1.05ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Multi-sort two columns (10,000 items)": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 89,
+              "hzLabel": "89 ops/s",
+              "mean": 11.19906077777915,
+              "meanLabel": "11.20ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Toggle sort cycle 3 times (1,000 items)": {
+              "name": "Toggle sort cycle 3 times (1,000 items)",
+              "hz": 1545,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6471583790422998,
+              "meanLabel": "647.2μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3647,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.2742180509870658,
+              "meanLabel": "274.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 89,
+              "hzLabel": "89 ops/s",
+              "mean": 11.19906077777915,
+              "meanLabel": "11.20ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 801715,
+              "hzLabel": "801.7k ops/s",
+              "mean": 0.0012473268189840015,
+              "meanLabel": "1.2μs",
+              "rme": 3.6,
+              "tier": "blazing"
+            },
+            "Select all items (1,000 items)": {
+              "name": "Select all items (1,000 items)",
+              "hz": 1803,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5545190498898487,
+              "meanLabel": "554.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all items (10,000 items)": {
+              "name": "Select all items (10,000 items)",
+              "hz": 171,
+              "hzLabel": "171 ops/s",
+              "mean": 5.860215267444674,
+              "meanLabel": "5.86ms",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Select all with itemSelectable (1,000 items)": {
+              "name": "Select all with itemSelectable (1,000 items)",
+              "hz": 2227,
+              "hzLabel": "2.2k ops/s",
+              "mean": 0.44909006104141197,
+              "meanLabel": "449.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle all then check isAllSelected (1,000 items)": {
+              "name": "Toggle all then check isAllSelected (1,000 items)",
+              "hz": 861,
+              "hzLabel": "861 ops/s",
+              "mean": 1.1615997819019144,
+              "meanLabel": "1.16ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle 100 individual rows (1,000 items)": {
+              "name": "Toggle 100 individual rows (1,000 items)",
+              "hz": 8015,
+              "hzLabel": "8.0k ops/s",
+              "mean": 0.12476710978055104,
+              "meanLabel": "124.8μs",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 801715,
+              "hzLabel": "801.7k ops/s",
+              "mean": 0.0012473268189840015,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all items (10,000 items)",
+              "hz": 171,
+              "hzLabel": "171 ops/s",
+              "mean": 5.860215267444674,
+              "meanLabel": "5.86ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "grouping": {
+            "Compute groups (1,000 items, 8 groups)": {
+              "name": "Compute groups (1,000 items, 8 groups)",
+              "hz": 1027,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.973783324903558,
+              "meanLabel": "973.8μs",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "Compute groups (10,000 items, 8 groups)": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.800661659574116,
+              "meanLabel": "10.80ms",
+              "rme": 10.1,
+              "tier": "fast"
+            },
+            "Open all then close all groups (1,000 items)": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 192095,
+              "hzLabel": "192.1k ops/s",
+              "mean": 0.005205761098648787,
+              "meanLabel": "5.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Create with openAll (1,000 items)": {
+              "name": "Create with openAll (1,000 items)",
+              "hz": 687,
+              "hzLabel": "687 ops/s",
+              "mean": 1.4565209593019972,
+              "meanLabel": "1.46ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 192095,
+              "hzLabel": "192.1k ops/s",
+              "mean": 0.005205761098648787,
+              "meanLabel": "5.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 93,
+              "hzLabel": "93 ops/s",
+              "mean": 10.800661659574116,
+              "meanLabel": "10.80ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 605586,
+              "hzLabel": "605.6k ops/s",
+              "mean": 0.0016512919443776542,
+              "meanLabel": "1.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 584742,
+              "hzLabel": "584.7k ops/s",
+              "mean": 0.0017101544744436382,
+              "meanLabel": "1.7μs",
+              "rme": 7,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 614798,
+              "hzLabel": "614.8k ops/s",
+              "mean": 0.0016265501854339668,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access total 100 times (1,000 items, cached)": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 443087,
+              "hzLabel": "443.1k ops/s",
+              "mean": 0.0022568928520105224,
+              "meanLabel": "2.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 614798,
+              "hzLabel": "614.8k ops/s",
+              "mean": 0.0016265501854339668,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 443087,
+              "hzLabel": "443.1k ops/s",
+              "mean": 0.0022568928520105224,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1378,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7254863173907549,
+              "meanLabel": "725.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.776809702702087,
+              "meanLabel": "6.78ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search + multi-sort + paginate (1,000 items)": {
+              "name": "Search + multi-sort + paginate (1,000 items)",
+              "hz": 566,
+              "hzLabel": "566 ops/s",
+              "mean": 1.768034823321739,
+              "meanLabel": "1.77ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1378,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7254863173907549,
+              "meanLabel": "725.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.776809702702087,
+              "meanLabel": "6.78ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "adapter comparison": {
+            "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 380,
+              "hzLabel": "380 ops/s",
+              "mean": 2.6320893894738555,
+              "meanLabel": "2.63ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 378,
+              "hzLabel": "378 ops/s",
+              "mean": 2.6475896613771543,
+              "meanLabel": "2.65ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "ClientDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 147,
+              "hzLabel": "147 ops/s",
+              "mean": 6.784130175675052,
+              "meanLabel": "6.78ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.758011891889288,
+              "meanLabel": "6.76ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 380,
+              "hzLabel": "380 ops/s",
+              "mean": 2.6320893894738555,
+              "meanLabel": "2.63ms",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 147,
+              "hzLabel": "147 ops/s",
+              "mean": 6.784130175675052,
+              "meanLabel": "6.78ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create table (1,000 items)": {
+          "name": "Create table (1,000 items)",
+          "hz": 1210,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8264259558095584,
+          "meanLabel": "826.4μs",
+          "rme": 8.5,
+          "tier": "blazing"
+        },
+        "Create table (10,000 items)": {
+          "name": "Create table (10,000 items)",
+          "hz": 106,
+          "hzLabel": "106 ops/s",
+          "mean": 9.423470537038089,
+          "meanLabel": "9.42ms",
+          "rme": 12.6,
+          "tier": "blazing"
+        },
+        "Create table with groupBy (1,000 items)": {
+          "name": "Create table with groupBy (1,000 items)",
+          "hz": 1176,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8500141116749895,
+          "meanLabel": "850.0μs",
+          "rme": 9.6,
+          "tier": "blazing"
+        },
+        "Create table with all options (1,000 items)": {
+          "name": "Create table with all options (1,000 items)",
+          "hz": 679,
+          "hzLabel": "679 ops/s",
+          "mean": 1.4717096705888466,
+          "meanLabel": "1.47ms",
+          "rme": 6.1,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1535,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6515282981767996,
+          "meanLabel": "651.5μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 152,
+          "hzLabel": "152 ops/s",
+          "mean": 6.5613979350634875,
+          "meanLabel": "6.56ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (1,000 items)": {
+          "name": "Search with custom column filter (1,000 items)",
+          "hz": 1617,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6182917713228143,
+          "meanLabel": "618.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (10,000 items)": {
+          "name": "Search with custom column filter (10,000 items)",
+          "hz": 162,
+          "hzLabel": "162 ops/s",
+          "mean": 6.16208120731803,
+          "meanLabel": "6.16ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Update search 10 times (1,000 items)": {
+          "name": "Update search 10 times (1,000 items)",
+          "hz": 151,
+          "hzLabel": "151 ops/s",
+          "mean": 6.616578013156724,
+          "meanLabel": "6.62ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3647,
+          "hzLabel": "3.6k ops/s",
+          "mean": 0.2742180509870658,
+          "meanLabel": "274.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 444,
+          "hzLabel": "444 ops/s",
+          "mean": 2.2536107792786737,
+          "meanLabel": "2.25ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 2970,
+          "hzLabel": "3.0k ops/s",
+          "mean": 0.33667953364764314,
+          "meanLabel": "336.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 102,
+          "hzLabel": "102 ops/s",
+          "mean": 9.822704529409142,
+          "meanLabel": "9.82ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Multi-sort two columns (1,000 items)": {
+          "name": "Multi-sort two columns (1,000 items)",
+          "hz": 950,
+          "hzLabel": "950 ops/s",
+          "mean": 1.053160972631855,
+          "meanLabel": "1.05ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Multi-sort two columns (10,000 items)": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 89,
+          "hzLabel": "89 ops/s",
+          "mean": 11.19906077777915,
+          "meanLabel": "11.20ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Toggle sort cycle 3 times (1,000 items)": {
+          "name": "Toggle sort cycle 3 times (1,000 items)",
+          "hz": 1545,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6471583790422998,
+          "meanLabel": "647.2μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 801715,
+          "hzLabel": "801.7k ops/s",
+          "mean": 0.0012473268189840015,
+          "meanLabel": "1.2μs",
+          "rme": 3.6,
+          "tier": "blazing"
+        },
+        "Select all items (1,000 items)": {
+          "name": "Select all items (1,000 items)",
+          "hz": 1803,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5545190498898487,
+          "meanLabel": "554.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all items (10,000 items)": {
+          "name": "Select all items (10,000 items)",
+          "hz": 171,
+          "hzLabel": "171 ops/s",
+          "mean": 5.860215267444674,
+          "meanLabel": "5.86ms",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Select all with itemSelectable (1,000 items)": {
+          "name": "Select all with itemSelectable (1,000 items)",
+          "hz": 2227,
+          "hzLabel": "2.2k ops/s",
+          "mean": 0.44909006104141197,
+          "meanLabel": "449.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle all then check isAllSelected (1,000 items)": {
+          "name": "Toggle all then check isAllSelected (1,000 items)",
+          "hz": 861,
+          "hzLabel": "861 ops/s",
+          "mean": 1.1615997819019144,
+          "meanLabel": "1.16ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle 100 individual rows (1,000 items)": {
+          "name": "Toggle 100 individual rows (1,000 items)",
+          "hz": 8015,
+          "hzLabel": "8.0k ops/s",
+          "mean": 0.12476710978055104,
+          "meanLabel": "124.8μs",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "Compute groups (1,000 items, 8 groups)": {
+          "name": "Compute groups (1,000 items, 8 groups)",
+          "hz": 1027,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.973783324903558,
+          "meanLabel": "973.8μs",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Compute groups (10,000 items, 8 groups)": {
+          "name": "Compute groups (10,000 items, 8 groups)",
+          "hz": 93,
+          "hzLabel": "93 ops/s",
+          "mean": 10.800661659574116,
+          "meanLabel": "10.80ms",
+          "rme": 10.1,
+          "tier": "fast"
+        },
+        "Open all then close all groups (1,000 items)": {
+          "name": "Open all then close all groups (1,000 items)",
+          "hz": 192095,
+          "hzLabel": "192.1k ops/s",
+          "mean": 0.005205761098648787,
+          "meanLabel": "5.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Create with openAll (1,000 items)": {
+          "name": "Create with openAll (1,000 items)",
+          "hz": 687,
+          "hzLabel": "687 ops/s",
+          "mean": 1.4565209593019972,
+          "meanLabel": "1.46ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 605586,
+          "hzLabel": "605.6k ops/s",
+          "mean": 0.0016512919443776542,
+          "meanLabel": "1.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 584742,
+          "hzLabel": "584.7k ops/s",
+          "mean": 0.0017101544744436382,
+          "meanLabel": "1.7μs",
+          "rme": 7,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 614798,
+          "hzLabel": "614.8k ops/s",
+          "mean": 0.0016265501854339668,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access total 100 times (1,000 items, cached)": {
+          "name": "Access total 100 times (1,000 items, cached)",
+          "hz": 443087,
+          "hzLabel": "443.1k ops/s",
+          "mean": 0.0022568928520105224,
+          "meanLabel": "2.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1378,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.7254863173907549,
+          "meanLabel": "725.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 148,
+          "hzLabel": "148 ops/s",
+          "mean": 6.776809702702087,
+          "meanLabel": "6.78ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search + multi-sort + paginate (1,000 items)": {
+          "name": "Search + multi-sort + paginate (1,000 items)",
+          "hz": 566,
+          "hzLabel": "566 ops/s",
+          "mean": 1.768034823321739,
+          "meanLabel": "1.77ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+          "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+          "hz": 380,
+          "hzLabel": "380 ops/s",
+          "mean": 2.6320893894738555,
+          "meanLabel": "2.63ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+          "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+          "hz": 378,
+          "hzLabel": "378 ops/s",
+          "mean": 2.6475896613771543,
+          "meanLabel": "2.65ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "ClientDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 147,
+          "hzLabel": "147 ops/s",
+          "mean": 6.784130175675052,
+          "meanLabel": "6.78ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 148,
+          "hzLabel": "148 ops/s",
+          "mean": 6.758011891889288,
+          "meanLabel": "6.76ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Select single item (1,000 items)",
+          "hz": 801715,
+          "hzLabel": "801.7k ops/s",
+          "mean": 0.0012473268189840015,
+          "meanLabel": "1.2μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 89,
+          "hzLabel": "89 ops/s",
+          "mean": 11.19906077777915,
+          "meanLabel": "11.20ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createDataGrid": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create grid (1,000 items)": {
+              "name": "Create grid (1,000 items)",
+              "hz": 267,
+              "hzLabel": "267 ops/s",
+              "mean": 3.7474875522398654,
+              "meanLabel": "3.75ms",
+              "rme": 11.8,
+              "tier": "fast"
+            },
+            "Create grid (10,000 items)": {
+              "name": "Create grid (10,000 items)",
+              "hz": 29,
+              "hzLabel": "29 ops/s",
+              "mean": 34.208017733330294,
+              "meanLabel": "34.21ms",
+              "rme": 4.6,
+              "tier": "good"
+            },
+            "Create grid with pinned columns (1,000 items)": {
+              "name": "Create grid with pinned columns (1,000 items)",
+              "hz": 271,
+              "hzLabel": "271 ops/s",
+              "mean": 3.6870899411756803,
+              "meanLabel": "3.69ms",
+              "rme": 8.7,
+              "tier": "fast"
+            },
+            "Create grid with editable columns (1,000 items)": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 298,
+              "hzLabel": "298 ops/s",
+              "mean": 3.353858264901333,
+              "meanLabel": "3.35ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Create grid with all options (1,000 items)": {
+              "name": "Create grid with all options (1,000 items)",
+              "hz": 286,
+              "hzLabel": "286 ops/s",
+              "mean": 3.490959390412421,
+              "meanLabel": "3.49ms",
+              "rme": 7.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 298,
+              "hzLabel": "298 ops/s",
+              "mean": 3.353858264901333,
+              "meanLabel": "3.35ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create grid (10,000 items)",
+              "hz": 29,
+              "hzLabel": "29 ops/s",
+              "mean": 34.208017733330294,
+              "meanLabel": "34.21ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1527,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6549157421463837,
+              "meanLabel": "654.9μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.610152973680095,
+              "meanLabel": "6.61ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1527,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6549157421463837,
+              "meanLabel": "654.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 151,
+              "hzLabel": "151 ops/s",
+              "mean": 6.610152973680095,
+              "meanLabel": "6.61ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3072,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.32556409570232364,
+              "meanLabel": "325.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 375,
+              "hzLabel": "375 ops/s",
+              "mean": 2.6649418723409712,
+              "meanLabel": "2.66ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 2891,
+              "hzLabel": "2.9k ops/s",
+              "mean": 0.34588330428771846,
+              "meanLabel": "345.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 100,
+              "hzLabel": "100 ops/s",
+              "mean": 10.024443780006841,
+              "meanLabel": "10.02ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3072,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.32556409570232364,
+              "meanLabel": "325.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 100,
+              "hzLabel": "100 ops/s",
+              "mean": 10.024443780006841,
+              "meanLabel": "10.02ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "column layout": {
+            "Pin column (1,000 items)": {
+              "name": "Pin column (1,000 items)",
+              "hz": 15510,
+              "hzLabel": "15.5k ops/s",
+              "mean": 0.0644747162192179,
+              "meanLabel": "64.5μs",
+              "rme": 0.9,
+              "tier": "blazing"
+            },
+            "Resize column (1,000 items)": {
+              "name": "Resize column (1,000 items)",
+              "hz": 13478,
+              "hzLabel": "13.5k ops/s",
+              "mean": 0.0741935859049048,
+              "meanLabel": "74.2μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Resize column 10 times (1,000 items)": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5129,
+              "hzLabel": "5.1k ops/s",
+              "mean": 0.19495783898585475,
+              "meanLabel": "195.0μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Reorder column (1,000 items)": {
+              "name": "Reorder column (1,000 items)",
+              "hz": 11603,
+              "hzLabel": "11.6k ops/s",
+              "mean": 0.08618441537455467,
+              "meanLabel": "86.2μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Reset layout (1,000 items)": {
+              "name": "Reset layout (1,000 items)",
+              "hz": 13177,
+              "hzLabel": "13.2k ops/s",
+              "mean": 0.0758883689480034,
+              "meanLabel": "75.9μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Pin column (1,000 items)",
+              "hz": 15510,
+              "hzLabel": "15.5k ops/s",
+              "mean": 0.0644747162192179,
+              "meanLabel": "64.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5129,
+              "hzLabel": "5.1k ops/s",
+              "mean": 0.19495783898585475,
+              "meanLabel": "195.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "cell editing": {
+            "Edit cell (1,000 items)": {
+              "name": "Edit cell (1,000 items)",
+              "hz": 248116,
+              "hzLabel": "248.1k ops/s",
+              "mean": 0.0040303658823091755,
+              "meanLabel": "4.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Edit then commit (1,000 items)": {
+              "name": "Edit then commit (1,000 items)",
+              "hz": 140472,
+              "hzLabel": "140.5k ops/s",
+              "mean": 0.007118859730027563,
+              "meanLabel": "7.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit then cancel (1,000 items)": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 252822,
+              "hzLabel": "252.8k ops/s",
+              "mean": 0.0039553579435681625,
+              "meanLabel": "4.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Edit with validation failure (1,000 items)": {
+              "name": "Edit with validation failure (1,000 items)",
+              "hz": 138974,
+              "hzLabel": "139.0k ops/s",
+              "mean": 0.0071956138412878476,
+              "meanLabel": "7.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Edit 10 cells sequentially (1,000 items)": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14456,
+              "hzLabel": "14.5k ops/s",
+              "mean": 0.06917468211398287,
+              "meanLabel": "69.2μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 252822,
+              "hzLabel": "252.8k ops/s",
+              "mean": 0.0039553579435681625,
+              "meanLabel": "4.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14456,
+              "hzLabel": "14.5k ops/s",
+              "mean": 0.06917468211398287,
+              "meanLabel": "69.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row ordering": {
+            "Move row (1,000 items)": {
+              "name": "Move row (1,000 items)",
+              "hz": 985,
+              "hzLabel": "985 ops/s",
+              "mean": 1.0150738444449756,
+              "meanLabel": "1.02ms",
+              "rme": 4.1,
+              "tier": "fast"
+            },
+            "Move 10 rows (1,000 items)": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1188,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8415314386557678,
+              "meanLabel": "841.5μs",
+              "rme": 3.9,
+              "tier": "blazing"
+            },
+            "Reset row order (1,000 items)": {
+              "name": "Reset row order (1,000 items)",
+              "hz": 1093,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9144986160898665,
+              "meanLabel": "914.5μs",
+              "rme": 6.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1188,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8415314386557678,
+              "meanLabel": "841.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move row (1,000 items)",
+              "hz": 985,
+              "hzLabel": "985 ops/s",
+              "mean": 1.0150738444449756,
+              "meanLabel": "1.02ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "row spanning": {
+            "Compute spans (1,000 items, 1 column)": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 282,
+              "hzLabel": "282 ops/s",
+              "mean": 3.551678801419425,
+              "meanLabel": "3.55ms",
+              "rme": 5.7,
+              "tier": "fast"
+            },
+            "Compute spans (10,000 items, 1 column)": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.83652271429725,
+              "meanLabel": "35.84ms",
+              "rme": 3.2,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 282,
+              "hzLabel": "282 ops/s",
+              "mean": 3.551678801419425,
+              "meanLabel": "3.55ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.83652271429725,
+              "meanLabel": "35.84ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 440159,
+              "hzLabel": "440.2k ops/s",
+              "mean": 0.0022719051753575894,
+              "meanLabel": "2.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 447605,
+              "hzLabel": "447.6k ops/s",
+              "mean": 0.0022341105033984016,
+              "meanLabel": "2.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 635718,
+              "hzLabel": "635.7k ops/s",
+              "mean": 0.0015730241615391825,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access layout.columns 100 times (1,000 items, cached)": {
+              "name": "Access layout.columns 100 times (1,000 items, cached)",
+              "hz": 615284,
+              "hzLabel": "615.3k ops/s",
+              "mean": 0.0016252654147791026,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access layout.pinned 100 times (1,000 items, cached)": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 631498,
+              "hzLabel": "631.5k ops/s",
+              "mean": 0.0015835374204414864,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 635718,
+              "hzLabel": "635.7k ops/s",
+              "mean": 0.0015730241615391825,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 440159,
+              "hzLabel": "440.2k ops/s",
+              "mean": 0.0022719051753575894,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1296,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7716074567882812,
+              "meanLabel": "771.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 134,
+              "hzLabel": "134 ops/s",
+              "mean": 7.469946641790326,
+              "meanLabel": "7.47ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (1,000 items)": {
+              "name": "Search + sort + paginate + layout (1,000 items)",
+              "hz": 1136,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.8805690598591112,
+              "meanLabel": "880.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (10,000 items)": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 133,
+              "hzLabel": "133 ops/s",
+              "mean": 7.541079910446841,
+              "meanLabel": "7.54ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1296,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7716074567882812,
+              "meanLabel": "771.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 133,
+              "hzLabel": "133 ops/s",
+              "mean": 7.541079910446841,
+              "meanLabel": "7.54ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create grid (1,000 items)": {
+          "name": "Create grid (1,000 items)",
+          "hz": 267,
+          "hzLabel": "267 ops/s",
+          "mean": 3.7474875522398654,
+          "meanLabel": "3.75ms",
+          "rme": 11.8,
+          "tier": "fast"
+        },
+        "Create grid (10,000 items)": {
+          "name": "Create grid (10,000 items)",
+          "hz": 29,
+          "hzLabel": "29 ops/s",
+          "mean": 34.208017733330294,
+          "meanLabel": "34.21ms",
+          "rme": 4.6,
+          "tier": "good"
+        },
+        "Create grid with pinned columns (1,000 items)": {
+          "name": "Create grid with pinned columns (1,000 items)",
+          "hz": 271,
+          "hzLabel": "271 ops/s",
+          "mean": 3.6870899411756803,
+          "meanLabel": "3.69ms",
+          "rme": 8.7,
+          "tier": "fast"
+        },
+        "Create grid with editable columns (1,000 items)": {
+          "name": "Create grid with editable columns (1,000 items)",
+          "hz": 298,
+          "hzLabel": "298 ops/s",
+          "mean": 3.353858264901333,
+          "meanLabel": "3.35ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Create grid with all options (1,000 items)": {
+          "name": "Create grid with all options (1,000 items)",
+          "hz": 286,
+          "hzLabel": "286 ops/s",
+          "mean": 3.490959390412421,
+          "meanLabel": "3.49ms",
+          "rme": 7.2,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1527,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6549157421463837,
+          "meanLabel": "654.9μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 151,
+          "hzLabel": "151 ops/s",
+          "mean": 6.610152973680095,
+          "meanLabel": "6.61ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3072,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.32556409570232364,
+          "meanLabel": "325.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 375,
+          "hzLabel": "375 ops/s",
+          "mean": 2.6649418723409712,
+          "meanLabel": "2.66ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 2891,
+          "hzLabel": "2.9k ops/s",
+          "mean": 0.34588330428771846,
+          "meanLabel": "345.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 100,
+          "hzLabel": "100 ops/s",
+          "mean": 10.024443780006841,
+          "meanLabel": "10.02ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Pin column (1,000 items)": {
+          "name": "Pin column (1,000 items)",
+          "hz": 15510,
+          "hzLabel": "15.5k ops/s",
+          "mean": 0.0644747162192179,
+          "meanLabel": "64.5μs",
+          "rme": 0.9,
+          "tier": "blazing"
+        },
+        "Resize column (1,000 items)": {
+          "name": "Resize column (1,000 items)",
+          "hz": 13478,
+          "hzLabel": "13.5k ops/s",
+          "mean": 0.0741935859049048,
+          "meanLabel": "74.2μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Resize column 10 times (1,000 items)": {
+          "name": "Resize column 10 times (1,000 items)",
+          "hz": 5129,
+          "hzLabel": "5.1k ops/s",
+          "mean": 0.19495783898585475,
+          "meanLabel": "195.0μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Reorder column (1,000 items)": {
+          "name": "Reorder column (1,000 items)",
+          "hz": 11603,
+          "hzLabel": "11.6k ops/s",
+          "mean": 0.08618441537455467,
+          "meanLabel": "86.2μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Reset layout (1,000 items)": {
+          "name": "Reset layout (1,000 items)",
+          "hz": 13177,
+          "hzLabel": "13.2k ops/s",
+          "mean": 0.0758883689480034,
+          "meanLabel": "75.9μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Edit cell (1,000 items)": {
+          "name": "Edit cell (1,000 items)",
+          "hz": 248116,
+          "hzLabel": "248.1k ops/s",
+          "mean": 0.0040303658823091755,
+          "meanLabel": "4.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Edit then commit (1,000 items)": {
+          "name": "Edit then commit (1,000 items)",
+          "hz": 140472,
+          "hzLabel": "140.5k ops/s",
+          "mean": 0.007118859730027563,
+          "meanLabel": "7.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit then cancel (1,000 items)": {
+          "name": "Edit then cancel (1,000 items)",
+          "hz": 252822,
+          "hzLabel": "252.8k ops/s",
+          "mean": 0.0039553579435681625,
+          "meanLabel": "4.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Edit with validation failure (1,000 items)": {
+          "name": "Edit with validation failure (1,000 items)",
+          "hz": 138974,
+          "hzLabel": "139.0k ops/s",
+          "mean": 0.0071956138412878476,
+          "meanLabel": "7.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Edit 10 cells sequentially (1,000 items)": {
+          "name": "Edit 10 cells sequentially (1,000 items)",
+          "hz": 14456,
+          "hzLabel": "14.5k ops/s",
+          "mean": 0.06917468211398287,
+          "meanLabel": "69.2μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Move row (1,000 items)": {
+          "name": "Move row (1,000 items)",
+          "hz": 985,
+          "hzLabel": "985 ops/s",
+          "mean": 1.0150738444449756,
+          "meanLabel": "1.02ms",
+          "rme": 4.1,
+          "tier": "fast"
+        },
+        "Move 10 rows (1,000 items)": {
+          "name": "Move 10 rows (1,000 items)",
+          "hz": 1188,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8415314386557678,
+          "meanLabel": "841.5μs",
+          "rme": 3.9,
+          "tier": "blazing"
+        },
+        "Reset row order (1,000 items)": {
+          "name": "Reset row order (1,000 items)",
+          "hz": 1093,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9144986160898665,
+          "meanLabel": "914.5μs",
+          "rme": 6.5,
+          "tier": "blazing"
+        },
+        "Compute spans (1,000 items, 1 column)": {
+          "name": "Compute spans (1,000 items, 1 column)",
+          "hz": 282,
+          "hzLabel": "282 ops/s",
+          "mean": 3.551678801419425,
+          "meanLabel": "3.55ms",
+          "rme": 5.7,
+          "tier": "fast"
+        },
+        "Compute spans (10,000 items, 1 column)": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 28,
+          "hzLabel": "28 ops/s",
+          "mean": 35.83652271429725,
+          "meanLabel": "35.84ms",
+          "rme": 3.2,
+          "tier": "good"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 440159,
+          "hzLabel": "440.2k ops/s",
+          "mean": 0.0022719051753575894,
+          "meanLabel": "2.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 447605,
+          "hzLabel": "447.6k ops/s",
+          "mean": 0.0022341105033984016,
+          "meanLabel": "2.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 635718,
+          "hzLabel": "635.7k ops/s",
+          "mean": 0.0015730241615391825,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access layout.columns 100 times (1,000 items, cached)": {
+          "name": "Access layout.columns 100 times (1,000 items, cached)",
+          "hz": 615284,
+          "hzLabel": "615.3k ops/s",
+          "mean": 0.0016252654147791026,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access layout.pinned 100 times (1,000 items, cached)": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 631498,
+          "hzLabel": "631.5k ops/s",
+          "mean": 0.0015835374204414864,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1296,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7716074567882812,
+          "meanLabel": "771.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 134,
+          "hzLabel": "134 ops/s",
+          "mean": 7.469946641790326,
+          "meanLabel": "7.47ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (1,000 items)": {
+          "name": "Search + sort + paginate + layout (1,000 items)",
+          "hz": 1136,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.8805690598591112,
+          "meanLabel": "880.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (10,000 items)": {
+          "name": "Search + sort + paginate + layout (10,000 items)",
+          "hz": 133,
+          "hzLabel": "133 ops/s",
+          "mean": 7.541079910446841,
+          "meanLabel": "7.54ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 635718,
+          "hzLabel": "635.7k ops/s",
+          "mean": 0.0015730241615391825,
+          "meanLabel": "1.6μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 28,
+          "hzLabel": "28 ops/s",
+          "mean": 35.83652271429725,
+          "meanLabel": "35.84ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createFilter": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty filter": {
+              "name": "Create empty filter",
+              "hz": 7727533,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012940739930640663,
+              "meanLabel": "129ns",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Create filter with keys constraint": {
+              "name": "Create filter with keys constraint",
+              "hz": 7704370,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.0001297964623147311,
+              "meanLabel": "130ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Create filter with custom matcher": {
+              "name": "Create filter with custom matcher",
+              "hz": 6838253,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014623617432506255,
+              "meanLabel": "146ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty filter",
+              "hz": 7727533,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012940739930640663,
+              "meanLabel": "129ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create filter with custom matcher",
+              "hz": 6838253,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014623617432506255,
+              "meanLabel": "146ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "primitive filtering": {
+            "Filter 1,000 string primitives with single query": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 6631562,
+              "hzLabel": "6.6M ops/s",
+              "mean": 0.0001507940289722069,
+              "meanLabel": "151ns",
+              "rme": 3.7,
+              "tier": "blazing"
+            },
+            "Filter 10,000 string primitives with single query": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 6882661,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014529264810036506,
+              "meanLabel": "145ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 6882661,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014529264810036506,
+              "meanLabel": "145ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 6631562,
+              "hzLabel": "6.6M ops/s",
+              "mean": 0.0001507940289722069,
+              "meanLabel": "151ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "object filtering": {
+            "Filter 1,000 objects across all keys": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 6704524,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00014915302771381699,
+              "meanLabel": "149ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with single key constraint": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 6773757,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014762857071992384,
+              "meanLabel": "148ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects across all keys": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 6765977,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014779831178176025,
+              "meanLabel": "148ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with single key constraint": {
+              "name": "Filter 10,000 objects with single key constraint",
+              "hz": 6760232,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.0001479239179951715,
+              "meanLabel": "148ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 6773757,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014762857071992384,
+              "meanLabel": "148ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 6704524,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00014915302771381699,
+              "meanLabel": "149ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "filter modes": {
+            "Filter 1,000 objects with some mode": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 6681673,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.0001496631251473255,
+              "meanLabel": "150ns",
+              "rme": 4.2,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with every mode": {
+              "name": "Filter 1,000 objects with every mode",
+              "hz": 6861639,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014573778367265406,
+              "meanLabel": "146ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with union mode (2 queries)": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 6681725,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00014966196099703072,
+              "meanLabel": "150ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with intersection mode (2 queries)": {
+              "name": "Filter 1,000 objects with intersection mode (2 queries)",
+              "hz": 6691331,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00014944710022923657,
+              "meanLabel": "149ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with some mode": {
+              "name": "Filter 10,000 objects with some mode",
+              "hz": 6843696,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.0001461198820079055,
+              "meanLabel": "146ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with every mode": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 6847849,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014603126762384948,
+              "meanLabel": "146ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 objects with every mode",
+              "hz": 6861639,
+              "hzLabel": "6.9M ops/s",
+              "mean": 0.00014573778367265406,
+              "meanLabel": "146ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 6681673,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.0001496631251473255,
+              "meanLabel": "150ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Access filtered 100 times (1,000 items, cached)": {
+              "name": "Access filtered 100 times (1,000 items, cached)",
+              "hz": 2100430,
+              "hzLabel": "2.1M ops/s",
+              "mean": 0.0004760929104121287,
+              "meanLabel": "476ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access filtered 100 times (10,000 items, cached)": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 2189126,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045680339551513663,
+              "meanLabel": "457ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Update query 10 times (1,000 items)": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 515451,
+              "hzLabel": "515.5k ops/s",
+              "mean": 0.0019400479423434,
+              "meanLabel": "1.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Update query 10 times (10,000 items)": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 520141,
+              "hzLabel": "520.1k ops/s",
+              "mean": 0.0019225554098255982,
+              "meanLabel": "1.9μs",
+              "rme": 2.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 2189126,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045680339551513663,
+              "meanLabel": "457ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 515451,
+              "hzLabel": "515.5k ops/s",
+              "mean": 0.0019400479423434,
+              "meanLabel": "1.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "native comparison": {
+            "Native Array.filter 1,000 objects": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1756,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5696094362190827,
+              "meanLabel": "569.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Native Array.filter 10,000 objects": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 174,
+              "hzLabel": "174 ops/s",
+              "mean": 5.734675136361395,
+              "meanLabel": "5.73ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1756,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5696094362190827,
+              "meanLabel": "569.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 174,
+              "hzLabel": "174 ops/s",
+              "mean": 5.734675136361395,
+              "meanLabel": "5.73ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty filter": {
+          "name": "Create empty filter",
+          "hz": 7727533,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012940739930640663,
+          "meanLabel": "129ns",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Create filter with keys constraint": {
+          "name": "Create filter with keys constraint",
+          "hz": 7704370,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.0001297964623147311,
+          "meanLabel": "130ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Create filter with custom matcher": {
+          "name": "Create filter with custom matcher",
+          "hz": 6838253,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014623617432506255,
+          "meanLabel": "146ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 string primitives with single query": {
+          "name": "Filter 1,000 string primitives with single query",
+          "hz": 6631562,
+          "hzLabel": "6.6M ops/s",
+          "mean": 0.0001507940289722069,
+          "meanLabel": "151ns",
+          "rme": 3.7,
+          "tier": "blazing"
+        },
+        "Filter 10,000 string primitives with single query": {
+          "name": "Filter 10,000 string primitives with single query",
+          "hz": 6882661,
+          "hzLabel": "6.9M ops/s",
+          "mean": 0.00014529264810036506,
+          "meanLabel": "145ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects across all keys": {
+          "name": "Filter 1,000 objects across all keys",
+          "hz": 6704524,
+          "hzLabel": "6.7M ops/s",
+          "mean": 0.00014915302771381699,
+          "meanLabel": "149ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with single key constraint": {
+          "name": "Filter 1,000 objects with single key constraint",
+          "hz": 6773757,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014762857071992384,
+          "meanLabel": "148ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects across all keys": {
+          "name": "Filter 10,000 objects across all keys",
+          "hz": 6765977,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014779831178176025,
+          "meanLabel": "148ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with single key constraint": {
+          "name": "Filter 10,000 objects with single key constraint",
+          "hz": 6760232,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.0001479239179951715,
+          "meanLabel": "148ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with some mode": {
+          "name": "Filter 1,000 objects with some mode",
+          "hz": 6681673,
+          "hzLabel": "6.7M ops/s",
+          "mean": 0.0001496631251473255,
+          "meanLabel": "150ns",
+          "rme": 4.2,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with every mode": {
+          "name": "Filter 1,000 objects with every mode",
+          "hz": 6861639,
+          "hzLabel": "6.9M ops/s",
+          "mean": 0.00014573778367265406,
+          "meanLabel": "146ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with union mode (2 queries)": {
+          "name": "Filter 1,000 objects with union mode (2 queries)",
+          "hz": 6681725,
+          "hzLabel": "6.7M ops/s",
+          "mean": 0.00014966196099703072,
+          "meanLabel": "150ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with intersection mode (2 queries)": {
+          "name": "Filter 1,000 objects with intersection mode (2 queries)",
+          "hz": 6691331,
+          "hzLabel": "6.7M ops/s",
+          "mean": 0.00014944710022923657,
+          "meanLabel": "149ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with some mode": {
+          "name": "Filter 10,000 objects with some mode",
+          "hz": 6843696,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.0001461198820079055,
+          "meanLabel": "146ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with every mode": {
+          "name": "Filter 10,000 objects with every mode",
+          "hz": 6847849,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014603126762384948,
+          "meanLabel": "146ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (1,000 items, cached)": {
+          "name": "Access filtered 100 times (1,000 items, cached)",
+          "hz": 2100430,
+          "hzLabel": "2.1M ops/s",
+          "mean": 0.0004760929104121287,
+          "meanLabel": "476ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (10,000 items, cached)": {
+          "name": "Access filtered 100 times (10,000 items, cached)",
+          "hz": 2189126,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00045680339551513663,
+          "meanLabel": "457ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Update query 10 times (1,000 items)": {
+          "name": "Update query 10 times (1,000 items)",
+          "hz": 515451,
+          "hzLabel": "515.5k ops/s",
+          "mean": 0.0019400479423434,
+          "meanLabel": "1.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Update query 10 times (10,000 items)": {
+          "name": "Update query 10 times (10,000 items)",
+          "hz": 520141,
+          "hzLabel": "520.1k ops/s",
+          "mean": 0.0019225554098255982,
+          "meanLabel": "1.9μs",
+          "rme": 2.1,
+          "tier": "blazing"
+        },
+        "Native Array.filter 1,000 objects": {
+          "name": "Native Array.filter 1,000 objects",
+          "hz": 1756,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5696094362190827,
+          "meanLabel": "569.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Native Array.filter 10,000 objects": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 174,
+          "hzLabel": "174 ops/s",
+          "mean": 5.734675136361395,
+          "meanLabel": "5.73ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Create empty filter",
+          "hz": 7727533,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012940739930640663,
+          "meanLabel": "129ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 174,
+          "hzLabel": "174 ops/s",
+          "mean": 5.734675136361395,
+          "meanLabel": "5.73ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createGroup": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty group": {
+              "name": "Create empty group",
+              "hz": 27745,
+              "hzLabel": "27.7k ops/s",
+              "mean": 0.036042139623711396,
+              "meanLabel": "36.0μs",
+              "rme": 9.5,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 494,
+              "hzLabel": "494 ops/s",
+              "mean": 2.0247326923087936,
+              "meanLabel": "2.02ms",
+              "rme": 8.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 46,
+              "hzLabel": "46 ops/s",
+              "mean": 21.854734391310636,
+              "meanLabel": "21.85ms",
+              "rme": 4.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 466,
+              "hzLabel": "466 ops/s",
+              "mean": 2.146809401709992,
+              "meanLabel": "2.15ms",
+              "rme": 9.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.48679231817633,
+              "meanLabel": "23.49ms",
+              "rme": 9.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty group",
+              "hz": 27745,
+              "hzLabel": "27.7k ops/s",
+              "mean": 0.036042139623711396,
+              "meanLabel": "36.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.48679231817633,
+              "meanLabel": "23.49ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2203010,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045392442886339377,
+              "meanLabel": "454ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2211470,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.000452187951876914,
+              "meanLabel": "452ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2211470,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.000452187951876914,
+              "meanLabel": "452ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2203010,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045392442886339377,
+              "meanLabel": "454ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 992459,
+              "hzLabel": "992.5k ops/s",
+              "mean": 0.001007598194404451,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 995201,
+              "hzLabel": "995.2k ops/s",
+              "mean": 0.0010048225063987956,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 566750,
+              "hzLabel": "566.7k ops/s",
+              "mean": 0.001764447834100336,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 567983,
+              "hzLabel": "568.0k ops/s",
+              "mean": 0.0017606151159053405,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 693035,
+              "hzLabel": "693.0k ops/s",
+              "mean": 0.0014429276834292478,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 669866,
+              "hzLabel": "669.9k ops/s",
+              "mean": 0.0014928360896319028,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (10,000 items)",
+              "hz": 995201,
+              "hzLabel": "995.2k ops/s",
+              "mean": 0.0010048225063987956,
+              "meanLabel": "1.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 566750,
+              "hzLabel": "566.7k ops/s",
+              "mean": 0.001764447834100336,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mixed state": {
+            "Mix single item (1,000 items)": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 438553,
+              "hzLabel": "438.6k ops/s",
+              "mean": 0.002280224756773669,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unmix single item (1,000 items)": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 600959,
+              "hzLabel": "601.0k ops/s",
+              "mean": 0.0016640073515496135,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 600959,
+              "hzLabel": "601.0k ops/s",
+              "mean": 0.0016640073515496135,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 438553,
+              "hzLabel": "438.6k ops/s",
+              "mean": 0.002280224756773669,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1014,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9864967061143325,
+              "meanLabel": "986.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.35314108163584,
+              "meanLabel": "10.35ms",
+              "rme": 0.5,
+              "tier": "fast"
+            },
+            "Unselect all 1,000 items (from full)": {
+              "name": "Unselect all 1,000 items (from full)",
+              "hz": 997,
+              "hzLabel": "997 ops/s",
+              "mean": 1.002547849698635,
+              "meanLabel": "1.00ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (none→all)": {
+              "name": "Toggle all 1,000 items (none→all)",
+              "hz": 914,
+              "hzLabel": "914 ops/s",
+              "mean": 1.093647104804404,
+              "meanLabel": "1.09ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (all→none)": {
+              "name": "Toggle all 1,000 items (all→none)",
+              "hz": 652,
+              "hzLabel": "652 ops/s",
+              "mean": 1.5334297828750103,
+              "meanLabel": "1.53ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 1014,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9864967061143325,
+              "meanLabel": "986.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all 10,000 items",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.35314108163584,
+              "meanLabel": "10.35ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 639639,
+              "hzLabel": "639.6k ops/s",
+              "mean": 0.0015633816553445698,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 594183,
+              "hzLabel": "594.2k ops/s",
+              "mean": 0.0016829827393690653,
+              "meanLabel": "1.7μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Access isAllSelected 100 times (partial, cached)": {
+              "name": "Access isAllSelected 100 times (partial, cached)",
+              "hz": 637048,
+              "hzLabel": "637.0k ops/s",
+              "mean": 0.0015697410839005648,
+              "meanLabel": "1.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access isNoneSelected 100 times (partial, cached)": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43617,
+              "hzLabel": "43.6k ops/s",
+              "mean": 0.02292670049057588,
+              "meanLabel": "22.9μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isMixed 100 times (partial, cached)": {
+              "name": "Access isMixed 100 times (partial, cached)",
+              "hz": 598166,
+              "hzLabel": "598.2k ops/s",
+              "mean": 0.0016717762936600236,
+              "meanLabel": "1.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 639639,
+              "hzLabel": "639.6k ops/s",
+              "mean": 0.0015633816553445698,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43617,
+              "hzLabel": "43.6k ops/s",
+              "mean": 0.02292670049057588,
+              "meanLabel": "22.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty group": {
+          "name": "Create empty group",
+          "hz": 27745,
+          "hzLabel": "27.7k ops/s",
+          "mean": 0.036042139623711396,
+          "meanLabel": "36.0μs",
+          "rme": 9.5,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 494,
+          "hzLabel": "494 ops/s",
+          "mean": 2.0247326923087936,
+          "meanLabel": "2.02ms",
+          "rme": 8.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 46,
+          "hzLabel": "46 ops/s",
+          "mean": 21.854734391310636,
+          "meanLabel": "21.85ms",
+          "rme": 4.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 466,
+          "hzLabel": "466 ops/s",
+          "mean": 2.146809401709992,
+          "meanLabel": "2.15ms",
+          "rme": 9.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.48679231817633,
+          "meanLabel": "23.49ms",
+          "rme": 9.5,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2203010,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00045392442886339377,
+          "meanLabel": "454ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2211470,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.000452187951876914,
+          "meanLabel": "452ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 992459,
+          "hzLabel": "992.5k ops/s",
+          "mean": 0.001007598194404451,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 995201,
+          "hzLabel": "995.2k ops/s",
+          "mean": 0.0010048225063987956,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 566750,
+          "hzLabel": "566.7k ops/s",
+          "mean": 0.001764447834100336,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 567983,
+          "hzLabel": "568.0k ops/s",
+          "mean": 0.0017606151159053405,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 693035,
+          "hzLabel": "693.0k ops/s",
+          "mean": 0.0014429276834292478,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 669866,
+          "hzLabel": "669.9k ops/s",
+          "mean": 0.0014928360896319028,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Mix single item (1,000 items)": {
+          "name": "Mix single item (1,000 items)",
+          "hz": 438553,
+          "hzLabel": "438.6k ops/s",
+          "mean": 0.002280224756773669,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unmix single item (1,000 items)": {
+          "name": "Unmix single item (1,000 items)",
+          "hz": 600959,
+          "hzLabel": "601.0k ops/s",
+          "mean": 0.0016640073515496135,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1014,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9864967061143325,
+          "meanLabel": "986.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.35314108163584,
+          "meanLabel": "10.35ms",
+          "rme": 0.5,
+          "tier": "fast"
+        },
+        "Unselect all 1,000 items (from full)": {
+          "name": "Unselect all 1,000 items (from full)",
+          "hz": 997,
+          "hzLabel": "997 ops/s",
+          "mean": 1.002547849698635,
+          "meanLabel": "1.00ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (none→all)": {
+          "name": "Toggle all 1,000 items (none→all)",
+          "hz": 914,
+          "hzLabel": "914 ops/s",
+          "mean": 1.093647104804404,
+          "meanLabel": "1.09ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (all→none)": {
+          "name": "Toggle all 1,000 items (all→none)",
+          "hz": 652,
+          "hzLabel": "652 ops/s",
+          "mean": 1.5334297828750103,
+          "meanLabel": "1.53ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+          "hz": 639639,
+          "hzLabel": "639.6k ops/s",
+          "mean": 0.0015633816553445698,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 594183,
+          "hzLabel": "594.2k ops/s",
+          "mean": 0.0016829827393690653,
+          "meanLabel": "1.7μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Access isAllSelected 100 times (partial, cached)": {
+          "name": "Access isAllSelected 100 times (partial, cached)",
+          "hz": 637048,
+          "hzLabel": "637.0k ops/s",
+          "mean": 0.0015697410839005648,
+          "meanLabel": "1.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access isNoneSelected 100 times (partial, cached)": {
+          "name": "Access isNoneSelected 100 times (partial, cached)",
+          "hz": 43617,
+          "hzLabel": "43.6k ops/s",
+          "mean": 0.02292670049057588,
+          "meanLabel": "22.9μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isMixed 100 times (partial, cached)": {
+          "name": "Access isMixed 100 times (partial, cached)",
+          "hz": 598166,
+          "hzLabel": "598.2k ops/s",
+          "mean": 0.0016717762936600236,
+          "meanLabel": "1.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2211470,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.000452187951876914,
+          "meanLabel": "452ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.48679231817633,
+          "meanLabel": "23.49ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createModel": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty model": {
+              "name": "Create empty model",
+              "hz": 89721,
+              "hzLabel": "89.7k ops/s",
+              "mean": 0.011145605068865685,
+              "meanLabel": "11.1μs",
+              "rme": 11.1,
+              "tier": "fast"
+            },
+            "Register 1,000 items": {
+              "name": "Register 1,000 items",
+              "hz": 481,
+              "hzLabel": "481 ops/s",
+              "mean": 2.078216211618643,
+              "meanLabel": "2.08ms",
+              "rme": 8.1,
+              "tier": "fast"
+            },
+            "Register 10,000 items": {
+              "name": "Register 10,000 items",
+              "hz": 49,
+              "hzLabel": "49 ops/s",
+              "mean": 20.554921719999985,
+              "meanLabel": "20.55ms",
+              "rme": 5,
+              "tier": "fast"
+            },
+            "Register 1,000 items (disabled)": {
+              "name": "Register 1,000 items (disabled)",
+              "hz": 1025,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9752426783624151,
+              "meanLabel": "975.2μs",
+              "rme": 9,
+              "tier": "blazing"
+            },
+            "Register 10,000 items (disabled)": {
+              "name": "Register 10,000 items (disabled)",
+              "hz": 96,
+              "hzLabel": "96 ops/s",
+              "mean": 10.421785897959609,
+              "meanLabel": "10.42ms",
+              "rme": 10.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty model",
+              "hz": 89721,
+              "hzLabel": "89.7k ops/s",
+              "mean": 0.011145605068865685,
+              "meanLabel": "11.1μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items",
+              "hz": 49,
+              "hzLabel": "49 ops/s",
+              "mean": 20.554921719999985,
+              "meanLabel": "20.55ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2210024,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004524838101266566,
+              "meanLabel": "452ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2200536,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004544348013106449,
+              "meanLabel": "454ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7347486,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013610097766587916,
+              "meanLabel": "136ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7302570,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013693809166356242,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6443844,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015518687881856284,
+              "meanLabel": "155ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6295391,
+              "hzLabel": "6.3M ops/s",
+              "mean": 0.00015884636287166788,
+              "meanLabel": "159ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7347486,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013610097766587916,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2200536,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004544348013106449,
+              "meanLabel": "454ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 866482,
+              "hzLabel": "866.5k ops/s",
+              "mean": 0.0011540923619926533,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 834199,
+              "hzLabel": "834.2k ops/s",
+              "mean": 0.001198754205226715,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 598263,
+              "hzLabel": "598.3k ops/s",
+              "mean": 0.0016715046400608282,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 594246,
+              "hzLabel": "594.2k ops/s",
+              "mean": 0.001682805528354266,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 795754,
+              "hzLabel": "795.8k ops/s",
+              "mean": 0.0012566704710012997,
+              "meanLabel": "1.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 808629,
+              "hzLabel": "808.6k ops/s",
+              "mean": 0.0012366611181806734,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select disabled item (1,000 items)": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7080447,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014123401909580692,
+              "meanLabel": "141ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7080447,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014123401909580692,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 594246,
+              "hzLabel": "594.2k ops/s",
+              "mean": 0.001682805528354266,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "apply operations": {
+            "Apply static value (1,000 items)": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 282486,
+              "hzLabel": "282.5k ops/s",
+              "mean": 0.0035399984565484236,
+              "meanLabel": "3.5μs",
+              "rme": 4,
+              "tier": "blazing"
+            },
+            "Apply static value (10,000 items)": {
+              "name": "Apply static value (10,000 items)",
+              "hz": 272945,
+              "hzLabel": "272.9k ops/s",
+              "mean": 0.0036637399998173535,
+              "meanLabel": "3.7μs",
+              "rme": 5.1,
+              "tier": "blazing"
+            },
+            "Apply ref value (1,000 items)": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 57530,
+              "hzLabel": "57.5k ops/s",
+              "mean": 0.01738229910745753,
+              "meanLabel": "17.4μs",
+              "rme": 10.4,
+              "tier": "blazing"
+            },
+            "Apply undefined (1,000 items)": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 293581,
+              "hzLabel": "293.6k ops/s",
+              "mean": 0.003406217649586617,
+              "meanLabel": "3.4μs",
+              "rme": 3.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 293581,
+              "hzLabel": "293.6k ops/s",
+              "mean": 0.003406217649586617,
+              "meanLabel": "3.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 57530,
+              "hzLabel": "57.5k ops/s",
+              "mean": 0.01738229910745753,
+              "meanLabel": "17.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 1,000 then offboard 100 items": {
+              "name": "Onboard 1,000 then offboard 100 items",
+              "hz": 434,
+              "hzLabel": "434 ops/s",
+              "mean": 2.3017770733948373,
+              "meanLabel": "2.30ms",
+              "rme": 7.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 then offboard 1,000 items": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.521807636361867,
+              "meanLabel": "23.52ms",
+              "rme": 4.7,
+              "tier": "fast"
+            },
+            "Reset (1,000 items)": {
+              "name": "Reset (1,000 items)",
+              "hz": 610486,
+              "hzLabel": "610.5k ops/s",
+              "mean": 0.0016380401221176644,
+              "meanLabel": "1.6μs",
+              "rme": 3.9,
+              "tier": "blazing"
+            },
+            "Reset (10,000 items)": {
+              "name": "Reset (10,000 items)",
+              "hz": 633043,
+              "hzLabel": "633.0k ops/s",
+              "mean": 0.001579671719491943,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reset (10,000 items)",
+              "hz": 633043,
+              "hzLabel": "633.0k ops/s",
+              "mean": 0.001579671719491943,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.521807636361867,
+              "meanLabel": "23.52ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 667948,
+              "hzLabel": "667.9k ops/s",
+              "mean": 0.0014971214641975306,
+              "meanLabel": "1.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+              "hz": 668356,
+              "hzLabel": "668.4k ops/s",
+              "mean": 0.0014962089934202555,
+              "meanLabel": "1.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 805740,
+              "hzLabel": "805.7k ops/s",
+              "mean": 0.0012410955147013172,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 635840,
+              "hzLabel": "635.8k ops/s",
+              "mean": 0.0015727236915191282,
+              "meanLabel": "1.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 805740,
+              "hzLabel": "805.7k ops/s",
+              "mean": 0.0012410955147013172,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 635840,
+              "hzLabel": "635.8k ops/s",
+              "mean": 0.0015727236915191282,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty model": {
+          "name": "Create empty model",
+          "hz": 89721,
+          "hzLabel": "89.7k ops/s",
+          "mean": 0.011145605068865685,
+          "meanLabel": "11.1μs",
+          "rme": 11.1,
+          "tier": "fast"
+        },
+        "Register 1,000 items": {
+          "name": "Register 1,000 items",
+          "hz": 481,
+          "hzLabel": "481 ops/s",
+          "mean": 2.078216211618643,
+          "meanLabel": "2.08ms",
+          "rme": 8.1,
+          "tier": "fast"
+        },
+        "Register 10,000 items": {
+          "name": "Register 10,000 items",
+          "hz": 49,
+          "hzLabel": "49 ops/s",
+          "mean": 20.554921719999985,
+          "meanLabel": "20.55ms",
+          "rme": 5,
+          "tier": "fast"
+        },
+        "Register 1,000 items (disabled)": {
+          "name": "Register 1,000 items (disabled)",
+          "hz": 1025,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9752426783624151,
+          "meanLabel": "975.2μs",
+          "rme": 9,
+          "tier": "blazing"
+        },
+        "Register 10,000 items (disabled)": {
+          "name": "Register 10,000 items (disabled)",
+          "hz": 96,
+          "hzLabel": "96 ops/s",
+          "mean": 10.421785897959609,
+          "meanLabel": "10.42ms",
+          "rme": 10.1,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2210024,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004524838101266566,
+          "meanLabel": "452ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2200536,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004544348013106449,
+          "meanLabel": "454ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7347486,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013610097766587916,
+          "meanLabel": "136ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7302570,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013693809166356242,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6443844,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.00015518687881856284,
+          "meanLabel": "155ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6295391,
+          "hzLabel": "6.3M ops/s",
+          "mean": 0.00015884636287166788,
+          "meanLabel": "159ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 866482,
+          "hzLabel": "866.5k ops/s",
+          "mean": 0.0011540923619926533,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 834199,
+          "hzLabel": "834.2k ops/s",
+          "mean": 0.001198754205226715,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 598263,
+          "hzLabel": "598.3k ops/s",
+          "mean": 0.0016715046400608282,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 594246,
+          "hzLabel": "594.2k ops/s",
+          "mean": 0.001682805528354266,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 795754,
+          "hzLabel": "795.8k ops/s",
+          "mean": 0.0012566704710012997,
+          "meanLabel": "1.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 808629,
+          "hzLabel": "808.6k ops/s",
+          "mean": 0.0012366611181806734,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select disabled item (1,000 items)": {
+          "name": "Select disabled item (1,000 items)",
+          "hz": 7080447,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014123401909580692,
+          "meanLabel": "141ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Apply static value (1,000 items)": {
+          "name": "Apply static value (1,000 items)",
+          "hz": 282486,
+          "hzLabel": "282.5k ops/s",
+          "mean": 0.0035399984565484236,
+          "meanLabel": "3.5μs",
+          "rme": 4,
+          "tier": "blazing"
+        },
+        "Apply static value (10,000 items)": {
+          "name": "Apply static value (10,000 items)",
+          "hz": 272945,
+          "hzLabel": "272.9k ops/s",
+          "mean": 0.0036637399998173535,
+          "meanLabel": "3.7μs",
+          "rme": 5.1,
+          "tier": "blazing"
+        },
+        "Apply ref value (1,000 items)": {
+          "name": "Apply ref value (1,000 items)",
+          "hz": 57530,
+          "hzLabel": "57.5k ops/s",
+          "mean": 0.01738229910745753,
+          "meanLabel": "17.4μs",
+          "rme": 10.4,
+          "tier": "blazing"
+        },
+        "Apply undefined (1,000 items)": {
+          "name": "Apply undefined (1,000 items)",
+          "hz": 293581,
+          "hzLabel": "293.6k ops/s",
+          "mean": 0.003406217649586617,
+          "meanLabel": "3.4μs",
+          "rme": 3.2,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 100 items": {
+          "name": "Onboard 1,000 then offboard 100 items",
+          "hz": 434,
+          "hzLabel": "434 ops/s",
+          "mean": 2.3017770733948373,
+          "meanLabel": "2.30ms",
+          "rme": 7.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 then offboard 1,000 items": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.521807636361867,
+          "meanLabel": "23.52ms",
+          "rme": 4.7,
+          "tier": "fast"
+        },
+        "Reset (1,000 items)": {
+          "name": "Reset (1,000 items)",
+          "hz": 610486,
+          "hzLabel": "610.5k ops/s",
+          "mean": 0.0016380401221176644,
+          "meanLabel": "1.6μs",
+          "rme": 3.9,
+          "tier": "blazing"
+        },
+        "Reset (10,000 items)": {
+          "name": "Reset (10,000 items)",
+          "hz": 633043,
+          "hzLabel": "633.0k ops/s",
+          "mean": 0.001579671719491943,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+          "hz": 667948,
+          "hzLabel": "667.9k ops/s",
+          "mean": 0.0014971214641975306,
+          "meanLabel": "1.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+          "hz": 668356,
+          "hzLabel": "668.4k ops/s",
+          "mean": 0.0014962089934202555,
+          "meanLabel": "1.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+          "hz": 805740,
+          "hzLabel": "805.7k ops/s",
+          "mean": 0.0012410955147013172,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+          "hz": 635840,
+          "hzLabel": "635.8k ops/s",
+          "mean": 0.0015727236915191282,
+          "meanLabel": "1.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7347486,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013610097766587916,
+          "meanLabel": "136ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.521807636361867,
+          "meanLabel": "23.52ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createNested": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty nested": {
+              "name": "Create empty nested",
+              "hz": 17370,
+              "hzLabel": "17.4k ops/s",
+              "mean": 0.057571517789258064,
+              "meanLabel": "57.6μs",
+              "rme": 8.1,
+              "tier": "fast"
+            },
+            "Onboard 1,000 flat items": {
+              "name": "Onboard 1,000 flat items",
+              "hz": 177,
+              "hzLabel": "177 ops/s",
+              "mean": 5.656014707864977,
+              "meanLabel": "5.66ms",
+              "rme": 7.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 flat items": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 18,
+              "hzLabel": "18 ops/s",
+              "mean": 54.44263539999956,
+              "meanLabel": "54.44ms",
+              "rme": 2.4,
+              "tier": "good"
+            },
+            "Onboard ~1,000 tree items (depth 3)": {
+              "name": "Onboard ~1,000 tree items (depth 3)",
+              "hz": 191,
+              "hzLabel": "191 ops/s",
+              "mean": 5.246560312500075,
+              "meanLabel": "5.25ms",
+              "rme": 7,
+              "tier": "fast"
+            },
+            "Onboard ~10,000 tree items (depth 4)": {
+              "name": "Onboard ~10,000 tree items (depth 4)",
+              "hz": 15,
+              "hzLabel": "15 ops/s",
+              "mean": 68.84874090000012,
+              "meanLabel": "68.85ms",
+              "rme": 36.8,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Create empty nested",
+              "hz": 17370,
+              "hzLabel": "17.4k ops/s",
+              "mean": 0.057571517789258064,
+              "meanLabel": "57.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard ~10,000 tree items (depth 4)",
+              "hz": 15,
+              "hzLabel": "15 ops/s",
+              "mean": 68.84874090000012,
+              "meanLabel": "68.85ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "lookup operations": {
+            "Get by id (1,000 flat items)": {
+              "name": "Get by id (1,000 flat items)",
+              "hz": 7217552,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013855113811279184,
+              "meanLabel": "139ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 flat items)": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 7191617,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001390507899617338,
+              "meanLabel": "139ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Check isLeaf (1,000 tree items)": {
+              "name": "Check isLeaf (1,000 tree items)",
+              "hz": 1754269,
+              "hzLabel": "1.8M ops/s",
+              "mean": 0.0005700379052288386,
+              "meanLabel": "570ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check isLeaf (10,000 tree items)": {
+              "name": "Check isLeaf (10,000 tree items)",
+              "hz": 1758120,
+              "hzLabel": "1.8M ops/s",
+              "mean": 0.0005687892592173776,
+              "meanLabel": "569ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get depth (1,000 tree items)": {
+              "name": "Get depth (1,000 tree items)",
+              "hz": 584843,
+              "hzLabel": "584.8k ops/s",
+              "mean": 0.0017098598976639356,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get depth (10,000 tree items)": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 454190,
+              "hzLabel": "454.2k ops/s",
+              "mean": 0.0022017205235015332,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check opened state (1,000 items)": {
+              "name": "Check opened state (1,000 items)",
+              "hz": 2180530,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045860400948082724,
+              "meanLabel": "459ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected state (1,000 items)": {
+              "name": "Check selected state (1,000 items)",
+              "hz": 2184974,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045767130805892997,
+              "meanLabel": "458ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (1,000 flat items)",
+              "hz": 7217552,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013855113811279184,
+              "meanLabel": "139ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 454190,
+              "hzLabel": "454.2k ops/s",
+              "mean": 0.0022017205235015332,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "traversal operations": {
+            "Get path to deep node (1,000 tree items)": {
+              "name": "Get path to deep node (1,000 tree items)",
+              "hz": 599983,
+              "hzLabel": "600.0k ops/s",
+              "mean": 0.001666714292370274,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get path to deep node (10,000 tree items)": {
+              "name": "Get path to deep node (10,000 tree items)",
+              "hz": 467401,
+              "hzLabel": "467.4k ops/s",
+              "mean": 0.0021394891121577398,
+              "meanLabel": "2.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (1,000 tree items)": {
+              "name": "Get ancestors of deep node (1,000 tree items)",
+              "hz": 591975,
+              "hzLabel": "592.0k ops/s",
+              "mean": 0.0016892604193435082,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (10,000 tree items)": {
+              "name": "Get ancestors of deep node (10,000 tree items)",
+              "hz": 460249,
+              "hzLabel": "460.2k ops/s",
+              "mean": 0.002172735235194227,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (1,000 tree items)": {
+              "name": "Get descendants of root node (1,000 tree items)",
+              "hz": 19197,
+              "hzLabel": "19.2k ops/s",
+              "mean": 0.05209274653613451,
+              "meanLabel": "52.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (10,000 tree items)": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1867,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5356527944319008,
+              "meanLabel": "535.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access roots (1,000 tree items)": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 6802077,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014701392044665597,
+              "meanLabel": "147ns",
+              "rme": 2.1,
+              "tier": "blazing"
+            },
+            "Access leaves (1,000 tree items)": {
+              "name": "Access leaves (1,000 tree items)",
+              "hz": 7056682,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014170966411886391,
+              "meanLabel": "142ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access leaves (1,000 tree items)",
+              "hz": 7056682,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014170966411886391,
+              "meanLabel": "142ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1867,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5356527944319008,
+              "meanLabel": "535.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open/close operations": {
+            "Open single node (1,000 tree items)": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1626788,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.000614708168837662,
+              "meanLabel": "615ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open single node (10,000 tree items)": {
+              "name": "Open single node (10,000 tree items)",
+              "hz": 1600235,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006249080848084969,
+              "meanLabel": "625ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Close single node (1,000 tree items)": {
+              "name": "Close single node (1,000 tree items)",
+              "hz": 635155,
+              "hzLabel": "635.2k ops/s",
+              "mean": 0.0015744183822635064,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle open (1,000 tree items)": {
+              "name": "Toggle open (1,000 tree items)",
+              "hz": 832669,
+              "hzLabel": "832.7k ops/s",
+              "mean": 0.0012009568664720425,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Expand all (1,000 tree items)": {
+              "name": "Expand all (1,000 tree items)",
+              "hz": 21428,
+              "hzLabel": "21.4k ops/s",
+              "mean": 0.04666682314504961,
+              "meanLabel": "46.7μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Expand all (10,000 tree items)": {
+              "name": "Expand all (10,000 tree items)",
+              "hz": 2111,
+              "hzLabel": "2.1k ops/s",
+              "mean": 0.47379451988626897,
+              "meanLabel": "473.8μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Collapse all (1,000 tree items)": {
+              "name": "Collapse all (1,000 tree items)",
+              "hz": 15888,
+              "hzLabel": "15.9k ops/s",
+              "mean": 0.06294017835112352,
+              "meanLabel": "62.9μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Collapse all (10,000 tree items)": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1514,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6606012721268182,
+              "meanLabel": "660.6μs",
+              "rme": 1.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1626788,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.000614708168837662,
+              "meanLabel": "615ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1514,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6606012721268182,
+              "meanLabel": "660.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select leaf node (1,000 tree items)": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 72362,
+              "hzLabel": "72.4k ops/s",
+              "mean": 0.013819477681718326,
+              "meanLabel": "13.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (1,000 tree items)": {
+              "name": "Select root node with cascade (1,000 tree items)",
+              "hz": 7486,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13357457211535273,
+              "meanLabel": "133.6μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (10,000 tree items)": {
+              "name": "Select root node with cascade (10,000 tree items)",
+              "hz": 729,
+              "hzLabel": "729 ops/s",
+              "mean": 1.3710930575345952,
+              "meanLabel": "1.37ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect root node with cascade (1,000 tree items)": {
+              "name": "Unselect root node with cascade (1,000 tree items)",
+              "hz": 3371,
+              "hzLabel": "3.4k ops/s",
+              "mean": 0.29667113582446514,
+              "meanLabel": "296.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle selection (1,000 tree items)": {
+              "name": "Toggle selection (1,000 tree items)",
+              "hz": 6601,
+              "hzLabel": "6.6k ops/s",
+              "mean": 0.1514845446834487,
+              "meanLabel": "151.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (1,000 tree items)": {
+              "name": "Select all via selectAll (1,000 tree items)",
+              "hz": 2643,
+              "hzLabel": "2.6k ops/s",
+              "mean": 0.3783889046898726,
+              "meanLabel": "378.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (10,000 tree items)": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 251,
+              "hzLabel": "251 ops/s",
+              "mean": 3.9829586825396133,
+              "meanLabel": "3.98ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 72362,
+              "hzLabel": "72.4k ops/s",
+              "mean": 0.013819477681718326,
+              "meanLabel": "13.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 251,
+              "hzLabel": "251 ops/s",
+              "mean": 3.9829586825396133,
+              "meanLabel": "3.98ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single root item": {
+              "name": "Register single root item",
+              "hz": 14931,
+              "hzLabel": "14.9k ops/s",
+              "mean": 0.06697457447096408,
+              "meanLabel": "67.0μs",
+              "rme": 10.6,
+              "tier": "fast"
+            },
+            "Register item with parent (1,000 items)": {
+              "name": "Register item with parent (1,000 items)",
+              "hz": 125,
+              "hzLabel": "125 ops/s",
+              "mean": 7.975299333332389,
+              "meanLabel": "7.98ms",
+              "rme": 47.3,
+              "tier": "fast"
+            },
+            "Unregister leaf node (1,000 tree items)": {
+              "name": "Unregister leaf node (1,000 tree items)",
+              "hz": 192,
+              "hzLabel": "192 ops/s",
+              "mean": 5.216640052083828,
+              "meanLabel": "5.22ms",
+              "rme": 6.7,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (1,000 tree items)": {
+              "name": "Unregister root with cascade (1,000 tree items)",
+              "hz": 168,
+              "hzLabel": "168 ops/s",
+              "mean": 5.956838583333246,
+              "meanLabel": "5.96ms",
+              "rme": 6,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (10,000 tree items)": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 13,
+              "hzLabel": "13 ops/s",
+              "mean": 77.1741635000013,
+              "meanLabel": "77.17ms",
+              "rme": 29.9,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Register single root item",
+              "hz": 14931,
+              "hzLabel": "14.9k ops/s",
+              "mean": 0.06697457447096408,
+              "meanLabel": "67.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 13,
+              "hzLabel": "13 ops/s",
+              "mean": 77.1741635000013,
+              "meanLabel": "77.17ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 tree items": {
+              "name": "Onboard then clear 1,000 tree items",
+              "hz": 235,
+              "hzLabel": "235 ops/s",
+              "mean": 4.248468127118925,
+              "meanLabel": "4.25ms",
+              "rme": 1.7,
+              "tier": "fast"
+            },
+            "Onboard then clear 10,000 tree items": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 18,
+              "hzLabel": "18 ops/s",
+              "mean": 56.00297730000166,
+              "meanLabel": "56.00ms",
+              "rme": 2.4,
+              "tier": "good"
+            },
+            "toFlat conversion (1,000 tree items)": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2017,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.4958553221010241,
+              "meanLabel": "495.9μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "toFlat conversion (10,000 tree items)": {
+              "name": "toFlat conversion (10,000 tree items)",
+              "hz": 191,
+              "hzLabel": "191 ops/s",
+              "mean": 5.239605041667346,
+              "meanLabel": "5.24ms",
+              "rme": 1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2017,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.4958553221010241,
+              "meanLabel": "495.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 18,
+              "hzLabel": "18 ops/s",
+              "mean": 56.00297730000166,
+              "meanLabel": "56.00ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "selection mode comparison": {
+            "Select root - cascade mode (1,000 tree items)": {
+              "name": "Select root - cascade mode (1,000 tree items)",
+              "hz": 7493,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13345598211918475,
+              "meanLabel": "133.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root - independent mode (1,000 tree items)": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 917199,
+              "hzLabel": "917.2k ops/s",
+              "mean": 0.0010902755974677876,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root - leaf mode (1,000 tree items)": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5308,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.1883861137475343,
+              "meanLabel": "188.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 917199,
+              "hzLabel": "917.2k ops/s",
+              "mean": 0.0010902755974677876,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5308,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.1883861137475343,
+              "meanLabel": "188.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open mode comparison": {
+            "Open 3 nodes - multiple mode (1,000 tree items)": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 633120,
+              "hzLabel": "633.1k ops/s",
+              "mean": 0.0015794783374957185,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Open 3 nodes - single mode (1,000 tree items)": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 105155,
+              "hzLabel": "105.2k ops/s",
+              "mean": 0.009509796302665756,
+              "meanLabel": "9.5μs",
+              "rme": 4.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 633120,
+              "hzLabel": "633.1k ops/s",
+              "mean": 0.0015794783374957185,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 105155,
+              "hzLabel": "105.2k ops/s",
+              "mean": 0.009509796302665756,
+              "meanLabel": "9.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty nested": {
+          "name": "Create empty nested",
+          "hz": 17370,
+          "hzLabel": "17.4k ops/s",
+          "mean": 0.057571517789258064,
+          "meanLabel": "57.6μs",
+          "rme": 8.1,
+          "tier": "fast"
+        },
+        "Onboard 1,000 flat items": {
+          "name": "Onboard 1,000 flat items",
+          "hz": 177,
+          "hzLabel": "177 ops/s",
+          "mean": 5.656014707864977,
+          "meanLabel": "5.66ms",
+          "rme": 7.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 flat items": {
+          "name": "Onboard 10,000 flat items",
+          "hz": 18,
+          "hzLabel": "18 ops/s",
+          "mean": 54.44263539999956,
+          "meanLabel": "54.44ms",
+          "rme": 2.4,
+          "tier": "good"
+        },
+        "Onboard ~1,000 tree items (depth 3)": {
+          "name": "Onboard ~1,000 tree items (depth 3)",
+          "hz": 191,
+          "hzLabel": "191 ops/s",
+          "mean": 5.246560312500075,
+          "meanLabel": "5.25ms",
+          "rme": 7,
+          "tier": "fast"
+        },
+        "Onboard ~10,000 tree items (depth 4)": {
+          "name": "Onboard ~10,000 tree items (depth 4)",
+          "hz": 15,
+          "hzLabel": "15 ops/s",
+          "mean": 68.84874090000012,
+          "meanLabel": "68.85ms",
+          "rme": 36.8,
+          "tier": "good"
+        },
+        "Get by id (1,000 flat items)": {
+          "name": "Get by id (1,000 flat items)",
+          "hz": 7217552,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013855113811279184,
+          "meanLabel": "139ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 flat items)": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 7191617,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.0001390507899617338,
+          "meanLabel": "139ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Check isLeaf (1,000 tree items)": {
+          "name": "Check isLeaf (1,000 tree items)",
+          "hz": 1754269,
+          "hzLabel": "1.8M ops/s",
+          "mean": 0.0005700379052288386,
+          "meanLabel": "570ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check isLeaf (10,000 tree items)": {
+          "name": "Check isLeaf (10,000 tree items)",
+          "hz": 1758120,
+          "hzLabel": "1.8M ops/s",
+          "mean": 0.0005687892592173776,
+          "meanLabel": "569ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get depth (1,000 tree items)": {
+          "name": "Get depth (1,000 tree items)",
+          "hz": 584843,
+          "hzLabel": "584.8k ops/s",
+          "mean": 0.0017098598976639356,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get depth (10,000 tree items)": {
+          "name": "Get depth (10,000 tree items)",
+          "hz": 454190,
+          "hzLabel": "454.2k ops/s",
+          "mean": 0.0022017205235015332,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check opened state (1,000 items)": {
+          "name": "Check opened state (1,000 items)",
+          "hz": 2180530,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00045860400948082724,
+          "meanLabel": "459ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected state (1,000 items)": {
+          "name": "Check selected state (1,000 items)",
+          "hz": 2184974,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00045767130805892997,
+          "meanLabel": "458ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get path to deep node (1,000 tree items)": {
+          "name": "Get path to deep node (1,000 tree items)",
+          "hz": 599983,
+          "hzLabel": "600.0k ops/s",
+          "mean": 0.001666714292370274,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get path to deep node (10,000 tree items)": {
+          "name": "Get path to deep node (10,000 tree items)",
+          "hz": 467401,
+          "hzLabel": "467.4k ops/s",
+          "mean": 0.0021394891121577398,
+          "meanLabel": "2.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (1,000 tree items)": {
+          "name": "Get ancestors of deep node (1,000 tree items)",
+          "hz": 591975,
+          "hzLabel": "592.0k ops/s",
+          "mean": 0.0016892604193435082,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (10,000 tree items)": {
+          "name": "Get ancestors of deep node (10,000 tree items)",
+          "hz": 460249,
+          "hzLabel": "460.2k ops/s",
+          "mean": 0.002172735235194227,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (1,000 tree items)": {
+          "name": "Get descendants of root node (1,000 tree items)",
+          "hz": 19197,
+          "hzLabel": "19.2k ops/s",
+          "mean": 0.05209274653613451,
+          "meanLabel": "52.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (10,000 tree items)": {
+          "name": "Get descendants of root node (10,000 tree items)",
+          "hz": 1867,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5356527944319008,
+          "meanLabel": "535.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access roots (1,000 tree items)": {
+          "name": "Access roots (1,000 tree items)",
+          "hz": 6802077,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014701392044665597,
+          "meanLabel": "147ns",
+          "rme": 2.1,
+          "tier": "blazing"
+        },
+        "Access leaves (1,000 tree items)": {
+          "name": "Access leaves (1,000 tree items)",
+          "hz": 7056682,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014170966411886391,
+          "meanLabel": "142ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Open single node (1,000 tree items)": {
+          "name": "Open single node (1,000 tree items)",
+          "hz": 1626788,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.000614708168837662,
+          "meanLabel": "615ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open single node (10,000 tree items)": {
+          "name": "Open single node (10,000 tree items)",
+          "hz": 1600235,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006249080848084969,
+          "meanLabel": "625ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Close single node (1,000 tree items)": {
+          "name": "Close single node (1,000 tree items)",
+          "hz": 635155,
+          "hzLabel": "635.2k ops/s",
+          "mean": 0.0015744183822635064,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle open (1,000 tree items)": {
+          "name": "Toggle open (1,000 tree items)",
+          "hz": 832669,
+          "hzLabel": "832.7k ops/s",
+          "mean": 0.0012009568664720425,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Expand all (1,000 tree items)": {
+          "name": "Expand all (1,000 tree items)",
+          "hz": 21428,
+          "hzLabel": "21.4k ops/s",
+          "mean": 0.04666682314504961,
+          "meanLabel": "46.7μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Expand all (10,000 tree items)": {
+          "name": "Expand all (10,000 tree items)",
+          "hz": 2111,
+          "hzLabel": "2.1k ops/s",
+          "mean": 0.47379451988626897,
+          "meanLabel": "473.8μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Collapse all (1,000 tree items)": {
+          "name": "Collapse all (1,000 tree items)",
+          "hz": 15888,
+          "hzLabel": "15.9k ops/s",
+          "mean": 0.06294017835112352,
+          "meanLabel": "62.9μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Collapse all (10,000 tree items)": {
+          "name": "Collapse all (10,000 tree items)",
+          "hz": 1514,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6606012721268182,
+          "meanLabel": "660.6μs",
+          "rme": 1.3,
+          "tier": "blazing"
+        },
+        "Select leaf node (1,000 tree items)": {
+          "name": "Select leaf node (1,000 tree items)",
+          "hz": 72362,
+          "hzLabel": "72.4k ops/s",
+          "mean": 0.013819477681718326,
+          "meanLabel": "13.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (1,000 tree items)": {
+          "name": "Select root node with cascade (1,000 tree items)",
+          "hz": 7486,
+          "hzLabel": "7.5k ops/s",
+          "mean": 0.13357457211535273,
+          "meanLabel": "133.6μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (10,000 tree items)": {
+          "name": "Select root node with cascade (10,000 tree items)",
+          "hz": 729,
+          "hzLabel": "729 ops/s",
+          "mean": 1.3710930575345952,
+          "meanLabel": "1.37ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect root node with cascade (1,000 tree items)": {
+          "name": "Unselect root node with cascade (1,000 tree items)",
+          "hz": 3371,
+          "hzLabel": "3.4k ops/s",
+          "mean": 0.29667113582446514,
+          "meanLabel": "296.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle selection (1,000 tree items)": {
+          "name": "Toggle selection (1,000 tree items)",
+          "hz": 6601,
+          "hzLabel": "6.6k ops/s",
+          "mean": 0.1514845446834487,
+          "meanLabel": "151.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (1,000 tree items)": {
+          "name": "Select all via selectAll (1,000 tree items)",
+          "hz": 2643,
+          "hzLabel": "2.6k ops/s",
+          "mean": 0.3783889046898726,
+          "meanLabel": "378.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (10,000 tree items)": {
+          "name": "Select all via selectAll (10,000 tree items)",
+          "hz": 251,
+          "hzLabel": "251 ops/s",
+          "mean": 3.9829586825396133,
+          "meanLabel": "3.98ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Register single root item": {
+          "name": "Register single root item",
+          "hz": 14931,
+          "hzLabel": "14.9k ops/s",
+          "mean": 0.06697457447096408,
+          "meanLabel": "67.0μs",
+          "rme": 10.6,
+          "tier": "fast"
+        },
+        "Register item with parent (1,000 items)": {
+          "name": "Register item with parent (1,000 items)",
+          "hz": 125,
+          "hzLabel": "125 ops/s",
+          "mean": 7.975299333332389,
+          "meanLabel": "7.98ms",
+          "rme": 47.3,
+          "tier": "fast"
+        },
+        "Unregister leaf node (1,000 tree items)": {
+          "name": "Unregister leaf node (1,000 tree items)",
+          "hz": 192,
+          "hzLabel": "192 ops/s",
+          "mean": 5.216640052083828,
+          "meanLabel": "5.22ms",
+          "rme": 6.7,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (1,000 tree items)": {
+          "name": "Unregister root with cascade (1,000 tree items)",
+          "hz": 168,
+          "hzLabel": "168 ops/s",
+          "mean": 5.956838583333246,
+          "meanLabel": "5.96ms",
+          "rme": 6,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (10,000 tree items)": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 13,
+          "hzLabel": "13 ops/s",
+          "mean": 77.1741635000013,
+          "meanLabel": "77.17ms",
+          "rme": 29.9,
+          "tier": "good"
+        },
+        "Onboard then clear 1,000 tree items": {
+          "name": "Onboard then clear 1,000 tree items",
+          "hz": 235,
+          "hzLabel": "235 ops/s",
+          "mean": 4.248468127118925,
+          "meanLabel": "4.25ms",
+          "rme": 1.7,
+          "tier": "fast"
+        },
+        "Onboard then clear 10,000 tree items": {
+          "name": "Onboard then clear 10,000 tree items",
+          "hz": 18,
+          "hzLabel": "18 ops/s",
+          "mean": 56.00297730000166,
+          "meanLabel": "56.00ms",
+          "rme": 2.4,
+          "tier": "good"
+        },
+        "toFlat conversion (1,000 tree items)": {
+          "name": "toFlat conversion (1,000 tree items)",
+          "hz": 2017,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.4958553221010241,
+          "meanLabel": "495.9μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "toFlat conversion (10,000 tree items)": {
+          "name": "toFlat conversion (10,000 tree items)",
+          "hz": 191,
+          "hzLabel": "191 ops/s",
+          "mean": 5.239605041667346,
+          "meanLabel": "5.24ms",
+          "rme": 1,
+          "tier": "blazing"
+        },
+        "Select root - cascade mode (1,000 tree items)": {
+          "name": "Select root - cascade mode (1,000 tree items)",
+          "hz": 7493,
+          "hzLabel": "7.5k ops/s",
+          "mean": 0.13345598211918475,
+          "meanLabel": "133.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root - independent mode (1,000 tree items)": {
+          "name": "Select root - independent mode (1,000 tree items)",
+          "hz": 917199,
+          "hzLabel": "917.2k ops/s",
+          "mean": 0.0010902755974677876,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root - leaf mode (1,000 tree items)": {
+          "name": "Select root - leaf mode (1,000 tree items)",
+          "hz": 5308,
+          "hzLabel": "5.3k ops/s",
+          "mean": 0.1883861137475343,
+          "meanLabel": "188.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - multiple mode (1,000 tree items)": {
+          "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+          "hz": 633120,
+          "hzLabel": "633.1k ops/s",
+          "mean": 0.0015794783374957185,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - single mode (1,000 tree items)": {
+          "name": "Open 3 nodes - single mode (1,000 tree items)",
+          "hz": 105155,
+          "hzLabel": "105.2k ops/s",
+          "mean": 0.009509796302665756,
+          "meanLabel": "9.5μs",
+          "rme": 4.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (1,000 flat items)",
+          "hz": 7217552,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013855113811279184,
+          "meanLabel": "139ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 13,
+          "hzLabel": "13 ops/s",
+          "mean": 77.1741635000013,
+          "meanLabel": "77.17ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty registry": {
+              "name": "Create empty registry",
+              "hz": 262893,
+              "hzLabel": "262.9k ops/s",
+              "mean": 0.0038038292924146926,
+              "meanLabel": "3.8μs",
+              "rme": 13.1,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 2715,
+              "hzLabel": "2.7k ops/s",
+              "mean": 0.36834610279002256,
+              "meanLabel": "368.3μs",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 194,
+              "hzLabel": "194 ops/s",
+              "mean": 5.159105659793798,
+              "meanLabel": "5.16ms",
+              "rme": 11.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty registry",
+              "hz": 262893,
+              "hzLabel": "262.9k ops/s",
+              "mean": 0.0038038292924146926,
+              "meanLabel": "3.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 194,
+              "hzLabel": "194 ops/s",
+              "mean": 5.159105659793798,
+              "meanLabel": "5.16ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7442471,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013436398040870553,
+              "meanLabel": "134ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7408727,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013497595133717865,
+              "meanLabel": "135ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Lookup by index (1,000 items)": {
+              "name": "Lookup by index (1,000 items)",
+              "hz": 7470202,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.0001338651830654943,
+              "meanLabel": "134ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Lookup by index (10,000 items)": {
+              "name": "Lookup by index (10,000 items)",
+              "hz": 7310255,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013679413251753604,
+              "meanLabel": "137ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6201112,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016126139883933867,
+              "meanLabel": "161ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6202487,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016122563880838876,
+              "meanLabel": "161ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check has (1,000 items)": {
+              "name": "Check has (1,000 items)",
+              "hz": 7343607,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013617286407494958,
+              "meanLabel": "136ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (10,000 items)": {
+              "name": "Check has (10,000 items)",
+              "hz": 7315410,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001366977370515075,
+              "meanLabel": "137ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Lookup by index (1,000 items)",
+              "hz": 7470202,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.0001338651830654943,
+              "meanLabel": "134ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6201112,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016126139883933867,
+              "meanLabel": "161ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 1752691,
+              "hzLabel": "1.8M ops/s",
+              "mean": 0.0005705511978121465,
+              "meanLabel": "571ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 1870094,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005347324458195622,
+              "meanLabel": "535ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Register single item": {
+              "name": "Register single item",
+              "hz": 247894,
+              "hzLabel": "247.9k ops/s",
+              "mean": 0.004033988317589904,
+              "meanLabel": "4.0μs",
+              "rme": 11.3,
+              "tier": "blazing"
+            },
+            "Register then unregister single item": {
+              "name": "Register then unregister single item",
+              "hz": 244303,
+              "hzLabel": "244.3k ops/s",
+              "mean": 0.004093270392620262,
+              "meanLabel": "4.1μs",
+              "rme": 9.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 1870094,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005347324458195622,
+              "meanLabel": "535ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register then unregister single item",
+              "hz": 244303,
+              "hzLabel": "244.3k ops/s",
+              "mean": 0.004093270392620262,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 items": {
+              "name": "Onboard then clear 1,000 items",
+              "hz": 3692,
+              "hzLabel": "3.7k ops/s",
+              "mean": 0.2708683022751791,
+              "meanLabel": "270.9μs",
+              "rme": 2.6,
+              "tier": "blazing"
+            },
+            "Onboard then clear 10,000 items": {
+              "name": "Onboard then clear 10,000 items",
+              "hz": 289,
+              "hzLabel": "289 ops/s",
+              "mean": 3.4556513793103134,
+              "meanLabel": "3.46ms",
+              "rme": 2.3,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 1,000 items": {
+              "name": "Onboard then reindex 1,000 items",
+              "hz": 2171,
+              "hzLabel": "2.2k ops/s",
+              "mean": 0.4606870184161849,
+              "meanLabel": "460.7μs",
+              "rme": 8.7,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 10,000 items": {
+              "name": "Onboard then reindex 10,000 items",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.763032400000035,
+              "meanLabel": "6.76ms",
+              "rme": 13.3,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 then offboard 500 items": {
+              "name": "Onboard 1,000 then offboard 500 items",
+              "hz": 1665,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.600665626347333,
+              "meanLabel": "600.7μs",
+              "rme": 3.7,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 then offboard 5,000 items": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 124,
+              "hzLabel": "124 ops/s",
+              "mean": 8.068694822580579,
+              "meanLabel": "8.07ms",
+              "rme": 3.7,
+              "tier": "blazing"
+            },
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 7147,
+              "hzLabel": "7.1k ops/s",
+              "mean": 0.13991473754892136,
+              "meanLabel": "139.9μs",
+              "rme": 5.6,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 373,
+              "hzLabel": "373 ops/s",
+              "mean": 2.6787668181818916,
+              "meanLabel": "2.68ms",
+              "rme": 8.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 7147,
+              "hzLabel": "7.1k ops/s",
+              "mean": 0.13991473754892136,
+              "meanLabel": "139.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 124,
+              "hzLabel": "124 ops/s",
+              "mean": 8.068694822580579,
+              "meanLabel": "8.07ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access keys 100 times (1,000 items, cached)": {
+              "name": "Access keys 100 times (1,000 items, cached)",
+              "hz": 777348,
+              "hzLabel": "777.3k ops/s",
+              "mean": 0.0012864250697885954,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, cached)": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 794387,
+              "hzLabel": "794.4k ops/s",
+              "mean": 0.001258832328786293,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, cached)": {
+              "name": "Access values 100 times (1,000 items, cached)",
+              "hz": 789090,
+              "hzLabel": "789.1k ops/s",
+              "mean": 0.0012672829107098732,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, cached)": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 832290,
+              "hzLabel": "832.3k ops/s",
+              "mean": 0.0012015044491748234,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, cached)": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 831533,
+              "hzLabel": "831.5k ops/s",
+              "mean": 0.001202598806547389,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, cached)": {
+              "name": "Access entries 100 times (10,000 items, cached)",
+              "hz": 817604,
+              "hzLabel": "817.6k ops/s",
+              "mean": 0.001223086533332193,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 832290,
+              "hzLabel": "832.3k ops/s",
+              "mean": 0.0012015044491748234,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access keys 100 times (1,000 items, cached)",
+              "hz": 777348,
+              "hzLabel": "777.3k ops/s",
+              "mean": 0.0012864250697885954,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reactive access": {
+            "Access keys 100 times (1,000 items, reactive)": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 726244,
+              "hzLabel": "726.2k ops/s",
+              "mean": 0.0013769475632210543,
+              "meanLabel": "1.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, reactive)": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 748090,
+              "hzLabel": "748.1k ops/s",
+              "mean": 0.0013367370537270295,
+              "meanLabel": "1.3μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, reactive)": {
+              "name": "Access values 100 times (1,000 items, reactive)",
+              "hz": 730961,
+              "hzLabel": "731.0k ops/s",
+              "mean": 0.0013680617241395988,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, reactive)": {
+              "name": "Access values 100 times (10,000 items, reactive)",
+              "hz": 730756,
+              "hzLabel": "730.8k ops/s",
+              "mean": 0.0013684451569468267,
+              "meanLabel": "1.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, reactive)": {
+              "name": "Access entries 100 times (1,000 items, reactive)",
+              "hz": 719896,
+              "hzLabel": "719.9k ops/s",
+              "mean": 0.0013890898927884745,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, reactive)": {
+              "name": "Access entries 100 times (10,000 items, reactive)",
+              "hz": 709383,
+              "hzLabel": "709.4k ops/s",
+              "mean": 0.0014096765700937275,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (1,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 230377,
+              "hzLabel": "230.4k ops/s",
+              "mean": 0.0043407030966478395,
+              "meanLabel": "4.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (10,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 226464,
+              "hzLabel": "226.5k ops/s",
+              "mean": 0.004415714011921132,
+              "meanLabel": "4.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 748090,
+              "hzLabel": "748.1k ops/s",
+              "mean": 0.0013367370537270295,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 226464,
+              "hzLabel": "226.5k ops/s",
+              "mean": 0.004415714011921132,
+              "meanLabel": "4.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "seek operations": {
+            "Seek first (1,000 items)": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7310921,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013678167021704274,
+              "meanLabel": "137ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Seek first (10,000 items)": {
+              "name": "Seek first (10,000 items)",
+              "hz": 7174935,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013937407859671073,
+              "meanLabel": "139ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Seek last (1,000 items)": {
+              "name": "Seek last (1,000 items)",
+              "hz": 7248590,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013795786711722987,
+              "meanLabel": "138ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek last (10,000 items)": {
+              "name": "Seek last (10,000 items)",
+              "hz": 7217100,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013855980502996813,
+              "meanLabel": "139ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (1,000 items)": {
+              "name": "Seek with predicate (1,000 items)",
+              "hz": 804690,
+              "hzLabel": "804.7k ops/s",
+              "mean": 0.0012427152692298616,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Seek with predicate (10,000 items)": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 26754,
+              "hzLabel": "26.8k ops/s",
+              "mean": 0.03737726080131026,
+              "meanLabel": "37.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7310921,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013678167021704274,
+              "meanLabel": "137ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 26754,
+              "hzLabel": "26.8k ops/s",
+              "mean": 0.03737726080131026,
+              "meanLabel": "37.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty registry": {
+          "name": "Create empty registry",
+          "hz": 262893,
+          "hzLabel": "262.9k ops/s",
+          "mean": 0.0038038292924146926,
+          "meanLabel": "3.8μs",
+          "rme": 13.1,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 2715,
+          "hzLabel": "2.7k ops/s",
+          "mean": 0.36834610279002256,
+          "meanLabel": "368.3μs",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 194,
+          "hzLabel": "194 ops/s",
+          "mean": 5.159105659793798,
+          "meanLabel": "5.16ms",
+          "rme": 11.8,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7442471,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013436398040870553,
+          "meanLabel": "134ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7408727,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013497595133717865,
+          "meanLabel": "135ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Lookup by index (1,000 items)": {
+          "name": "Lookup by index (1,000 items)",
+          "hz": 7470202,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.0001338651830654943,
+          "meanLabel": "134ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Lookup by index (10,000 items)": {
+          "name": "Lookup by index (10,000 items)",
+          "hz": 7310255,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013679413251753604,
+          "meanLabel": "137ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6201112,
+          "hzLabel": "6.2M ops/s",
+          "mean": 0.00016126139883933867,
+          "meanLabel": "161ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6202487,
+          "hzLabel": "6.2M ops/s",
+          "mean": 0.00016122563880838876,
+          "meanLabel": "161ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check has (1,000 items)": {
+          "name": "Check has (1,000 items)",
+          "hz": 7343607,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013617286407494958,
+          "meanLabel": "136ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (10,000 items)": {
+          "name": "Check has (10,000 items)",
+          "hz": 7315410,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001366977370515075,
+          "meanLabel": "137ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 1752691,
+          "hzLabel": "1.8M ops/s",
+          "mean": 0.0005705511978121465,
+          "meanLabel": "571ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 1870094,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005347324458195622,
+          "meanLabel": "535ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single item": {
+          "name": "Register single item",
+          "hz": 247894,
+          "hzLabel": "247.9k ops/s",
+          "mean": 0.004033988317589904,
+          "meanLabel": "4.0μs",
+          "rme": 11.3,
+          "tier": "blazing"
+        },
+        "Register then unregister single item": {
+          "name": "Register then unregister single item",
+          "hz": 244303,
+          "hzLabel": "244.3k ops/s",
+          "mean": 0.004093270392620262,
+          "meanLabel": "4.1μs",
+          "rme": 9.7,
+          "tier": "blazing"
+        },
+        "Onboard then clear 1,000 items": {
+          "name": "Onboard then clear 1,000 items",
+          "hz": 3692,
+          "hzLabel": "3.7k ops/s",
+          "mean": 0.2708683022751791,
+          "meanLabel": "270.9μs",
+          "rme": 2.6,
+          "tier": "blazing"
+        },
+        "Onboard then clear 10,000 items": {
+          "name": "Onboard then clear 10,000 items",
+          "hz": 289,
+          "hzLabel": "289 ops/s",
+          "mean": 3.4556513793103134,
+          "meanLabel": "3.46ms",
+          "rme": 2.3,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 1,000 items": {
+          "name": "Onboard then reindex 1,000 items",
+          "hz": 2171,
+          "hzLabel": "2.2k ops/s",
+          "mean": 0.4606870184161849,
+          "meanLabel": "460.7μs",
+          "rme": 8.7,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 10,000 items": {
+          "name": "Onboard then reindex 10,000 items",
+          "hz": 148,
+          "hzLabel": "148 ops/s",
+          "mean": 6.763032400000035,
+          "meanLabel": "6.76ms",
+          "rme": 13.3,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 500 items": {
+          "name": "Onboard 1,000 then offboard 500 items",
+          "hz": 1665,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.600665626347333,
+          "meanLabel": "600.7μs",
+          "rme": 3.7,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 then offboard 5,000 items": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 124,
+          "hzLabel": "124 ops/s",
+          "mean": 8.068694822580579,
+          "meanLabel": "8.07ms",
+          "rme": 3.7,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 7147,
+          "hzLabel": "7.1k ops/s",
+          "mean": 0.13991473754892136,
+          "meanLabel": "139.9μs",
+          "rme": 5.6,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 373,
+          "hzLabel": "373 ops/s",
+          "mean": 2.6787668181818916,
+          "meanLabel": "2.68ms",
+          "rme": 8.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, cached)": {
+          "name": "Access keys 100 times (1,000 items, cached)",
+          "hz": 777348,
+          "hzLabel": "777.3k ops/s",
+          "mean": 0.0012864250697885954,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, cached)": {
+          "name": "Access keys 100 times (10,000 items, cached)",
+          "hz": 794387,
+          "hzLabel": "794.4k ops/s",
+          "mean": 0.001258832328786293,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, cached)": {
+          "name": "Access values 100 times (1,000 items, cached)",
+          "hz": 789090,
+          "hzLabel": "789.1k ops/s",
+          "mean": 0.0012672829107098732,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, cached)": {
+          "name": "Access values 100 times (10,000 items, cached)",
+          "hz": 832290,
+          "hzLabel": "832.3k ops/s",
+          "mean": 0.0012015044491748234,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, cached)": {
+          "name": "Access entries 100 times (1,000 items, cached)",
+          "hz": 831533,
+          "hzLabel": "831.5k ops/s",
+          "mean": 0.001202598806547389,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, cached)": {
+          "name": "Access entries 100 times (10,000 items, cached)",
+          "hz": 817604,
+          "hzLabel": "817.6k ops/s",
+          "mean": 0.001223086533332193,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, reactive)": {
+          "name": "Access keys 100 times (1,000 items, reactive)",
+          "hz": 726244,
+          "hzLabel": "726.2k ops/s",
+          "mean": 0.0013769475632210543,
+          "meanLabel": "1.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, reactive)": {
+          "name": "Access keys 100 times (10,000 items, reactive)",
+          "hz": 748090,
+          "hzLabel": "748.1k ops/s",
+          "mean": 0.0013367370537270295,
+          "meanLabel": "1.3μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, reactive)": {
+          "name": "Access values 100 times (1,000 items, reactive)",
+          "hz": 730961,
+          "hzLabel": "731.0k ops/s",
+          "mean": 0.0013680617241395988,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, reactive)": {
+          "name": "Access values 100 times (10,000 items, reactive)",
+          "hz": 730756,
+          "hzLabel": "730.8k ops/s",
+          "mean": 0.0013684451569468267,
+          "meanLabel": "1.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, reactive)": {
+          "name": "Access entries 100 times (1,000 items, reactive)",
+          "hz": 719896,
+          "hzLabel": "719.9k ops/s",
+          "mean": 0.0013890898927884745,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, reactive)": {
+          "name": "Access entries 100 times (10,000 items, reactive)",
+          "hz": 709383,
+          "hzLabel": "709.4k ops/s",
+          "mean": 0.0014096765700937275,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (1,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+          "hz": 230377,
+          "hzLabel": "230.4k ops/s",
+          "mean": 0.0043407030966478395,
+          "meanLabel": "4.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (10,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+          "hz": 226464,
+          "hzLabel": "226.5k ops/s",
+          "mean": 0.004415714011921132,
+          "meanLabel": "4.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek first (1,000 items)": {
+          "name": "Seek first (1,000 items)",
+          "hz": 7310921,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013678167021704274,
+          "meanLabel": "137ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Seek first (10,000 items)": {
+          "name": "Seek first (10,000 items)",
+          "hz": 7174935,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013937407859671073,
+          "meanLabel": "139ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Seek last (1,000 items)": {
+          "name": "Seek last (1,000 items)",
+          "hz": 7248590,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013795786711722987,
+          "meanLabel": "138ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek last (10,000 items)": {
+          "name": "Seek last (10,000 items)",
+          "hz": 7217100,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013855980502996813,
+          "meanLabel": "139ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (1,000 items)": {
+          "name": "Seek with predicate (1,000 items)",
+          "hz": 804690,
+          "hzLabel": "804.7k ops/s",
+          "mean": 0.0012427152692298616,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Seek with predicate (10,000 items)": {
+          "name": "Seek with predicate (10,000 items)",
+          "hz": 26754,
+          "hzLabel": "26.8k ops/s",
+          "mean": 0.03737726080131026,
+          "meanLabel": "37.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Lookup by index (1,000 items)",
+          "hz": 7470202,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.0001338651830654943,
+          "meanLabel": "134ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 124,
+          "hzLabel": "124 ops/s",
+          "mean": 8.068694822580579,
+          "meanLabel": "8.07ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createSelection": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty selection": {
+              "name": "Create empty selection",
+              "hz": 46375,
+              "hzLabel": "46.4k ops/s",
+              "mean": 0.021563204329797775,
+              "meanLabel": "21.6μs",
+              "rme": 11.9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 661,
+              "hzLabel": "661 ops/s",
+              "mean": 1.5120832402397726,
+              "meanLabel": "1.51ms",
+              "rme": 11.1,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 64,
+              "hzLabel": "64 ops/s",
+              "mean": 15.667571718749969,
+              "meanLabel": "15.67ms",
+              "rme": 7.8,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (enroll)": {
+              "name": "Onboard 1,000 items (enroll)",
+              "hz": 475,
+              "hzLabel": "475 ops/s",
+              "mean": 2.1062261638660305,
+              "meanLabel": "2.11ms",
+              "rme": 7.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (enroll)": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.649233857140644,
+              "meanLabel": "24.65ms",
+              "rme": 13.6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory: force)": {
+              "name": "Onboard 1,000 items (mandatory: force)",
+              "hz": 579,
+              "hzLabel": "579 ops/s",
+              "mean": 1.7266485551726434,
+              "meanLabel": "1.73ms",
+              "rme": 8.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory: force)": {
+              "name": "Onboard 10,000 items (mandatory: force)",
+              "hz": 53,
+              "hzLabel": "53 ops/s",
+              "mean": 18.872997222219258,
+              "meanLabel": "18.87ms",
+              "rme": 7.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty selection",
+              "hz": 46375,
+              "hzLabel": "46.4k ops/s",
+              "mean": 0.021563204329797775,
+              "meanLabel": "21.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.649233857140644,
+              "meanLabel": "24.65ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2206344,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004532385820072673,
+              "meanLabel": "453ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2168883,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00046106682975253366,
+              "meanLabel": "461ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2206344,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004532385820072673,
+              "meanLabel": "453ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2168883,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00046106682975253366,
+              "meanLabel": "461ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1908008,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005241068894747488,
+              "meanLabel": "524ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 1909913,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005235840168730026,
+              "meanLabel": "524ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 804528,
+              "hzLabel": "804.5k ops/s",
+              "mean": 0.0012429642424759259,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 759784,
+              "hzLabel": "759.8k ops/s",
+              "mean": 0.0013161642572140169,
+              "meanLabel": "1.3μs",
+              "rme": 5.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 978454,
+              "hzLabel": "978.5k ops/s",
+              "mean": 0.0010220200581317438,
+              "meanLabel": "1.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 970777,
+              "hzLabel": "970.8k ops/s",
+              "mean": 0.0010301028927067162,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (10,000 items)",
+              "hz": 1909913,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005235840168730026,
+              "meanLabel": "524ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 759784,
+              "hzLabel": "759.8k ops/s",
+              "mean": 0.0013161642572140169,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mandatory enforcement": {
+            "Select with mandatory (1,000 items)": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 856473,
+              "hzLabel": "856.5k ops/s",
+              "mean": 0.0011675794875373568,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect blocked by mandatory (1,000 items)": {
+              "name": "Unselect blocked by mandatory (1,000 items)",
+              "hz": 656267,
+              "hzLabel": "656.3k ops/s",
+              "mean": 0.0015237701731692869,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Mandate on empty (1,000 items)": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 497112,
+              "hzLabel": "497.1k ops/s",
+              "mean": 0.002011617958879879,
+              "meanLabel": "2.0μs",
+              "rme": 5.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 856473,
+              "hzLabel": "856.5k ops/s",
+              "mean": 0.0011675794875373568,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 497112,
+              "hzLabel": "497.1k ops/s",
+              "mean": 0.002011617958879879,
+              "meanLabel": "2.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1555,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.64297561953772,
+              "meanLabel": "643.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 143,
+              "hzLabel": "143 ops/s",
+              "mean": 7.010518208332845,
+              "meanLabel": "7.01ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Select then unselect all 1,000 items": {
+              "name": "Select then unselect all 1,000 items",
+              "hz": 897,
+              "hzLabel": "897 ops/s",
+              "mean": 1.1145277750558575,
+              "meanLabel": "1.11ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Reset selection (1,000 items)": {
+              "name": "Reset selection (1,000 items)",
+              "hz": 437,
+              "hzLabel": "437 ops/s",
+              "mean": 2.287338319634163,
+              "meanLabel": "2.29ms",
+              "rme": 9.3,
+              "tier": "fast"
+            },
+            "Reset selection (10,000 items)": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.4727026818172,
+              "meanLabel": "23.47ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 1555,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.64297561953772,
+              "meanLabel": "643.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.4727026818172,
+              "meanLabel": "23.47ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+              "hz": 598312,
+              "hzLabel": "598.3k ops/s",
+              "mean": 0.001671368964664665,
+              "meanLabel": "1.7μs",
+              "rme": 7.3,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 637555,
+              "hzLabel": "637.6k ops/s",
+              "mean": 0.0015684912258789908,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 638276,
+              "hzLabel": "638.3k ops/s",
+              "mean": 0.0015667194450864706,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 585575,
+              "hzLabel": "585.6k ops/s",
+              "mean": 0.0017077218123398151,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 566670,
+              "hzLabel": "566.7k ops/s",
+              "mean": 0.0017646968217951986,
+              "meanLabel": "1.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 594931,
+              "hzLabel": "594.9k ops/s",
+              "mean": 0.0016808676655724647,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 638276,
+              "hzLabel": "638.3k ops/s",
+              "mean": 0.0015667194450864706,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 566670,
+              "hzLabel": "566.7k ops/s",
+              "mean": 0.0017646968217951986,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty selection": {
+          "name": "Create empty selection",
+          "hz": 46375,
+          "hzLabel": "46.4k ops/s",
+          "mean": 0.021563204329797775,
+          "meanLabel": "21.6μs",
+          "rme": 11.9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 661,
+          "hzLabel": "661 ops/s",
+          "mean": 1.5120832402397726,
+          "meanLabel": "1.51ms",
+          "rme": 11.1,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 64,
+          "hzLabel": "64 ops/s",
+          "mean": 15.667571718749969,
+          "meanLabel": "15.67ms",
+          "rme": 7.8,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (enroll)": {
+          "name": "Onboard 1,000 items (enroll)",
+          "hz": 475,
+          "hzLabel": "475 ops/s",
+          "mean": 2.1062261638660305,
+          "meanLabel": "2.11ms",
+          "rme": 7.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (enroll)": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.649233857140644,
+          "meanLabel": "24.65ms",
+          "rme": 13.6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory: force)": {
+          "name": "Onboard 1,000 items (mandatory: force)",
+          "hz": 579,
+          "hzLabel": "579 ops/s",
+          "mean": 1.7266485551726434,
+          "meanLabel": "1.73ms",
+          "rme": 8.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory: force)": {
+          "name": "Onboard 10,000 items (mandatory: force)",
+          "hz": 53,
+          "hzLabel": "53 ops/s",
+          "mean": 18.872997222219258,
+          "meanLabel": "18.87ms",
+          "rme": 7.4,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2206344,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004532385820072673,
+          "meanLabel": "453ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2168883,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00046106682975253366,
+          "meanLabel": "461ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 1908008,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005241068894747488,
+          "meanLabel": "524ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 1909913,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005235840168730026,
+          "meanLabel": "524ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 804528,
+          "hzLabel": "804.5k ops/s",
+          "mean": 0.0012429642424759259,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 759784,
+          "hzLabel": "759.8k ops/s",
+          "mean": 0.0013161642572140169,
+          "meanLabel": "1.3μs",
+          "rme": 5.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 978454,
+          "hzLabel": "978.5k ops/s",
+          "mean": 0.0010220200581317438,
+          "meanLabel": "1.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 970777,
+          "hzLabel": "970.8k ops/s",
+          "mean": 0.0010301028927067162,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select with mandatory (1,000 items)": {
+          "name": "Select with mandatory (1,000 items)",
+          "hz": 856473,
+          "hzLabel": "856.5k ops/s",
+          "mean": 0.0011675794875373568,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect blocked by mandatory (1,000 items)": {
+          "name": "Unselect blocked by mandatory (1,000 items)",
+          "hz": 656267,
+          "hzLabel": "656.3k ops/s",
+          "mean": 0.0015237701731692869,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Mandate on empty (1,000 items)": {
+          "name": "Mandate on empty (1,000 items)",
+          "hz": 497112,
+          "hzLabel": "497.1k ops/s",
+          "mean": 0.002011617958879879,
+          "meanLabel": "2.0μs",
+          "rme": 5.9,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1555,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.64297561953772,
+          "meanLabel": "643.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 143,
+          "hzLabel": "143 ops/s",
+          "mean": 7.010518208332845,
+          "meanLabel": "7.01ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Select then unselect all 1,000 items": {
+          "name": "Select then unselect all 1,000 items",
+          "hz": 897,
+          "hzLabel": "897 ops/s",
+          "mean": 1.1145277750558575,
+          "meanLabel": "1.11ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Reset selection (1,000 items)": {
+          "name": "Reset selection (1,000 items)",
+          "hz": 437,
+          "hzLabel": "437 ops/s",
+          "mean": 2.287338319634163,
+          "meanLabel": "2.29ms",
+          "rme": 9.3,
+          "tier": "fast"
+        },
+        "Reset selection (10,000 items)": {
+          "name": "Reset selection (10,000 items)",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.4727026818172,
+          "meanLabel": "23.47ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+          "hz": 598312,
+          "hzLabel": "598.3k ops/s",
+          "mean": 0.001671368964664665,
+          "meanLabel": "1.7μs",
+          "rme": 7.3,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 637555,
+          "hzLabel": "637.6k ops/s",
+          "mean": 0.0015684912258789908,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 638276,
+          "hzLabel": "638.3k ops/s",
+          "mean": 0.0015667194450864706,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+          "hz": 585575,
+          "hzLabel": "585.6k ops/s",
+          "mean": 0.0017077218123398151,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 566670,
+          "hzLabel": "566.7k ops/s",
+          "mean": 0.0017646968217951986,
+          "meanLabel": "1.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 594931,
+          "hzLabel": "594.9k ops/s",
+          "mean": 0.0016808676655724647,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2206344,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004532385820072673,
+          "meanLabel": "453ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.649233857140644,
+          "meanLabel": "24.65ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSingle": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty single": {
+              "name": "Create empty single",
+              "hz": 36315,
+              "hzLabel": "36.3k ops/s",
+              "mean": 0.027536701013101548,
+              "meanLabel": "27.5μs",
+              "rme": 7.6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 735,
+              "hzLabel": "735 ops/s",
+              "mean": 1.361208404313473,
+              "meanLabel": "1.36ms",
+              "rme": 8.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 67,
+              "hzLabel": "67 ops/s",
+              "mean": 14.882897147054523,
+              "meanLabel": "14.88ms",
+              "rme": 9.6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 734,
+              "hzLabel": "734 ops/s",
+              "mean": 1.363086228880794,
+              "meanLabel": "1.36ms",
+              "rme": 9.1,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 67,
+              "hzLabel": "67 ops/s",
+              "mean": 14.99594785293619,
+              "meanLabel": "15.00ms",
+              "rme": 11.7,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty single",
+              "hz": 36315,
+              "hzLabel": "36.3k ops/s",
+              "mean": 0.027536701013101548,
+              "meanLabel": "27.5μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 67,
+              "hzLabel": "67 ops/s",
+              "mean": 14.99594785293619,
+              "meanLabel": "15.00ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2255146,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00044343028167323126,
+              "meanLabel": "443ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2262887,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.000441913341721989,
+              "meanLabel": "442ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2262887,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.000441913341721989,
+              "meanLabel": "442ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2255146,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00044343028167323126,
+              "meanLabel": "443ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 841839,
+              "hzLabel": "841.8k ops/s",
+              "mean": 0.0011878756652070187,
+              "meanLabel": "1.2μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 873624,
+              "hzLabel": "873.6k ops/s",
+              "mean": 0.0011446573147985257,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 620771,
+              "hzLabel": "620.8k ops/s",
+              "mean": 0.001610900079257997,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 606832,
+              "hzLabel": "606.8k ops/s",
+              "mean": 0.0016479038848101358,
+              "meanLabel": "1.6μs",
+              "rme": 2.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 811619,
+              "hzLabel": "811.6k ops/s",
+              "mean": 0.0012321050048097362,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 804587,
+              "hzLabel": "804.6k ops/s",
+              "mean": 0.0012428739007681916,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (10,000 items)",
+              "hz": 873624,
+              "hzLabel": "873.6k ops/s",
+              "mean": 0.0011446573147985257,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 606832,
+              "hzLabel": "606.8k ops/s",
+              "mean": 0.0016479038848101358,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6520,
+              "hzLabel": "6.5k ops/s",
+              "mean": 0.1533655427780493,
+              "meanLabel": "153.4μs",
+              "rme": 4.6,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (10,000 items, cached)": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 6040,
+              "hzLabel": "6.0k ops/s",
+              "mean": 0.16556763600386395,
+              "meanLabel": "165.6μs",
+              "rme": 9.9,
+              "tier": "blazing"
+            },
+            "Access selectedItem 100 times (1,000 items, cached)": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 321885,
+              "hzLabel": "321.9k ops/s",
+              "mean": 0.003106702938335755,
+              "meanLabel": "3.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 241336,
+              "hzLabel": "241.3k ops/s",
+              "mean": 0.00414360357345303,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 249316,
+              "hzLabel": "249.3k ops/s",
+              "mean": 0.004010967054108718,
+              "meanLabel": "4.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 321885,
+              "hzLabel": "321.9k ops/s",
+              "mean": 0.003106702938335755,
+              "meanLabel": "3.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 6040,
+              "hzLabel": "6.0k ops/s",
+              "mean": 0.16556763600386395,
+              "meanLabel": "165.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty single": {
+          "name": "Create empty single",
+          "hz": 36315,
+          "hzLabel": "36.3k ops/s",
+          "mean": 0.027536701013101548,
+          "meanLabel": "27.5μs",
+          "rme": 7.6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 735,
+          "hzLabel": "735 ops/s",
+          "mean": 1.361208404313473,
+          "meanLabel": "1.36ms",
+          "rme": 8.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 67,
+          "hzLabel": "67 ops/s",
+          "mean": 14.882897147054523,
+          "meanLabel": "14.88ms",
+          "rme": 9.6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 734,
+          "hzLabel": "734 ops/s",
+          "mean": 1.363086228880794,
+          "meanLabel": "1.36ms",
+          "rme": 9.1,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 67,
+          "hzLabel": "67 ops/s",
+          "mean": 14.99594785293619,
+          "meanLabel": "15.00ms",
+          "rme": 11.7,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2255146,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00044343028167323126,
+          "meanLabel": "443ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2262887,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.000441913341721989,
+          "meanLabel": "442ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 841839,
+          "hzLabel": "841.8k ops/s",
+          "mean": 0.0011878756652070187,
+          "meanLabel": "1.2μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 873624,
+          "hzLabel": "873.6k ops/s",
+          "mean": 0.0011446573147985257,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 620771,
+          "hzLabel": "620.8k ops/s",
+          "mean": 0.001610900079257997,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 606832,
+          "hzLabel": "606.8k ops/s",
+          "mean": 0.0016479038848101358,
+          "meanLabel": "1.6μs",
+          "rme": 2.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 811619,
+          "hzLabel": "811.6k ops/s",
+          "mean": 0.0012321050048097362,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 804587,
+          "hzLabel": "804.6k ops/s",
+          "mean": 0.0012428739007681916,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6520,
+          "hzLabel": "6.5k ops/s",
+          "mean": 0.1533655427780493,
+          "meanLabel": "153.4μs",
+          "rme": 4.6,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (10,000 items, cached)": {
+          "name": "Access selectedId 100 times (10,000 items, cached)",
+          "hz": 6040,
+          "hzLabel": "6.0k ops/s",
+          "mean": 0.16556763600386395,
+          "meanLabel": "165.6μs",
+          "rme": 9.9,
+          "tier": "blazing"
+        },
+        "Access selectedItem 100 times (1,000 items, cached)": {
+          "name": "Access selectedItem 100 times (1,000 items, cached)",
+          "hz": 321885,
+          "hzLabel": "321.9k ops/s",
+          "mean": 0.003106702938335755,
+          "meanLabel": "3.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 241336,
+          "hzLabel": "241.3k ops/s",
+          "mean": 0.00414360357345303,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 249316,
+          "hzLabel": "249.3k ops/s",
+          "mean": 0.004010967054108718,
+          "meanLabel": "4.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2262887,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.000441913341721989,
+          "meanLabel": "442ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 67,
+          "hzLabel": "67 ops/s",
+          "mean": 14.99594785293619,
+          "meanLabel": "15.00ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSortable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty sortable": {
+              "name": "Create empty sortable",
+              "hz": 34223,
+              "hzLabel": "34.2k ops/s",
+              "mean": 0.0292203772341659,
+              "meanLabel": "29.2μs",
+              "rme": 49.6,
+              "tier": "fast"
+            },
+            "Create empty sortable (disabled)": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 47517,
+              "hzLabel": "47.5k ops/s",
+              "mean": 0.02104506317605264,
+              "meanLabel": "21.0μs",
+              "rme": 8.9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 47517,
+              "hzLabel": "47.5k ops/s",
+              "mean": 0.02104506317605264,
+              "meanLabel": "21.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create empty sortable",
+              "hz": 34223,
+              "hzLabel": "34.2k ops/s",
+              "mean": 0.0292203772341659,
+              "meanLabel": "29.2μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7352292,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013601200387729405,
+              "meanLabel": "136ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7418579,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013479670287928818,
+              "meanLabel": "135ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Values snapshot (10,000 items)": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7024677,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014235530880437017,
+              "meanLabel": "142ns",
+              "rme": 6.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 7418579,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013479670287928818,
+              "meanLabel": "135ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7024677,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014235530880437017,
+              "meanLabel": "142ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "move operations": {
+            "Move first to last (1,000 items)": {
+              "name": "Move first to last (1,000 items)",
+              "hz": 8481,
+              "hzLabel": "8.5k ops/s",
+              "mean": 0.11790734614494071,
+              "meanLabel": "117.9μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Move first to last (10,000 items)": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 505,
+              "hzLabel": "505 ops/s",
+              "mean": 1.9787883043476462,
+              "meanLabel": "1.98ms",
+              "rme": 9.2,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (1,000 items)": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 244909,
+              "hzLabel": "244.9k ops/s",
+              "mean": 0.00408314378334579,
+              "meanLabel": "4.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (10,000 items)": {
+              "name": "Move mid by 1 (10,000 items)",
+              "hz": 29444,
+              "hzLabel": "29.4k ops/s",
+              "mean": 0.03396253603196839,
+              "meanLabel": "34.0μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 244909,
+              "hzLabel": "244.9k ops/s",
+              "mean": 0.00408314378334579,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 505,
+              "hzLabel": "505 ops/s",
+              "mean": 1.9787883043476462,
+              "meanLabel": "1.98ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "swap operations": {
+            "Swap two tickets (1,000 items)": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7950,
+              "hzLabel": "7.9k ops/s",
+              "mean": 0.12578995924482544,
+              "meanLabel": "125.8μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Swap two tickets (10,000 items)": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 443,
+              "hzLabel": "443 ops/s",
+              "mean": 2.255909635134509,
+              "meanLabel": "2.26ms",
+              "rme": 11.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7950,
+              "hzLabel": "7.9k ops/s",
+              "mean": 0.12578995924482544,
+              "meanLabel": "125.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 443,
+              "hzLabel": "443 ops/s",
+              "mean": 2.255909635134509,
+              "meanLabel": "2.26ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reorder operations": {
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2514,
+              "hzLabel": "2.5k ops/s",
+              "mean": 0.39782826571312996,
+              "meanLabel": "397.8μs",
+              "rme": 5.7,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 181,
+              "hzLabel": "181 ops/s",
+              "mean": 5.53278865934104,
+              "meanLabel": "5.53ms",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2514,
+              "hzLabel": "2.5k ops/s",
+              "mean": 0.39782826571312996,
+              "meanLabel": "397.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 181,
+              "hzLabel": "181 ops/s",
+              "mean": 5.53278865934104,
+              "meanLabel": "5.53ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 100 items": {
+              "name": "Onboard 100 items",
+              "hz": 4319,
+              "hzLabel": "4.3k ops/s",
+              "mean": 0.23154533796319068,
+              "meanLabel": "231.5μs",
+              "rme": 7.9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 496,
+              "hzLabel": "496 ops/s",
+              "mean": 2.0162721532230328,
+              "meanLabel": "2.02ms",
+              "rme": 4.8,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.750232863634167,
+              "meanLabel": "22.75ms",
+              "rme": 8.8,
+              "tier": "fast"
+            },
+            "Register then move to mid (1,000 items)": {
+              "name": "Register then move to mid (1,000 items)",
+              "hz": 482,
+              "hzLabel": "482 ops/s",
+              "mean": 2.076590473028199,
+              "meanLabel": "2.08ms",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Register then move to mid (10,000 items)": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.50455347826178,
+              "meanLabel": "22.50ms",
+              "rme": 4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Onboard 100 items",
+              "hz": 4319,
+              "hzLabel": "4.3k ops/s",
+              "mean": 0.23154533796319068,
+              "meanLabel": "231.5μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 44,
+              "hzLabel": "44 ops/s",
+              "mean": 22.750232863634167,
+              "meanLabel": "22.75ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "events overhead": {
+            "Move with no listeners (1,000 items)": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 232579,
+              "hzLabel": "232.6k ops/s",
+              "mean": 0.0042996071631102905,
+              "meanLabel": "4.3μs",
+              "rme": 5.4,
+              "tier": "blazing"
+            },
+            "Move with listener attached (1,000 items)": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 242503,
+              "hzLabel": "242.5k ops/s",
+              "mean": 0.004123663890124931,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Move with no listeners (10,000 items)": {
+              "name": "Move with no listeners (10,000 items)",
+              "hz": 29434,
+              "hzLabel": "29.4k ops/s",
+              "mean": 0.03397451892400137,
+              "meanLabel": "34.0μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Move with listener attached (10,000 items)": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29339,
+              "hzLabel": "29.3k ops/s",
+              "mean": 0.034083756032748526,
+              "meanLabel": "34.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 242503,
+              "hzLabel": "242.5k ops/s",
+              "mean": 0.004123663890124931,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29339,
+              "hzLabel": "29.3k ops/s",
+              "mean": 0.034083756032748526,
+              "meanLabel": "34.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty sortable": {
+          "name": "Create empty sortable",
+          "hz": 34223,
+          "hzLabel": "34.2k ops/s",
+          "mean": 0.0292203772341659,
+          "meanLabel": "29.2μs",
+          "rme": 49.6,
+          "tier": "fast"
+        },
+        "Create empty sortable (disabled)": {
+          "name": "Create empty sortable (disabled)",
+          "hz": 47517,
+          "hzLabel": "47.5k ops/s",
+          "mean": 0.02104506317605264,
+          "meanLabel": "21.0μs",
+          "rme": 8.9,
+          "tier": "fast"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7352292,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013601200387729405,
+          "meanLabel": "136ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7418579,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013479670287928818,
+          "meanLabel": "135ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Values snapshot (10,000 items)": {
+          "name": "Values snapshot (10,000 items)",
+          "hz": 7024677,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014235530880437017,
+          "meanLabel": "142ns",
+          "rme": 6.1,
+          "tier": "blazing"
+        },
+        "Move first to last (1,000 items)": {
+          "name": "Move first to last (1,000 items)",
+          "hz": 8481,
+          "hzLabel": "8.5k ops/s",
+          "mean": 0.11790734614494071,
+          "meanLabel": "117.9μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Move first to last (10,000 items)": {
+          "name": "Move first to last (10,000 items)",
+          "hz": 505,
+          "hzLabel": "505 ops/s",
+          "mean": 1.9787883043476462,
+          "meanLabel": "1.98ms",
+          "rme": 9.2,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (1,000 items)": {
+          "name": "Move mid by 1 (1,000 items)",
+          "hz": 244909,
+          "hzLabel": "244.9k ops/s",
+          "mean": 0.00408314378334579,
+          "meanLabel": "4.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (10,000 items)": {
+          "name": "Move mid by 1 (10,000 items)",
+          "hz": 29444,
+          "hzLabel": "29.4k ops/s",
+          "mean": 0.03396253603196839,
+          "meanLabel": "34.0μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Swap two tickets (1,000 items)": {
+          "name": "Swap two tickets (1,000 items)",
+          "hz": 7950,
+          "hzLabel": "7.9k ops/s",
+          "mean": 0.12578995924482544,
+          "meanLabel": "125.8μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Swap two tickets (10,000 items)": {
+          "name": "Swap two tickets (10,000 items)",
+          "hz": 443,
+          "hzLabel": "443 ops/s",
+          "mean": 2.255909635134509,
+          "meanLabel": "2.26ms",
+          "rme": 11.6,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 2514,
+          "hzLabel": "2.5k ops/s",
+          "mean": 0.39782826571312996,
+          "meanLabel": "397.8μs",
+          "rme": 5.7,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 181,
+          "hzLabel": "181 ops/s",
+          "mean": 5.53278865934104,
+          "meanLabel": "5.53ms",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Onboard 100 items": {
+          "name": "Onboard 100 items",
+          "hz": 4319,
+          "hzLabel": "4.3k ops/s",
+          "mean": 0.23154533796319068,
+          "meanLabel": "231.5μs",
+          "rme": 7.9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 496,
+          "hzLabel": "496 ops/s",
+          "mean": 2.0162721532230328,
+          "meanLabel": "2.02ms",
+          "rme": 4.8,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 44,
+          "hzLabel": "44 ops/s",
+          "mean": 22.750232863634167,
+          "meanLabel": "22.75ms",
+          "rme": 8.8,
+          "tier": "fast"
+        },
+        "Register then move to mid (1,000 items)": {
+          "name": "Register then move to mid (1,000 items)",
+          "hz": 482,
+          "hzLabel": "482 ops/s",
+          "mean": 2.076590473028199,
+          "meanLabel": "2.08ms",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Register then move to mid (10,000 items)": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 44,
+          "hzLabel": "44 ops/s",
+          "mean": 22.50455347826178,
+          "meanLabel": "22.50ms",
+          "rme": 4,
+          "tier": "fast"
+        },
+        "Move with no listeners (1,000 items)": {
+          "name": "Move with no listeners (1,000 items)",
+          "hz": 232579,
+          "hzLabel": "232.6k ops/s",
+          "mean": 0.0042996071631102905,
+          "meanLabel": "4.3μs",
+          "rme": 5.4,
+          "tier": "blazing"
+        },
+        "Move with listener attached (1,000 items)": {
+          "name": "Move with listener attached (1,000 items)",
+          "hz": 242503,
+          "hzLabel": "242.5k ops/s",
+          "mean": 0.004123663890124931,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move with no listeners (10,000 items)": {
+          "name": "Move with no listeners (10,000 items)",
+          "hz": 29434,
+          "hzLabel": "29.4k ops/s",
+          "mean": 0.03397451892400137,
+          "meanLabel": "34.0μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Move with listener attached (10,000 items)": {
+          "name": "Move with listener attached (10,000 items)",
+          "hz": 29339,
+          "hzLabel": "29.3k ops/s",
+          "mean": 0.034083756032748526,
+          "meanLabel": "34.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 7418579,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013479670287928818,
+          "meanLabel": "135ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 44,
+          "hzLabel": "44 ops/s",
+          "mean": 22.750232863634167,
+          "meanLabel": "22.75ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createStep": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty step": {
+              "name": "Create empty step",
+              "hz": 28053,
+              "hzLabel": "28.1k ops/s",
+              "mean": 0.03564728167115643,
+              "meanLabel": "35.6μs",
+              "rme": 5.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 693,
+              "hzLabel": "693 ops/s",
+              "mean": 1.4437059510062429,
+              "meanLabel": "1.44ms",
+              "rme": 11.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.290496914278316,
+              "meanLabel": "14.29ms",
+              "rme": 7.5,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (circular)": {
+              "name": "Onboard 1,000 items (circular)",
+              "hz": 767,
+              "hzLabel": "767 ops/s",
+              "mean": 1.304625489581061,
+              "meanLabel": "1.30ms",
+              "rme": 8.3,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 724,
+              "hzLabel": "724 ops/s",
+              "mean": 1.380275707990162,
+              "meanLabel": "1.38ms",
+              "rme": 9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty step",
+              "hz": 28053,
+              "hzLabel": "28.1k ops/s",
+              "mean": 0.03564728167115643,
+              "meanLabel": "35.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.290496914278316,
+              "meanLabel": "14.29ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation operations (linear)": {
+            "next() from mid-point (1,000 items)": {
+              "name": "next() from mid-point (1,000 items)",
+              "hz": 120684,
+              "hzLabel": "120.7k ops/s",
+              "mean": 0.008286128931802212,
+              "meanLabel": "8.3μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "next() from mid-point (10,000 items)": {
+              "name": "next() from mid-point (10,000 items)",
+              "hz": 122572,
+              "hzLabel": "122.6k ops/s",
+              "mean": 0.008158453309952676,
+              "meanLabel": "8.2μs",
+              "rme": 2.7,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (1,000 items)": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 116063,
+              "hzLabel": "116.1k ops/s",
+              "mean": 0.008615981734322853,
+              "meanLabel": "8.6μs",
+              "rme": 6.3,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (10,000 items)": {
+              "name": "prev() from mid-point (10,000 items)",
+              "hz": 122886,
+              "hzLabel": "122.9k ops/s",
+              "mean": 0.008137654069757949,
+              "meanLabel": "8.1μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "first() (1,000 items)": {
+              "name": "first() (1,000 items)",
+              "hz": 382081,
+              "hzLabel": "382.1k ops/s",
+              "mean": 0.0026172465282977763,
+              "meanLabel": "2.6μs",
+              "rme": 5.8,
+              "tier": "blazing"
+            },
+            "last() (1,000 items)": {
+              "name": "last() (1,000 items)",
+              "hz": 401746,
+              "hzLabel": "401.7k ops/s",
+              "mean": 0.0024891321723892724,
+              "meanLabel": "2.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "step(+5) from mid-point (1,000 items)": {
+              "name": "step(+5) from mid-point (1,000 items)",
+              "hz": 122936,
+              "hzLabel": "122.9k ops/s",
+              "mean": 0.008134303144648514,
+              "meanLabel": "8.1μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "step(+50) from mid-point (1,000 items)": {
+              "name": "step(+50) from mid-point (1,000 items)",
+              "hz": 118585,
+              "hzLabel": "118.6k ops/s",
+              "mean": 0.008432760376356069,
+              "meanLabel": "8.4μs",
+              "rme": 4.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "last() (1,000 items)",
+              "hz": 401746,
+              "hzLabel": "401.7k ops/s",
+              "mean": 0.0024891321723892724,
+              "meanLabel": "2.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 116063,
+              "hzLabel": "116.1k ops/s",
+              "mean": 0.008615981734322853,
+              "meanLabel": "8.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "navigation operations (circular)": {
+            "next() from mid-point circular (1,000 items)": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 119889,
+              "hzLabel": "119.9k ops/s",
+              "mean": 0.008341061422977398,
+              "meanLabel": "8.3μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "next() wrapping past end circular (1,000 items)": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 150330,
+              "hzLabel": "150.3k ops/s",
+              "mean": 0.006652028161097518,
+              "meanLabel": "6.7μs",
+              "rme": 2.1,
+              "tier": "blazing"
+            },
+            "prev() wrapping past start circular (1,000 items)": {
+              "name": "prev() wrapping past start circular (1,000 items)",
+              "hz": 148768,
+              "hzLabel": "148.8k ops/s",
+              "mean": 0.006721883563770388,
+              "meanLabel": "6.7μs",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 150330,
+              "hzLabel": "150.3k ops/s",
+              "mean": 0.006652028161097518,
+              "meanLabel": "6.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 119889,
+              "hzLabel": "119.9k ops/s",
+              "mean": 0.008341061422977398,
+              "meanLabel": "8.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "boundary conditions": {
+            "next() at last item — no-op (1,000 items)": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 266272,
+              "hzLabel": "266.3k ops/s",
+              "mean": 0.003755562131996839,
+              "meanLabel": "3.8μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "prev() at first item — no-op (1,000 items)": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 257001,
+              "hzLabel": "257.0k ops/s",
+              "mean": 0.0038910373693086587,
+              "meanLabel": "3.9μs",
+              "rme": 7.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 266272,
+              "hzLabel": "266.3k ops/s",
+              "mean": 0.003755562131996839,
+              "meanLabel": "3.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 257001,
+              "hzLabel": "257.0k ops/s",
+              "mean": 0.0038910373693086587,
+              "meanLabel": "3.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 269221,
+              "hzLabel": "269.2k ops/s",
+              "mean": 0.003714415003283965,
+              "meanLabel": "3.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (10,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (10,000 items, cached)",
+              "hz": 268401,
+              "hzLabel": "268.4k ops/s",
+              "mean": 0.0037257663429513216,
+              "meanLabel": "3.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6474,
+              "hzLabel": "6.5k ops/s",
+              "mean": 0.15445416924066802,
+              "meanLabel": "154.5μs",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 268141,
+              "hzLabel": "268.1k ops/s",
+              "mean": 0.0037293826331421024,
+              "meanLabel": "3.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 269221,
+              "hzLabel": "269.2k ops/s",
+              "mean": 0.003714415003283965,
+              "meanLabel": "3.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6474,
+              "hzLabel": "6.5k ops/s",
+              "mean": 0.15445416924066802,
+              "meanLabel": "154.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty step": {
+          "name": "Create empty step",
+          "hz": 28053,
+          "hzLabel": "28.1k ops/s",
+          "mean": 0.03564728167115643,
+          "meanLabel": "35.6μs",
+          "rme": 5.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 693,
+          "hzLabel": "693 ops/s",
+          "mean": 1.4437059510062429,
+          "meanLabel": "1.44ms",
+          "rme": 11.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.290496914278316,
+          "meanLabel": "14.29ms",
+          "rme": 7.5,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (circular)": {
+          "name": "Onboard 1,000 items (circular)",
+          "hz": 767,
+          "hzLabel": "767 ops/s",
+          "mean": 1.304625489581061,
+          "meanLabel": "1.30ms",
+          "rme": 8.3,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 724,
+          "hzLabel": "724 ops/s",
+          "mean": 1.380275707990162,
+          "meanLabel": "1.38ms",
+          "rme": 9,
+          "tier": "fast"
+        },
+        "next() from mid-point (1,000 items)": {
+          "name": "next() from mid-point (1,000 items)",
+          "hz": 120684,
+          "hzLabel": "120.7k ops/s",
+          "mean": 0.008286128931802212,
+          "meanLabel": "8.3μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "next() from mid-point (10,000 items)": {
+          "name": "next() from mid-point (10,000 items)",
+          "hz": 122572,
+          "hzLabel": "122.6k ops/s",
+          "mean": 0.008158453309952676,
+          "meanLabel": "8.2μs",
+          "rme": 2.7,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (1,000 items)": {
+          "name": "prev() from mid-point (1,000 items)",
+          "hz": 116063,
+          "hzLabel": "116.1k ops/s",
+          "mean": 0.008615981734322853,
+          "meanLabel": "8.6μs",
+          "rme": 6.3,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (10,000 items)": {
+          "name": "prev() from mid-point (10,000 items)",
+          "hz": 122886,
+          "hzLabel": "122.9k ops/s",
+          "mean": 0.008137654069757949,
+          "meanLabel": "8.1μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "first() (1,000 items)": {
+          "name": "first() (1,000 items)",
+          "hz": 382081,
+          "hzLabel": "382.1k ops/s",
+          "mean": 0.0026172465282977763,
+          "meanLabel": "2.6μs",
+          "rme": 5.8,
+          "tier": "blazing"
+        },
+        "last() (1,000 items)": {
+          "name": "last() (1,000 items)",
+          "hz": 401746,
+          "hzLabel": "401.7k ops/s",
+          "mean": 0.0024891321723892724,
+          "meanLabel": "2.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "step(+5) from mid-point (1,000 items)": {
+          "name": "step(+5) from mid-point (1,000 items)",
+          "hz": 122936,
+          "hzLabel": "122.9k ops/s",
+          "mean": 0.008134303144648514,
+          "meanLabel": "8.1μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "step(+50) from mid-point (1,000 items)": {
+          "name": "step(+50) from mid-point (1,000 items)",
+          "hz": 118585,
+          "hzLabel": "118.6k ops/s",
+          "mean": 0.008432760376356069,
+          "meanLabel": "8.4μs",
+          "rme": 4.8,
+          "tier": "blazing"
+        },
+        "next() from mid-point circular (1,000 items)": {
+          "name": "next() from mid-point circular (1,000 items)",
+          "hz": 119889,
+          "hzLabel": "119.9k ops/s",
+          "mean": 0.008341061422977398,
+          "meanLabel": "8.3μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "next() wrapping past end circular (1,000 items)": {
+          "name": "next() wrapping past end circular (1,000 items)",
+          "hz": 150330,
+          "hzLabel": "150.3k ops/s",
+          "mean": 0.006652028161097518,
+          "meanLabel": "6.7μs",
+          "rme": 2.1,
+          "tier": "blazing"
+        },
+        "prev() wrapping past start circular (1,000 items)": {
+          "name": "prev() wrapping past start circular (1,000 items)",
+          "hz": 148768,
+          "hzLabel": "148.8k ops/s",
+          "mean": 0.006721883563770388,
+          "meanLabel": "6.7μs",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "next() at last item — no-op (1,000 items)": {
+          "name": "next() at last item — no-op (1,000 items)",
+          "hz": 266272,
+          "hzLabel": "266.3k ops/s",
+          "mean": 0.003755562131996839,
+          "meanLabel": "3.8μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "prev() at first item — no-op (1,000 items)": {
+          "name": "prev() at first item — no-op (1,000 items)",
+          "hz": 257001,
+          "hzLabel": "257.0k ops/s",
+          "mean": 0.0038910373693086587,
+          "meanLabel": "3.9μs",
+          "rme": 7.2,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 269221,
+          "hzLabel": "269.2k ops/s",
+          "mean": 0.003714415003283965,
+          "meanLabel": "3.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (10,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (10,000 items, cached)",
+          "hz": 268401,
+          "hzLabel": "268.4k ops/s",
+          "mean": 0.0037257663429513216,
+          "meanLabel": "3.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6474,
+          "hzLabel": "6.5k ops/s",
+          "mean": 0.15445416924066802,
+          "meanLabel": "154.5μs",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 268141,
+          "hzLabel": "268.1k ops/s",
+          "mean": 0.0037293826331421024,
+          "meanLabel": "3.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "last() (1,000 items)",
+          "hz": 401746,
+          "hzLabel": "401.7k ops/s",
+          "mean": 0.0024891321723892724,
+          "meanLabel": "2.5μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.290496914278316,
+          "meanLabel": "14.29ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createTokens": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create tokens (~100 tokens)": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6141,
+              "hzLabel": "6.1k ops/s",
+              "mean": 0.16283381504363928,
+              "meanLabel": "162.8μs",
+              "rme": 8.3,
+              "tier": "fast"
+            },
+            "Create tokens (1,000 tokens)": {
+              "name": "Create tokens (1,000 tokens)",
+              "hz": 839,
+              "hzLabel": "839 ops/s",
+              "mean": 1.1915628321519194,
+              "meanLabel": "1.19ms",
+              "rme": 5.3,
+              "tier": "fast"
+            },
+            "Create tokens (10,000 tokens)": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.204959611114141,
+              "meanLabel": "14.20ms",
+              "rme": 4.9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6141,
+              "hzLabel": "6.1k ops/s",
+              "mean": 0.16283381504363928,
+              "meanLabel": "162.8μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.204959611114141,
+              "meanLabel": "14.20ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Resolve primitive token": {
+              "name": "Resolve primitive token",
+              "hz": 3859392,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025910815585066465,
+              "meanLabel": "259ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Resolve nested path (3 levels)": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 3917241,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025528169614434296,
+              "meanLabel": "255ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve deep nested path (5 levels)": {
+              "name": "Resolve deep nested path (5 levels)",
+              "hz": 3915217,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.0002554136776547286,
+              "meanLabel": "255ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve by id (1,000 tokens)": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 3920924,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.0002550419395646044,
+              "meanLabel": "255ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve by id (10,000 tokens)": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 3931871,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025433185057999365,
+              "meanLabel": "254ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 3931871,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025433185057999365,
+              "meanLabel": "254ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve primitive token",
+              "hz": 3859392,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025910815585066465,
+              "meanLabel": "259ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "alias resolution": {
+            "Resolve single alias": {
+              "name": "Resolve single alias",
+              "hz": 3911399,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.0002556629764550767,
+              "meanLabel": "256ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve chained alias (2 levels)": {
+              "name": "Resolve chained alias (2 levels)",
+              "hz": 3946943,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025336062078668464,
+              "meanLabel": "253ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve component alias reference": {
+              "name": "Resolve component alias reference",
+              "hz": 3967690,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00025203584301890453,
+              "meanLabel": "252ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve alias (1,000 tokens)": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 3891929,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.0002569419732845598,
+              "meanLabel": "257ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (10,000 tokens)": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 3941107,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.00025373578395394597,
+              "meanLabel": "254ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve component alias reference",
+              "hz": 3967690,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00025203584301890453,
+              "meanLabel": "252ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 3891929,
+              "hzLabel": "3.9M ops/s",
+              "mean": 0.0002569419732845598,
+              "meanLabel": "257ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch resolution": {
+            "Resolve 5 different paths sequentially": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1267385,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007890263187060202,
+              "meanLabel": "789ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Resolve 100 paths (20 unique, repeated)": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 76894,
+              "hzLabel": "76.9k ops/s",
+              "mean": 0.013004864336375217,
+              "meanLabel": "13.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1267385,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007890263187060202,
+              "meanLabel": "789ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 76894,
+              "hzLabel": "76.9k ops/s",
+              "mean": 0.013004864336375217,
+              "meanLabel": "13.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access token 100 times (fixture, cached)": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 84505,
+              "hzLabel": "84.5k ops/s",
+              "mean": 0.0118335544456983,
+              "meanLabel": "11.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access token 100 times (1,000 tokens, cached)": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 84818,
+              "hzLabel": "84.8k ops/s",
+              "mean": 0.011789901745007688,
+              "meanLabel": "11.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access token 100 times (10,000 tokens, cached)": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 84332,
+              "hzLabel": "84.3k ops/s",
+              "mean": 0.011857953920319582,
+              "meanLabel": "11.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 84818,
+              "hzLabel": "84.8k ops/s",
+              "mean": 0.011789901745007688,
+              "meanLabel": "11.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 84332,
+              "hzLabel": "84.3k ops/s",
+              "mean": 0.011857953920319582,
+              "meanLabel": "11.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create tokens (~100 tokens)": {
+          "name": "Create tokens (~100 tokens)",
+          "hz": 6141,
+          "hzLabel": "6.1k ops/s",
+          "mean": 0.16283381504363928,
+          "meanLabel": "162.8μs",
+          "rme": 8.3,
+          "tier": "fast"
+        },
+        "Create tokens (1,000 tokens)": {
+          "name": "Create tokens (1,000 tokens)",
+          "hz": 839,
+          "hzLabel": "839 ops/s",
+          "mean": 1.1915628321519194,
+          "meanLabel": "1.19ms",
+          "rme": 5.3,
+          "tier": "fast"
+        },
+        "Create tokens (10,000 tokens)": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.204959611114141,
+          "meanLabel": "14.20ms",
+          "rme": 4.9,
+          "tier": "fast"
+        },
+        "Resolve primitive token": {
+          "name": "Resolve primitive token",
+          "hz": 3859392,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.00025910815585066465,
+          "meanLabel": "259ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Resolve nested path (3 levels)": {
+          "name": "Resolve nested path (3 levels)",
+          "hz": 3917241,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.00025528169614434296,
+          "meanLabel": "255ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve deep nested path (5 levels)": {
+          "name": "Resolve deep nested path (5 levels)",
+          "hz": 3915217,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.0002554136776547286,
+          "meanLabel": "255ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve by id (1,000 tokens)": {
+          "name": "Resolve by id (1,000 tokens)",
+          "hz": 3920924,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.0002550419395646044,
+          "meanLabel": "255ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve by id (10,000 tokens)": {
+          "name": "Resolve by id (10,000 tokens)",
+          "hz": 3931871,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.00025433185057999365,
+          "meanLabel": "254ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve single alias": {
+          "name": "Resolve single alias",
+          "hz": 3911399,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.0002556629764550767,
+          "meanLabel": "256ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve chained alias (2 levels)": {
+          "name": "Resolve chained alias (2 levels)",
+          "hz": 3946943,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.00025336062078668464,
+          "meanLabel": "253ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve component alias reference": {
+          "name": "Resolve component alias reference",
+          "hz": 3967690,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00025203584301890453,
+          "meanLabel": "252ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve alias (1,000 tokens)": {
+          "name": "Resolve alias (1,000 tokens)",
+          "hz": 3891929,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.0002569419732845598,
+          "meanLabel": "257ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (10,000 tokens)": {
+          "name": "Resolve alias (10,000 tokens)",
+          "hz": 3941107,
+          "hzLabel": "3.9M ops/s",
+          "mean": 0.00025373578395394597,
+          "meanLabel": "254ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resolve 5 different paths sequentially": {
+          "name": "Resolve 5 different paths sequentially",
+          "hz": 1267385,
+          "hzLabel": "1.3M ops/s",
+          "mean": 0.0007890263187060202,
+          "meanLabel": "789ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resolve 100 paths (20 unique, repeated)": {
+          "name": "Resolve 100 paths (20 unique, repeated)",
+          "hz": 76894,
+          "hzLabel": "76.9k ops/s",
+          "mean": 0.013004864336375217,
+          "meanLabel": "13.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (fixture, cached)": {
+          "name": "Access token 100 times (fixture, cached)",
+          "hz": 84505,
+          "hzLabel": "84.5k ops/s",
+          "mean": 0.0118335544456983,
+          "meanLabel": "11.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access token 100 times (1,000 tokens, cached)": {
+          "name": "Access token 100 times (1,000 tokens, cached)",
+          "hz": 84818,
+          "hzLabel": "84.8k ops/s",
+          "mean": 0.011789901745007688,
+          "meanLabel": "11.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access token 100 times (10,000 tokens, cached)": {
+          "name": "Access token 100 times (10,000 tokens, cached)",
+          "hz": 84332,
+          "hzLabel": "84.3k ops/s",
+          "mean": 0.011857953920319582,
+          "meanLabel": "11.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Resolve component alias reference",
+          "hz": 3967690,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00025203584301890453,
+          "meanLabel": "252ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.204959611114141,
+          "meanLabel": "14.20ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createVirtual": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create virtual (1,000 items)": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8538,
+              "hzLabel": "8.5k ops/s",
+              "mean": 0.1171264104005799,
+              "meanLabel": "117.1μs",
+              "rme": 5.4,
+              "tier": "blazing"
+            },
+            "Create virtual (10,000 items)": {
+              "name": "Create virtual (10,000 items)",
+              "hz": 958,
+              "hzLabel": "958 ops/s",
+              "mean": 1.0435273958340985,
+              "meanLabel": "1.04ms",
+              "rme": 6.8,
+              "tier": "blazing"
+            },
+            "Create virtual (100,000 items)": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.336482591839147,
+              "meanLabel": "10.34ms",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8538,
+              "hzLabel": "8.5k ops/s",
+              "mean": 0.1171264104005799,
+              "meanLabel": "117.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.336482591839147,
+              "meanLabel": "10.34ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scroll operations": {
+            "Scroll to start position (1,000 items)": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 470940,
+              "hzLabel": "470.9k ops/s",
+              "mean": 0.002123414745001238,
+              "meanLabel": "2.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Scroll to start position (10,000 items)": {
+              "name": "Scroll to start position (10,000 items)",
+              "hz": 448407,
+              "hzLabel": "448.4k ops/s",
+              "mean": 0.0022301169425736483,
+              "meanLabel": "2.2μs",
+              "rme": 4,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (1,000 items)": {
+              "name": "Scroll to middle position (1,000 items)",
+              "hz": 448970,
+              "hzLabel": "449.0k ops/s",
+              "mean": 0.0022273223289839385,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (10,000 items)": {
+              "name": "Scroll to middle position (10,000 items)",
+              "hz": 452043,
+              "hzLabel": "452.0k ops/s",
+              "mean": 0.0022121795931985795,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Scroll to end position (1,000 items)": {
+              "name": "Scroll to end position (1,000 items)",
+              "hz": 439668,
+              "hzLabel": "439.7k ops/s",
+              "mean": 0.002274442099767461,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (10,000 items)": {
+              "name": "Scroll to end position (10,000 items)",
+              "hz": 451914,
+              "hzLabel": "451.9k ops/s",
+              "mean": 0.0022128126280952023,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (1,000 items)": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4782,
+              "hzLabel": "4.8k ops/s",
+              "mean": 0.2090975932290388,
+              "meanLabel": "209.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (10,000 items)": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4891,
+              "hzLabel": "4.9k ops/s",
+              "mean": 0.20444065085832122,
+              "meanLabel": "204.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 470940,
+              "hzLabel": "470.9k ops/s",
+              "mean": 0.002123414745001238,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4782,
+              "hzLabel": "4.8k ops/s",
+              "mean": 0.2090975932290388,
+              "meanLabel": "209.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "resize operations": {
+            "Resize single item (1,000 items)": {
+              "name": "Resize single item (1,000 items)",
+              "hz": 1060674,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009427965542610548,
+              "meanLabel": "943ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Resize single item (10,000 items)": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1038842,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.000962610577880697,
+              "meanLabel": "963ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (1,000 items)": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 12623,
+              "hzLabel": "12.6k ops/s",
+              "mean": 0.079218471324543,
+              "meanLabel": "79.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (10,000 items)": {
+              "name": "Resize 100 items sequentially (10,000 items)",
+              "hz": 12762,
+              "hzLabel": "12.8k ops/s",
+              "mean": 0.07835604246349592,
+              "meanLabel": "78.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize with variable heights (1,000 items)": {
+              "name": "Resize with variable heights (1,000 items)",
+              "hz": 12685,
+              "hzLabel": "12.7k ops/s",
+              "mean": 0.07883080813463544,
+              "meanLabel": "78.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resize single item (1,000 items)",
+              "hz": 1060674,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009427965542610548,
+              "meanLabel": "943ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 12623,
+              "hzLabel": "12.6k ops/s",
+              "mean": 0.079218471324543,
+              "meanLabel": "79.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scrollTo operations": {
+            "ScrollTo start (1,000 items)": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 435456,
+              "hzLabel": "435.5k ops/s",
+              "mean": 0.0022964406900802163,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo start (10,000 items)": {
+              "name": "ScrollTo start (10,000 items)",
+              "hz": 431445,
+              "hzLabel": "431.4k ops/s",
+              "mean": 0.0023177921269538168,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (1,000 items)": {
+              "name": "ScrollTo middle (1,000 items)",
+              "hz": 426730,
+              "hzLabel": "426.7k ops/s",
+              "mean": 0.0023434005745295527,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (10,000 items)": {
+              "name": "ScrollTo middle (10,000 items)",
+              "hz": 418934,
+              "hzLabel": "418.9k ops/s",
+              "mean": 0.002387012608200548,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (1,000 items)": {
+              "name": "ScrollTo end (1,000 items)",
+              "hz": 419611,
+              "hzLabel": "419.6k ops/s",
+              "mean": 0.002383158117527064,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (10,000 items)": {
+              "name": "ScrollTo end (10,000 items)",
+              "hz": 421722,
+              "hzLabel": "421.7k ops/s",
+              "mean": 0.0023712281635171633,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo 5 positions (10,000 items)": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 84832,
+              "hzLabel": "84.8k ops/s",
+              "mean": 0.01178794719104501,
+              "meanLabel": "11.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 435456,
+              "hzLabel": "435.5k ops/s",
+              "mean": 0.0022964406900802163,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 84832,
+              "hzLabel": "84.8k ops/s",
+              "mean": 0.01178794719104501,
+              "meanLabel": "11.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 977424,
+              "hzLabel": "977.4k ops/s",
+              "mean": 0.0010230975932688136,
+              "meanLabel": "1.0μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1063111,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000940635402489851,
+              "meanLabel": "941ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (1,000 items, cached)": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 51375,
+              "hzLabel": "51.4k ops/s",
+              "mean": 0.0194645725241152,
+              "meanLabel": "19.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (10,000 items, cached)": {
+              "name": "Access offset 100 times (10,000 items, cached)",
+              "hz": 51284,
+              "hzLabel": "51.3k ops/s",
+              "mean": 0.019499237530525595,
+              "meanLabel": "19.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (1,000 items, cached)": {
+              "name": "Access size 100 times (1,000 items, cached)",
+              "hz": 51437,
+              "hzLabel": "51.4k ops/s",
+              "mean": 0.019441307165786778,
+              "meanLabel": "19.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (10,000 items, cached)": {
+              "name": "Access size 100 times (10,000 items, cached)",
+              "hz": 51383,
+              "hzLabel": "51.4k ops/s",
+              "mean": 0.0194615922465062,
+              "meanLabel": "19.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1063111,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.000940635402489851,
+              "meanLabel": "941ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access offset 100 times (10,000 items, cached)",
+              "hz": 51284,
+              "hzLabel": "51.3k ops/s",
+              "mean": 0.019499237530525595,
+              "meanLabel": "19.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create virtual (1,000 items)": {
+          "name": "Create virtual (1,000 items)",
+          "hz": 8538,
+          "hzLabel": "8.5k ops/s",
+          "mean": 0.1171264104005799,
+          "meanLabel": "117.1μs",
+          "rme": 5.4,
+          "tier": "blazing"
+        },
+        "Create virtual (10,000 items)": {
+          "name": "Create virtual (10,000 items)",
+          "hz": 958,
+          "hzLabel": "958 ops/s",
+          "mean": 1.0435273958340985,
+          "meanLabel": "1.04ms",
+          "rme": 6.8,
+          "tier": "blazing"
+        },
+        "Create virtual (100,000 items)": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.336482591839147,
+          "meanLabel": "10.34ms",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Scroll to start position (1,000 items)": {
+          "name": "Scroll to start position (1,000 items)",
+          "hz": 470940,
+          "hzLabel": "470.9k ops/s",
+          "mean": 0.002123414745001238,
+          "meanLabel": "2.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Scroll to start position (10,000 items)": {
+          "name": "Scroll to start position (10,000 items)",
+          "hz": 448407,
+          "hzLabel": "448.4k ops/s",
+          "mean": 0.0022301169425736483,
+          "meanLabel": "2.2μs",
+          "rme": 4,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (1,000 items)": {
+          "name": "Scroll to middle position (1,000 items)",
+          "hz": 448970,
+          "hzLabel": "449.0k ops/s",
+          "mean": 0.0022273223289839385,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (10,000 items)": {
+          "name": "Scroll to middle position (10,000 items)",
+          "hz": 452043,
+          "hzLabel": "452.0k ops/s",
+          "mean": 0.0022121795931985795,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Scroll to end position (1,000 items)": {
+          "name": "Scroll to end position (1,000 items)",
+          "hz": 439668,
+          "hzLabel": "439.7k ops/s",
+          "mean": 0.002274442099767461,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (10,000 items)": {
+          "name": "Scroll to end position (10,000 items)",
+          "hz": 451914,
+          "hzLabel": "451.9k ops/s",
+          "mean": 0.0022128126280952023,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (1,000 items)": {
+          "name": "Process 100 scroll events (1,000 items)",
+          "hz": 4782,
+          "hzLabel": "4.8k ops/s",
+          "mean": 0.2090975932290388,
+          "meanLabel": "209.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (10,000 items)": {
+          "name": "Process 100 scroll events (10,000 items)",
+          "hz": 4891,
+          "hzLabel": "4.9k ops/s",
+          "mean": 0.20444065085832122,
+          "meanLabel": "204.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resize single item (1,000 items)": {
+          "name": "Resize single item (1,000 items)",
+          "hz": 1060674,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009427965542610548,
+          "meanLabel": "943ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resize single item (10,000 items)": {
+          "name": "Resize single item (10,000 items)",
+          "hz": 1038842,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.000962610577880697,
+          "meanLabel": "963ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (1,000 items)": {
+          "name": "Resize 100 items sequentially (1,000 items)",
+          "hz": 12623,
+          "hzLabel": "12.6k ops/s",
+          "mean": 0.079218471324543,
+          "meanLabel": "79.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (10,000 items)": {
+          "name": "Resize 100 items sequentially (10,000 items)",
+          "hz": 12762,
+          "hzLabel": "12.8k ops/s",
+          "mean": 0.07835604246349592,
+          "meanLabel": "78.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize with variable heights (1,000 items)": {
+          "name": "Resize with variable heights (1,000 items)",
+          "hz": 12685,
+          "hzLabel": "12.7k ops/s",
+          "mean": 0.07883080813463544,
+          "meanLabel": "78.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "ScrollTo start (1,000 items)": {
+          "name": "ScrollTo start (1,000 items)",
+          "hz": 435456,
+          "hzLabel": "435.5k ops/s",
+          "mean": 0.0022964406900802163,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo start (10,000 items)": {
+          "name": "ScrollTo start (10,000 items)",
+          "hz": 431445,
+          "hzLabel": "431.4k ops/s",
+          "mean": 0.0023177921269538168,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (1,000 items)": {
+          "name": "ScrollTo middle (1,000 items)",
+          "hz": 426730,
+          "hzLabel": "426.7k ops/s",
+          "mean": 0.0023434005745295527,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (10,000 items)": {
+          "name": "ScrollTo middle (10,000 items)",
+          "hz": 418934,
+          "hzLabel": "418.9k ops/s",
+          "mean": 0.002387012608200548,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (1,000 items)": {
+          "name": "ScrollTo end (1,000 items)",
+          "hz": 419611,
+          "hzLabel": "419.6k ops/s",
+          "mean": 0.002383158117527064,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (10,000 items)": {
+          "name": "ScrollTo end (10,000 items)",
+          "hz": 421722,
+          "hzLabel": "421.7k ops/s",
+          "mean": 0.0023712281635171633,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo 5 positions (10,000 items)": {
+          "name": "ScrollTo 5 positions (10,000 items)",
+          "hz": 84832,
+          "hzLabel": "84.8k ops/s",
+          "mean": 0.01178794719104501,
+          "meanLabel": "11.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 977424,
+          "hzLabel": "977.4k ops/s",
+          "mean": 0.0010230975932688136,
+          "meanLabel": "1.0μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1063111,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000940635402489851,
+          "meanLabel": "941ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (1,000 items, cached)": {
+          "name": "Access offset 100 times (1,000 items, cached)",
+          "hz": 51375,
+          "hzLabel": "51.4k ops/s",
+          "mean": 0.0194645725241152,
+          "meanLabel": "19.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (10,000 items, cached)": {
+          "name": "Access offset 100 times (10,000 items, cached)",
+          "hz": 51284,
+          "hzLabel": "51.3k ops/s",
+          "mean": 0.019499237530525595,
+          "meanLabel": "19.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (1,000 items, cached)": {
+          "name": "Access size 100 times (1,000 items, cached)",
+          "hz": 51437,
+          "hzLabel": "51.4k ops/s",
+          "mean": 0.019441307165786778,
+          "meanLabel": "19.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (10,000 items, cached)": {
+          "name": "Access size 100 times (10,000 items, cached)",
+          "hz": 51383,
+          "hzLabel": "51.4k ops/s",
+          "mean": 0.0194615922465062,
+          "meanLabel": "19.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1063111,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.000940635402489851,
+          "meanLabel": "941ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.336482591839147,
+          "meanLabel": "10.34ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "useDate": {
+      "benchmarks": {
+        "_groups": {
+          "construction": {
+            "create date from null (now)": {
+              "name": "create date from null (now)",
+              "hz": 698630,
+              "hzLabel": "698.6k ops/s",
+              "mean": 0.0014313733735479423,
+              "meanLabel": "1.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "create date from ISO string": {
+              "name": "create date from ISO string",
+              "hz": 1572125,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006360818840349605,
+              "meanLabel": "636ns",
+              "rme": 18.6,
+              "tier": "blazing"
+            },
+            "create date from timestamp": {
+              "name": "create date from timestamp",
+              "hz": 742022,
+              "hzLabel": "742.0k ops/s",
+              "mean": 0.0013476697752772375,
+              "meanLabel": "1.3μs",
+              "rme": 9.5,
+              "tier": "blazing"
+            },
+            "create 1000 dates": {
+              "name": "create 1000 dates",
+              "hz": 1636,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6113477383859366,
+              "meanLabel": "611.3μs",
+              "rme": 32.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "create date from ISO string",
+              "hz": 1572125,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006360818840349605,
+              "meanLabel": "636ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "create 1000 dates",
+              "hz": 1636,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6113477383859366,
+              "meanLabel": "611.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "formatting": {
+            "format fullDate": {
+              "name": "format fullDate",
+              "hz": 509591,
+              "hzLabel": "509.6k ops/s",
+              "mean": 0.001962357325036285,
+              "meanLabel": "2.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format shortDate": {
+              "name": "format shortDate",
+              "hz": 479595,
+              "hzLabel": "479.6k ops/s",
+              "mean": 0.002085091110009756,
+              "meanLabel": "2.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "format 1000 dates": {
+              "name": "format 1000 dates",
+              "hz": 559,
+              "hzLabel": "559 ops/s",
+              "mean": 1.7898369249989627,
+              "meanLabel": "1.79ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "format fullDate",
+              "hz": 509591,
+              "hzLabel": "509.6k ops/s",
+              "mean": 0.001962357325036285,
+              "meanLabel": "2.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "format 1000 dates",
+              "hz": 559,
+              "hzLabel": "559 ops/s",
+              "mean": 1.7898369249989627,
+              "meanLabel": "1.79ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation": {
+            "startOfDay": {
+              "name": "startOfDay",
+              "hz": 1080844,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009252026264285862,
+              "meanLabel": "925ns",
+              "rme": 9.5,
+              "tier": "blazing"
+            },
+            "startOfWeek": {
+              "name": "startOfWeek",
+              "hz": 478883,
+              "hzLabel": "478.9k ops/s",
+              "mean": 0.002088194072064602,
+              "meanLabel": "2.1μs",
+              "rme": 20.9,
+              "tier": "blazing"
+            },
+            "startOfMonth": {
+              "name": "startOfMonth",
+              "hz": 578950,
+              "hzLabel": "579.0k ops/s",
+              "mean": 0.0017272639735870662,
+              "meanLabel": "1.7μs",
+              "rme": 15.8,
+              "tier": "blazing"
+            },
+            "getWeekArray": {
+              "name": "getWeekArray",
+              "hz": 17707,
+              "hzLabel": "17.7k ops/s",
+              "mean": 0.05647545041766268,
+              "meanLabel": "56.5μs",
+              "rme": 34.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "startOfDay",
+              "hz": 1080844,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009252026264285862,
+              "meanLabel": "925ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "getWeekArray",
+              "hz": 17707,
+              "hzLabel": "17.7k ops/s",
+              "mean": 0.05647545041766268,
+              "meanLabel": "56.5μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "arithmetic": {
+            "addDays": {
+              "name": "addDays",
+              "hz": 980146,
+              "hzLabel": "980.1k ops/s",
+              "mean": 0.0010202565842012908,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "addMonths": {
+              "name": "addMonths",
+              "hz": 1020311,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.000980092955836977,
+              "meanLabel": "980ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "chain 10 additions": {
+              "name": "chain 10 additions",
+              "hz": 87424,
+              "hzLabel": "87.4k ops/s",
+              "mean": 0.01143853166166556,
+              "meanLabel": "11.4μs",
+              "rme": 38.7,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "addMonths",
+              "hz": 1020311,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.000980092955836977,
+              "meanLabel": "980ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "chain 10 additions",
+              "hz": 87424,
+              "hzLabel": "87.4k ops/s",
+              "mean": 0.01143853166166556,
+              "meanLabel": "11.4μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "comparison": {
+            "isAfter": {
+              "name": "isAfter",
+              "hz": 1253923,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007974968961491568,
+              "meanLabel": "797ns",
+              "rme": 30.9,
+              "tier": "blazing"
+            },
+            "isSameDay": {
+              "name": "isSameDay",
+              "hz": 699408,
+              "hzLabel": "699.4k ops/s",
+              "mean": 0.0014297814179808728,
+              "meanLabel": "1.4μs",
+              "rme": 39.5,
+              "tier": "blazing"
+            },
+            "compare 1000 pairs": {
+              "name": "compare 1000 pairs",
+              "hz": 1387,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7208900648412114,
+              "meanLabel": "720.9μs",
+              "rme": 54.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "isAfter",
+              "hz": 1253923,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007974968961491568,
+              "meanLabel": "797ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "compare 1000 pairs",
+              "hz": 1387,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7208900648412114,
+              "meanLabel": "720.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "getters/setters": {
+            "get components": {
+              "name": "get components",
+              "hz": 5557352,
+              "hzLabel": "5.6M ops/s",
+              "mean": 0.00017994180466864406,
+              "meanLabel": "180ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "set components": {
+              "name": "set components",
+              "hz": 407557,
+              "hzLabel": "407.6k ops/s",
+              "mean": 0.0024536443008820463,
+              "meanLabel": "2.5μs",
+              "rme": 18.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "get components",
+              "hz": 5557352,
+              "hzLabel": "5.6M ops/s",
+              "mean": 0.00017994180466864406,
+              "meanLabel": "180ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "set components",
+              "hz": 407557,
+              "hzLabel": "407.6k ops/s",
+              "mean": 0.0024536443008820463,
+              "meanLabel": "2.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "locale switching": {
+            "locale change + reformat": {
+              "name": "locale change + reformat",
+              "hz": 20868,
+              "hzLabel": "20.9k ops/s",
+              "mean": 0.047919965309310024,
+              "meanLabel": "47.9μs",
+              "rme": 0.9,
+              "tier": "fast"
+            },
+            "toggle locale 10 times": {
+              "name": "toggle locale 10 times",
+              "hz": 1593,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6276004642409265,
+              "meanLabel": "627.6μs",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "cache eviction (60 unique formats)": {
+              "name": "cache eviction (60 unique formats)",
+              "hz": 13666,
+              "hzLabel": "13.7k ops/s",
+              "mean": 0.07317270734584186,
+              "meanLabel": "73.2μs",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "locale change + reformat",
+              "hz": 20868,
+              "hzLabel": "20.9k ops/s",
+              "mean": 0.047919965309310024,
+              "meanLabel": "47.9μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "toggle locale 10 times",
+              "hz": 1593,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6276004642409265,
+              "meanLabel": "627.6μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          }
+        },
+        "create date from null (now)": {
+          "name": "create date from null (now)",
+          "hz": 698630,
+          "hzLabel": "698.6k ops/s",
+          "mean": 0.0014313733735479423,
+          "meanLabel": "1.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "create date from ISO string": {
+          "name": "create date from ISO string",
+          "hz": 1572125,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006360818840349605,
+          "meanLabel": "636ns",
+          "rme": 18.6,
+          "tier": "blazing"
+        },
+        "create date from timestamp": {
+          "name": "create date from timestamp",
+          "hz": 742022,
+          "hzLabel": "742.0k ops/s",
+          "mean": 0.0013476697752772375,
+          "meanLabel": "1.3μs",
+          "rme": 9.5,
+          "tier": "blazing"
+        },
+        "create 1000 dates": {
+          "name": "create 1000 dates",
+          "hz": 1636,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6113477383859366,
+          "meanLabel": "611.3μs",
+          "rme": 32.9,
+          "tier": "blazing"
+        },
+        "format fullDate": {
+          "name": "format fullDate",
+          "hz": 509591,
+          "hzLabel": "509.6k ops/s",
+          "mean": 0.001962357325036285,
+          "meanLabel": "2.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format shortDate": {
+          "name": "format shortDate",
+          "hz": 479595,
+          "hzLabel": "479.6k ops/s",
+          "mean": 0.002085091110009756,
+          "meanLabel": "2.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "format 1000 dates": {
+          "name": "format 1000 dates",
+          "hz": 559,
+          "hzLabel": "559 ops/s",
+          "mean": 1.7898369249989627,
+          "meanLabel": "1.79ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "startOfDay": {
+          "name": "startOfDay",
+          "hz": 1080844,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009252026264285862,
+          "meanLabel": "925ns",
+          "rme": 9.5,
+          "tier": "blazing"
+        },
+        "startOfWeek": {
+          "name": "startOfWeek",
+          "hz": 478883,
+          "hzLabel": "478.9k ops/s",
+          "mean": 0.002088194072064602,
+          "meanLabel": "2.1μs",
+          "rme": 20.9,
+          "tier": "blazing"
+        },
+        "startOfMonth": {
+          "name": "startOfMonth",
+          "hz": 578950,
+          "hzLabel": "579.0k ops/s",
+          "mean": 0.0017272639735870662,
+          "meanLabel": "1.7μs",
+          "rme": 15.8,
+          "tier": "blazing"
+        },
+        "getWeekArray": {
+          "name": "getWeekArray",
+          "hz": 17707,
+          "hzLabel": "17.7k ops/s",
+          "mean": 0.05647545041766268,
+          "meanLabel": "56.5μs",
+          "rme": 34.3,
+          "tier": "fast"
+        },
+        "addDays": {
+          "name": "addDays",
+          "hz": 980146,
+          "hzLabel": "980.1k ops/s",
+          "mean": 0.0010202565842012908,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "addMonths": {
+          "name": "addMonths",
+          "hz": 1020311,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.000980092955836977,
+          "meanLabel": "980ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "chain 10 additions": {
+          "name": "chain 10 additions",
+          "hz": 87424,
+          "hzLabel": "87.4k ops/s",
+          "mean": 0.01143853166166556,
+          "meanLabel": "11.4μs",
+          "rme": 38.7,
+          "tier": "fast"
+        },
+        "isAfter": {
+          "name": "isAfter",
+          "hz": 1253923,
+          "hzLabel": "1.3M ops/s",
+          "mean": 0.0007974968961491568,
+          "meanLabel": "797ns",
+          "rme": 30.9,
+          "tier": "blazing"
+        },
+        "isSameDay": {
+          "name": "isSameDay",
+          "hz": 699408,
+          "hzLabel": "699.4k ops/s",
+          "mean": 0.0014297814179808728,
+          "meanLabel": "1.4μs",
+          "rme": 39.5,
+          "tier": "blazing"
+        },
+        "compare 1000 pairs": {
+          "name": "compare 1000 pairs",
+          "hz": 1387,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.7208900648412114,
+          "meanLabel": "720.9μs",
+          "rme": 54.3,
+          "tier": "blazing"
+        },
+        "get components": {
+          "name": "get components",
+          "hz": 5557352,
+          "hzLabel": "5.6M ops/s",
+          "mean": 0.00017994180466864406,
+          "meanLabel": "180ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "set components": {
+          "name": "set components",
+          "hz": 407557,
+          "hzLabel": "407.6k ops/s",
+          "mean": 0.0024536443008820463,
+          "meanLabel": "2.5μs",
+          "rme": 18.5,
+          "tier": "blazing"
+        },
+        "locale change + reformat": {
+          "name": "locale change + reformat",
+          "hz": 20868,
+          "hzLabel": "20.9k ops/s",
+          "mean": 0.047919965309310024,
+          "meanLabel": "47.9μs",
+          "rme": 0.9,
+          "tier": "fast"
+        },
+        "toggle locale 10 times": {
+          "name": "toggle locale 10 times",
+          "hz": 1593,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6276004642409265,
+          "meanLabel": "627.6μs",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "cache eviction (60 unique formats)": {
+          "name": "cache eviction (60 unique formats)",
+          "hz": 13666,
+          "hzLabel": "13.7k ops/s",
+          "mean": 0.07317270734584186,
+          "meanLabel": "73.2μs",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "_fastest": {
+          "name": "get components",
+          "hz": 5557352,
+          "hzLabel": "5.6M ops/s",
+          "mean": 0.00017994180466864406,
+          "meanLabel": "180ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "format 1000 dates",
+          "hz": 559,
+          "hzLabel": "559 ops/s",
+          "mean": 1.7898369249989627,
+          "meanLabel": "1.79ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "useProxyRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty proxy": {
+              "name": "Create empty proxy",
+              "hz": 97268,
+              "hzLabel": "97.3k ops/s",
+              "mean": 0.010280894435976838,
+              "meanLabel": "10.3μs",
+              "rme": 14.3,
+              "tier": "fast"
+            },
+            "Create proxy (1,000 items)": {
+              "name": "Create proxy (1,000 items)",
+              "hz": 1936,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5166076787189179,
+              "meanLabel": "516.6μs",
+              "rme": 16.4,
+              "tier": "blazing"
+            },
+            "Create proxy (10,000 items)": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 178,
+              "hzLabel": "178 ops/s",
+              "mean": 5.633152444445296,
+              "meanLabel": "5.63ms",
+              "rme": 9.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty proxy",
+              "hz": 97268,
+              "hzLabel": "97.3k ops/s",
+              "mean": 0.010280894435976838,
+              "meanLabel": "10.3μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 178,
+              "hzLabel": "178 ops/s",
+              "mean": 5.633152444445296,
+              "meanLabel": "5.63ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "registry.keys() (1,000 items)": {
+              "name": "registry.keys() (1,000 items)",
+              "hz": 6817694,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014667716796871208,
+              "meanLabel": "147ns",
+              "rme": 3.7,
+              "tier": "blazing"
+            },
+            "proxy.keys (1,000 items)": {
+              "name": "proxy.keys (1,000 items)",
+              "hz": 3194105,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031307677391179757,
+              "meanLabel": "313ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.keys() (10,000 items)": {
+              "name": "registry.keys() (10,000 items)",
+              "hz": 7036328,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014211958879867476,
+              "meanLabel": "142ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.keys (10,000 items)": {
+              "name": "proxy.keys (10,000 items)",
+              "hz": 3146152,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.00031784855223662993,
+              "meanLabel": "318ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.values() (1,000 items)": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7085971,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014112392880328986,
+              "meanLabel": "141ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "proxy.values (1,000 items)": {
+              "name": "proxy.values (1,000 items)",
+              "hz": 3169832,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.0003154741582609312,
+              "meanLabel": "315ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.values() (10,000 items)": {
+              "name": "registry.values() (10,000 items)",
+              "hz": 7054435,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014175480449079076,
+              "meanLabel": "142ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.values (10,000 items)": {
+              "name": "proxy.values (10,000 items)",
+              "hz": 3161785,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031627704531480373,
+              "meanLabel": "316ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.entries() (1,000 items)": {
+              "name": "registry.entries() (1,000 items)",
+              "hz": 7061644,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014161007618673966,
+              "meanLabel": "142ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.entries (1,000 items)": {
+              "name": "proxy.entries (1,000 items)",
+              "hz": 3114137,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.00032111627423701947,
+              "meanLabel": "321ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.entries() (10,000 items)": {
+              "name": "registry.entries() (10,000 items)",
+              "hz": 7049528,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014185346905038555,
+              "meanLabel": "142ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.entries (10,000 items)": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 3175645,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031489663266885914,
+              "meanLabel": "315ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.size (1,000 items)": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 3098330,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.0003227545561601297,
+              "meanLabel": "323ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "proxy.size (10,000 items)": {
+              "name": "proxy.size (10,000 items)",
+              "hz": 3149383,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.0003175225351983402,
+              "meanLabel": "318ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7085971,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014112392880328986,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 3098330,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.0003227545561601297,
+              "meanLabel": "323ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single item (1,000 items)": {
+              "name": "Register single item (1,000 items)",
+              "hz": 139219,
+              "hzLabel": "139.2k ops/s",
+              "mean": 0.0071829123114707785,
+              "meanLabel": "7.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Register single item (10,000 items)": {
+              "name": "Register single item (10,000 items)",
+              "hz": 21660,
+              "hzLabel": "21.7k ops/s",
+              "mean": 0.04616894201824578,
+              "meanLabel": "46.2μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Unregister single item (1,000 items)": {
+              "name": "Unregister single item (1,000 items)",
+              "hz": 2262,
+              "hzLabel": "2.3k ops/s",
+              "mean": 0.44205828747835063,
+              "meanLabel": "442.1μs",
+              "rme": 9.5,
+              "tier": "blazing"
+            },
+            "Unregister single item (10,000 items)": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 180,
+              "hzLabel": "180 ops/s",
+              "mean": 5.562473144443033,
+              "meanLabel": "5.56ms",
+              "rme": 10.2,
+              "tier": "blazing"
+            },
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 559868,
+              "hzLabel": "559.9k ops/s",
+              "mean": 0.0017861344847801292,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 48025,
+              "hzLabel": "48.0k ops/s",
+              "mean": 0.02082240265692925,
+              "meanLabel": "20.8μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 559868,
+              "hzLabel": "559.9k ops/s",
+              "mean": 0.0017861344847801292,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 180,
+              "hzLabel": "180 ops/s",
+              "mean": 5.562473144443033,
+              "meanLabel": "5.56ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "bulk registration": {
+            "Onboard 1,000 items (proxy attached)": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1905,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5249759024136457,
+              "meanLabel": "525.0μs",
+              "rme": 7.7,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items (proxy attached)": {
+              "name": "Onboard 10,000 items (proxy attached)",
+              "hz": 139,
+              "hzLabel": "139 ops/s",
+              "mean": 7.2063976571454464,
+              "meanLabel": "7.21ms",
+              "rme": 11.1,
+              "tier": "blazing"
+            },
+            "Register 1,000 items one-by-one (proxy attached)": {
+              "name": "Register 1,000 items one-by-one (proxy attached)",
+              "hz": 1554,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6432991298199883,
+              "meanLabel": "643.3μs",
+              "rme": 7.4,
+              "tier": "blazing"
+            },
+            "Register 10,000 items one-by-one (proxy attached)": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 130,
+              "hzLabel": "130 ops/s",
+              "mean": 7.714841523076533,
+              "meanLabel": "7.71ms",
+              "rme": 9.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1905,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5249759024136457,
+              "meanLabel": "525.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 130,
+              "hzLabel": "130 ops/s",
+              "mean": 7.714841523076533,
+              "meanLabel": "7.71ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty proxy": {
+          "name": "Create empty proxy",
+          "hz": 97268,
+          "hzLabel": "97.3k ops/s",
+          "mean": 0.010280894435976838,
+          "meanLabel": "10.3μs",
+          "rme": 14.3,
+          "tier": "fast"
+        },
+        "Create proxy (1,000 items)": {
+          "name": "Create proxy (1,000 items)",
+          "hz": 1936,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5166076787189179,
+          "meanLabel": "516.6μs",
+          "rme": 16.4,
+          "tier": "blazing"
+        },
+        "Create proxy (10,000 items)": {
+          "name": "Create proxy (10,000 items)",
+          "hz": 178,
+          "hzLabel": "178 ops/s",
+          "mean": 5.633152444445296,
+          "meanLabel": "5.63ms",
+          "rme": 9.7,
+          "tier": "blazing"
+        },
+        "registry.keys() (1,000 items)": {
+          "name": "registry.keys() (1,000 items)",
+          "hz": 6817694,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014667716796871208,
+          "meanLabel": "147ns",
+          "rme": 3.7,
+          "tier": "blazing"
+        },
+        "proxy.keys (1,000 items)": {
+          "name": "proxy.keys (1,000 items)",
+          "hz": 3194105,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031307677391179757,
+          "meanLabel": "313ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.keys() (10,000 items)": {
+          "name": "registry.keys() (10,000 items)",
+          "hz": 7036328,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014211958879867476,
+          "meanLabel": "142ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.keys (10,000 items)": {
+          "name": "proxy.keys (10,000 items)",
+          "hz": 3146152,
+          "hzLabel": "3.1M ops/s",
+          "mean": 0.00031784855223662993,
+          "meanLabel": "318ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.values() (1,000 items)": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7085971,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014112392880328986,
+          "meanLabel": "141ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "proxy.values (1,000 items)": {
+          "name": "proxy.values (1,000 items)",
+          "hz": 3169832,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.0003154741582609312,
+          "meanLabel": "315ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.values() (10,000 items)": {
+          "name": "registry.values() (10,000 items)",
+          "hz": 7054435,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014175480449079076,
+          "meanLabel": "142ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.values (10,000 items)": {
+          "name": "proxy.values (10,000 items)",
+          "hz": 3161785,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031627704531480373,
+          "meanLabel": "316ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.entries() (1,000 items)": {
+          "name": "registry.entries() (1,000 items)",
+          "hz": 7061644,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014161007618673966,
+          "meanLabel": "142ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.entries (1,000 items)": {
+          "name": "proxy.entries (1,000 items)",
+          "hz": 3114137,
+          "hzLabel": "3.1M ops/s",
+          "mean": 0.00032111627423701947,
+          "meanLabel": "321ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.entries() (10,000 items)": {
+          "name": "registry.entries() (10,000 items)",
+          "hz": 7049528,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014185346905038555,
+          "meanLabel": "142ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.entries (10,000 items)": {
+          "name": "proxy.entries (10,000 items)",
+          "hz": 3175645,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031489663266885914,
+          "meanLabel": "315ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.size (1,000 items)": {
+          "name": "proxy.size (1,000 items)",
+          "hz": 3098330,
+          "hzLabel": "3.1M ops/s",
+          "mean": 0.0003227545561601297,
+          "meanLabel": "323ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "proxy.size (10,000 items)": {
+          "name": "proxy.size (10,000 items)",
+          "hz": 3149383,
+          "hzLabel": "3.1M ops/s",
+          "mean": 0.0003175225351983402,
+          "meanLabel": "318ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Register single item (1,000 items)": {
+          "name": "Register single item (1,000 items)",
+          "hz": 139219,
+          "hzLabel": "139.2k ops/s",
+          "mean": 0.0071829123114707785,
+          "meanLabel": "7.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Register single item (10,000 items)": {
+          "name": "Register single item (10,000 items)",
+          "hz": 21660,
+          "hzLabel": "21.7k ops/s",
+          "mean": 0.04616894201824578,
+          "meanLabel": "46.2μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Unregister single item (1,000 items)": {
+          "name": "Unregister single item (1,000 items)",
+          "hz": 2262,
+          "hzLabel": "2.3k ops/s",
+          "mean": 0.44205828747835063,
+          "meanLabel": "442.1μs",
+          "rme": 9.5,
+          "tier": "blazing"
+        },
+        "Unregister single item (10,000 items)": {
+          "name": "Unregister single item (10,000 items)",
+          "hz": 180,
+          "hzLabel": "180 ops/s",
+          "mean": 5.562473144443033,
+          "meanLabel": "5.56ms",
+          "rme": 10.2,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 559868,
+          "hzLabel": "559.9k ops/s",
+          "mean": 0.0017861344847801292,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 48025,
+          "hzLabel": "48.0k ops/s",
+          "mean": 0.02082240265692925,
+          "meanLabel": "20.8μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items (proxy attached)": {
+          "name": "Onboard 1,000 items (proxy attached)",
+          "hz": 1905,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5249759024136457,
+          "meanLabel": "525.0μs",
+          "rme": 7.7,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items (proxy attached)": {
+          "name": "Onboard 10,000 items (proxy attached)",
+          "hz": 139,
+          "hzLabel": "139 ops/s",
+          "mean": 7.2063976571454464,
+          "meanLabel": "7.21ms",
+          "rme": 11.1,
+          "tier": "blazing"
+        },
+        "Register 1,000 items one-by-one (proxy attached)": {
+          "name": "Register 1,000 items one-by-one (proxy attached)",
+          "hz": 1554,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6432991298199883,
+          "meanLabel": "643.3μs",
+          "rme": 7.4,
+          "tier": "blazing"
+        },
+        "Register 10,000 items one-by-one (proxy attached)": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 130,
+          "hzLabel": "130 ops/s",
+          "mean": 7.714841523076533,
+          "meanLabel": "7.71ms",
+          "rme": 9.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7085971,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014112392880328986,
+          "meanLabel": "141ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 130,
+          "hzLabel": "130 ops/s",
+          "mean": 7.714841523076533,
+          "meanLabel": "7.71ms",
+          "tier": "blazing"
+        },
+        "_tier": "fast"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fills the only gap in the published 1.0.x benchmark history. `generate-metrics-history.ts --print-missing` reported `1.0.4`; it now reports clean.

## Provenance

Measured on the fixed reference host per `.claude/rules/benchmarks.md` § Reference host — not on a CI runner.

| | |
|---|---|
| CPU | Intel i9-7980XE @ 2.60GHz (18C/36T) |
| Node | v26.0.0 (matches `.nvmrc`) |
| governor | `performance` |
| `busy` / `peak` | 0.06% / 1.0% — uncontended |
| scope | 433 benches across 16 files |

Host, Node and governor match the committed 1.0.0–1.0.3 snapshots exactly, so the series stays comparable end to end.

## Notes for review

- `metrics:history` measures **median of 1**, unlike the median-of-3 behind `benchmarks.json`. That is the script's designed backfill behaviour, but it means per-bench figures here carry more run-to-run noise than the live artifact — read at **feature** level, and treat the documented unstable benches as uninformative.
- `apps/docs/public/benchmarks.json` is **not** touched by this PR.
- Renders as a binary diff because `.gitattributes` marks these artifacts `linguist-generated` by design.