### PR TITLE
fix(usePopover): hide leftover popover nodes after close

### DIFF
--- a/packages/0/src/composables/usePopover/index.test.ts
+++ b/packages/0/src/composables/usePopover/index.test.ts
@@ -3,7 +3,37 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { usePopover } from './index'
 
 // Utilities
-import { effectScope, shallowRef } from 'vue'
+import { effectScope, nextTick, shallowRef } from 'vue'
+
+function createPopoverElement (options: { open?: boolean, connected?: boolean } = {}) {
+  const state = {
+    open: options.open ?? false,
+    connected: options.connected ?? true,
+  }
+
+  const showPopover = vi.fn(() => {
+    state.open = true
+  })
+  const hidePopover = vi.fn(() => {
+    state.open = false
+  })
+
+  const element = {
+    get isConnected () {
+      return state.connected
+    },
+    set isConnected (value: boolean) {
+      state.connected = value
+    },
+    showPopover,
+    hidePopover,
+    matches: vi.fn((selector: string) => selector === ':popover-open' && state.open),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as HTMLElement
+
+  return { element, showPopover, hidePopover }
+}
 
 describe('usePopover', () => {
   beforeEach(() => {
@@ -212,6 +242,116 @@ describe('usePopover', () => {
 
       vi.advanceTimersByTime(500)
       expect(popover!.isOpen.value).toBe(false)
+    })
+  })
+
+  describe('attach', () => {
+    it('should hide when the same still-open node reappears after close while the getter is null', async () => {
+      const scope = effectScope()
+      const { element, showPopover, hidePopover } = createPopoverElement()
+      const target = shallowRef<HTMLElement | null>(element)
+
+      const popover = scope.run(() => {
+        const instance = usePopover()
+        instance.attach(() => target.value)
+        return instance
+      })!
+
+      popover.isOpen.value = true
+      await nextTick()
+      expect(showPopover).toHaveBeenCalledTimes(1)
+
+      target.value = null
+      popover.isOpen.value = false
+      await nextTick()
+
+      target.value = element
+      await nextTick()
+
+      expect(hidePopover).toHaveBeenCalled()
+      scope.stop()
+    })
+
+    it('should hide when isOpen becomes false while the element is disconnected', async () => {
+      const scope = effectScope()
+      const { element, showPopover, hidePopover } = createPopoverElement()
+      const target = shallowRef<HTMLElement | null>(element)
+
+      const popover = scope.run(() => {
+        const instance = usePopover()
+        instance.attach(() => target.value)
+        return instance
+      })!
+
+      popover.isOpen.value = true
+      await nextTick()
+      expect(showPopover).toHaveBeenCalledTimes(1)
+
+      Object.defineProperty(element, 'isConnected', { value: false, configurable: true })
+      popover.isOpen.value = false
+      await nextTick()
+
+      expect(hidePopover).toHaveBeenCalled()
+      scope.stop()
+    })
+
+    it('should hide the previous node when the getter swaps away from a still-open popover', async () => {
+      const scope = effectScope()
+      const previous = createPopoverElement()
+      const next = createPopoverElement()
+      const target = shallowRef<HTMLElement | null>(previous.element)
+
+      const popover = scope.run(() => {
+        const instance = usePopover()
+        instance.attach(() => target.value)
+        return instance
+      })!
+
+      popover.isOpen.value = true
+      await nextTick()
+      expect(previous.showPopover).toHaveBeenCalledTimes(1)
+
+      target.value = next.element
+      await nextTick()
+
+      expect(previous.hidePopover).toHaveBeenCalled()
+      scope.stop()
+    })
+
+    it('should show when attach is called while isOpen is already true', async () => {
+      const scope = effectScope()
+      const isOpen = shallowRef(true)
+      const { element, showPopover } = createPopoverElement()
+      const target = shallowRef<HTMLElement | null>(element)
+
+      scope.run(() => {
+        const instance = usePopover({ isOpen })
+        instance.attach(() => target.value)
+      })
+
+      await nextTick()
+      expect(showPopover).toHaveBeenCalledTimes(1)
+      scope.stop()
+    })
+
+    it('should hide a still-open node on scope dispose', async () => {
+      const scope = effectScope()
+      const { element, showPopover, hidePopover } = createPopoverElement()
+      const target = shallowRef<HTMLElement | null>(element)
+
+      const popover = scope.run(() => {
+        const instance = usePopover()
+        instance.attach(() => target.value)
+        return instance
+      })!
+
+      popover.isOpen.value = true
+      await nextTick()
+      expect(showPopover).toHaveBeenCalledTimes(1)
+
+      scope.stop()
+
+      expect(hidePopover).toHaveBeenCalled()
     })
   })
 })

--- a/packages/0/src/composables/usePopover/index.ts
+++ b/packages/0/src/composables/usePopover/index.ts
@@ -31,9 +31,12 @@
 import { useDelay } from '#v0/composables/useDelay'
 import { useEventListener } from '#v0/composables/useEventListener'
 
+// Globals
+import { IN_BROWSER } from '#v0/constants/globals'
+
 // Utilities
-import { useId } from '#v0/utilities'
-import { onMounted, shallowRef, toRef, toValue, watch } from 'vue'
+import { isNullOrUndefined, useId } from '#v0/utilities'
+import { onScopeDispose, shallowRef, toRef, toValue, watch } from 'vue'
 
 // Types
 import type { MaybeRefOrGetter, Ref } from 'vue'
@@ -131,26 +134,49 @@ export function usePopover (options: PopoverOptions = {}): PopoverReturn {
     'position-try-fallbacks': positionTry,
   }))
 
-  /* v8 ignore start -- browser popover API */
   function attach (el: MaybeRefOrGetter<HTMLElement | null | undefined>) {
-    onMounted(() => {
-      const element = toValue(el)
-      if (isOpen.value) {
-        element?.showPopover?.()
-      }
-    })
+    let current: HTMLElement | undefined
 
-    watch(isOpen, value => {
-      const element = toValue(el)
-      if (!element?.isConnected) return
-      if (value === element.matches?.(':popover-open')) return
+    function hide (element?: HTMLElement | null) {
+      if (!IN_BROWSER || isNullOrUndefined(element)) return
 
-      if (value) {
-        element.showPopover?.()
-      } else {
+      try {
+        if (element.matches?.(':popover-open') === false) return
         element.hidePopover?.()
+      } catch {
+        // hidePopover throws if the node is not a popover or is already hidden
       }
-    })
+    }
+
+    function sync () {
+      if (!IN_BROWSER) return
+
+      const element = toValue(el)
+
+      if (!isNullOrUndefined(current) && current !== element) {
+        hide(current)
+      }
+
+      current = isNullOrUndefined(element) ? undefined : element
+
+      if (isNullOrUndefined(element)) return
+
+      if (!isOpen.value) {
+        hide(element)
+        return
+      }
+
+      if (!element.isConnected) return
+      if (element.matches?.(':popover-open')) return
+
+      element.showPopover?.()
+    }
+
+    watch([isOpen, () => toValue(el)], sync, { immediate: true, flush: 'post' })
+
+    onScopeDispose(() => {
+      hide(toValue(el) ?? current)
+    }, true)
 
     useEventListener<ToggleEvent>(
       el,
@@ -162,7 +188,6 @@ export function usePopover (options: PopoverOptions = {}): PopoverReturn {
       },
     )
   }
-  /* v8 ignore stop */
 
   return {
     isOpen,


### PR DESCRIPTION
## Summary
- `usePopover.attach()` now syncs the native popover to `isOpen` even when the content getter is briefly null or disconnected, hides the previous node on getter swap, and hides on dispose.
- Fixes the Emerald Select ghost: after picking an option the empty popover shell stayed in the top layer and jumped with CSS-anchor positioning.

## Test plan
- [ ] Unit: usePopover attach cases (null-getter reappear, disconnected close, getter swap, already-open attach, dispose hide)
- [ ] Live Emerald Select basic example: pick an option — the popover shell must disappear, not linger or teleport
- [ ] Multi-select stays open after picking an item
- [ ] Escape, Tab, and light-dismiss still close
- [ ] First open still lazy-renders items
