### PR TITLE
docs: make custom themes selectable

### DIFF
--- a/apps/docs/src/components/app/settings/AppSettingsColorInput.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsColorInput.vue
@@ -17,8 +17,8 @@
     const target = event.target as HTMLInputElement
     let value = target.value.trim()
 
-    // Auto-add # prefix if missing
-    if (value && !value.startsWith('#')) {
+    // Auto-add # prefix for bare hex, but leave rgb()/hsl()/named colors alone
+    if (/^[\da-f]{3,8}$/i.test(value)) {
       value = `#${value}`
     }
 

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -3,24 +3,20 @@
   import { useClipboard } from '@/composables/useClipboard'
   import { useCustomThemes } from '@/composables/useCustomThemes'
   import { useSettings } from '@/composables/useSettings'
-  import { useThemeToggle } from '@/composables/useThemeToggle'
 
   // Themes
-  import { exportThemeAsVuetifyConfig, type ThemeId } from '@/themes'
+  import { exportThemeAsVuetifyConfig, themes } from '@/themes'
 
   // Utilities
   import { computed } from 'vue'
 
-  const toggle = useThemeToggle()
   const customThemes = useCustomThemes()
   const clipboard = useClipboard()
   const settings = useSettings()
 
-  // Current active theme (resolves 'system' to actual theme)
-  const currentThemeId = computed<ThemeId>(() => toggle.theme.selectedId.value as ThemeId)
-
   function exportTheme () {
-    const config = exportThemeAsVuetifyConfig(currentThemeId.value)
+    const theme = customThemes.current() ?? themes.light
+    const config = exportThemeAsVuetifyConfig(theme)
     clipboard.copy(config)
   }
 

--- a/apps/docs/src/components/app/settings/AppSettingsThemeEditor.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsThemeEditor.vue
@@ -36,7 +36,7 @@
     },
     surfaces: {
       label: 'Surfaces',
-      colors: ['background', 'surface', 'surface-tint', 'surface-variant', 'divider', 'pre'],
+      colors: ['background', 'surface', 'surface-tint', 'surface-variant', 'divider', 'pre', 'scrollbar-thumb'],
     },
     text: {
       label: 'Text / Contrast',
@@ -63,6 +63,7 @@
     'surface-variant': 'Surface Variant',
     'divider': 'Divider',
     'pre': 'Code Block',
+    'scrollbar-thumb': 'Scrollbar',
     'on-primary': 'On Primary',
     'on-secondary': 'On Secondary',
     'on-accent': 'On Accent',

--- a/apps/docs/src/components/app/theme/mode/AppThemeDarkButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeDarkButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'dark',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'dark',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/mode/AppThemeLightButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeLightButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'light',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'light',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/mode/AppThemeSystemButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeSystemButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'system',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'system',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteAntDesignButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteAntDesignButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'ant-design',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'ant-design',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteMaterial3Button.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteMaterial3Button.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'material-3',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'material-3',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteRadixButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteRadixButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'radix',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'radix',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteTailwindButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteTailwindButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'tailwind',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'tailwind',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteVuetify0Button.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteVuetify0Button.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggle()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'vuetify0',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'vuetify0',
   )
 </script>
 

--- a/apps/docs/src/composables/useCustomThemes.ts
+++ b/apps/docs/src/composables/useCustomThemes.ts
@@ -38,7 +38,7 @@ export interface UseCustomThemesReturn {
   }
 }
 
-const STORAGE_KEY = 'v0:custom-themes'
+const STORAGE_KEY = 'custom-themes'
 
 // Shared singleton state
 const customThemes = shallowRef<CustomTheme[]>([])
@@ -82,6 +82,10 @@ export function useCustomThemes (): UseCustomThemesReturn {
         value: custom.colors,
         dark: custom.dark,
       })
+    }
+
+    if (customThemes.value.some(t => t.id === toggle.preference.value)) {
+      theme.select(toggle.preference.value)
     }
   }
 

--- a/apps/docs/src/composables/useThemeToggle.ts
+++ b/apps/docs/src/composables/useThemeToggle.ts
@@ -64,7 +64,7 @@ export interface UseThemeToggleReturn {
   mode: ShallowRef<ModePreference>
   palette: ShallowRef<Palette>
   preference: ShallowRef<ThemePreference>
-  isAccessibilityActive: Ref<boolean>
+  isOverrideActive: Ref<boolean>
   icon: Ref<string>
   title: Ref<string>
   toggle: () => void
@@ -85,6 +85,14 @@ function isValidPalette (value: string | undefined): value is Palette {
 
 function isAccessibilityTheme (value: string): value is AccessibilityTheme {
   return (ACCESSIBILITY_THEMES as readonly string[]).includes(value)
+}
+
+function isCustomTheme (value: string): boolean {
+  return value.startsWith('custom-')
+}
+
+function isOverride (value: string): boolean {
+  return isAccessibilityTheme(value) || isCustomTheme(value)
 }
 
 let initialized = false
@@ -130,9 +138,9 @@ export function useThemeToggle (): UseThemeToggleReturn {
       }
     }
 
-    // Sync preference from mode (for accessibility overrides)
-    const storedAccessibility = storage.get<string>('theme-accessibility')
-    preference.value = storedAccessibility.value && isAccessibilityTheme(storedAccessibility.value) ? storedAccessibility.value : mode.value
+    // Sync preference from mode (for accessibility / custom overrides)
+    const storedOverride = storage.get<string>('theme-accessibility')
+    preference.value = storedOverride.value && isOverride(storedOverride.value) ? storedOverride.value : mode.value
 
     watch(
       [mode, palette, prefersDark],
@@ -140,8 +148,8 @@ export function useThemeToggle (): UseThemeToggleReturn {
         storage.set('theme-mode', m)
         storage.set('theme-palette', p)
 
-        // If preference is an accessibility theme, use it directly
-        if (isAccessibilityTheme(preference.value)) {
+        // If preference is a direct override, use it as-is
+        if (isOverride(preference.value)) {
           storage.set('theme-accessibility', preference.value)
           storage.set('theme', preference.value)
           theme.select(preference.value as ThemeId)
@@ -160,9 +168,9 @@ export function useThemeToggle (): UseThemeToggleReturn {
       { immediate: true },
     )
 
-    // Also watch preference for accessibility toggle
+    // Also watch preference for override selection
     watch(preference, pref => {
-      if (isAccessibilityTheme(pref)) {
+      if (isOverride(pref)) {
         storage.set('theme-accessibility', pref)
         storage.set('theme', pref)
         theme.select(pref as ThemeId)
@@ -178,11 +186,14 @@ export function useThemeToggle (): UseThemeToggleReturn {
     })
   }
 
-  const isAccessibilityActive = toRef(() => isAccessibilityTheme(preference.value))
+  const isOverrideActive = toRef(() => isOverride(preference.value))
 
   const icon = toRef(() => {
     if (isAccessibilityTheme(preference.value)) {
       return `theme-${preference.value}`
+    }
+    if (isCustomTheme(preference.value)) {
+      return 'theme-custom'
     }
     return PALETTE_ICONS[palette.value] ?? 'theme-custom'
   })
@@ -190,6 +201,9 @@ export function useThemeToggle (): UseThemeToggleReturn {
   const title = toRef(() => {
     if (isAccessibilityTheme(preference.value)) {
       return `Theme: ${preference.value}`
+    }
+    if (isCustomTheme(preference.value)) {
+      return 'Theme: Custom'
     }
     return `Theme: ${PALETTE_LABELS[palette.value] ?? 'Custom'}`
   })
@@ -202,7 +216,7 @@ export function useThemeToggle (): UseThemeToggleReturn {
   }
 
   function setPreference (pref: ThemePreference) {
-    if (isAccessibilityTheme(pref)) {
+    if (isOverride(pref)) {
       preference.value = pref
     } else if (['system', 'light', 'dark'].includes(pref)) {
       mode.value = pref as ModePreference
@@ -220,8 +234,8 @@ export function useThemeToggle (): UseThemeToggleReturn {
 
   function setPalette (p: Palette) {
     palette.value = p
-    // Clear accessibility override when picking a palette
-    if (isAccessibilityTheme(preference.value)) {
+    // Clear the direct override when picking a palette
+    if (isOverride(preference.value)) {
       preference.value = mode.value
     }
   }
@@ -232,7 +246,7 @@ export function useThemeToggle (): UseThemeToggleReturn {
     mode,
     palette,
     preference,
-    isAccessibilityActive,
+    isOverrideActive,
     icon,
     title,
     toggle,

--- a/apps/docs/src/themes/index.ts
+++ b/apps/docs/src/themes/index.ts
@@ -686,8 +686,7 @@ export function getAllThemeConfigs (): Record<ThemeId, { dark: boolean, colors: 
  * Export theme as Vuetify config format.
  * Ready to paste into createVuetify() themes option.
  */
-export function exportThemeAsVuetifyConfig (id: ThemeId): string {
-  const theme = themes[id]
+export function exportThemeAsVuetifyConfig (theme: Pick<ThemeDefinition, 'dark' | 'colors'>): string {
   const config = {
     dark: theme.dark,
     colors: { ...theme.colors },


### PR DESCRIPTION
Problem:
1. open docs theme customization
2. configure custom theme
3. try to select (not working)

Note:
- when starting from a11y themes (that have tinted scrollbars) the custom theme does not allow changing scrollbar thumb variable, so I included quick fix for this as well