### PR TITLE
fix(SplitterPanel): stop clipping panel content

### DIFF
--- a/.changeset/fix-splitter-panel-min-size.md
+++ b/.changeset/fix-splitter-panel-min-size.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(SplitterPanel): panels no longer clip overflowing content (popovers, focus rings) — flex shrink now comes from min-size: 0 instead of overflow: hidden

--- a/packages/0/src/components/Splitter/SplitterPanel.vue
+++ b/packages/0/src/components/Splitter/SplitterPanel.vue
@@ -200,7 +200,8 @@
       flexGrow: 0,
       flexShrink: 0,
       flexBasis: `${size}%`,
-      overflow: 'hidden',
+      minWidth: 0,
+      minHeight: 0,
     }]"
   >
     <slot v-bind="slotProps" />


### PR DESCRIPTION
Replaces `overflow: hidden` on panels with `minWidth/minHeight: 0`. The overflow rule gave flex panels the ability to shrink below their content's intrinsic size as a side effect, but also clipped anything that pokes out of a panel — popovers, focus rings, drag grips. min-size preserves the shrink behavior without the clipping.

Relabeled from draft #217 (`refactor:` → `fix:`) with a patch changeset added, per review in the v1.0.x triage session. Supersedes #217.