### PR TITLE
feat(playground): format, hard-reload, viewport presets, cheatsheet

### DIFF
--- a/apps/playground/src/components/playground/app/PlaygroundApp.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundApp.vue
@@ -49,6 +49,8 @@
     showConfig: ShallowRef<boolean>
     /** Current playground locked state from Vuetify One. */
     isLocked: Ref<boolean>
+    /** Keyboard shortcuts dialog. */
+    cheatsheet: ShallowRef<boolean>
   }
 
   export const [usePlayground, providePlayground] = createContext<PlaygroundContext>('v0:playground')
@@ -117,6 +119,7 @@
   // Shared with the tabs strip so config files are enrolled as tabbable
   // before a click can race the mandatory Tabs.Root selection.
   const showConfig = shallowRef(false)
+  const cheatsheet = shallowRef(false)
 
   providePlayground({
     store,
@@ -149,6 +152,7 @@
     snapshotContent,
     showConfig,
     isLocked,
+    cheatsheet,
   })
 
   // Restore panel state on runtime breakpoint changes

--- a/apps/playground/src/components/playground/app/PlaygroundAppBar.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundAppBar.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
   // Framework
-  import { useHotkey, useTheme, useTimer } from '@vuetify/v0'
+  import { IN_BROWSER, useEventListener, useHotkey, useTheme, useTimer } from '@vuetify/v0'
 
   // Components
+  import PlaygroundCheatsheet from '@/components/playground/app/PlaygroundCheatsheet.vue'
   import PlaygroundSaveDialog from '@/components/playground/app/PlaygroundSaveDialog.vue'
   import PlaygroundSettings from '@/components/playground/settings/PlaygroundSettings.vue'
 
@@ -11,6 +12,7 @@
   import PlaygroundMenuBar from './PlaygroundMenuBar.vue'
 
   // Composables
+  import { formatActiveFile } from '@/composables/formatActiveFile'
   import { useExport } from '@/composables/useExport'
   import { useOnePlaygrounds } from '@/composables/useOnePlaygrounds'
 
@@ -57,6 +59,19 @@
   useHotkey('ctrl+b', () => {
     playground.tree.value = !playground.tree.value
   }, { inputs: true })
+
+  // Capture: @vue/repl registers an empty Monaco Ctrl/Cmd+S command that
+  // swallows the event before a bubble-phase useHotkey can format.
+  const isMac = IN_BROWSER && /mac|iphone|ipad|ipod/i.test(navigator.userAgent)
+
+  function onFormatSave (e: KeyboardEvent) {
+    if (e.key.toLowerCase() !== 's' || e.altKey) return
+    if (isMac ? !e.metaKey || e.ctrlKey : !e.ctrlKey || e.metaKey) return
+    e.preventDefault()
+    void formatActiveFile()
+  }
+
+  useEventListener(() => IN_BROWSER ? window : undefined, 'keydown', onFormatSave, { capture: true })
 
   function onView () {
     playground.editor.value = !playground.editor.value
@@ -192,6 +207,18 @@
       </AppTooltip>
 
       <AppTooltip
+        aria-label="Keyboard shortcuts"
+        :aria-pressed="playground.cheatsheet.value"
+        class="pa-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity"
+        :class="playground.cheatsheet.value ? 'opacity-80' : 'opacity-50'"
+        position-area="bottom"
+        text="Keyboard shortcuts"
+        @click="playground.cheatsheet.value = true"
+      >
+        <AppIcon icon="keyboard" />
+      </AppTooltip>
+
+      <AppTooltip
         aria-label="Settings"
         :aria-pressed="open"
         class="pa-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity"
@@ -209,5 +236,7 @@
     <PlaygroundSettings v-if="open" @close="open = false" />
 
     <PlaygroundSaveDialog v-model="saveOpen" />
+
+    <PlaygroundCheatsheet />
   </header>
 </template>

--- a/apps/playground/src/components/playground/app/PlaygroundCheatsheet.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundCheatsheet.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+  // Framework
+  import { Dialog, useHotkey } from '@vuetify/v0'
+
+  // Components
+  import AppCloseButton from '@/components/app/AppCloseButton.vue'
+
+  // Context
+  import { usePlayground } from './PlaygroundApp.vue'
+
+  // Utilities
+  import { computed } from 'vue'
+
+  const playground = usePlayground()
+  const open = computed({
+    get: () => playground.cheatsheet.value,
+    set: value => {
+      playground.cheatsheet.value = value
+    },
+  })
+
+  const shortcuts = [
+    { action: 'File tree', keys: 'Ctrl+B' },
+    { action: 'Format', keys: 'Ctrl/Cmd+S' },
+    { action: 'Hard reload', keys: 'Ctrl/Cmd+Shift+R' },
+    { action: 'Keyboard shortcuts', keys: '?' },
+  ] as const
+
+  function onToggle () {
+    playground.cheatsheet.value = !playground.cheatsheet.value
+  }
+
+  useHotkey('shift+?', onToggle)
+  useHotkey('?', onToggle)
+</script>
+
+<template>
+  <Dialog.Root v-model="open">
+    <Dialog.Content
+      class="m-auto rounded-lg bg-surface border border-divider w-[min(20rem,calc(100vw-2rem))] p-0 shadow-xl"
+    >
+      <div class="flex items-start justify-between gap-3 px-4 py-3 border-b border-divider">
+        <Dialog.Title as="h2" class="text-sm font-medium text-on-surface">
+          Keyboard shortcuts
+        </Dialog.Title>
+
+        <AppCloseButton @click="playground.cheatsheet.value = false" />
+      </div>
+
+      <ul class="py-1">
+        <li
+          v-for="item in shortcuts"
+          :key="item.action"
+          class="flex items-center justify-between gap-4 px-4 py-1.5 text-xs text-on-surface"
+        >
+          <span>{{ item.action }}</span>
+
+          <kbd class="shrink-0 px-1.5 py-0.5 rounded border border-divider bg-surface-variant font-mono text-[10px] text-on-surface-variant">
+            {{ item.keys }}
+          </kbd>
+        </li>
+      </ul>
+    </Dialog.Content>
+  </Dialog.Root>
+</template>

--- a/apps/playground/src/components/playground/app/PlaygroundMenuBar.vue
+++ b/apps/playground/src/components/playground/app/PlaygroundMenuBar.vue
@@ -14,6 +14,7 @@
   import { usePlayground } from './PlaygroundApp.vue'
 
   // Composables
+  import { formatActiveFile } from '@/composables/formatActiveFile'
   import { useOnePlaygrounds } from '@/composables/useOnePlaygrounds'
 
   // Stores
@@ -101,6 +102,18 @@
   function onTree () {
     menu.value = false
     playground.tree.value = !playground.tree.value
+  }
+
+  function onFormat () {
+    menu.value = false
+    file.value = false
+    void formatActiveFile()
+  }
+
+  function onCheatsheet () {
+    menu.value = false
+    view.value = false
+    playground.cheatsheet.value = true
   }
 
   function onSide () {
@@ -425,6 +438,13 @@
 
           <div class="border-t border-divider my-1" />
 
+          <PlaygroundMenuItem @click="onFormat">
+            <span class="flex-1">Format</span>
+            <span class="text-on-surface/40 text-2.5">Ctrl+S</span>
+          </PlaygroundMenuItem>
+
+          <div class="border-t border-divider my-1" />
+
           <PlaygroundMenuItem
             :confirm="confirming"
             @click="onReset"
@@ -480,6 +500,18 @@
           >
             <AppIcon :icon="playground.left.value ? 'book-open' : 'book-closed'" :size="14" />
             Intro Panel
+          </button>
+
+          <div class="border-t border-divider my-1" />
+
+          <button
+            class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-on-surface hover:bg-surface-tint transition-colors text-left"
+            type="button"
+            @click="onCheatsheet"
+          >
+            <AppIcon icon="keyboard" :size="14" />
+            <span class="flex-1">Keyboard shortcuts</span>
+            <span class="text-on-surface/40 text-2.5">?</span>
           </button>
         </Popover.Content>
       </Popover.Root>

--- a/apps/playground/src/components/playground/editor/PlaygroundEditor.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditor.vue
@@ -14,9 +14,14 @@
   const Repl = defineAsyncComponent(() =>
     import('@vue/repl').then(m => m.Repl),
   )
-  const Monaco = defineAsyncComponent(() =>
-    import('@vue/repl/monaco-editor'),
-  )
+  const Monaco = defineAsyncComponent(() => {
+    const g = globalThis as typeof globalThis & {
+      MonacoEnvironment?: { globalAPI?: boolean }
+    }
+    g.MonacoEnvironment ??= {}
+    g.MonacoEnvironment.globalAPI = true
+    return import('@vue/repl/monaco-editor')
+  })
 </script>
 
 <template>

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorBreadcrumbs.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorBreadcrumbs.vue
@@ -2,6 +2,9 @@
   // Framework
   import { Breadcrumbs } from '@vuetify/v0'
 
+  // Composables
+  import { formatActiveFile } from '@/composables/formatActiveFile'
+
   // Utilities
   import { toRef } from 'vue'
 
@@ -13,46 +16,63 @@
   const segments = toRef(() => {
     return playground.store.activeFile?.filename?.split('/') ?? []
   })
+
+  function onFormat () {
+    void formatActiveFile()
+  }
 </script>
 
 <template>
-  <Breadcrumbs.Root
-    v-if="playground.isReady.value"
-    as="div"
-    class="flex items-center min-h-[24px] px-3 border-b border-divider bg-surface text-xs"
-    label="File path"
-  >
-    <Breadcrumbs.List class="flex items-center gap-1.5">
-      <template
-        v-for="(segment, i) in segments"
-        :key="i"
-      >
-        <Breadcrumbs.Divider
-          v-if="i > 0"
-          class="text-on-surface-variant opacity-40"
-        />
+  <div class="flex items-center justify-between gap-1 min-h-[24px] border-b border-divider bg-surface">
+    <Breadcrumbs.Root
+      v-if="playground.isReady.value"
+      as="div"
+      class="flex items-center min-h-[24px] px-3 text-xs min-w-0"
+      label="File path"
+    >
+      <Breadcrumbs.List class="flex items-center gap-1.5">
+        <template
+          v-for="(segment, i) in segments"
+          :key="i"
+        >
+          <Breadcrumbs.Divider
+            v-if="i > 0"
+            class="text-on-surface-variant opacity-40"
+          />
 
-        <Breadcrumbs.Item :text="segment">
-          <Breadcrumbs.Page
-            v-if="i === segments.length - 1"
-            class="text-on-surface-variant"
-          >
-            {{ segment }}
-          </Breadcrumbs.Page>
+          <Breadcrumbs.Item :text="segment">
+            <Breadcrumbs.Page
+              v-if="i === segments.length - 1"
+              class="text-on-surface-variant"
+            >
+              {{ segment }}
+            </Breadcrumbs.Page>
 
-          <Breadcrumbs.Link
-            v-else
-            as="span"
-            class="text-on-surface-variant cursor-default"
-          >
-            {{ segment }}
-          </Breadcrumbs.Link>
-        </Breadcrumbs.Item>
-      </template>
-    </Breadcrumbs.List>
-  </Breadcrumbs.Root>
+            <Breadcrumbs.Link
+              v-else
+              as="span"
+              class="text-on-surface-variant cursor-default"
+            >
+              {{ segment }}
+            </Breadcrumbs.Link>
+          </Breadcrumbs.Item>
+        </template>
+      </Breadcrumbs.List>
+    </Breadcrumbs.Root>
 
-  <div v-else class="flex items-center min-h-[24px] px-3 border-b border-divider bg-surface">
-    <AppSkeleton height="h-2.5" :lines="1" :widths="['w-24']" />
+    <div v-else class="flex items-center min-h-[24px] px-3">
+      <AppSkeleton height="h-2.5" :lines="1" :widths="['w-24']" />
+    </div>
+
+    <AppTooltip
+      v-if="playground.isReady.value"
+      aria-label="Format file"
+      class="pa-1 me-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity opacity-50"
+      position-area="bottom"
+      text="Format"
+      @click="onFormat"
+    >
+      <AppIcon icon="format" :size="14" />
+    </AppTooltip>
   </div>
 </template>

--- a/apps/playground/src/components/playground/editor/PlaygroundEditorPreview.vue
+++ b/apps/playground/src/components/playground/editor/PlaygroundEditorPreview.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { useTheme } from '@vuetify/v0'
+  import { Button, useHotkey, useStorage, useTheme } from '@vuetify/v0'
 
   // Components
   import { usePlayground } from '@/components/playground/app/PlaygroundApp.vue'
@@ -9,15 +9,40 @@
   import { usePreviewHealth } from '@/composables/usePreviewHealth'
 
   // Utilities
-  import { defineAsyncComponent, useTemplateRef } from 'vue'
+  import { defineAsyncComponent, toRef, useTemplateRef } from 'vue'
+
+  const PRESETS = ['375', '768', '1024', '100%'] as const
+
+  type Viewport = typeof PRESETS[number]
+
+  const WIDTHS = {
+    '375': 'w-[375px]',
+    '768': 'w-[768px]',
+    '1024': 'w-[1024px]',
+    '100%': 'w-full',
+  } as const
+
+  function isViewport (value: unknown): value is Viewport {
+    return PRESETS.includes(value as Viewport)
+  }
 
   const playground = usePlayground()
   const theme = useTheme()
+  const storage = useStorage()
+  const viewport = storage.get<Viewport>('playground-viewport', '100%')
+
+  if (!isViewport(viewport.value)) viewport.value = '100%'
+
+  const widthClass = toRef(() => WIDTHS[isViewport(viewport.value) ? viewport.value : '100%'])
 
   const host = useTemplateRef<HTMLElement>('host')
-  const { status, failed, dismissed, reloadKey, retry, dismiss } = usePreviewHealth(
+  const { status, failed, dismissed, reloadKey, reload, retry, dismiss } = usePreviewHealth(
     () => host.value?.querySelector('iframe'),
   )
+
+  useHotkey('cmd+shift+r', () => {
+    reload()
+  }, { inputs: true })
 
   const Sandbox = defineAsyncComponent(() =>
     import('@vue/repl').then(m => m.Sandbox),
@@ -25,27 +50,62 @@
 </script>
 
 <template>
-  <div ref="host" class="relative flex-1 min-w-0 min-h-0">
-    <Sandbox
-      v-if="playground.isReady.value"
-      :key="reloadKey"
-      :auto-store-init="false"
-      :clear-console="false"
-      show
-      :store="playground.store"
-      :theme="theme.isDark.value ? 'dark' : 'light'"
-    />
+  <div class="flex flex-col flex-1 min-w-0 min-h-0">
+    <div class="flex items-center gap-1 h-7 px-1.5 border-b border-divider bg-surface shrink-0">
+      <AppTooltip
+        aria-label="Hard reload preview"
+        class="pa-1 inline-flex rounded hover:opacity-80 hover:bg-surface-tint focus-visible:opacity-80 focus-visible:bg-surface-tint focus-visible:outline-none cursor-pointer transition-opacity opacity-50"
+        position-area="bottom"
+        text="Hard reload"
+        @click="reload"
+      >
+        <AppIcon icon="reset" :size="14" />
+      </AppTooltip>
 
-    <div v-else class="absolute inset-0 flex items-center justify-center">
-      <AppSkeleton height="h-16" :lines="1" :widths="['w-16']" />
+      <Button.Group
+        v-model="viewport"
+        class="ms-auto flex items-center"
+        label="Viewport width"
+        mandatory
+      >
+        <Button.Root
+          v-for="preset in PRESETS"
+          :key="preset"
+          class="px-1.5 py-0.5 rounded text-[10px] leading-none transition-colors border-0 bg-transparent text-on-surface-variant hover:bg-surface-tint data-[selected]:bg-surface-tint data-[selected]:text-on-surface data-[selected]:opacity-100 opacity-50"
+          :value="preset"
+        >
+          {{ preset }}
+        </Button.Root>
+      </Button.Group>
     </div>
 
-    <PlaygroundPreviewError
-      v-if="status === 'failed' && !dismissed"
-      :failed
-      @dismiss="dismiss"
-      @retry="retry"
-    />
+    <div ref="host" class="relative flex-1 min-w-0 min-h-0 overflow-hidden bg-background">
+      <div
+        class="relative h-full mx-auto max-w-full"
+        :class="widthClass"
+      >
+        <Sandbox
+          v-if="playground.isReady.value"
+          :key="reloadKey"
+          :auto-store-init="false"
+          :clear-console="false"
+          show
+          :store="playground.store"
+          :theme="theme.isDark.value ? 'dark' : 'light'"
+        />
+
+        <div v-else class="absolute inset-0 flex items-center justify-center">
+          <AppSkeleton height="h-16" :lines="1" :widths="['w-16']" />
+        </div>
+      </div>
+
+      <PlaygroundPreviewError
+        v-if="status === 'failed' && !dismissed"
+        :failed
+        @dismiss="dismiss"
+        @retry="retry"
+      />
+    </div>
   </div>
 </template>
 

--- a/apps/playground/src/composables/formatActiveFile.ts
+++ b/apps/playground/src/composables/formatActiveFile.ts
@@ -1,0 +1,31 @@
+// Framework
+import { IN_BROWSER } from '@vuetify/v0'
+
+interface MonacoEditor {
+  hasTextFocus?: () => boolean
+  getAction: (id: string) => { run: () => void | Promise<void> } | null
+}
+
+interface MonacoApi {
+  editor: {
+    getEditors: () => MonacoEditor[]
+  }
+}
+
+function getMonaco (): MonacoApi | undefined {
+  if (!IN_BROWSER) return undefined
+  return (globalThis as { monaco?: MonacoApi }).monaco
+}
+
+/** Format the active Monaco buffer via the editor's registered document formatter. */
+export async function formatActiveFile () {
+  const monaco = getMonaco()
+  if (!monaco) return
+
+  const editors = monaco.editor.getEditors()
+  const editor = editors.find(item => item.hasTextFocus?.()) ?? editors[0]
+  const action = editor?.getAction('editor.action.formatDocument')
+  if (!action) return
+
+  await action.run()
+}

--- a/apps/playground/src/composables/usePreviewHealth.ts
+++ b/apps/playground/src/composables/usePreviewHealth.ts
@@ -110,9 +110,13 @@ export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undef
     watchdog.start()
   }
 
-  function retry () {
+  function reload () {
     reloadKey.value++
     start()
+  }
+
+  function retry () {
+    reload()
   }
 
   function dismiss () {
@@ -127,5 +131,5 @@ export function usePreviewHealth (iframe: () => HTMLIFrameElement | null | undef
     { immediate: true },
   )
 
-  return { status, failed, dismissed, reloadKey, retry, dismiss }
+  return { status, failed, dismissed, reloadKey, reload, retry, dismiss }
 }

--- a/apps/playground/src/plugins/icons.ts
+++ b/apps/playground/src/plugins/icons.ts
@@ -136,6 +136,8 @@ export const [useIconContext, provideIconContext, context] = createTokensContext
     'lang-vue': mdiVuejs,
     'lang-json': mdiCodeJson,
     'reset': mdiRefresh,
+    'keyboard': mdiKeyboardOutline,
+    'format': mdiCodeBraces,
     'theme-light': mdiWeatherSunny,
     'theme-dark': mdiWeatherNight,
     'layers': mdiLayersOutline,

--- a/packages/emerald/src/components/EmCheckbox/EmCheckbox.vue
+++ b/packages/emerald/src/components/EmCheckbox/EmCheckbox.vue
@@ -3,14 +3,14 @@
   import { Checkbox } from '@vuetify/v0'
   import { useId } from '@vuetify/v0/utilities'
 
-  // Components
-  import EmIcon from '../EmIcon/EmIcon.vue'
-
   // Utilities
   import { toValue } from 'vue'
 
   // Types
   import type { CheckboxRootProps } from '@vuetify/v0'
+
+  // Components
+  import EmIcon from '../EmIcon/EmIcon.vue'
 
   export type EmCheckboxSize = 'sm' | 'md' | 'lg'
 

--- a/packages/emerald/src/components/EmDialog/EmDialogClose.vue
+++ b/packages/emerald/src/components/EmDialog/EmDialogClose.vue
@@ -2,11 +2,11 @@
   // Framework
   import { Dialog } from '@vuetify/v0'
 
-  // Components
-  import EmIcon from '../EmIcon/EmIcon.vue'
-
   // Types
   import type { DialogCloseProps } from '@vuetify/v0'
+
+  // Components
+  import EmIcon from '../EmIcon/EmIcon.vue'
 
   export interface EmDialogCloseProps extends Omit<DialogCloseProps, 'as' | 'renderless'> {}
 </script>

--- a/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelCue.vue
+++ b/packages/emerald/src/components/EmExpansionPanel/EmExpansionPanelCue.vue
@@ -2,11 +2,11 @@
   // Framework
   import { ExpansionPanel } from '@vuetify/v0'
 
-  // Components
-  import EmIcon from '../EmIcon/EmIcon.vue'
-
   // Types
   import type { ExpansionPanelCueProps } from '@vuetify/v0'
+
+  // Components
+  import EmIcon from '../EmIcon/EmIcon.vue'
 
   export interface EmExpansionPanelCueProps extends Omit<ExpansionPanelCueProps, 'as' | 'renderless'> {}
 </script>

--- a/packages/emerald/src/components/EmSelect/EmSelectActivator.vue
+++ b/packages/emerald/src/components/EmSelect/EmSelectActivator.vue
@@ -2,11 +2,11 @@
   // Framework
   import { Select } from '@vuetify/v0'
 
-  // Components
-  import EmIcon from '../EmIcon/EmIcon.vue'
-
   // Types
   import type { SelectActivatorProps } from '@vuetify/v0'
+
+  // Components
+  import EmIcon from '../EmIcon/EmIcon.vue'
 
   export interface EmSelectActivatorProps extends Omit<SelectActivatorProps, 'as' | 'renderless'> {}
 </script>

--- a/packages/emerald/src/components/EmSnackbar/EmSnackbarClose.vue
+++ b/packages/emerald/src/components/EmSnackbar/EmSnackbarClose.vue
@@ -2,11 +2,11 @@
   // Framework
   import { Snackbar } from '@vuetify/v0'
 
-  // Components
-  import EmIcon from '../EmIcon/EmIcon.vue'
-
   // Types
   import type { SnackbarCloseProps } from '@vuetify/v0'
+
+  // Components
+  import EmIcon from '../EmIcon/EmIcon.vue'
 
   export interface EmSnackbarCloseProps extends Omit<SnackbarCloseProps, 'as' | 'renderless'> {}
 </script>


### PR DESCRIPTION
## Summary
- Format current file on Ctrl/Cmd+S (Classic Play already did this; v0play never called a formatter), plus breadcrumbs and File menu.
- Hard-reload remounts a healthy preview (`reloadKey`), not only the error overlay Retry.
- Viewport presets 375 / 768 / 1024 / 100% (100% is fluid).
- Keyboard cheatsheet (`?`, app bar, View menu).

Output drawer not in this slice.

## Test plan
- [ ] Ctrl/Cmd+S formats the focused Monaco buffer
- [ ] Hard-reload remounts a working preview
- [ ] Viewport chips 375 / 768 / 1024 / 100%
- [ ] `?` opens the cheatsheet