### PR TITLE
fix(playground): stack Open dialog nav on small screens

### DIFF
--- a/apps/playground/src/components/playground/open/PlaygroundOpenDialog.vue
+++ b/apps/playground/src/components/playground/open/PlaygroundOpenDialog.vue
@@ -820,19 +820,23 @@
       <div
         aria-labelledby="open-title"
         aria-modal="true"
-        class="relative bg-surface border border-divider rounded-lg shadow-xl w-[900px] max-w-[calc(100vw-2rem)] h-[640px] max-h-[calc(100vh-2rem)] flex overflow-hidden"
+        class="relative bg-surface border border-divider rounded-lg shadow-xl w-[900px] max-w-[calc(100vw-2rem)] h-[640px] max-h-[calc(100vh-2rem)] flex flex-col sm:flex-row overflow-hidden"
         role="dialog"
       >
         <!-- Left rail: product stacks (same search model) + Vuetify One -->
-        <nav class="w-36 shrink-0 border-r border-divider flex flex-col gap-1 py-2 bg-surface">
+        <nav
+          aria-label="Open source"
+          class="flex flex-row flex-wrap sm:flex-nowrap sm:flex-col w-full sm:w-36 shrink-0 border-b sm:border-b-0 sm:border-r border-divider gap-1 p-2 bg-surface"
+        >
           <template v-for="item in rails" :key="item.id">
             <div
               v-if="item.id === 'saved'"
-              class="mx-3 my-2 border-t border-divider"
+              class="hidden sm:block mx-3 my-2 border-t border-divider"
             />
 
             <button
-              class="mx-1.5 flex items-center justify-between gap-2 px-2.5 py-2 text-xs text-left rounded-md transition-colors"
+              :aria-pressed="rail === item.id"
+              class="flex-1 sm:flex-none min-w-0 mx-0 sm:mx-1.5 flex items-center justify-center sm:justify-between gap-2 px-2.5 py-1.5 sm:py-2 text-xs text-center sm:text-left rounded-md transition-colors"
               :class="railActiveClass(item.id)"
               type="button"
               @click="onRail(item.id)"

--- a/apps/playground/src/components/playground/open/PlaygroundOpenGallery.vue
+++ b/apps/playground/src/components/playground/open/PlaygroundOpenGallery.vue
@@ -64,7 +64,7 @@
 
 <template>
   <div v-if="loading" class="p-4">
-    <div class="grid grid-cols-2 gap-2">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
       <div
         v-for="i in 6"
         :key="i"


### PR DESCRIPTION
## Summary
- Open dialog shell is `flex-col` below `sm` (640px) and `flex-row` from `sm` up.
- Source rail is a horizontal strip on small screens (`w-36` column from `sm`).
- Gallery skeleton is `grid-cols-1 sm:grid-cols-2`.
- Uses the `sm` breakpoint, not `useBreakpoints().isMobile` (that is `< lg` / 1145px).

## Test plan
- [ ] Open dialog under 640px: rail is a top strip, not a 9rem sidebar
- [ ] From 640px up: rail is the usual column
- [ ] Gallery skeleton is one column on small screens