### PR TITLE
feat(emerald): reach a compound's sub-components from the root import

### DIFF
--- a/.changeset/emerald-compound-dot-notation.md
+++ b/.changeset/emerald-compound-dot-notation.md
@@ -1,0 +1,25 @@
+---
+'@paper/emerald': minor
+---
+
+feat(emerald): reach a compound's sub-components from the root import
+
+Importing `EmCalendar` now brings its whole tree with it — `<EmCalendar.Grid />`, `<EmCalendar.Header />`, and the rest — so a compound costs one import instead of eight. The sub-key drops the parent prefix (`EmCalendarGrid` is `EmCalendar.Grid`, `EmListItemTitle` is `EmList.ItemTitle`).
+
+```vue
+<script setup lang="ts">
+  import { EmCalendar } from '@paper/emerald'
+</script>
+
+<template>
+  <EmCalendar>
+    <EmCalendar.Header>
+      <EmCalendar.Prev />
+    </EmCalendar.Header>
+
+    <EmCalendar.Grid />
+  </EmCalendar>
+</template>
+```
+
+Nothing is removed: every flat name (`EmCalendarGrid`, `EmDialogContent`, …) is still exported and resolves to the same component, so existing imports keep working and the two styles can be mixed.

--- a/packages/emerald/SPEC.md
+++ b/packages/emerald/SPEC.md
@@ -76,6 +76,33 @@ showcase quality.
 - **Compounds** (Dialog, Select, Tabs, Pagination, Avatar, Card, Alert): one Em* per region; consumer builds the tree with default slots only.
 - **Install:** consumers use `createEmeraldPlugin` + CSS; they do not construct the stylesheet adapter unless they already own a theme plugin.
 
+## Compound access
+
+Every compound attaches its sub-components to the root, so one import reaches
+the whole tree. The sub-key drops the parent prefix — `EmCalendarGrid` is
+`EmCalendar.Grid`, `EmListItemTitle` is `EmList.ItemTitle`.
+
+```vue
+<script setup lang="ts">
+  import { EmCalendar } from '@paper/emerald'
+</script>
+
+<template>
+  <EmCalendar>
+    <EmCalendar.Header>
+      <EmCalendar.Prev />
+    </EmCalendar.Header>
+
+    <EmCalendar.Grid />
+  </EmCalendar>
+</template>
+```
+
+- The flat names stay exported and stay valid — the dot path and `EmCalendarGrid` are the same component object, so mixing the two styles is safe.
+- The root is the compound: Emerald has no `.Root` key, unlike v0's `Splitter.Root`.
+- A key that reads as a parent in the markup (`EmExpansionPanel.Group`, `EmSnackbar.Portal`, `EmRadio.Group`) is still reached through the root — the dot path is an access path, not a nesting claim.
+- Single-SFC shells (`EmButton`, `EmIcon`, `EmTextField`, …) attach nothing.
+
 ## Wave 1 surface (preview)
 
 | Component | v0 primitive |

--- a/packages/emerald/src/components/EmAlert/index.ts
+++ b/packages/emerald/src/components/EmAlert/index.ts
@@ -1,4 +1,36 @@
 export type { EmAlertProps, EmAlertRole, EmAlertVariant } from './EmAlert.vue'
-export { default as EmAlert } from './EmAlert.vue'
 export { default as EmAlertDescription } from './EmAlertDescription.vue'
 export { default as EmAlertTitle } from './EmAlertTitle.vue'
+
+// Context
+import Root from './EmAlert.vue'
+import Description from './EmAlertDescription.vue'
+import Title from './EmAlertTitle.vue'
+
+/**
+ * Inline status message. Owns the tone and renders the icon that matches it.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmAlertTitle`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmAlert } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmAlert tone="success">
+ *     <EmAlert.Title />
+ *
+ *     <EmAlert.Description />
+ *   </EmAlert>
+ * </template>
+ * ```
+ */
+export const EmAlert = Object.assign(Root, {
+  /** Short headline for the message. */
+  Title,
+  /** Supporting copy under the title. */
+  Description,
+})

--- a/packages/emerald/src/components/EmAvatar/index.ts
+++ b/packages/emerald/src/components/EmAvatar/index.ts
@@ -1,6 +1,38 @@
 export type { EmAvatarProps, EmAvatarSize } from './EmAvatar.vue'
-export { default as EmAvatar } from './EmAvatar.vue'
 export type { EmAvatarFallbackProps } from './EmAvatarFallback.vue'
 export { default as EmAvatarFallback } from './EmAvatarFallback.vue'
 export type { EmAvatarImageProps } from './EmAvatarImage.vue'
 export { default as EmAvatarImage } from './EmAvatarImage.vue'
+
+// Context
+import Root from './EmAvatar.vue'
+import Fallback from './EmAvatarFallback.vue'
+import Image from './EmAvatarImage.vue'
+
+/**
+ * User or entity avatar. Shows the image once it loads and the fallback until then.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmAvatarImage`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmAvatar } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmAvatar>
+ *     <EmAvatar.Image />
+ *
+ *     <EmAvatar.Fallback />
+ *   </EmAvatar>
+ * </template>
+ * ```
+ */
+export const EmAvatar = Object.assign(Root, {
+  /** The avatar image; hidden until it loads. */
+  Image,
+  /** Initials or icon shown while the image loads or after it fails. */
+  Fallback,
+})

--- a/packages/emerald/src/components/EmBreadcrumbs/index.ts
+++ b/packages/emerald/src/components/EmBreadcrumbs/index.ts
@@ -1,5 +1,4 @@
 export type { EmBreadcrumbsProps } from './EmBreadcrumbs.vue'
-export { default as EmBreadcrumbs } from './EmBreadcrumbs.vue'
 export type { EmBreadcrumbsDividerProps } from './EmBreadcrumbsDivider.vue'
 export { default as EmBreadcrumbsDivider } from './EmBreadcrumbsDivider.vue'
 export type { EmBreadcrumbsEllipsisProps } from './EmBreadcrumbsEllipsis.vue'
@@ -9,3 +8,56 @@ export { default as EmBreadcrumbsItem } from './EmBreadcrumbsItem.vue'
 export { default as EmBreadcrumbsLink } from './EmBreadcrumbsLink.vue'
 export { default as EmBreadcrumbsList } from './EmBreadcrumbsList.vue'
 export { default as EmBreadcrumbsPage } from './EmBreadcrumbsPage.vue'
+
+// Context
+import Root from './EmBreadcrumbs.vue'
+import Divider from './EmBreadcrumbsDivider.vue'
+import Ellipsis from './EmBreadcrumbsEllipsis.vue'
+import Item from './EmBreadcrumbsItem.vue'
+import Link from './EmBreadcrumbsLink.vue'
+import List from './EmBreadcrumbsList.vue'
+import Page from './EmBreadcrumbsPage.vue'
+
+/**
+ * Breadcrumb trail. Provides the nav landmark its list and items render into.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmBreadcrumbsList`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmBreadcrumbs } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmBreadcrumbs>
+ *     <EmBreadcrumbs.List>
+ *       <EmBreadcrumbs.Item>
+ *         <EmBreadcrumbs.Link />
+ *       </EmBreadcrumbs.Item>
+ *
+ *       <EmBreadcrumbs.Divider />
+ *
+ *       <EmBreadcrumbs.Item>
+ *         <EmBreadcrumbs.Page />
+ *       </EmBreadcrumbs.Item>
+ *     </EmBreadcrumbs.List>
+ *   </EmBreadcrumbs>
+ * </template>
+ * ```
+ */
+export const EmBreadcrumbs = Object.assign(Root, {
+  /** Ordered list that holds the trail. */
+  List,
+  /** One crumb in the trail. */
+  Item,
+  /** Navigable crumb. */
+  Link,
+  /** Current-page crumb, marked with aria-current. */
+  Page,
+  /** Separator drawn between crumbs. */
+  Divider,
+  /** Collapsed-crumbs indicator. */
+  Ellipsis,
+})

--- a/packages/emerald/src/components/EmCalendar/index.ts
+++ b/packages/emerald/src/components/EmCalendar/index.ts
@@ -37,22 +37,56 @@ export { default as EmCalendarToday } from './EmCalendarToday.vue'
 
 export type { EmCalendarProps } from './EmCalendar.vue'
 
+// Context
+import Root from './EmCalendar.vue'
+import Grid from './EmCalendarGrid.vue'
+import Header from './EmCalendarHeader.vue'
+import Mini from './EmCalendarMini.vue'
+import Next from './EmCalendarNext.vue'
+import Prev from './EmCalendarPrev.vue'
+import Title from './EmCalendarTitle.vue'
+import Today from './EmCalendarToday.vue'
+
 /**
  * Month calendar. Owns the visible-month cursor, day selection, and events;
  * provides the `emerald:calendar` context its children read.
  *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmCalendarGrid`) remain exported and valid.
+ *
  * @example
  * ```vue
- * <EmCalendar v-model="selected" v-model:month="month" :events>
- *   <EmCalendarHeader>
- *     <EmCalendarPrev />
- *     <EmCalendarNext />
- *     <EmCalendarTitle />
- *     <EmCalendarToday />
- *   </EmCalendarHeader>
+ * <script lang="ts" setup>
+ *   import { EmCalendar } from '@paper/emerald'
+ * </script>
  *
- *   <EmCalendarGrid />
- * </EmCalendar>
+ * <template>
+ *   <EmCalendar v-model="selected" v-model:month="month" :events>
+ *     <EmCalendar.Header>
+ *       <EmCalendar.Prev />
+ *       <EmCalendar.Next />
+ *       <EmCalendar.Title />
+ *       <EmCalendar.Today />
+ *     </EmCalendar.Header>
+ *
+ *     <EmCalendar.Grid />
+ *   </EmCalendar>
+ * </template>
  * ```
  */
-export { default as EmCalendar } from './EmCalendar.vue'
+export const EmCalendar = Object.assign(Root, {
+  /** The month grid — weekday header plus 42 day cells, wired to the APG grid pattern. */
+  Grid,
+  /** Toolbar row above the grid; holds the nav and title controls. */
+  Header,
+  /** Compact month with tone dots — a nav widget, deliberately not a grid. */
+  Mini,
+  /** Advances the visible month. */
+  Next,
+  /** Rewinds the visible month. */
+  Prev,
+  /** Live label for the visible month, and the grid's accessible name. */
+  Title,
+  /** Jumps the cursor back to the current month. */
+  Today,
+})

--- a/packages/emerald/src/components/EmCard/index.ts
+++ b/packages/emerald/src/components/EmCard/index.ts
@@ -1,7 +1,54 @@
 export type { EmCardProps, EmCardVariant } from './EmCard.vue'
-export { default as EmCard } from './EmCard.vue'
 export { default as EmCardBody } from './EmCardBody.vue'
 export { default as EmCardFooter } from './EmCardFooter.vue'
 export { default as EmCardHeader } from './EmCardHeader.vue'
 export { default as EmCardSubtitle } from './EmCardSubtitle.vue'
 export { default as EmCardTitle } from './EmCardTitle.vue'
+
+// Context
+import Root from './EmCard.vue'
+import Body from './EmCardBody.vue'
+import Footer from './EmCardFooter.vue'
+import Header from './EmCardHeader.vue'
+import Subtitle from './EmCardSubtitle.vue'
+import Title from './EmCardTitle.vue'
+
+/**
+ * Surface container. Owns the elevation and the padding rhythm its sections inherit.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmCardHeader`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmCard } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmCard>
+ *     <EmCard.Header>
+ *       <EmCard.Title />
+ *
+ *       <EmCard.Subtitle />
+ *     </EmCard.Header>
+ *
+ *     <EmCard.Body />
+ *
+ *     <EmCard.Footer />
+ *   </EmCard>
+ * </template>
+ * ```
+ */
+export const EmCard = Object.assign(Root, {
+  /** Top section, typically the title and subtitle. */
+  Header,
+  /** Primary heading. */
+  Title,
+  /** Secondary line under the title. */
+  Subtitle,
+  /** Main content region. */
+  Body,
+  /** Bottom section, typically actions. */
+  Footer,
+})

--- a/packages/emerald/src/components/EmDialog/index.ts
+++ b/packages/emerald/src/components/EmDialog/index.ts
@@ -9,6 +9,58 @@ export { default as EmDialogDescription } from './EmDialogDescription.vue'
 export type { EmDialogFooterProps, EmDialogFooterVariant } from './EmDialogFooter.vue'
 export { default as EmDialogFooter } from './EmDialogFooter.vue'
 export type { EmDialogProps } from './EmDialog.vue'
-export { default as EmDialog } from './EmDialog.vue'
 export type { EmDialogTitleProps } from './EmDialogTitle.vue'
 export { default as EmDialogTitle } from './EmDialogTitle.vue'
+
+// Context
+import Root from './EmDialog.vue'
+import Activator from './EmDialogActivator.vue'
+import Close from './EmDialogClose.vue'
+import Content from './EmDialogContent.vue'
+import Description from './EmDialogDescription.vue'
+import Footer from './EmDialogFooter.vue'
+import Title from './EmDialogTitle.vue'
+
+/**
+ * Modal dialog. Owns the open state, focus trap, and scrim its parts render against.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmDialogActivator`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmDialog } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmDialog>
+ *     <EmDialog.Activator />
+ *
+ *     <EmDialog.Content>
+ *       <EmDialog.Title />
+ *
+ *       <EmDialog.Description />
+ *
+ *       <EmDialog.Footer />
+ *
+ *       <EmDialog.Close />
+ *     </EmDialog.Content>
+ *   </EmDialog>
+ * </template>
+ * ```
+ */
+export const EmDialog = Object.assign(Root, {
+  /** Trigger that opens the dialog. */
+  Activator,
+  /** The dialog surface itself. */
+  Content,
+  /** Accessible name for the dialog. */
+  Title,
+  /** Accessible description for the dialog. */
+  Description,
+  /** Action row at the bottom of the surface. */
+  Footer,
+  /** Dismisses the dialog. */
+  Close,
+})

--- a/packages/emerald/src/components/EmExpansionPanel/index.ts
+++ b/packages/emerald/src/components/EmExpansionPanel/index.ts
@@ -1,5 +1,4 @@
 export type { EmExpansionPanelProps } from './EmExpansionPanel.vue'
-export { default as EmExpansionPanel } from './EmExpansionPanel.vue'
 export type { EmExpansionPanelActivatorProps } from './EmExpansionPanelActivator.vue'
 export { default as EmExpansionPanelActivator } from './EmExpansionPanelActivator.vue'
 export type { EmExpansionPanelContentProps } from './EmExpansionPanelContent.vue'
@@ -10,3 +9,51 @@ export type { EmExpansionPanelGroupProps } from './EmExpansionPanelGroup.vue'
 export { default as EmExpansionPanelGroup } from './EmExpansionPanelGroup.vue'
 export type { EmExpansionPanelHeaderProps } from './EmExpansionPanelHeader.vue'
 export { default as EmExpansionPanelHeader } from './EmExpansionPanelHeader.vue'
+
+// Context
+import Root from './EmExpansionPanel.vue'
+import Activator from './EmExpansionPanelActivator.vue'
+import Content from './EmExpansionPanelContent.vue'
+import Cue from './EmExpansionPanelCue.vue'
+import Group from './EmExpansionPanelGroup.vue'
+import Header from './EmExpansionPanelHeader.vue'
+
+/**
+ * Single collapsible panel. Owns its open state and the header/content pairing.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmExpansionPanelGroup`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmExpansionPanel } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmExpansionPanel.Group>
+ *     <EmExpansionPanel>
+ *       <EmExpansionPanel.Header>
+ *         <EmExpansionPanel.Activator>
+ *           <EmExpansionPanel.Cue />
+ *         </EmExpansionPanel.Activator>
+ *       </EmExpansionPanel.Header>
+ *
+ *       <EmExpansionPanel.Content />
+ *     </EmExpansionPanel>
+ *   </EmExpansionPanel.Group>
+ * </template>
+ * ```
+ */
+export const EmExpansionPanel = Object.assign(Root, {
+  /** Wraps sibling panels and coordinates which of them may be open. */
+  Group,
+  /** Always-visible row that holds the activator. */
+  Header,
+  /** Toggles the panel open and closed. */
+  Activator,
+  /** Rotating affordance that tracks the open state. */
+  Cue,
+  /** Region revealed while the panel is open. */
+  Content,
+})

--- a/packages/emerald/src/components/EmKanban/index.ts
+++ b/packages/emerald/src/components/EmKanban/index.ts
@@ -11,8 +11,47 @@ export type {
 } from './context'
 export { EM_KANBAN_NAMESPACE, useEmKanbanContext } from './context'
 export type { EmKanbanProps } from './EmKanban.vue'
-export { default as EmKanban } from './EmKanban.vue'
 export type { EmKanbanCardProps } from './EmKanbanCard.vue'
 export { default as EmKanbanCard } from './EmKanbanCard.vue'
 export type { EmKanbanColumnProps } from './EmKanbanColumn.vue'
 export { default as EmKanbanColumn } from './EmKanbanColumn.vue'
+
+// Context
+import Root from './EmKanban.vue'
+import Card from './EmKanbanCard.vue'
+import Column from './EmKanbanColumn.vue'
+
+/**
+ * Board surface. Owns column and card registration plus the drag-and-drop moves.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmKanbanColumn`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmKanban } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmKanban @move="onMove">
+ *     <EmKanban.Column
+ *       v-for="col in board"
+ *       :id="col.id"
+ *       :key="col.id"
+ *       v-slot="{ card }"
+ *       :cards="col.cards"
+ *       :title="col.title"
+ *     >
+ *       {{ card.value.title }}
+ *     </EmKanban.Column>
+ *   </EmKanban>
+ * </template>
+ * ```
+ */
+export const EmKanban = Object.assign(Root, {
+  /** A board column; renders its card stack from the `cards` it registers. */
+  Column,
+  /** The card wrapper `EmKanban.Column` renders internally — exported for typing and styling reference, not consumer-placed. */
+  Card,
+})

--- a/packages/emerald/src/components/EmList/index.ts
+++ b/packages/emerald/src/components/EmList/index.ts
@@ -6,4 +6,56 @@ export { default as EmListItemMeta } from './EmListItemMeta.vue'
 export { default as EmListItemSubtitle } from './EmListItemSubtitle.vue'
 export { default as EmListItemTitle } from './EmListItemTitle.vue'
 export type { EmListProps } from './EmList.vue'
-export { default as EmList } from './EmList.vue'
+
+// Context
+import Root from './EmList.vue'
+import Item from './EmListItem.vue'
+import ItemContent from './EmListItemContent.vue'
+import ItemMedia from './EmListItemMedia.vue'
+import ItemMeta from './EmListItemMeta.vue'
+import ItemSubtitle from './EmListItemSubtitle.vue'
+import ItemTitle from './EmListItemTitle.vue'
+
+/**
+ * List container. Owns the density and divider rhythm its items inherit.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmListItem`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmList } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmList>
+ *     <EmList.Item>
+ *       <EmList.ItemMedia />
+ *
+ *       <EmList.ItemContent>
+ *         <EmList.ItemTitle />
+ *
+ *         <EmList.ItemSubtitle />
+ *       </EmList.ItemContent>
+ *
+ *       <EmList.ItemMeta />
+ *     </EmList.Item>
+ *   </EmList>
+ * </template>
+ * ```
+ */
+export const EmList = Object.assign(Root, {
+  /** A single row. */
+  Item,
+  /** Leading slot for an avatar or icon. */
+  ItemMedia,
+  /** Text column between the media and the meta. */
+  ItemContent,
+  /** Primary line of the row. */
+  ItemTitle,
+  /** Secondary line of the row. */
+  ItemSubtitle,
+  /** Trailing slot for a value or action. */
+  ItemMeta,
+})

--- a/packages/emerald/src/components/EmPagination/index.ts
+++ b/packages/emerald/src/components/EmPagination/index.ts
@@ -1,8 +1,45 @@
 export type { EmPaginationProps } from './EmPagination.vue'
-export { default as EmPagination } from './EmPagination.vue'
 export type { EmPaginationItemProps } from './EmPaginationItem.vue'
 export { default as EmPaginationItem } from './EmPaginationItem.vue'
 export type { EmPaginationNextProps } from './EmPaginationNext.vue'
 export { default as EmPaginationNext } from './EmPaginationNext.vue'
 export type { EmPaginationPrevProps } from './EmPaginationPrev.vue'
 export { default as EmPaginationPrev } from './EmPaginationPrev.vue'
+
+// Context
+import Root from './EmPagination.vue'
+import Item from './EmPaginationItem.vue'
+import Next from './EmPaginationNext.vue'
+import Prev from './EmPaginationPrev.vue'
+
+/**
+ * Pager. Owns the current page and the window of page numbers on show.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmPaginationPrev`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmPagination } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmPagination>
+ *     <EmPagination.Prev />
+ *
+ *     <EmPagination.Item />
+ *
+ *     <EmPagination.Next />
+ *   </EmPagination>
+ * </template>
+ * ```
+ */
+export const EmPagination = Object.assign(Root, {
+  /** Steps back one page. */
+  Prev,
+  /** A page number. */
+  Item,
+  /** Steps forward one page. */
+  Next,
+})

--- a/packages/emerald/src/components/EmPopover/index.ts
+++ b/packages/emerald/src/components/EmPopover/index.ts
@@ -3,4 +3,36 @@ export { default as EmPopoverActivator } from './EmPopoverActivator.vue'
 export type { EmPopoverContentProps } from './EmPopoverContent.vue'
 export { default as EmPopoverContent } from './EmPopoverContent.vue'
 export type { EmPopoverProps } from './EmPopover.vue'
-export { default as EmPopover } from './EmPopover.vue'
+
+// Context
+import Root from './EmPopover.vue'
+import Activator from './EmPopoverActivator.vue'
+import Content from './EmPopoverContent.vue'
+
+/**
+ * Anchored overlay. Owns the open state and positions its content against the activator.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmPopoverActivator`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmPopover } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmPopover>
+ *     <EmPopover.Activator />
+ *
+ *     <EmPopover.Content />
+ *   </EmPopover>
+ * </template>
+ * ```
+ */
+export const EmPopover = Object.assign(Root, {
+  /** Trigger that opens the popover. */
+  Activator,
+  /** The floating surface. */
+  Content,
+})

--- a/packages/emerald/src/components/EmRadio/index.ts
+++ b/packages/emerald/src/components/EmRadio/index.ts
@@ -1,5 +1,4 @@
 export type { EmRadioProps, EmRadioSize } from './EmRadio.vue'
-export { default as EmRadio } from './EmRadio.vue'
 export type { EmRadioGroupProps } from './EmRadioGroup.vue'
 
 /**
@@ -14,3 +13,33 @@ export type { EmRadioGroupProps } from './EmRadioGroup.vue'
  * ```
  */
 export { default as EmRadioGroup } from './EmRadioGroup.vue'
+
+// Context
+import Root from './EmRadio.vue'
+import Group from './EmRadioGroup.vue'
+
+/**
+ * Radio input. Reads the selection from the enclosing group.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmRadioGroup`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmRadio } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmRadio.Group v-model="size">
+ *     <EmRadio value="sm" />
+ *
+ *     <EmRadio value="md" />
+ *   </EmRadio.Group>
+ * </template>
+ * ```
+ */
+export const EmRadio = Object.assign(Root, {
+  /** Wraps sibling radios and owns the selected value. */
+  Group,
+})

--- a/packages/emerald/src/components/EmSelect/index.ts
+++ b/packages/emerald/src/components/EmSelect/index.ts
@@ -7,6 +7,53 @@ export { default as EmSelectItem } from './EmSelectItem.vue'
 export type { EmSelectPlaceholderProps } from './EmSelectPlaceholder.vue'
 export { default as EmSelectPlaceholder } from './EmSelectPlaceholder.vue'
 export type { EmSelectProps } from './EmSelect.vue'
-export { default as EmSelect } from './EmSelect.vue'
 export type { EmSelectValueProps } from './EmSelectValue.vue'
 export { default as EmSelectValue } from './EmSelectValue.vue'
+
+// Context
+import Root from './EmSelect.vue'
+import Activator from './EmSelectActivator.vue'
+import Content from './EmSelectContent.vue'
+import Item from './EmSelectItem.vue'
+import Placeholder from './EmSelectPlaceholder.vue'
+import Value from './EmSelectValue.vue'
+
+/**
+ * Select. Owns the selected value, the listbox open state, and typeahead focus.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmSelectActivator`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmSelect } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmSelect v-model="value">
+ *     <EmSelect.Activator>
+ *       <EmSelect.Value />
+ *
+ *       <EmSelect.Placeholder />
+ *     </EmSelect.Activator>
+ *
+ *     <EmSelect.Content>
+ *       <EmSelect.Item />
+ *     </EmSelect.Content>
+ *   </EmSelect>
+ * </template>
+ * ```
+ */
+export const EmSelect = Object.assign(Root, {
+  /** Trigger that opens the listbox. */
+  Activator,
+  /** Renders the current selection. */
+  Value,
+  /** Stands in while nothing is selected. */
+  Placeholder,
+  /** The listbox surface. */
+  Content,
+  /** One selectable option. */
+  Item,
+})

--- a/packages/emerald/src/components/EmSnackbar/index.ts
+++ b/packages/emerald/src/components/EmSnackbar/index.ts
@@ -6,4 +6,46 @@ export { default as EmSnackbarPortal } from './EmSnackbarPortal.vue'
 export type { EmSnackbarQueueProps } from './EmSnackbarQueue.vue'
 export { default as EmSnackbarQueue } from './EmSnackbarQueue.vue'
 export type { EmSnackbarProps, EmSnackbarVariant } from './EmSnackbar.vue'
-export { default as EmSnackbar } from './EmSnackbar.vue'
+
+// Context
+import Root from './EmSnackbar.vue'
+import Close from './EmSnackbarClose.vue'
+import Content from './EmSnackbarContent.vue'
+import Portal from './EmSnackbarPortal.vue'
+import Queue from './EmSnackbarQueue.vue'
+
+/**
+ * A single snackbar. Owns its variant and dismissal.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmSnackbarPortal`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmSnackbar } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmSnackbar.Portal>
+ *     <EmSnackbar.Queue>
+ *       <EmSnackbar>
+ *         <EmSnackbar.Content />
+ *
+ *         <EmSnackbar.Close />
+ *       </EmSnackbar>
+ *     </EmSnackbar.Queue>
+ *   </EmSnackbar.Portal>
+ * </template>
+ * ```
+ */
+export const EmSnackbar = Object.assign(Root, {
+  /** Teleports the queue to the document, out of the local stacking context. */
+  Portal,
+  /** Stacks active snackbars and manages their timeouts. */
+  Queue,
+  /** Message body. */
+  Content,
+  /** Dismisses the snackbar. */
+  Close,
+})

--- a/packages/emerald/src/components/EmStep/index.ts
+++ b/packages/emerald/src/components/EmStep/index.ts
@@ -1,4 +1,31 @@
 export type { EmStepProps } from './EmStep.vue'
-export { default as EmStep } from './EmStep.vue'
 export type { EmStepItemProps } from './EmStepItem.vue'
 export { default as EmStepItem } from './EmStepItem.vue'
+
+// Context
+import Root from './EmStep.vue'
+import Item from './EmStepItem.vue'
+
+/**
+ * Stepper. Owns the active step and the completed/upcoming states its items read.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmStepItem`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmStep } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmStep v-model="step">
+ *     <EmStep.Item />
+ *   </EmStep>
+ * </template>
+ * ```
+ */
+export const EmStep = Object.assign(Root, {
+  /** One step in the sequence. */
+  Item,
+})

--- a/packages/emerald/src/components/EmTabs/index.ts
+++ b/packages/emerald/src/components/EmTabs/index.ts
@@ -1,8 +1,45 @@
 export type { EmTabsOrientation, EmTabsProps } from './EmTabs.vue'
-export { default as EmTabs } from './EmTabs.vue'
 export type { EmTabsItemProps } from './EmTabsItem.vue'
 export { default as EmTabsItem } from './EmTabsItem.vue'
 export type { EmTabsListProps } from './EmTabsList.vue'
 export { default as EmTabsList } from './EmTabsList.vue'
 export type { EmTabsPanelProps } from './EmTabsPanel.vue'
 export { default as EmTabsPanel } from './EmTabsPanel.vue'
+
+// Context
+import Root from './EmTabs.vue'
+import Item from './EmTabsItem.vue'
+import List from './EmTabsList.vue'
+import Panel from './EmTabsPanel.vue'
+
+/**
+ * Tabs. Owns the selected tab, roving focus, and the tab/panel pairing.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmTabsList`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmTabs } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmTabs v-model="tab">
+ *     <EmTabs.List>
+ *       <EmTabs.Item />
+ *     </EmTabs.List>
+ *
+ *     <EmTabs.Panel />
+ *   </EmTabs>
+ * </template>
+ * ```
+ */
+export const EmTabs = Object.assign(Root, {
+  /** Tablist that holds the tab items. */
+  List,
+  /** A single tab. */
+  Item,
+  /** Content shown for the matching tab. */
+  Panel,
+})

--- a/packages/emerald/src/components/EmTooltip/index.ts
+++ b/packages/emerald/src/components/EmTooltip/index.ts
@@ -3,4 +3,36 @@ export { default as EmTooltipActivator } from './EmTooltipActivator.vue'
 export type { EmTooltipContentProps } from './EmTooltipContent.vue'
 export { default as EmTooltipContent } from './EmTooltipContent.vue'
 export type { EmTooltipProps } from './EmTooltip.vue'
-export { default as EmTooltip } from './EmTooltip.vue'
+
+// Context
+import Root from './EmTooltip.vue'
+import Activator from './EmTooltipActivator.vue'
+import Content from './EmTooltipContent.vue'
+
+/**
+ * Tooltip. Owns the hover and focus delays plus the positioning of its content.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`EmTooltipActivator`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { EmTooltip } from '@paper/emerald'
+ * </script>
+ *
+ * <template>
+ *   <EmTooltip>
+ *     <EmTooltip.Activator />
+ *
+ *     <EmTooltip.Content />
+ *   </EmTooltip>
+ * </template>
+ * ```
+ */
+export const EmTooltip = Object.assign(Root, {
+  /** Element the tooltip describes. */
+  Activator,
+  /** The floating label. */
+  Content,
+})


### PR DESCRIPTION
Dot-notation access on every Emerald compound: import the root, reach the whole tree — `<EmCalendar.Grid />`, `<EmDialog.Content />`. 17 compounds, 62 attached sub-components, verified by inventory (not assumed).

- **Pattern**: `Object.assign(Root, { Sub, ... })` on each compound's barrel; sub-keys drop the parent prefix (`EmCalendarGrid` → `.Grid`, `EmListItemTitle` → `.ItemTitle`). Unlike v0's `Splitter.Root` namespace, the Emerald root IS the component — `<EmCalendar>` keeps working unchanged.
- **Zero breaks**: all 91 flat `Em*` exports remain and are identity-equal to their attached counterparts (asserted at runtime against the built bundle, not just presence-checked).
- **Typing proven the hard way**: prop inference survives the assign — wrong prop types and missing required props error through the dot path (`<EmSelect.Item>` without `value` fails typecheck).
- SPEC gains a **Compound access** section: the convention, plus the honest caveats (`EmExpansionPanel.Group` / `EmSnackbar.Portal` / `EmRadio.Group` are access paths, not nesting claims; no `.Root` key).
- Changeset: `@paper/emerald` minor.

**Deliberately excluded**: the docs Anatomy rewrite — the `systems/emerald` pages live on master, and dot-notation anatomies would break master's docs build until this package change reaches it. That rewrite lands on dev right after the scheduled master→dev sync, batched with the emerald-light docs-side rename.

Verified: emerald typecheck + build green, docs build green, kitchen sink renders (flat and dot forms), eslint + repo:check clean. Pre-existing on dev, untouched: `verify:showcase` fails (sink lacks an EmKanban reference).