### PR TITLE
chore: add the missing changeset for the usePopover ghost-node fix

### DIFF
--- a/.changeset/fix-select-popover-ghost.md
+++ b/.changeset/fix-select-popover-ghost.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(usePopover): closed popovers no longer leave a visible ghost node — attached elements are force-hidden on close, unmount, and scope dispose


### PR DESCRIPTION
#864 merged without its changeset, so the fix would have been skipped by the release train. One file: a patch changeset for `@vuetify/v0` covering the usePopover ghost-node fix.