### PR TITLE
fix(docs): resolve @paper/emerald in examples typecheck

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -47,6 +47,7 @@
     "@js-temporal/polyfill": "catalog:",
     "@mdi/js": "catalog:",
     "@octokit/core": "catalog:",
+    "@paper/emerald": "workspace:*",
     "@paper/genesis": "workspace:*",
     "@vue/repl": "catalog:",
     "@vuetify/auth": "catalog:",

--- a/apps/docs/tsconfig.examples.json
+++ b/apps/docs/tsconfig.examples.json
@@ -9,7 +9,9 @@
       "@vuetify/v0": ["../../packages/0/src"],
       "@vuetify/v0/*": ["../../packages/0/src/*"],
       "#v0": ["../../packages/0/src"],
-      "#v0/*": ["../../packages/0/src/*"]
+      "#v0/*": ["../../packages/0/src/*"],
+      "@paper/emerald": ["../../packages/emerald/src"],
+      "@paper/emerald/*": ["../../packages/emerald/src/*"]
     },
     "lib": [
       "dom",
@@ -30,10 +32,13 @@
     "src/examples/**/*.ts",
     "src/examples/**/*.vue",
     "../../packages/0/src/**/*.ts",
-    "../../packages/0/src/**/*.vue"
+    "../../packages/0/src/**/*.vue",
+    "../../packages/emerald/src/**/*.ts",
+    "../../packages/emerald/src/**/*.vue"
   ],
   "exclude": [
     "../../packages/0/src/**/__tests__/*",
+    "../../packages/emerald/src/**/__tests__/*",
     "src/examples/composables/create-data-table/**",
     "src/examples/composables/create-data-grid/**",
     "src/examples/composables/create-queue/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       '@octokit/core':
         specifier: 'catalog:'
         version: 7.0.6
+      '@paper/emerald':
+        specifier: workspace:*
+        version: link:../../packages/emerald
       '@paper/genesis':
         specifier: workspace:*
         version: link:../../packages/genesis


### PR DESCRIPTION
## Summary
- Master typecheck/Release are red on `9a83344` and `85040ee` with `TS2307: Cannot find module '@paper/emerald'` in `apps/docs` examples.
- `#802` only changed Emerald prop interfaces. It does not wire the docs workspace.
- Vite already aliases `@paper/emerald`. This adds the workspace dep and `tsconfig.examples.json` paths/include so `vue-tsc -p tsconfig.examples.json` can resolve it.

## Test plan
- [ ] PR Checks typecheck green
- [ ] Release typecheck green after merge