### PR TITLE
docs(emerald): add Open Graph tags for the live demo

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -7,8 +7,10 @@ on:
     # after a positive match wins, so a test-only src commit is excluded.
     paths:
       - 'apps/docs/**'
+      - 'dev/**'
       - 'packages/0/src/**'
       - 'packages/0/package.json'
+      - 'packages/emerald/**'
       - 'packages/genesis/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/dev/package.json
+++ b/dev/package.json
@@ -10,6 +10,7 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.typecheck.json"
   },
   "devDependencies": {
+    "@unhead/vue": "catalog:",
     "sass-embedded": "catalog:",
     "typescript": "catalog:",
     "unocss": "catalog:",

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -1,12 +1,37 @@
 <script setup lang="ts">
+  import { useHead } from '@unhead/vue'
+
   // Utilities
-  import { computed } from 'vue'
+  import { computed, toRef } from 'vue'
   import { useRoute } from 'vue-router'
 
+  const TITLE = 'Emerald'
+  const DESCRIPTION = 'Emerald is a complete design system built on Vuetify0 — Figma-derived tokens, an icon set addressed by role, and Em* components that compose v0\'s headless compounds.'
+  const IMAGE = 'https://cdn.vuetifyjs.com/docs/images/one/logos/emerald.png'
+
   const route = useRoute()
+  /** Same gate as `main.ts` — the demo deploy (`BASE_URL=/demo/emerald/`) is Emerald. */
+  const demo = import.meta.env.BASE_URL.includes('/demo/')
+  const emerald = computed(() => demo || route.path === '/emerald' || route.path.startsWith('/emerald/'))
 
   /** Full-bleed product shells (no app chrome padding) */
   const bare = computed(() => route.path === '/emerald' || route.path.startsWith('/emerald/'))
+
+  useHead({
+    title: toRef(() => emerald.value ? TITLE : 'Vuetify0'),
+    meta: toRef(() => {
+      if (!emerald.value) return []
+
+      return [
+        { key: 'description', name: 'description', content: DESCRIPTION },
+        { key: 'og:title', property: 'og:title', content: TITLE },
+        { key: 'og:description', property: 'og:description', content: DESCRIPTION },
+        { key: 'og:image', property: 'og:image', content: IMAGE },
+        { key: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
+        { key: 'twitter:site', name: 'twitter:site', content: '@VuetifyJS' },
+      ]
+    }),
+  })
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
         specifier: 'catalog:'
         version: 3.5.39(typescript@6.0.3)
     devDependencies:
+      '@unhead/vue':
+        specifier: 'catalog:'
+        version: 2.1.15(vue@3.5.39(typescript@6.0.3))
       sass-embedded:
         specifier: 'catalog:'
         version: 1.100.0


### PR DESCRIPTION
The live demo at `/demo/emerald/` prerendered with title `Vuetify0` and no `og:*` / `twitter:*` tags, so Discord/Slack/iMessage had nothing to unfurl.

Follows playground's `useHead` shape (`description`, `og:title`, `og:description`, `og:image`) plus docs' `twitter:card` / `twitter:site`. Image is the CDN Emerald isologo — `emerald-logo-og.png` does not exist. Also wires `dev/**` and `packages/emerald/**` into docs-deploy so demo-only changes actually ship.