### PR TITLE
fix: serve docs markdown twins as text

### DIFF
--- a/apps/docs/nginx.conf
+++ b/apps/docs/nginx.conf
@@ -6,6 +6,11 @@ events {
 
 http {
   include       mime.types;
+  # Stock mime.types has no .md mapping, so SKILL.md / page twins
+  # would otherwise be application/octet-stream (WebFetch 500s).
+  types {
+    text/markdown  md markdown;
+  }
   default_type  application/octet-stream;
   root          /usr/share/nginx/html;
 

--- a/apps/docs/src/pages/guide/essentials/using-the-docs.md
+++ b/apps/docs/src/pages/guide/essentials/using-the-docs.md
@@ -401,9 +401,9 @@ Click any item to expand its details, including code examples where available.
 
 ### Dedicated API Pages
 
-For focused reference, visit `/api/{name}`:
+For focused reference, visit `/api/{name}` (kebab-case slug, e.g. `/api/dialog`):
 
-- All component variants shown together (e.g., Dialog.Root, Dialog.Content)
+- All component variants shown together (e.g. Dialog.Root, Dialog.Content)
 - Full details without page navigation
 - Useful for side-by-side comparison
 

--- a/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
@@ -229,7 +229,7 @@ Manual configuration for each IDE. Use the interactive setup above for automatic
 | Claude Code | `~/.claude.json` or `.mcp.json` | `~/.claude.json` or `.mcp.json` |
 | Claude Desktop[^cd] | N/A | `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | VS Code | `~/.config/Code/User/mcp.json` | `~/Library/Application Support/Code/User/mcp.json` |
-| Cursor | `~/.config/Cursor/User/mcp.json` | `~/Library/Application Support/Cursor/User/mcp.json` |
+| Cursor | `.cursor/mcp.json` or `~/.cursor/mcp.json` | `.cursor/mcp.json` or `~/.cursor/mcp.json` |
 | Windsurf | `~/.config/Windsurf/User/mcp.json` | `~/Library/Application Support/Windsurf/User/mcp.json` |
 | Trae | `~/.config/Trae/User/mcp.json` | `~/Library/Application Support/Trae/User/mcp.json` |
 

--- a/skills/vuetify0/SKILL.md
+++ b/skills/vuetify0/SKILL.md
@@ -31,6 +31,9 @@ Check this table **before writing custom logic**. Match by problem, not by keywo
 
 | Problem | Use | Category |
 |---|---|---|
+| Native `<button>` (click, submit, toggle) | `Button` | actions |
+| Homemade overlay / dialog / modal | `Dialog` | disclosure |
+| Homemade popover / anchored overlay | `Popover` | disclosure |
 | Single-choice state (tabs, theme picker) | `createSingle` | selection |
 | Multi-choice state (filters, tag pickers) | `createSelection` | selection |
 | Select-all with tri-state | `createGroup` | selection |


### PR DESCRIPTION
## Summary

- Serve `*.md` twins (`/SKILL.md`, page sources, `/REFERENCE.md`) as `text/markdown` instead of `application/octet-stream`. Stock nginx `mime.types` has no `.md` mapping, so the docs container fell through to `default_type application/octet-stream`. Live GET is 200 but WebFetch 500s on that type. Extra `types { text/markdown md markdown; }` in `apps/docs/nginx.conf` (merges with `include mime.types`; does not replace it).
- Add Button, Dialog, and Popover rows to the SKILL.md reach-first table so it matches the skill / AGENTS.md trigger (native `<button>` / homemade overlay). Names are the existing exported components — no new APIs.
- Change the Using the Docs `/api/{name}` example to kebab-case (`/api/dialog`). Live `/api/Dialog` 404s; `/api/dialog` is 200. No PascalCase redirects.
- Correct the MCP IDE Configuration Cursor paths from `~/.config/Cursor/User/mcp.json` to `.cursor/mcp.json` / `~/.cursor/mcp.json`, matching Quick Start.

## Test plan

- [ ] After deploy, `curl -sI https://0.vuetifyjs.com/SKILL.md` is `Content-Type: text/markdown` (charset from the existing `charset utf-8`)
- [ ] Same for a page twin (e.g. `/composables/data/create-filter.md`) and `/REFERENCE.md`
- [ ] `/llms.txt` still `text/plain`
- [ ] SKILL.md table lists Button, Dialog, Popover
- [ ] Using the Docs shows `/api/dialog`
- [ ] MCP page Cursor row matches Quick Start paths