### PR TITLE
docs: custom themes as first-class overrides in the theme controller

### DIFF
--- a/apps/docs/src/components/app/AppThemeMenu.vue
+++ b/apps/docs/src/components/app/AppThemeMenu.vue
@@ -1,8 +1,25 @@
 <script setup lang="ts">
   /**
-   * Shared mode / palette / a11y grid used by the app-bar selector and the
-   * per-example theme popover. Buttons read `useThemeToggleController()`.
+   * Shared mode / palette / a11y / custom grid used by the app-bar selector and
+   * the per-example theme popover. Buttons read `useThemeToggleController()`.
    */
+
+  // Composables
+  import { useCustomThemes } from '@/composables/useCustomThemes'
+
+  const { editable = false } = defineProps<{
+    editable?: boolean
+  }>()
+
+  const emit = defineEmits<{
+    edit: [id: string]
+  }>()
+
+  const { customThemes } = useCustomThemes()
+
+  function onEdit (id: string) {
+    emit('edit', id)
+  }
 </script>
 
 <template>
@@ -39,6 +56,20 @@
         <AppThemeProtanopiaButton />
         <AppThemeDeuteranopiaButton />
         <AppThemeTritanopiaButton />
+      </div>
+    </div>
+
+    <div v-if="customThemes.length > 0" class="mt-3">
+      <div class="text-xs font-medium text-on-surface-variant mb-2 px-1">Custom</div>
+
+      <div class="grid grid-cols-2 gap-2">
+        <AppThemeCustomButton
+          v-for="custom in customThemes"
+          :key="custom.id"
+          :editable
+          :theme-id="custom.id"
+          @edit="onEdit"
+        />
       </div>
     </div>
   </div>

--- a/apps/docs/src/components/app/AppThemeSelector.vue
+++ b/apps/docs/src/components/app/AppThemeSelector.vue
@@ -47,7 +47,8 @@
     >
       <Popover.Activator
         aria-label="Select theme"
-        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant transition-all cursor-pointer"
+        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded hover:bg-surface-variant data-[state=open]:bg-surface-variant transition-all cursor-pointer"
+        :data-state="isOpen ? 'open' : undefined"
       >
         <AppIcon :icon="toggle.icon.value" />
       </Popover.Activator>

--- a/apps/docs/src/components/app/AppThemeSelector.vue
+++ b/apps/docs/src/components/app/AppThemeSelector.vue
@@ -14,7 +14,7 @@
   const router = useRouter()
 
   const toggle = useThemeToggle()
-  const { customThemes: themes, editor } = useCustomThemes()
+  const { editor } = useCustomThemes()
   const settings = useSettings()
 
   const isOpen = shallowRef(false)
@@ -65,7 +65,7 @@
         <AppCloseButton size="sm" @click="isOpen = false" />
       </div>
 
-      <AppThemeMenu>
+      <AppThemeMenu editable @edit="onEdit">
         <template #palettes-footer>
           <button
             class="w-full text-xs text-primary border border-primary rounded py-1.5 transition-colors hover:bg-primary/15 text-center mt-2"
@@ -86,21 +86,6 @@
         <AppIcon icon="plus" size="16" />
         <span>Create Theme</span>
       </button>
-
-      <!-- Custom Themes -->
-      <div v-if="themes.length > 0" class="mt-3">
-        <div class="text-xs font-medium text-on-surface-variant mb-2 px-1">Custom Themes</div>
-
-        <div class="grid grid-cols-2 gap-2">
-          <AppThemeCustomButton
-            v-for="theme in themes"
-            :key="theme.id"
-            editable
-            :theme-id="theme.id"
-            @edit="onEdit"
-          />
-        </div>
-      </div>
     </Popover.Content>
   </Popover.Root>
 </template>

--- a/apps/docs/src/components/app/settings/AppSettingsColorInput.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsColorInput.vue
@@ -17,8 +17,8 @@
     const target = event.target as HTMLInputElement
     let value = target.value.trim()
 
-    // Auto-add # prefix if missing
-    if (value && !value.startsWith('#')) {
+    // Auto-add # prefix for bare hex, but leave rgb()/hsl()/named colors alone
+    if (/^[\da-f]{3,8}$/i.test(value)) {
       value = `#${value}`
     }
 

--- a/apps/docs/src/components/app/settings/AppSettingsTheme.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsTheme.vue
@@ -3,24 +3,21 @@
   import { useClipboard } from '@/composables/useClipboard'
   import { useCustomThemes } from '@/composables/useCustomThemes'
   import { useSettings } from '@/composables/useSettings'
-  import { useThemeToggle } from '@/composables/useThemeToggle'
 
   // Themes
-  import { exportThemeAsVuetifyConfig, type ThemeId } from '@/themes'
+  import { exportThemeAsVuetifyConfig, themes } from '@/themes'
 
   // Utilities
   import { computed } from 'vue'
 
-  const toggle = useThemeToggle()
   const customThemes = useCustomThemes()
   const clipboard = useClipboard()
   const settings = useSettings()
 
-  // Current active theme (resolves 'system' to actual theme)
-  const currentThemeId = computed<ThemeId>(() => toggle.theme.selectedId.value as ThemeId)
-
   function exportTheme () {
-    const config = exportThemeAsVuetifyConfig(currentThemeId.value)
+    // `current()` resolves token aliases and covers user-created themes, which
+    // the preset map does not contain.
+    const config = exportThemeAsVuetifyConfig(customThemes.current() ?? themes.light)
     clipboard.copy(config)
   }
 

--- a/apps/docs/src/components/app/settings/AppSettingsThemeEditor.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsThemeEditor.vue
@@ -36,7 +36,7 @@
     },
     surfaces: {
       label: 'Surfaces',
-      colors: ['background', 'surface', 'surface-tint', 'surface-variant', 'divider', 'pre'],
+      colors: ['background', 'surface', 'surface-tint', 'surface-variant', 'divider', 'pre', 'scrollbar-thumb'],
     },
     text: {
       label: 'Text / Contrast',
@@ -63,6 +63,7 @@
     'surface-variant': 'Surface Variant',
     'divider': 'Divider',
     'pre': 'Code Block',
+    'scrollbar-thumb': 'Scrollbar',
     'on-primary': 'On Primary',
     'on-secondary': 'On Secondary',
     'on-accent': 'On Accent',

--- a/apps/docs/src/components/app/theme/AppThemeCustomButton.vue
+++ b/apps/docs/src/components/app/theme/AppThemeCustomButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   // Composables
   import { useCustomThemes } from '@/composables/useCustomThemes'
-  import { useThemeToggle, type ThemePreference } from '@/composables/useThemeToggle'
+  import { type ThemePreference, useThemeToggleController } from '@/composables/useThemeToggle'
 
   // Utilities
   import { toRef } from 'vue'
@@ -15,7 +15,7 @@
     edit: [id: string]
   }>()
 
-  const toggle = useThemeToggle()
+  const toggle = useThemeToggleController()
   const themes = useCustomThemes()
   const theme = toRef(() => themes.customThemes.value.find(t => t.id === themeId))
   const active = toRef(() => toggle.preference.value === themeId)

--- a/apps/docs/src/components/app/theme/mode/AppThemeDarkButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeDarkButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'dark',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'dark',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/mode/AppThemeLightButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeLightButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'light',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'light',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/mode/AppThemeSystemButton.vue
+++ b/apps/docs/src/components/app/theme/mode/AppThemeSystemButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.mode.value === 'system',
+    !toggle.isOverrideActive.value && toggle.mode.value === 'system',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteAntDesignButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteAntDesignButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'ant-design',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'ant-design',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteMaterial3Button.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteMaterial3Button.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'material-3',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'material-3',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteRadixButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteRadixButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'radix',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'radix',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteTailwindButton.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteTailwindButton.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'tailwind',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'tailwind',
   )
 </script>
 

--- a/apps/docs/src/components/app/theme/palette/AppPaletteVuetify0Button.vue
+++ b/apps/docs/src/components/app/theme/palette/AppPaletteVuetify0Button.vue
@@ -7,7 +7,7 @@
 
   const toggle = useThemeToggleController()
   const active = toRef(() =>
-    !toggle.isAccessibilityActive.value && toggle.palette.value === 'vuetify0',
+    !toggle.isOverrideActive.value && toggle.palette.value === 'vuetify0',
   )
 </script>
 

--- a/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
+++ b/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
@@ -24,7 +24,7 @@
     >
       <Popover.Activator
         aria-label="Example theme"
-        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] hover:bg-surface-variant transition-all cursor-pointer"
+        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] hover:bg-surface-variant data-[state=open]:bg-surface-variant transition-all cursor-pointer"
         :data-state="open ? 'open' : undefined"
       >
         <AppIcon :icon="toggle.icon.value" />

--- a/apps/docs/src/composables/useCustomThemes.ts
+++ b/apps/docs/src/composables/useCustomThemes.ts
@@ -38,7 +38,10 @@ export interface UseCustomThemesReturn {
   }
 }
 
-const STORAGE_KEY = 'v0:custom-themes'
+const STORAGE_KEY = 'custom-themes'
+// `useStorage` prefixes every key with `v0:`, so the original key wrote to
+// `v0:v0:custom-themes`. Read it once so existing themes survive the rename.
+const LEGACY_STORAGE_KEY = 'v0:custom-themes'
 
 // Shared singleton state
 const customThemes = shallowRef<CustomTheme[]>([])
@@ -69,8 +72,13 @@ export function useCustomThemes (): UseCustomThemesReturn {
 
     // Load stored custom themes
     const stored = storage.get<CustomTheme[]>(STORAGE_KEY)
+    const legacy = storage.get<CustomTheme[]>(LEGACY_STORAGE_KEY)
+
     if (Array.isArray(stored.value)) {
       customThemes.value = stored.value
+    } else if (Array.isArray(legacy.value)) {
+      customThemes.value = legacy.value
+      storage.set(STORAGE_KEY, legacy.value)
     }
 
     // Persist changes to storage
@@ -82,6 +90,12 @@ export function useCustomThemes (): UseCustomThemesReturn {
         value: custom.colors,
         dark: custom.dark,
       })
+    }
+
+    // The page toggle resolves its stored preference before this module has
+    // registered anything, so a custom preference needs re-selecting here.
+    if (customThemes.value.some(t => t.id === toggle.preference.value)) {
+      theme.select(toggle.preference.value)
     }
   }
 

--- a/apps/docs/src/composables/useThemeToggle.ts
+++ b/apps/docs/src/composables/useThemeToggle.ts
@@ -54,6 +54,9 @@ const ACCESSIBILITY_THEMES = [
 
 const MODES: ModePreference[] = ['system', 'light', 'dark']
 
+/** Id prefix minted by `useCustomThemes`. */
+const CUSTOM = 'custom-'
+
 export type AccessibilityTheme = typeof ACCESSIBILITY_THEMES[number]
 
 export type ThemePreference = ModePreference | AccessibilityTheme | Palette | (string & {})
@@ -71,7 +74,7 @@ export interface ThemeToggleContext {
   preference: ShallowRef<ThemePreference>
   currentThemeId: Ref<string>
   isOverridden: Ref<boolean>
-  isAccessibilityActive: Ref<boolean>
+  isOverrideActive: Ref<boolean>
   icon: Ref<string>
   title: Ref<string>
   isDark: Ref<boolean>
@@ -96,6 +99,18 @@ export function isModePreference (value: string): value is ModePreference {
   return (MODES as readonly string[]).includes(value)
 }
 
+export function isCustomTheme (value: string): boolean {
+  return value.startsWith(CUSTOM)
+}
+
+/**
+ * A preference that names a theme outright instead of resolving through
+ * mode + palette. Accessibility themes and user-created themes both qualify.
+ */
+export function isOverrideTheme (value: string): boolean {
+  return isAccessibilityTheme(value) || isCustomTheme(value)
+}
+
 export function resolveThemeId (
   mode: ModePreference,
   palette: Palette,
@@ -103,7 +118,7 @@ export function resolveThemeId (
   prefersDark: boolean,
 ): string {
   const pref = String(preference)
-  if (isAccessibilityTheme(pref)) {
+  if (isOverrideTheme(pref)) {
     return pref
   }
   if (!isModePreference(pref) && !isValidPalette(pref)) {
@@ -186,9 +201,10 @@ function createThemeToggleState (options: {
         const id = currentThemeId.value
         storage.set('theme-mode', mode.value)
         storage.set('theme-palette', palette.value)
+        // Legacy key name; holds any override id (accessibility or custom).
         storage.set(
           'theme-accessibility',
-          isAccessibilityTheme(String(preference.value)) ? preference.value : null,
+          isOverrideTheme(String(preference.value)) ? preference.value : null,
         )
         storage.set('theme', id)
         theme.select(id as ThemeId)
@@ -210,14 +226,14 @@ function createThemeToggleState (options: {
   function setPalette (next: Palette) {
     lock()
     palette.value = next
-    if (isAccessibilityTheme(String(preference.value))) {
+    if (isOverrideTheme(String(preference.value))) {
       preference.value = mode.value
     }
   }
 
   function setPreference (pref: ThemePreference) {
     lock()
-    if (isAccessibilityTheme(String(pref)) || isModePreference(pref)) {
+    if (isOverrideTheme(String(pref)) || isModePreference(pref)) {
       if (isModePreference(pref)) mode.value = pref
       preference.value = pref
     } else if (isValidPalette(pref)) {
@@ -254,14 +270,20 @@ function createThemeToggleState (options: {
     preference,
     currentThemeId,
     isOverridden: toRef(() => override.value),
-    isAccessibilityActive: toRef(() => isAccessibilityTheme(String(preference.value))),
+    isOverrideActive: toRef(() => isOverrideTheme(String(preference.value))),
     icon: toRef(() => {
+      if (isCustomTheme(String(preference.value))) {
+        return 'theme-custom'
+      }
       if (isAccessibilityTheme(String(preference.value))) {
         return `theme-${preference.value}`
       }
       return PALETTE_ICONS[palette.value] ?? 'theme-custom'
     }),
     title: toRef(() => {
+      if (isCustomTheme(String(preference.value))) {
+        return 'Theme: Custom'
+      }
       if (isAccessibilityTheme(String(preference.value))) {
         return `Theme: ${preference.value}`
       }
@@ -270,7 +292,7 @@ function createThemeToggleState (options: {
     isDark: bindPage
       ? theme.isDark
       : toRef(() => {
-          if (isAccessibilityTheme(String(preference.value))) {
+          if (isOverrideTheme(String(preference.value))) {
             return theme.get(preference.value)?.dark ?? theme.isDark.value
           }
           return mode.value === 'system' ? prefersDark.value : mode.value === 'dark'
@@ -320,8 +342,8 @@ function restore (
     }
   }
 
-  const storedAccessibility = storage.get<string>('theme-accessibility')
-  preference.value = storedAccessibility.value && isAccessibilityTheme(storedAccessibility.value)
-    ? storedAccessibility.value
+  const stored = storage.get<string>('theme-accessibility')
+  preference.value = stored.value && isOverrideTheme(stored.value)
+    ? stored.value
     : mode.value
 }

--- a/apps/docs/src/themes/index.ts
+++ b/apps/docs/src/themes/index.ts
@@ -686,8 +686,7 @@ export function getAllThemeConfigs (): Record<ThemeId, { dark: boolean, colors: 
  * Export theme as Vuetify config format.
  * Ready to paste into createVuetify() themes option.
  */
-export function exportThemeAsVuetifyConfig (id: ThemeId): string {
-  const theme = themes[id]
+export function exportThemeAsVuetifyConfig (theme: Pick<ThemeDefinition, 'colors' | 'dark'>): string {
   const config = {
     dark: theme.dark,
     colors: { ...theme.colors },


### PR DESCRIPTION
Reimplements #861's intent on the per-example theme controller architecture from #871 — custom themes are now overrides on equal footing with accessibility themes, everywhere a theme can be picked.

- **Selectable + persistent**: `isOverrideTheme` (accessibility ∪ `custom-`) generalizes every accessibility-only branch in the toggle — resolve, persist, restore, palette clearing, per-example `isDark`, icon/title. Page-level selection persists across reload and restores after runtime registration; per-example selection stays ephemeral by construction (only the page toggle owns the storage watch).
- **Both menus**: the shared `AppThemeMenu` gains a Custom section, so the app-bar selector and every per-example picker get custom themes from one implementation. Edit affordance only where editable (page selector).
- **Storage fix + migration**: `useCustomThemes` keyed `v0:custom-themes`, which the storage plugin's auto-prefix turned into `v0:v0:custom-themes`. Now keyed `custom-themes` with a one-time, non-destructive migration of the legacy key.
- **Ported from #861**: scrollbar-thumb row in the theme editor; color input only auto-prefixes `#` for bare hex (rgba values were being mangled). Plus a crash fix: 'Copy theme as Vuetify0 config' threw while a custom theme was selected.

Verified: full docs build green; in-browser (Playwright) end-to-end — create → select → reload-restore → per-example override with zero storage writes → follow-page reset → legacy-key migration.

Supersedes #861.