### PR TITLE
docs: correctness batch from the docs normalization audit

### DIFF
--- a/apps/docs/src/pages/guide/essentials/using-the-docs.md
+++ b/apps/docs/src/pages/guide/essentials/using-the-docs.md
@@ -14,7 +14,7 @@ related:
   - /introduction/getting-started
 ---
 
-<script setup>
+<script setup lang="ts">
 import { useRtl } from '@vuetify/v0'
 import { useSettings } from '@/composables/useSettings'
 

--- a/apps/docs/src/pages/guide/features/palettes.md
+++ b/apps/docs/src/pages/guide/features/palettes.md
@@ -14,7 +14,7 @@ related:
   - /composables/registration/create-tokens
 ---
 
-<script setup>
+<script setup lang="ts">
   import DocsPaletteExplorer from '@/components/docs/DocsPaletteExplorer.vue'
 </script>
 

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -16,7 +16,7 @@ related:
   - /introduction/getting-started
 ---
 
-<script setup>
+<script setup lang="ts">
   import llmsStats from 'virtual:llms-stats'
 </script>
 

--- a/apps/docs/src/pages/health.md
+++ b/apps/docs/src/pages/health.md
@@ -10,7 +10,7 @@ features:
   level: 1
 ---
 
-<script setup>
+<script setup lang="ts">
   import AppIcon from '@/components/app/AppIcon.vue'
   import DocsFreshnessSparkline from '@/components/docs/DocsFreshnessSparkline.vue'
   import DocsFreshnessTable from '@/components/docs/DocsFreshnessTable.vue'

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -126,9 +126,8 @@ pnpm build            # Build packages
 
 Only `master` publishes to npm. Work on `dev` and `next` merges into `master` at the next minor or major release, and that merge is what ships it. If you're unsure which base fits, open against `master` — a maintainer will retarget it.
 
-::: tip
-A `feat` that only touches the docs site, playground, or other tooling (not `packages/*` source) ships no package version, so it targets `master` — prefer a `docs`/`chore` prefix for those.
-:::
+> [!TIP]
+> A `feat` that only touches the docs site, playground, or other tooling (not `packages/*` source) ships no package version, so it targets `master` — prefer a `docs`/`chore` prefix for those.
 
 ### Before Submitting
 

--- a/apps/docs/src/pages/releases.md
+++ b/apps/docs/src/pages/releases.md
@@ -12,7 +12,7 @@ related:
   - /introduction/contributing
 ---
 
-<script setup>
+<script setup lang="ts">
   import DocsReleases from '@/components/docs/DocsReleases.vue'
 </script>
 

--- a/apps/docs/src/pages/skillz.[id].vue
+++ b/apps/docs/src/pages/skillz.[id].vue
@@ -165,7 +165,7 @@
 
         <div
           class="border border-divider rounded-xl p-4 md:p-6"
-          :class="settings.showBgGlass ? 'bg-glass-surface' : 'bg-surface'"
+          :class="settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface'"
         >
           <div class="flex items-center gap-2 mb-3">
             <SkillLevelBadge :level="tour.level" />

--- a/apps/docs/src/pages/skillz/index.md
+++ b/apps/docs/src/pages/skillz/index.md
@@ -9,7 +9,7 @@ features:
   level: 1
 ---
 
-<script setup>
+<script setup lang="ts">
   import { useSkillzStore } from '@/stores/skillz'
   import SkillCardDeck from '@/components/skillz/SkillCardDeck.vue'
 


### PR DESCRIPTION
Three mechanical fixes surfaced by the docs normalization audit:

- **Glass-surface setting ignored on the skillz tour page** — `settings.showBgGlass` accessed without `.value` in a template ternary (refs on plain objects don't unwrap), so the page always rendered glass. Now matches the other 12 consumers.
- **Stray `::: tip` container in contributing.md** — no `tip` container is registered in `build/markdown.ts`, so the block rendered as literal text. Converted to the blockquote callout syntax used everywhere else.
- **`lang="ts"` on the 6 page-level script blocks** — the only page scripts in the tree missing the script-setup convention.

Deliberately excluded: example tab-order numbering (initially planned) — inspection showed the last-listed `.vue` path is the preview entry contract and existing numbered blocks split between demo-first and pedagogical tab order, so that needs a convention ruling rather than a mechanical sweep.