### PR TITLE
feat(useTheme): follow a registered light/dark pair until select

### DIFF
--- a/.changeset/theme-system-pair.md
+++ b/.changeset/theme-system-pair.md
@@ -1,0 +1,10 @@
+---
+'@vuetify/v0': minor
+---
+
+feat(useTheme): follow a registered light/dark pair until an explicit select (#872)
+
+Pass `system: { light, dark }` on `createTheme` / `createThemePlugin`. The plugin
+tracks `prefers-color-scheme` while `isSystem` is true. `persist: true` stores a
+theme id only after `select`; `reset()` returns to the pair. Both ids must already
+be registered.

--- a/apps/docs/src/composables/useThemeToggle.ts
+++ b/apps/docs/src/composables/useThemeToggle.ts
@@ -134,48 +134,29 @@ export function useThemeToggle (): UseThemeToggleReturn {
     const storedAccessibility = storage.get<string>('theme-accessibility')
     preference.value = storedAccessibility.value && isAccessibilityTheme(storedAccessibility.value) ? storedAccessibility.value : mode.value
 
-    watch(
-      [mode, palette, prefersDark],
-      ([m, p, isDark]) => {
-        storage.set('theme-mode', m)
-        storage.set('theme-palette', p)
+    function apply () {
+      storage.set('theme-mode', mode.value)
+      storage.set('theme-palette', palette.value)
 
-        // If preference is an accessibility theme, use it directly
-        if (isAccessibilityTheme(preference.value)) {
-          storage.set('theme-accessibility', preference.value)
-          storage.set('theme', preference.value)
-          theme.select(preference.value as ThemeId)
-          return
-        }
-
-        storage.set('theme-accessibility', null)
-
-        // Resolve mode
-        const dark = m === 'system' ? isDark : m === 'dark'
-        const mapping = PALETTE_THEMES[p]
-        const actual = dark ? mapping.dark : mapping.light
-        storage.set('theme', actual)
-        theme.select(actual)
-      },
-      { immediate: true },
-    )
-
-    // Also watch preference for accessibility toggle
-    watch(preference, pref => {
-      if (isAccessibilityTheme(pref)) {
-        storage.set('theme-accessibility', pref)
-        storage.set('theme', pref)
-        theme.select(pref as ThemeId)
-      } else {
-        storage.set('theme-accessibility', null)
-        // Re-resolve from mode + palette
-        const dark = mode.value === 'system' ? prefersDark.value : mode.value === 'dark'
-        const mapping = PALETTE_THEMES[palette.value]
-        const actual = dark ? mapping.dark : mapping.light
-        storage.set('theme', actual)
-        theme.select(actual)
+      if (isAccessibilityTheme(preference.value)) {
+        storage.set('theme-accessibility', preference.value)
+        theme.select(preference.value as ThemeId)
+        return
       }
-    })
+
+      storage.set('theme-accessibility', null)
+
+      if (mode.value === 'system' && palette.value === 'vuetify0') {
+        theme.reset()
+        return
+      }
+
+      const dark = mode.value === 'system' ? prefersDark.value : mode.value === 'dark'
+      const mapping = PALETTE_THEMES[palette.value]
+      theme.select(dark ? mapping.dark : mapping.light)
+    }
+
+    watch([mode, palette, prefersDark, preference], apply, { immediate: true })
   }
 
   const isAccessibilityActive = toRef(() => isAccessibilityTheme(preference.value))

--- a/apps/docs/src/examples/composables/use-theme/system.vue
+++ b/apps/docs/src/examples/composables/use-theme/system.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+  import { createTheme } from '@vuetify/v0'
+  import { Theme } from '@vuetify/v0/components'
+
+  const theme = createTheme({
+    default: 'light',
+    system: { light: 'light', dark: 'dark' },
+    themes: {
+      light: {
+        dark: false,
+        colors: {
+          'primary': '#3b82f6',
+          'surface': '#ffffff',
+          'on-surface': '#111111',
+        },
+      },
+      dark: {
+        dark: true,
+        colors: {
+          'primary': '#675496',
+          'surface': '#1e1e1e',
+          'on-surface': '#eeeeee',
+        },
+      },
+    },
+  })
+</script>
+
+<template>
+  <Theme :theme="theme.selectedId.value">
+    <div class="flex flex-col gap-3 pa-4 rounded bg-surface text-on-surface">
+      <p class="text-sm">
+        selected: <code>{{ theme.selectedId }}</code>
+        · isSystem: <code>{{ theme.isSystem }}</code>
+      </p>
+
+      <p class="text-xs text-on-surface-variant">
+        Flip the OS / browser color scheme while isSystem is true. Select locks it; Reset follows the OS again.
+      </p>
+
+      <div class="flex gap-2">
+        <button class="px-3 py-1 rounded bg-primary text-white text-sm" type="button" @click="theme.select('light')">
+          Light
+        </button>
+
+        <button class="px-3 py-1 rounded bg-primary text-white text-sm" type="button" @click="theme.select('dark')">
+          Dark
+        </button>
+
+        <button class="px-3 py-1 rounded border border-divider text-sm" type="button" @click="theme.reset()">
+          Reset
+        </button>
+      </div>
+    </div>
+  </Theme>
+</template>

--- a/apps/docs/src/pages/composables/plugins/use-theme.md
+++ b/apps/docs/src/pages/composables/plugins/use-theme.md
@@ -126,7 +126,9 @@ Theme selection and computed colors are reactive. Switching themes automatically
 | `selectedIndex` | <AppSuccessIcon /> | Index in registry |
 | `colors` | <AppSuccessIcon /> | Resolved colors for all registered themes (keyed by theme ID) |
 | `isDark` | <AppSuccessIcon /> | Current theme is dark |
-| `select(id)` | — | Switch to a specific theme by ID |
+| `isSystem` | <AppSuccessIcon /> | OS pair is driving selection |
+| `select(id)` | — | Switch to a specific theme by ID. Stops following `system`. |
+| `reset()` | — | Follow the `system` pair again, or re-select `default` |
 | `cycle(ids?)` | — | Advance to the next theme. Pass an array to restrict which themes to cycle |
 
 ## Examples
@@ -154,6 +156,37 @@ Reach for `useTheme` when you need to read the active theme's colors in script (
 
 :::
 
+## Recipes
+
+### Follow the operating system
+
+Pass a `system` pair of **already registered** theme ids. The plugin follows `prefers-color-scheme` until the user calls `select`. With `persist: true`, a system-applied theme is not stored — the next load still asks the OS. An explicit `select` is stored; `reset()` returns to the pair.
+
+```ts collapse
+app.use(
+  createStoragePlugin(),
+)
+app.use(
+  createThemePlugin({
+    default: 'light',
+    system: { light: 'light', dark: 'dark' },
+    persist: true,
+    themes: {
+      light: { dark: false, colors: { primary: '#3b82f6' } },
+      dark: { dark: true, colors: { primary: '#675496' } },
+    },
+  }),
+)
+```
+
+On the server there is no media query; `default` is used until the client takes over. Pair with `V0UnheadThemeAdapter` if a flash on hydration matters.
+
+::: gn-example
+/composables/use-theme/system
+
+Flip the OS or browser color scheme while `isSystem` is true. Light/Dark calls `select` (stops following). Reset follows the OS again.
+:::
+
 ## FAQ
 
 ::: faq
@@ -169,6 +202,10 @@ Yes — `theme.register({ id, dark, colors })` adds a theme after install (e.g. 
 ??? When should I use useTheme vs the Theme provider?
 
 useTheme manages the app-wide theme. Reach for the [Theme](/components/providers/theme) provider when a subtree needs its own independent theme isolated from the rest of the app.
+
+??? How do I default to the operating system light/dark preference?
+
+Pass `system: { light, dark }` with two registered theme ids. The plugin follows `prefers-color-scheme` until `select`. With `persist: true`, only an explicit `select` is stored. Call `reset()` to follow the OS again. See [Follow the operating system](/composables/plugins/use-theme#follow-the-operating-system).
 
 ??? How do I toggle between two themes when more are registered?
 

--- a/apps/docs/src/pages/composables/plugins/use-theme.md
+++ b/apps/docs/src/pages/composables/plugins/use-theme.md
@@ -163,9 +163,7 @@ Reach for `useTheme` when you need to read the active theme's colors in script (
 Pass a `system` pair of **already registered** theme ids. The plugin follows `prefers-color-scheme` until the user calls `select`. With `persist: true`, a system-applied theme is not stored — the next load still asks the OS. An explicit `select` is stored; `reset()` returns to the pair.
 
 ```ts collapse
-app.use(
-  createStoragePlugin(),
-)
+app.use(createStoragePlugin())
 app.use(
   createThemePlugin({
     default: 'light',

--- a/apps/docs/src/pages/guide/features/theming.md
+++ b/apps/docs/src/pages/guide/features/theming.md
@@ -216,9 +216,7 @@ Use `useStorage` to persist theme selection across page loads. The key is instal
 > `createThemePlugin` ships `persist`/`restore` wiring out of the box — pass `persist: true` and skip the manual `useStorage` + `watch` code below:
 >
 > ```ts no-filename
-> app.use(
->   createStoragePlugin(),
-> )
+> app.use(createStoragePlugin())
 > app.use(
 >   createThemePlugin({
 >     default: 'light',
@@ -237,9 +235,7 @@ import App from './App.vue'
 
 const app = createApp(App)
 
-app.use(
-  createStoragePlugin(),
-)
+app.use(createStoragePlugin())
 app.use(
   createThemePlugin({
     default: 'light',

--- a/apps/docs/src/pages/guide/features/theming.md
+++ b/apps/docs/src/pages/guide/features/theming.md
@@ -216,7 +216,9 @@ Use `useStorage` to persist theme selection across page loads. The key is instal
 > `createThemePlugin` ships `persist`/`restore` wiring out of the box — pass `persist: true` and skip the manual `useStorage` + `watch` code below:
 >
 > ```ts no-filename
-> app.use(createStoragePlugin())
+> app.use(
+>   createStoragePlugin(),
+> )
 > app.use(
 >   createThemePlugin({
 >     default: 'light',
@@ -226,35 +228,23 @@ Use `useStorage` to persist theme selection across page loads. The key is instal
 > )
 > ```
 >
-> `createStoragePlugin()` still has to be installed first — the theme plugin reads/writes through it. Reach for the manual approach below when persistence needs custom logic the built-in path doesn't cover — a cookie for SSR, a backend call, or resolving `prefers-color-scheme` before the first paint.
+> `createStoragePlugin()` still has to be installed first — the theme plugin reads/writes through it. Reach for the manual approach below when persistence needs custom logic the built-in path doesn't cover — a cookie for SSR or a backend call. To follow the OS until the user picks a theme, pass `system` (see [Follow the operating system](/composables/plugins/use-theme#follow-the-operating-system)) instead of resolving `matchMedia` into `default`.
 
 ```ts main.ts collapse
 import { createApp } from 'vue'
-import {
-  createStoragePlugin,
-  createThemePlugin,
-  useStorage,
-  IN_BROWSER,
-} from '@vuetify/v0'
+import { createStoragePlugin, createThemePlugin } from '@vuetify/v0'
+import App from './App.vue'
 
 const app = createApp(App)
 
-// Install storage plugin first
-app.use(createStoragePlugin())
-
-// Helper to resolve system preference
-function getSystemTheme(): 'light' | 'dark' {
-  if (!IN_BROWSER) return 'light'
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-}
-
-// Read stored preference using app context
-const storedTheme = app.runWithContext(() => useStorage().get<string>('theme'))
-const initialTheme = storedTheme.value === 'dark' ? 'dark' : storedTheme.value === 'light' ? 'light' : getSystemTheme()
-
+app.use(
+  createStoragePlugin(),
+)
 app.use(
   createThemePlugin({
-    default: initialTheme,
+    default: 'light',
+    system: { light: 'light', dark: 'dark' },
+    persist: true,
     themes: {
       light: { dark: false, colors: { /* ... */ } },
       dark: { dark: true, colors: { /* ... */ } },
@@ -263,29 +253,7 @@ app.use(
 )
 ```
 
-Then sync theme changes back to storage:
-
-```vue ThemeToggle.vue
-<script setup lang="ts">
-  import { useStorage, useTheme } from '@vuetify/v0'
-  import { watch } from 'vue'
-
-  const storage = useStorage()
-  const theme = useTheme()
-  const storedTheme = storage.get<string>('theme')
-
-  // Persist changes to storage
-  watch(() => theme.selectedId.value, id => {
-    storedTheme.value = id
-  })
-</script>
-
-<template>
-  <button @click="theme.cycle()">
-    {{ theme.isDark ? 'Light' : 'Dark' }}
-  </button>
-</template>
-```
+`system` requires both ids to already be registered. A system-applied theme is not persisted; `select` is. `theme.reset()` follows the OS again.
 
 > [!TIP]
 > For SSR apps, use cookies instead of localStorage—see [Nuxt Theme Persistence](/guide/integration/nuxt#theme-persistence).

--- a/apps/docs/src/plugins/zero.ts
+++ b/apps/docs/src/plugins/zero.ts
@@ -74,7 +74,8 @@ export default function zero (app: App) {
     createThemePlugin({
       adapter: new V0UnheadThemeAdapter(),
       persist: true,
-      default: 'dark',
+      default: 'light',
+      system: { light: 'light', dark: 'dark' },
       target: 'html',
       palette: {
         brand: {

--- a/packages/0/src/composables/useTheme/index.ssr.test.ts
+++ b/packages/0/src/composables/useTheme/index.ssr.test.ts
@@ -10,7 +10,7 @@ vi.mock('#v0/constants/globals', () => ({
   IN_BROWSER: false,
 }))
 
-import { useTheme } from './index'
+import { createTheme, useTheme } from './index'
 
 describe('useTheme SSR', () => {
   it('does not throw when called without a provider', () => {
@@ -34,5 +34,19 @@ describe('useTheme SSR', () => {
     const second = useTheme()
 
     expect(first).not.toBe(second)
+  })
+
+  it('should keep default selected while following system on the server', () => {
+    const theme = createTheme({
+      default: 'dark',
+      system: { light: 'light', dark: 'dark' },
+      themes: {
+        light: { dark: false, colors: { primary: '#fff' } },
+        dark: { dark: true, colors: { primary: '#000' } },
+      },
+    })
+
+    expect(theme.isSystem.value).toBe(true)
+    expect(theme.selectedId.value).toBe('dark')
   })
 })

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -9,7 +9,22 @@ import { V0StyleSheetThemeAdapter } from './adapters/v0'
 import { createTheme, createThemePlugin, useTheme } from './index'
 
 // Utilities
-import { createApp, nextTick } from 'vue'
+import { createApp, nextTick, shallowRef } from 'vue'
+
+const prefersDark = shallowRef(false)
+
+vi.mock('#v0/composables/useMediaQuery', async () => {
+  const actual = await vi.importActual('#v0/composables/useMediaQuery')
+  return {
+    ...actual,
+    usePrefersDark: () => ({
+      matches: prefersDark,
+      query: shallowRef('(prefers-color-scheme: dark)'),
+      mediaQueryList: shallowRef(null),
+      stop: vi.fn(),
+    }),
+  }
+})
 
 // Types
 import type { ThemeContext } from './index'
@@ -19,6 +34,10 @@ vi.mock('#v0/constants/globals', () => ({
 }))
 
 describe('createTheme', () => {
+  beforeEach(() => {
+    prefersDark.value = false
+  })
+
   describe('basic functionality', () => {
     it('should create a theme context with default values', () => {
       const context = createTheme({})
@@ -763,6 +782,58 @@ describe('createTheme', () => {
 
         expect(theme!.selectedId.value).toBe('light')
       })
+
+      it('should not persist a system-applied theme and restore an explicit select', async () => {
+        const app = createApp({ render: () => null })
+        app.use(createStoragePlugin())
+        prefersDark.value = true
+
+        app.use(
+          createThemePlugin({
+            namespace: 'v0:theme-system-persist',
+            persist: true,
+            default: 'light',
+            system: { light: 'light', dark: 'dark' },
+            themes: {
+              light: { dark: false, colors: { primary: '#1976d2' } },
+              dark: { dark: true, colors: { primary: '#90caf9' } },
+            },
+          }),
+        )
+
+        let theme: ThemeContext | undefined
+        app.runWithContext(() => {
+          theme = useTheme('v0:theme-system-persist')
+        })
+
+        expect(theme!.isSystem.value).toBe(true)
+        expect(theme!.selectedId.value).toBe('dark')
+
+        let stored: unknown
+        app.runWithContext(() => {
+          stored = useStorage().get('theme-system-persist').value
+        })
+        expect(stored).toBeUndefined()
+
+        theme!.select('light')
+        await nextTick()
+
+        app.runWithContext(() => {
+          stored = useStorage().get('theme-system-persist').value
+        })
+        expect(stored).toBe('light')
+        expect(theme!.isSystem.value).toBe(false)
+
+        theme!.reset()
+        await nextTick()
+
+        app.runWithContext(() => {
+          stored = useStorage().get('theme-system-persist').value
+        })
+        expect(stored).toBeNull()
+        expect(theme!.isSystem.value).toBe(true)
+        expect(theme!.selectedId.value).toBe('dark')
+      })
     })
   })
 
@@ -1158,6 +1229,94 @@ describe('createTheme', () => {
       expect(theme.size).toBe(before)
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('light'))
+    })
+  })
+
+  describe('system pair', () => {
+    const pair = {
+      default: 'light' as const,
+      system: { light: 'light', dark: 'dark' },
+      themes: {
+        light: { dark: false, colors: { primary: '#fff' } },
+        dark: { dark: true, colors: { primary: '#000' } },
+      },
+    }
+
+    it('should select the light id when the OS prefers light', () => {
+      const theme = createTheme(pair)
+
+      expect(theme.isSystem.value).toBe(true)
+      expect(theme.selectedId.value).toBe('light')
+    })
+
+    it('should select the dark id when the OS prefers dark', () => {
+      prefersDark.value = true
+      const theme = createTheme(pair)
+
+      expect(theme.isSystem.value).toBe(true)
+      expect(theme.selectedId.value).toBe('dark')
+    })
+
+    it('should follow OS changes while isSystem', async () => {
+      const theme = createTheme(pair)
+      expect(theme.selectedId.value).toBe('light')
+
+      prefersDark.value = true
+      await nextTick()
+
+      expect(theme.isSystem.value).toBe(true)
+      expect(theme.selectedId.value).toBe('dark')
+    })
+
+    it('should stop following the OS after select', async () => {
+      const theme = createTheme(pair)
+      theme.select('light')
+
+      prefersDark.value = true
+      await nextTick()
+
+      expect(theme.isSystem.value).toBe(false)
+      expect(theme.selectedId.value).toBe('light')
+    })
+
+    it('should follow the OS again after reset', async () => {
+      prefersDark.value = true
+      const theme = createTheme(pair)
+      theme.select('light')
+      theme.reset()
+
+      expect(theme.isSystem.value).toBe(true)
+      expect(theme.selectedId.value).toBe('dark')
+    })
+
+    it('should warn and use default when a system id is missing', () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const theme = createTheme({
+        default: 'light',
+        system: { light: 'light', dark: 'missing' },
+        themes: {
+          light: { dark: false, colors: { primary: '#fff' } },
+        },
+      })
+
+      expect(theme.isSystem.value).toBe(false)
+      expect(theme.selectedId.value).toBe('light')
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('system.dark'))
+    })
+
+    it('should warn when the dark id is not a dark theme', () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      createTheme({
+        system: { light: 'light', dark: 'also-light' },
+        themes: {
+          'light': { dark: false, colors: { primary: '#fff' } },
+          'also-light': { dark: false, colors: { primary: '#eee' } },
+        },
+      })
+
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('dark: true'))
     })
   })
 

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -12,6 +12,7 @@ import { createTheme, createThemePlugin, useTheme } from './index'
 import { createApp, nextTick, shallowRef } from 'vue'
 
 const prefersDark = shallowRef(false)
+const stopPrefersDark = vi.fn()
 
 vi.mock('#v0/composables/useMediaQuery', async () => {
   const actual = await vi.importActual('#v0/composables/useMediaQuery')
@@ -21,7 +22,7 @@ vi.mock('#v0/composables/useMediaQuery', async () => {
       matches: prefersDark,
       query: shallowRef('(prefers-color-scheme: dark)'),
       mediaQueryList: shallowRef(null),
-      stop: vi.fn(),
+      stop: stopPrefersDark,
     }),
   }
 })
@@ -36,6 +37,7 @@ vi.mock('#v0/constants/globals', () => ({
 describe('createTheme', () => {
   beforeEach(() => {
     prefersDark.value = false
+    stopPrefersDark.mockClear()
   })
 
   describe('basic functionality', () => {
@@ -834,6 +836,35 @@ describe('createTheme', () => {
         expect(theme!.isSystem.value).toBe(true)
         expect(theme!.selectedId.value).toBe('dark')
       })
+
+      it('should restore an explicit select on a new plugin install', () => {
+        const app1 = createApp({ render: () => null })
+        app1.use(createStoragePlugin())
+        app1.runWithContext(() => {
+          useStorage().set('theme-system-restore', 'dark')
+        })
+
+        app1.use(
+          createThemePlugin({
+            namespace: 'v0:theme-system-restore',
+            persist: true,
+            default: 'light',
+            system: { light: 'light', dark: 'dark' },
+            themes: {
+              light: { dark: false, colors: { primary: '#1976d2' } },
+              dark: { dark: true, colors: { primary: '#90caf9' } },
+            },
+          }),
+        )
+
+        let theme: ThemeContext | undefined
+        app1.runWithContext(() => {
+          theme = useTheme('v0:theme-system-restore')
+        })
+
+        expect(theme!.isSystem.value).toBe(false)
+        expect(theme!.selectedId.value).toBe('dark')
+      })
     })
   })
 
@@ -856,7 +887,9 @@ describe('createTheme', () => {
       expect(theme!.isDark.value).toBe(false)
       expect(theme!.size).toBe(0)
       expect(theme!.colors.value).toEqual({})
+      expect(theme!.isSystem.value).toBe(false)
       theme!.cycle() // no-op, should not throw
+      theme!.reset() // no-op, should not throw
 
       app.unmount()
     })
@@ -1317,6 +1350,54 @@ describe('createTheme', () => {
       })
 
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('dark: true'))
+    })
+
+    it('should warn and use default when the light id is missing', () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const theme = createTheme({
+        default: 'dark',
+        system: { light: 'missing', dark: 'dark' },
+        themes: {
+          dark: { dark: true, colors: { primary: '#000' } },
+        },
+      })
+
+      expect(theme.isSystem.value).toBe(false)
+      expect(theme.selectedId.value).toBe('dark')
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('system.light'))
+    })
+
+    it('should stop following the OS after cycle', () => {
+      const theme = createTheme(pair)
+
+      theme.cycle(['light', 'dark'])
+
+      expect(theme.isSystem.value).toBe(false)
+    })
+
+    it('should re-select default on reset when system is not configured', () => {
+      const theme = createTheme({
+        default: 'dark',
+        themes: {
+          light: { dark: false, colors: { primary: '#fff' } },
+          dark: { dark: true, colors: { primary: '#000' } },
+        },
+      })
+
+      theme.select('light')
+      theme.reset()
+
+      expect(theme.isSystem.value).toBe(false)
+      expect(theme.selectedId.value).toBe('dark')
+    })
+
+    it('should stop the media query on dispose', () => {
+      const theme = createTheme(pair)
+
+      theme.dispose()
+
+      expect(stopPrefersDark).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/0/src/composables/useTheme/index.ts
+++ b/packages/0/src/composables/useTheme/index.ts
@@ -12,6 +12,7 @@
  * - Lazy theme loading (compute colors only when selected)
  * - CSS variable generation via adapter pattern
  * - `isDark` reactive flag on the theme context
+ * - Optional `system` pair that follows `prefers-color-scheme` until an explicit `select`
  * - SSR support with head integration
  * - Theme cycling
  *
@@ -31,13 +32,18 @@
 import { createPluginContext } from '#v0/composables/createPlugin'
 import { createSingle } from '#v0/composables/createSingle'
 import { createTokens, flatten } from '#v0/composables/createTokens'
+import { useLogger } from '#v0/composables/useLogger'
+import { usePrefersDark } from '#v0/composables/useMediaQuery'
 
 // Adapters
 import { V0StyleSheetThemeAdapter } from '#v0/composables/useTheme/adapters'
 
+// Globals
+import { IN_BROWSER } from '#v0/constants/globals'
+
 // Utilities
 import { foreground as foregroundFn, isNumber, isString } from '#v0/utilities'
-import { computed, shallowRef, toRef } from 'vue'
+import { computed, shallowRef, toRef, watch } from 'vue'
 
 // Types
 import type { RegistryOptions } from '#v0/composables/createRegistry'
@@ -176,6 +182,28 @@ export interface ThemeContext<
    */
   cycle: (themes?: ID[]) => void
   /**
+   * `true` while the configured `system` pair is driving selection.
+   * Becomes `false` after an explicit `select`.
+   *
+   * @example
+   * ```ts
+   * const theme = useTheme()
+   * console.log(theme.isSystem.value)
+   * ```
+   */
+  isSystem: Readonly<Ref<boolean>>
+  /**
+   * Return to following the `system` pair. Without `system`, re-selects `default`.
+   *
+   * @example
+   * ```ts
+   * const theme = useTheme()
+   * theme.select('dark')
+   * theme.reset()
+   * ```
+   */
+  reset: () => void
+  /**
    * Register a theme with optional colors.
    *
    * When `colors` is provided, onboards them as flat tokens for
@@ -201,6 +229,11 @@ export interface ThemeContext<
   dispose: () => void
 }
 
+export interface ThemeSystemPair {
+  light: ID
+  dark: ID
+}
+
 export interface ThemeOptions<Z extends ThemeRecord = ThemeRecord> extends RegistryOptions {
   /**
    * The theme adapter to use.
@@ -210,8 +243,29 @@ export interface ThemeOptions<Z extends ThemeRecord = ThemeRecord> extends Regis
   adapter?: ThemeAdapter
   /**
    * The default theme ID to select on initialization.
+   *
+   * @remarks Used on the server and when `system` is omitted or invalid.
    */
   default?: ID
+  /**
+   * Follow `prefers-color-scheme` using these registered theme ids until
+   * the user calls `select`. Both ids must already be in `themes`.
+   *
+   * @example
+   * ```ts
+   * app.use(
+   *   createThemePlugin({
+   *     system: { light: 'light', dark: 'dark' },
+   *     persist: true,
+   *     themes: {
+   *       light: { colors: { primary: '#3b82f6' } },
+   *       dark: { dark: true, colors: { primary: '#675496' } },
+   *     },
+   *   }),
+   * )
+   * ```
+   */
+  system?: ThemeSystemPair
   /**
    * Automatically generate `on-*` foreground colors for each theme color
    * using APCA contrast analysis.
@@ -283,18 +337,22 @@ export interface ThemePluginOptions extends ThemeContextOptions {
  */
 
 export function createTheme (_options: ThemeOptions = {}): ThemeContext {
-  const { themes = {}, palette = {}, foreground: genForeground, ...options } = _options
+  const { themes = {}, palette = {}, foreground: genForeground, system, ...options } = _options
   const tokens = createTokens({ palette, ...themes }, { flat: true })
   const registry = createSingle<SingleTicketInput<ThemeColors>, SingleTicket<SingleTicketInput<ThemeColors>>>({ ...options, reactive: true })
+  const logger = useLogger()
 
   for (const id in themes) {
     const { colors: value, ...theme } = themes[id]!
 
     register({ id, value, ...theme } as Partial<ThemeTicketInput>)
+  }
 
-    if (id === options.default && !registry.selectedId.value) {
-      registry.select(id as ID)
-    }
+  const pair = resolveSystemPair(system, registry, logger)
+  const following = shallowRef(Boolean(pair))
+
+  if (!pair && options.default && !registry.selectedId.value) {
+    registry.select(options.default)
   }
 
   type InternalTicket = SingleTicket<SingleTicketInput<ThemeColors>> & { dark: boolean, lazy: boolean }
@@ -324,12 +382,48 @@ export function createTheme (_options: ThemeOptions = {}): ThemeContext {
   })
 
   const isDark = toRef(() => (registry.selectedItem.value as InternalTicket | undefined)?.dark ?? false)
+  const isSystem = toRef(() => following.value)
+
+  const media = pair ? usePrefersDark() : undefined
+
+  function follow () {
+    if (!pair || !media) return
+    const id = media.matches.value ? pair.dark : pair.light
+    if (registry.has(id)) registry.select(id)
+  }
+
+  if (pair) {
+    if (IN_BROWSER) {
+      follow()
+    } else if (options.default && !registry.selectedId.value) {
+      registry.select(options.default)
+    }
+
+    watch(() => media!.matches.value, () => {
+      if (following.value) follow()
+    })
+  }
+
+  function select (id: ID) {
+    following.value = false
+    registry.select(id)
+  }
+
+  function reset () {
+    if (pair) {
+      following.value = true
+      follow()
+      return
+    }
+
+    if (options.default) registry.select(options.default)
+  }
 
   function cycle (themes: readonly ID[] = names.value) {
     const current = themes.indexOf(registry.selectedId.value ?? '')
     const next = current === -1 ? 0 : (current + 1) % themes.length
 
-    registry.select(themes[next]!)
+    select(themes[next]!)
   }
 
   function resolve (colors: Colors): Colors {
@@ -366,14 +460,46 @@ export function createTheme (_options: ThemeOptions = {}): ThemeContext {
     ...registry,
     colors,
     isDark,
+    isSystem,
+    select,
+    reset,
     register,
     onboard,
     cycle,
-    dispose: () => {},
+    dispose: () => {
+      media?.stop()
+    },
     get size () {
       return registry.size
     },
   } as ThemeContext
+}
+
+function resolveSystemPair (
+  system: ThemeSystemPair | undefined,
+  registry: { get: (id: ID) => unknown },
+  logger: { warn: (message: string) => void },
+): ThemeSystemPair | undefined {
+  if (!system) return undefined
+
+  const light = registry.get(system.light)
+  const dark = registry.get(system.dark) as { dark?: boolean } | undefined
+
+  if (!light) {
+    logger.warn(`[v0:theme] system.light "${String(system.light)}" is not registered`)
+    return undefined
+  }
+
+  if (!dark) {
+    logger.warn(`[v0:theme] system.dark "${String(system.dark)}" is not registered`)
+    return undefined
+  }
+
+  if (!dark.dark) {
+    logger.warn(`[v0:theme] system.dark "${String(system.dark)}" should have dark: true`)
+  }
+
+  return system
 }
 
 function createThemeFallback (): ThemeContext {
@@ -381,7 +507,9 @@ function createThemeFallback (): ThemeContext {
     size: 0,
     colors: computed(() => ({})),
     isDark: shallowRef(false),
+    isSystem: shallowRef(false),
     cycle: () => {},
+    reset: () => {},
     onboard: () => [],
     dispose: () => {},
   } as unknown as ThemeContext
@@ -398,7 +526,7 @@ export const [createThemeContext, createThemePlugin, useTheme] =
         adapter.setup(app, context, target)
         app.onUnmount(() => adapter.dispose?.())
       },
-      persist: ctx => ctx.selectedId.value,
+      persist: ctx => ctx.isSystem.value ? null : ctx.selectedId.value,
       restore: (ctx, saved) => {
         if (isString(saved) || isNumber(saved)) ctx.select(saved)
       },


### PR DESCRIPTION
`createThemePlugin({ system: { light, dark }, persist: true })` follows `prefers-color-scheme` until an explicit `select`. A system-applied theme is not persisted; `reset()` returns to the pair. Both ids must already be registered.

Docs install the pair for `light` / `dark` and the app-bar toggle calls `reset()` on that pair.

Emerald is **not** in this PR — stacked on #873.