### PR TITLE
fix(Dialog,AlertDialog): omit aria-labelledby/describedby when Title/Description absent

### DIFF
--- a/.changeset/dialog-presence-gate-aria-attrs.md
+++ b/.changeset/dialog-presence-gate-aria-attrs.md
@@ -1,0 +1,11 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Dialog,AlertDialog): omit aria-labelledby/describedby when Title/Description absent (#608)
+
+Dialog.Content and AlertDialog.Content now presence-track their Title and
+Description sub-components. The `aria-labelledby` and `aria-describedby`
+attributes are only emitted when the corresponding element is actually mounted,
+avoiding dangling IDREF warnings from assistive technologies. Follows the same
+pattern as Progress (`hasLabel`) and Combobox (`hasDescription`).

--- a/packages/0/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogContent.vue
@@ -48,8 +48,8 @@
       'id': string
       'role': 'alertdialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -168,8 +168,8 @@
       'id': context.id,
       'role': 'alertdialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.hasTitle.value ? context.titleId : undefined,
+      'aria-describedby': context.hasDescription.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogDescription.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogDescription' })
 
@@ -48,6 +48,14 @@
   } = defineProps<AlertDialogDescriptionProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasDescription.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasDescription.value = false
+  })
 
   const slotProps = toRef((): AlertDialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogRoot.vue
@@ -22,6 +22,10 @@
     id: string
     titleId: string
     descriptionId: string
+    /** Whether an AlertDialog.Title child is currently mounted */
+    hasTitle: ShallowRef<boolean>
+    /** Whether an AlertDialog.Description child is currently mounted */
+    hasDescription: ShallowRef<boolean>
     isPending: ShallowRef<boolean>
     cancelEl: ShallowRef<HTMLElement | null>
     open: () => void
@@ -83,6 +87,8 @@
 
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
+  const hasTitle = shallowRef(false)
+  const hasDescription = shallowRef(false)
 
   function open () {
     isOpen.value = true
@@ -98,6 +104,8 @@
     id,
     titleId,
     descriptionId,
+    hasTitle,
+    hasDescription,
     isPending,
     cancelEl,
     open,

--- a/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
+++ b/packages/0/src/components/AlertDialog/AlertDialogTitle.vue
@@ -33,7 +33,7 @@
   import { useAlertDialogContext } from './AlertDialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'AlertDialogTitle' })
 
@@ -48,6 +48,14 @@
   } = defineProps<AlertDialogTitleProps>()
 
   const context = useAlertDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasTitle.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasTitle.value = false
+  })
 
   const slotProps = toRef((): AlertDialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/AlertDialog/index.browser.test.ts
+++ b/packages/0/src/components/AlertDialog/index.browser.test.ts
@@ -287,7 +287,7 @@ describe('alertDialog', () => {
       expect(content.attributes('aria-modal')).toBe('true')
     })
 
-    it('should have aria-labelledby pointing to title', () => {
+    it('should have aria-labelledby pointing to title when Title is mounted', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -297,11 +297,12 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-labelledby')).toBe('test-alert-title')
     })
 
-    it('should have aria-describedby pointing to description', () => {
+    it('should have aria-describedby pointing to description when Description is mounted', async () => {
       const wrapper = mountWithStack(AlertDialog.Root, {
         props: { id: 'test-alert' },
         slots: {
@@ -311,6 +312,7 @@ describe('alertDialog', () => {
         },
       })
 
+      await nextTick()
       const content = wrapper.findComponent(AlertDialog.Content as any)
       expect(content.attributes('aria-describedby')).toBe('test-alert-description')
     })
@@ -1514,6 +1516,41 @@ describe('alertDialog', () => {
 
       expect(isOpen.value).toBe(false)
       expect(spy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should omit aria-labelledby/describedby when Title/Description are absent', () => {
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'no-title-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => 'Just content'),
+        },
+      })
+
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      // aria-labelledby/describedby should be omitted when Title/Description not mounted
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('should emit aria-labelledby/describedby when Title/Description are present', async () => {
+      const wrapper = mountWithStack(AlertDialog.Root, {
+        props: { id: 'with-title-alert' },
+        slots: {
+          default: () => h(AlertDialog.Content, {}, () => [
+            h(AlertDialog.Title, {}, () => 'Title'),
+            h(AlertDialog.Description, {}, () => 'Description'),
+            'Content',
+          ]),
+        },
+      })
+
+      await nextTick()
+      const content = wrapper.findComponent(AlertDialog.Content as any)
+      // aria-labelledby/describedby should be present when Title/Description are mounted
+      expect(content.attributes('aria-labelledby')).toBe('with-title-alert-title')
+      expect(content.attributes('aria-describedby')).toBe('with-title-alert-description')
     })
   })
 

--- a/packages/0/src/components/Dialog/DialogContent.vue
+++ b/packages/0/src/components/Dialog/DialogContent.vue
@@ -47,8 +47,8 @@
       'id': string
       'role': 'dialog'
       'aria-modal': 'true'
-      'aria-labelledby': string
-      'aria-describedby': string
+      'aria-labelledby': string | undefined
+      'aria-describedby': string | undefined
       'style': { zIndex: number }
       'onCancel': (e: Event) => void
       'onClose': (e: Event) => void
@@ -156,8 +156,8 @@
       'id': context.id,
       'role': 'dialog',
       'aria-modal': 'true',
-      'aria-labelledby': context.titleId,
-      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.hasTitle.value ? context.titleId : undefined,
+      'aria-describedby': context.hasDescription.value ? context.descriptionId : undefined,
       'style': { zIndex: ticket.zIndex.value },
       'onCancel': onCancel,
       'onClose': onClose,

--- a/packages/0/src/components/Dialog/DialogDescription.vue
+++ b/packages/0/src/components/Dialog/DialogDescription.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogDescription' })
 
@@ -48,6 +48,14 @@
   } = defineProps<DialogDescriptionProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasDescription.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasDescription.value = false
+  })
 
   const slotProps = toRef((): DialogDescriptionSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/DialogRoot.vue
+++ b/packages/0/src/components/Dialog/DialogRoot.vue
@@ -21,6 +21,10 @@
     id: string
     titleId: string
     descriptionId: string
+    /** Whether a Dialog.Title child is currently mounted */
+    hasTitle: ShallowRef<boolean>
+    /** Whether a Dialog.Description child is currently mounted */
+    hasDescription: ShallowRef<boolean>
     open: () => void
     close: () => void
   }
@@ -52,7 +56,7 @@
 
   // Utilities
   import { useId } from '#v0/utilities'
-  import { toRef } from 'vue'
+  import { shallowRef, toRef } from 'vue'
 
   defineOptions({ name: 'DialogRoot' })
 
@@ -75,6 +79,8 @@
   const id = _id ?? useId()
   const titleId = `${id}-title`
   const descriptionId = `${id}-description`
+  const hasTitle = shallowRef(false)
+  const hasDescription = shallowRef(false)
 
   function open () {
     isOpen.value = true
@@ -89,6 +95,8 @@
     id,
     titleId,
     descriptionId,
+    hasTitle,
+    hasDescription,
     open,
     close,
   })

--- a/packages/0/src/components/Dialog/DialogTitle.vue
+++ b/packages/0/src/components/Dialog/DialogTitle.vue
@@ -33,7 +33,7 @@
   import { useDialogContext } from './DialogRoot.vue'
 
   // Utilities
-  import { toRef } from 'vue'
+  import { onBeforeUnmount, onMounted, toRef } from 'vue'
 
   defineOptions({ name: 'DialogTitle' })
 
@@ -48,6 +48,14 @@
   } = defineProps<DialogTitleProps>()
 
   const context = useDialogContext(namespace)
+
+  onMounted(() => {
+    context.hasTitle.value = true
+  })
+
+  onBeforeUnmount(() => {
+    context.hasTitle.value = false
+  })
 
   const slotProps = toRef((): DialogTitleSlotProps => ({
     attrs: {

--- a/packages/0/src/components/Dialog/index.browser.test.ts
+++ b/packages/0/src/components/Dialog/index.browser.test.ts
@@ -478,7 +478,7 @@ describe('dialog', () => {
         expect(content.attributes('aria-modal')).toBe('true')
       })
 
-      it('should have aria-labelledby pointing to title', () => {
+      it('should have aria-labelledby pointing to title when Title is mounted', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -488,11 +488,12 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-labelledby')).toBe('test-dialog-title')
       })
 
-      it('should have aria-describedby pointing to description', () => {
+      it('should have aria-describedby pointing to description when Description is mounted', async () => {
         const wrapper = mountWithStack(Dialog.Root, {
           props: { id: 'test-dialog' },
           slots: {
@@ -502,6 +503,7 @@ describe('dialog', () => {
           },
         })
 
+        await nextTick()
         const content = wrapper.findComponent(Dialog.Content as any)
         expect(content.attributes('aria-describedby')).toBe('test-dialog-description')
       })
@@ -1143,7 +1145,7 @@ describe('dialog', () => {
       expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
     })
 
-    it('should handle missing title and description', () => {
+    it('should omit aria-labelledby/describedby when Title/Description are absent', () => {
       const wrapper = mountWithStack(Dialog.Root, {
         props: { id: 'no-title-dialog' },
         slots: {
@@ -1152,9 +1154,28 @@ describe('dialog', () => {
       })
 
       const content = wrapper.findComponent(Dialog.Content as any)
-      // Should still have aria attributes pointing to potentially missing elements
-      expect(content.attributes('aria-labelledby')).toBe('no-title-dialog-title')
-      expect(content.attributes('aria-describedby')).toBe('no-title-dialog-description')
+      // aria-labelledby/describedby should be omitted when Title/Description not mounted
+      expect(content.attributes('aria-labelledby')).toBeUndefined()
+      expect(content.attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('should emit aria-labelledby/describedby when Title/Description are present', async () => {
+      const wrapper = mountWithStack(Dialog.Root, {
+        props: { id: 'with-title-dialog' },
+        slots: {
+          default: () => h(Dialog.Content, {}, () => [
+            h(Dialog.Title, {}, () => 'Title'),
+            h(Dialog.Description, {}, () => 'Description'),
+            'Content',
+          ]),
+        },
+      })
+
+      await nextTick()
+      const content = wrapper.findComponent(Dialog.Content as any)
+      // aria-labelledby/describedby should be present when Title/Description are mounted
+      expect(content.attributes('aria-labelledby')).toBe('with-title-dialog-title')
+      expect(content.attributes('aria-describedby')).toBe('with-title-dialog-description')
     })
 
     it('should handle dialog without trigger (controlled)', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`DialogContent` and `AlertDialogContent` unconditionally emitted `aria-labelledby` and `aria-describedby` even when `DialogTitle` / `DialogDescription` were not rendered. If the referenced element doesn't exist in the DOM, the IDREF is dangling — invalid per the ARIA spec. Screen readers may announce empty text or skip the dialog's accessible name.

Fixes #608

## Solution

Presence-track `Title` and `Description` sub-components using `hasTitle` / `hasDescription` as `shallowRef<boolean>` flags on the Root context. Title/Description set the flag `true` in `onMounted` and `false` in `onBeforeUnmount`. Content components gate the ARIA attributes on these flags:

```ts
'aria-labelledby': context.hasTitle.value ? context.titleId : undefined,
'aria-describedby': context.hasDescription.value ? context.descriptionId : undefined,
```

This follows the same pattern as:
- `Progress` (`hasLabel`)
- `Combobox` (`hasDescription`)

## Changes

**Dialog:**
- `DialogRoot.vue` — add `hasTitle` and `hasDescription` shallowRef to context
- `DialogTitle.vue` — set `hasTitle` on mount/unmount
- `DialogDescription.vue` — set `hasDescription` on mount/unmount  
- `DialogContent.vue` — gate `aria-labelledby`/`aria-describedby` on presence flags; update slot prop types to `string | undefined`

**AlertDialog:**
- Same changes to `AlertDialogRoot`, `AlertDialogTitle`, `AlertDialogDescription`, `AlertDialogContent`
- Keeps `cancelEl`/`focusCancel` from master

**Tests:**
- Updated tests to verify both branches: attrs present when Title/Description mounted, attrs omitted when absent

## Supersedes

This PR supersedes the fork-based #631.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dc5bb8f-5f7c-4a9f-be41-8ce6e53bb58f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dc5bb8f-5f7c-4a9f-be41-8ce6e53bb58f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

