### PR TITLE
docs(docs): keep the example theme activator on surface-tint

### DIFF
--- a/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
+++ b/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
@@ -24,7 +24,7 @@
     >
       <Popover.Activator
         aria-label="Example theme"
-        class="bg-surface-tint text-on-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] hover:bg-surface-variant data-[state=open]:bg-surface-variant transition-all cursor-pointer"
+        class="bg-surface-tint text-on-surface-tint hover:bg-surface-tint data-[state=open]:bg-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] cursor-pointer"
         :data-state="open ? 'open' : undefined"
       >
         <AppIcon :icon="toggle.icon.value" />


### PR DESCRIPTION
The per-example theme activator sat on `surface-tint` at rest but flipped to `surface-variant` on hover and while the menu was open. Rest, hover, and open now all stay on `surface-tint` so the control matches the preview chrome.