### PR TITLE
fix(docs): serve the Emerald dashboard at /demo/emerald/

### DIFF
--- a/apps/docs/nginx.conf
+++ b/apps/docs/nginx.conf
@@ -25,6 +25,12 @@ http {
 
     charset utf-8;
 
+    location /demo/ {
+      index index.html;
+      try_files $uri $uri.html $uri/index.html =404;
+      add_header Cache-Control 'public, max-age=3600, s-maxage=60';
+    }
+
     location / {
       index index.html;
       try_files $uri $uri/index.html =404;

--- a/dev/src/main.ts
+++ b/dev/src/main.ts
@@ -48,7 +48,8 @@ export const createApp = ViteSSG(
     // RouterLink hrefs as /emerald/... and lychee fails offline file checks.
     base: import.meta.env.BASE_URL,
     routes: [
-      { path: '/', component: Playground },
+      // Demo deploy (`BASE_URL=/demo/emerald/`) serves the dashboard at `/`.
+      { path: '/', component: import.meta.env.BASE_URL.includes('/demo/') ? EmeraldDashboard : Playground },
       { path: '/create-overflow', component: CreateOverflowDemo },
       { path: '/emerald', component: EmeraldDashboard },
       { path: '/emerald/about', component: EmeraldAbout },


### PR DESCRIPTION
## Summary
- /demo/emerald/ already ships the dev app. The Live demo URL was the generic playground root.
- Demo-base builds render EmeraldDashboard at root. Local dev is unchanged.
- Docs nginx maps pretty demo paths to vite-ssg html files.

## Test plan
- [ ] Production demo root is the Emerald dashboard, not playground tabs
- [ ] Pretty kanban path without html extension loads
- [ ] Local dev still shows the generic playground at root
- [ ] Docs page Live demo copy is unchanged
