### PR TITLE
test(createTokens): cover flat-mode alias chains reached through a segment path

### DIFF
--- a/packages/0/src/composables/createTokens/index.test.ts
+++ b/packages/0/src/composables/createTokens/index.test.ts
@@ -1276,6 +1276,47 @@ describe('createTokens', () => {
           expect(result).toBe('#1976d2')
         }
       })
+
+      it('should resolve flat path-walked alias chains', () => {
+        const tokens: TokenCollection = {
+          palette: {
+            blue: '#0000FF',
+            primary: '{palette.blue}',
+          },
+        }
+
+        const context = createTokens(tokens, { flat: true })
+
+        expect(context.resolve('{palette.primary}')).toBe('#0000FF')
+      })
+
+      it('should resolve flat path-walked token alias object chains', () => {
+        const tokens: TokenCollection = {
+          palette: {
+            blue: { $value: '#0000FF' },
+            primary: { $value: '{palette.blue}' },
+          },
+        }
+
+        const context = createTokens(tokens, { flat: true })
+
+        expect(context.resolve('{palette.primary}')).toBe('#0000FF')
+      })
+
+      it('should prevent flat path-walked alias cycles', () => {
+        const tokens: TokenCollection = {
+          palette: {
+            primary: '{palette.secondary}',
+            secondary: { $value: '{palette.primary}' },
+          },
+        }
+
+        const context = createTokens(tokens, { flat: true })
+        using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        expect(context.resolve('{palette.primary}')).toBeUndefined()
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Circular alias detected'))
+      })
     })
 
     describe('segment-path terminal alias (#566)', () => {

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -470,6 +470,48 @@ describe('createTheme', () => {
       app.unmount()
     })
 
+    it('should emit CSS variables for palette alias chains', async () => {
+      let sheets: CSSStyleSheet[] = []
+      using spy = vi.spyOn(document, 'adoptedStyleSheets', 'get').mockImplementation(() => sheets)
+      using setSpy = vi.spyOn(document, 'adoptedStyleSheets', 'set').mockImplementation(value => {
+        sheets = value as CSSStyleSheet[]
+      })
+
+      const app = createApp({
+        template: '<div>Test</div>',
+      })
+
+      app.use(
+        createThemePlugin({
+          default: 'light',
+          palette: {
+            blue: '#0000FF',
+            primary: '{palette.blue}',
+          },
+          themes: {
+            light: {
+              colors: {
+                primary: '{palette.primary}',
+              },
+            },
+          },
+        }),
+      )
+
+      const container = document.createElement('div')
+      app.mount(container)
+
+      await nextTick()
+
+      const css = sheets[0]!.cssRules?.[0]?.cssText || ''
+      expect(css).toContain('--v0-primary: #0000FF')
+      expect(css).not.toContain('{palette.blue}')
+      expect(spy).toHaveBeenCalled()
+      expect(setSpy).toHaveBeenCalled()
+
+      app.unmount()
+    })
+
     it('should apply theme class to target element', async () => {
       const app = createApp({
         template: '<div>Test</div>',


### PR DESCRIPTION
Tests only, no changeset. The #566/#589 terminal-hop fix is exercised by master's tests only in default mode; these four (rescued from the July `fix/tokens-alias-path` branch, whose implementation those PRs independently superseded) pin `flat: true` — chained flat aliases, alias-object chains, cycle guards — plus useTheme's integration path emitting CSS variables from a flat-token theme.

Why they earn their place: the same bug was found and fixed **twice** (#566, then #589 re-found it). This is the flat-mode coverage that prevents a third round. Verified load-bearing: gating the terminal hop back to pre-fix behavior fails exactly these 4 plus master's own 3.

373/373 tokens+theme tests green; full v0:unit composables sweep 4059/4059; typecheck clean. The stale local branch is deleted.