### PR TITLE
docs: DRY consolidation phase A — glass token, commit fetch, maturity typing, nav walkers

### DIFF
--- a/apps/docs/src/components/app/AppAskInline.vue
+++ b/apps/docs/src/components/app/AppAskInline.vue
@@ -21,7 +21,7 @@
 
 <template>
   <form
-    :class="['rounded-full border border-divider flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 hover:border-primary/50 focus-within:border-primary focus-within:hover:border-primary transition-colors max-w-sm', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['rounded-full border border-divider flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 hover:border-primary/50 focus-within:border-primary focus-within:hover:border-primary transition-colors max-w-sm', settings.surface.value]"
     @submit.prevent="onSubmit"
   >
     <AppIcon

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -48,7 +48,7 @@
 <template>
   <Atom
     :as
-    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,24px)] px-3 text-on-surface border-b border-solid border-divider z-1', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,24px)] px-3 text-on-surface border-b border-solid border-divider z-1', settings.surface.value]"
     data-app-bar
   >
     <div class="flex items-center gap-2">

--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { useIntersectionObserver, useLogger } from '@vuetify/v0'
+  import { useIntersectionObserver } from '@vuetify/v0'
 
   // Composables
   import { useSettings } from '@/composables/useSettings'
@@ -22,7 +22,6 @@
 
   const app = useAppStore()
   const releases = useReleasesStore()
-  const logger = useLogger()
   const settings = useSettings()
   const toggle = useThemeToggle()
 
@@ -43,21 +42,7 @@
   )
 
   async function fetch () {
-    // Fetch latest commit
-    try {
-      const octokit = await import('@/plugins/octokit').then(m => m.default)
-      const { data = [] } = await octokit.request('GET /repos/{owner}/{repo}/commits', {
-        owner: 'vuetifyjs',
-        repo: '0',
-        per_page: 1,
-      })
-
-      if (data.length > 0) {
-        app.stats.commit = data[0] as typeof app.stats.commit
-      }
-    } catch (error) {
-      logger.warn('Failed to fetch commit info', error)
-    }
+    await app.fetchCommit()
 
     // Fetch latest release if not already loaded
     if (releases.releases.length === 0) {
@@ -80,7 +65,7 @@
   <footer
     ref="footer"
     class="app-footer py-4 border-t border-divider/50"
-    :class="[inset && 'md:ms-[230px]', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="[inset && 'md:ms-[230px]', settings.surface.value]"
   >
     <div class="max-w-[1200px] mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-4">
       <div class="flex flex-col md:flex-row items-center gap-4 text-sm opacity-60">

--- a/apps/docs/src/components/app/AppNav.vue
+++ b/apps/docs/src/components/app/AppNav.vue
@@ -16,11 +16,12 @@
   import { useAppStore } from '@/stores/app'
 
   // Utilities
+  import { findLink } from '@/utilities/nav'
   import { computed, nextTick, onMounted, shallowRef, toRef, useTemplateRef, watch } from 'vue'
   import { useRoute } from 'vue-router'
 
   // Types
-  import type { NavItem, NavItemLink } from '@/stores/app'
+  import type { NavItem } from '@/stores/app'
 
   const settings = useSettings()
   const devmode = useFeatures().get('devmode')!
@@ -50,21 +51,9 @@
   const { provide: provideNavNested, scrollEnabled } = createNavNested(visibleNav)
   provideNavNested()
 
-  // Find a page by path in nav tree
-  function findPage (items: NavItem[], path: string): NavItemLink | null {
-    for (const item of items) {
-      if ('to' in item && item.to === path) return item
-      if ('children' in item && item.children) {
-        const found = findPage(item.children, path)
-        if (found) return found
-      }
-    }
-    return null
-  }
-
   // Check if page exists in nav tree
   function hasPage (items: NavItem[], path: string): boolean {
-    return findPage(items, path) !== null
+    return findLink(items, path) !== null
   }
 
   // Current page info when it's filtered out (by skill level OR feature filter)
@@ -75,7 +64,7 @@
     const path = route.path
     // Check against configuredNav which is filtered by both skill level and features
     if (hasPage(navConfig.configuredNav.value, path)) return null
-    return findPage(app.nav, path)
+    return findLink(app.nav, path)
   })
 
   // Check if nav has real content (not just dividers)
@@ -162,7 +151,7 @@
     as="nav"
     :class="[
       'flex flex-col fixed w-[230px] top-0 md:top-[calc(48px+var(--app-banner-h,24px))] bottom-0 start-0 ltr:-translate-x-full rtl:translate-x-full md:ltr:translate-x-0 md:rtl:translate-x-0 border-e border-solid border-divider',
-      settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface',
+      settings.surface.value,
       navigation.isOpen.value && '!translate-x-0',
       !settings.prefersReducedMotion.value && 'transition-transform duration-200 ease-in-out',
     ]"

--- a/apps/docs/src/components/app/AppSearchInline.vue
+++ b/apps/docs/src/components/app/AppSearchInline.vue
@@ -10,7 +10,7 @@
 <template>
   <AppTooltip
     aria-label="Search (Ctrl+K)"
-    :class="['inline-flex items-center gap-1.5 rounded-full border border-divider pl-1.5 pr-1.5 py-1.5 hover:border-primary/50 focus-visible:border-primary focus-visible:outline-none transition-colors', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['inline-flex items-center gap-1.5 rounded-full border border-divider pl-1.5 pr-1.5 py-1.5 hover:border-primary/50 focus-visible:border-primary focus-visible:outline-none transition-colors', settings.surface.value]"
     position-area="bottom"
     text="Search (Ctrl+K)"
     @click="search.open"

--- a/apps/docs/src/components/app/AppSettingsSheet.vue
+++ b/apps/docs/src/components/app/AppSettingsSheet.vue
@@ -77,7 +77,7 @@
     ref="sheet"
     aria-labelledby="settings-title"
     aria-modal="true"
-    :class="['fixed inset-y-0 end-0 flex flex-col w-[320px] max-w-full shadow-xl outline-none', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['fixed inset-y-0 end-0 flex flex-col w-[320px] max-w-full shadow-xl outline-none', settings.surface.value]"
     role="dialog"
     :style="{ zIndex: ticket.zIndex.value }"
     tabindex="-1"

--- a/apps/docs/src/components/app/settings/AppSettingsCommits.vue
+++ b/apps/docs/src/components/app/settings/AppSettingsCommits.vue
@@ -1,47 +1,15 @@
 <script setup lang="ts">
-  // Framework
-  import { createStorage, useLogger } from '@vuetify/v0'
-
-  import { CACHE_TTL } from '@/constants/cache'
-
   // Stores
   import { useAppStore } from '@/stores/app'
 
   // Utilities
   import { onMounted } from 'vue'
 
-  const storage = createStorage({ prefix: 'v0-commit:', ttl: CACHE_TTL })
-
   const app = useAppStore()
-  const logger = useLogger()
 
   const buildSha = import.meta.env.VITE_GITHUB_SHA as string | undefined
 
-  onMounted(async () => {
-    if (app.stats.commit) return
-
-    const cached = storage.get<typeof app.stats.commit | null>('latest', null)
-    if (cached.value) {
-      app.stats.commit = cached.value
-      return
-    }
-
-    try {
-      const octokit = await import('@/plugins/octokit').then(m => m.default)
-      const { data = [] } = await octokit.request('GET /repos/{owner}/{repo}/commits', {
-        owner: 'vuetifyjs',
-        repo: '0',
-        per_page: 1,
-      })
-
-      if (data.length === 0) return
-
-      app.stats.commit = data[0] as typeof app.stats.commit
-      storage.set('latest', app.stats.commit)
-    } catch (error) {
-      logger.warn('Failed to fetch commit info', error)
-    }
-  })
+  onMounted(() => app.fetchCommit())
 </script>
 
 <template>

--- a/apps/docs/src/components/docs/DocsApiIndex.vue
+++ b/apps/docs/src/components/docs/DocsApiIndex.vue
@@ -4,6 +4,8 @@
   // Context
   import DocsHeaderAnchor from './DocsHeaderAnchor.vue'
 
+  import { MATURITY } from '@/constants/maturity'
+
   // Utilities
   import { renderInlineMarkdown } from '@/utilities/markdown'
   import { toKebab, toTitle } from '@/utilities/strings'
@@ -11,9 +13,6 @@
 
   // Types
   import type { ApiData } from '@build/generate-api'
-
-  // Maturity (relative path; #v0 alias also works)
-  import maturity from '../../../../../packages/0/src/maturity.json'
 
   type IndexEntry = {
     [key: string]: unknown
@@ -25,13 +24,9 @@
   }
 
   const data = apiData as ApiData
-  const maturityRecord = maturity as {
-    components?: Record<string, { category?: string, description?: string }>
-    composables?: Record<string, { category?: string, description?: string }>
-  }
 
   function categoryFor (name: string, kind: 'component' | 'composable'): string {
-    const bucket = kind === 'component' ? maturityRecord.components : maturityRecord.composables
+    const bucket = kind === 'component' ? MATURITY.components : MATURITY.composables
     return bucket?.[name]?.category ?? 'other'
   }
 
@@ -46,7 +41,7 @@
 
       out.push({
         name: root,
-        description: maturityRecord.components?.[root]?.description ?? '',
+        description: MATURITY.components?.[root]?.description ?? '',
         href: `/api/${toKebab(root)}`,
         kind: 'component',
         category: categoryFor(root, 'component'),
@@ -60,7 +55,7 @@
     return Object.keys(data.composables)
       .map(name => ({
         name,
-        description: maturityRecord.composables?.[name]?.description ?? '',
+        description: MATURITY.composables?.[name]?.description ?? '',
         href: `/api/${toKebab(name)}`,
         kind: 'composable' as const,
         category: categoryFor(name, 'composable'),

--- a/apps/docs/src/components/docs/DocsAskForm.vue
+++ b/apps/docs/src/components/docs/DocsAskForm.vue
@@ -45,7 +45,7 @@
 
 <template>
   <form
-    :class="['rounded-full border border-divider flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 hover:border-primary/50 focus-within:border-primary focus-within:hover:border-primary transition-colors', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['rounded-full border border-divider flex items-center gap-1.5 pl-2.5 pr-1.5 py-1.5 hover:border-primary/50 focus-within:border-primary focus-within:hover:border-primary transition-colors', settings.surface.value]"
     @submit.prevent="onSubmit"
   >
     <AppIcon

--- a/apps/docs/src/components/docs/DocsAskPanel.vue
+++ b/apps/docs/src/components/docs/DocsAskPanel.vue
@@ -150,7 +150,7 @@
     :aria-modal="!isDesktop"
     :class="[
       'flex flex-col',
-      settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface',
+      settings.surface.value,
       isDesktop && fullscreen
         ? 'fixed inset-4 rounded-lg border border-divider shadow-lg'
         : isDesktop

--- a/apps/docs/src/components/docs/DocsGraduation.vue
+++ b/apps/docs/src/components/docs/DocsGraduation.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
   // Framework
-  import maturityData from '#v0/maturity.json'
-  import { MATURITY_LEVELS as levels } from '@/constants/maturity'
+  import { MATURITY as data, MATURITY_LEVELS as levels } from '@/constants/maturity'
 
   // Types
-  import type { Level, MaturityData } from '@/constants/maturity'
+  import type { Level } from '@/constants/maturity'
 
   interface Gate {
     promoter: string
@@ -17,8 +16,6 @@
     /** Requirements to reach this rung from the one above it. Absent on the entry rung. */
     gate?: Gate
   }
-
-  const data = maturityData as MaturityData
 
   function tally (): Record<Level, number> {
     const result: Record<Level, number> = { draft: 0, preview: 0, stable: 0, mature: 0, deprecated: 0 }

--- a/apps/docs/src/components/docs/DocsMaturity.vue
+++ b/apps/docs/src/components/docs/DocsMaturity.vue
@@ -2,8 +2,7 @@
   // Framework
   import { createDataTable, createGroup, createSingle, isString, Tooltip, toHighlight } from '@vuetify/v0'
 
-  import maturityData from '#v0/maturity.json'
-  import { LEVEL_KEYS as levelKeys, MATURITY_LEVELS as levels } from '@/constants/maturity'
+  import { LEVEL_KEYS as levelKeys, MATURITY as data, MATURITY_LEVELS as levels } from '@/constants/maturity'
   import { releaseAlias } from '@/constants/releases'
 
   // Utilities
@@ -11,7 +10,7 @@
   import { RouterLink, useRoute } from 'vue-router'
 
   // Types
-  import type { Level, MaturityData } from '@/constants/maturity'
+  import type { Level } from '@/constants/maturity'
 
   type ItemType = 'composable' | 'component' | 'utility'
 
@@ -30,8 +29,6 @@
   function kebab (name: string): string {
     return name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
   }
-
-  const data = maturityData as MaturityData
 
   // Flatten JSON into MaturityItem[]
   function flatten (): MaturityItem[] {

--- a/apps/docs/src/components/docs/DocsMermaid.vue
+++ b/apps/docs/src/components/docs/DocsMermaid.vue
@@ -287,7 +287,7 @@
       </figure>
     </Dialog.Activator>
 
-    <Dialog.Content :class="['docs-mermaid-dialog m-auto rounded-xl border border-divider', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface', settings.prefersReducedMotion.value && 'reduce-motion']">
+    <Dialog.Content :class="['docs-mermaid-dialog m-auto rounded-xl border border-divider', settings.surface.value, settings.prefersReducedMotion.value && 'reduce-motion']">
       <!-- Header toolbar -->
       <div class="flex items-center justify-between gap-2 p-2 border-b border-divider">
         <Dialog.Title as="span" class="sr-only">

--- a/apps/docs/src/components/docs/DocsNavigator.vue
+++ b/apps/docs/src/components/docs/DocsNavigator.vue
@@ -6,6 +6,7 @@
   import { useNavConfigContext } from '@/composables/useNavConfig'
 
   // Utilities
+  import { flatten } from '@/utilities/nav'
   import { shallowRef, toRef, watch } from 'vue'
   import { useRoute } from 'vue-router'
 
@@ -19,17 +20,6 @@
   const isVisible = toRef(() => !route.path.startsWith('/skillz'))
 
   // Flatten nav items to route paths
-  function flattenRoutes (nav: NavItem): string[] {
-    const routes: string[] = []
-    if ('to' in nav && nav.to) {
-      routes.push(nav.to)
-    }
-    if ('children' in nav && nav.children) {
-      routes.push(...nav.children.flatMap(child => flattenRoutes(child)))
-    }
-    return routes
-  }
-
   // Use refs updated via watch to avoid reactivity timing issues during navigation
   const prev = shallowRef<string | false>(false)
   const next = shallowRef<string | false>(false)
@@ -40,7 +30,7 @@
       const pages: string[] = []
       for (const nav of navConfig.configuredNav.value) {
         if (!('children' in nav) && !('to' in nav)) continue
-        pages.push(...flattenRoutes(nav as NavItem))
+        pages.push(...flatten(nav as NavItem))
       }
 
       const normalizedPath = `/${path.split('/').slice(1).join('/')}`

--- a/apps/docs/src/components/docs/DocsSearch.vue
+++ b/apps/docs/src/components/docs/DocsSearch.vue
@@ -155,7 +155,7 @@
       role="dialog"
       :style="{ zIndex: ticket.zIndex.value }"
     >
-      <div :class="['rounded-lg shadow-xl border border-divider overflow-hidden', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']">
+      <div :class="['rounded-lg shadow-xl border border-divider overflow-hidden', settings.surface.value]">
         <Discovery.Activator
           class="flex-1 bg-transparent flex border-b border-divider outline-none text-on-surface rounded-lg rounded-b-0 items-center gap-3 px-4 py-3"
           step="search-input"

--- a/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
+++ b/apps/docs/src/components/docs/meta/DocsPageFeatures.vue
@@ -12,10 +12,9 @@
   import { providePageMeta } from '@/composables/usePageMeta'
 
   // Data
-  import maturityData from '#v0/maturity.json'
   import { MATURITY_MATRIX_HREF, SKILL_LEVELS_DOCS_HREF } from '@/constants/links'
   // Constants
-  import { MATURITY_LEVELS } from '@/constants/maturity'
+  import { MATURITY, MATURITY_LEVELS } from '@/constants/maturity'
 
   // Utilities
   import { useScrollToAnchor } from '@/utilities/scroll'
@@ -24,7 +23,6 @@
 
   // Types
   import type { PhaseConfig } from '@/composables/usePageMeta'
-  import type { MaturityData } from '@/constants/maturity'
 
   const scroll = useScrollToAnchor()
   const logger = useLogger()
@@ -220,7 +218,7 @@
     const name = itemName.value
     if (!type || !name) return null
 
-    const bucket = (maturityData as MaturityData)[type]
+    const bucket = MATURITY[type]
     const entry = bucket?.[name]
     if (!entry) return null
 
@@ -272,7 +270,7 @@
     const name = itemName.value
     if (!type || !name) return MATURITY_MATRIX_HREF
 
-    const bucket = (maturityData as MaturityData)[type]
+    const bucket = MATURITY[type]
     const category = bucket?.[name]?.category
     if (!category) return MATURITY_MATRIX_HREF
 

--- a/apps/docs/src/composables/useBreadcrumbItems.ts
+++ b/apps/docs/src/composables/useBreadcrumbItems.ts
@@ -2,35 +2,13 @@
 import { useAppStore } from '@/stores/app'
 
 // Utilities
+import { findNav } from '@/utilities/nav'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-
-// Types
-import type { NavItem } from '@/stores/app'
 
 export interface BreadcrumbItem {
   text: string
   to?: string
-}
-
-function findNavPath (items: NavItem[], targetPath: string): Array<{ name: string, to?: string }> | null {
-  for (const item of items) {
-    if ('divider' in item) continue
-
-    if ('to' in item && item.to === targetPath) {
-      return [{ name: item.name }]
-    }
-
-    if ('children' in item && item.children) {
-      const childPath = findNavPath(item.children, targetPath)
-      if (childPath) {
-        const entry: { name: string, to?: string } = { name: item.name }
-        if ('to' in item) entry.to = item.to
-        return [entry, ...childPath]
-      }
-    }
-  }
-  return null
 }
 
 export function useBreadcrumbItems () {
@@ -40,21 +18,22 @@ export function useBreadcrumbItems () {
 
   return computed<BreadcrumbItem[]>(() => {
     const path = route.path.replace(/\/$/, '') || '/'
-    const navPath = findNavPath(store.nav, path)
+    const navPath = findNav(store.nav, path)
 
     if (navPath) {
       return [
         { text: 'Home', to: '/' },
         ...navPath.map((entry, i) => {
           const isLast = i === navPath.length - 1
-          if (isLast || !entry.to) return { text: entry.name }
+          const to = 'to' in entry ? entry.to : undefined
+          if (isLast || !to) return { text: entry.name }
 
-          const { matched } = router.resolve(entry.to)
+          const { matched } = router.resolve(to)
           const hasPage = matched.some(r => !r.path.includes('*'))
 
           return {
             text: entry.name,
-            to: hasPage ? entry.to : undefined,
+            to: hasPage ? to : undefined,
           }
         }),
       ]

--- a/apps/docs/src/composables/useLevelFilter.ts
+++ b/apps/docs/src/composables/useLevelFilter.ts
@@ -2,6 +2,7 @@
 import { createContext, createGroup, useStorage } from '@vuetify/v0'
 
 // Utilities
+import { filterNav } from '@/utilities/nav'
 import { computed, onMounted, toRef, toValue, watch } from 'vue'
 
 // Types
@@ -41,7 +42,8 @@ export function createLevelFilter (nav: MaybeRefOrGetter<NavItem[]>) {
   const filteredNav = computed(() => {
     const items = toValue(nav)
     if (group.selectedIds.size === 0) return items
-    return filterNavByLevel(items, group.selectedIds as Set<number>)
+    const levels = group.selectedIds as Set<number>
+    return filterNav(items, item => !!item.level && levels.has(item.level))
   })
 
   const hasChanges = toRef(() => group.selectedIds.size > 0)
@@ -64,33 +66,4 @@ export function createLevelFilter (nav: MaybeRefOrGetter<NavItem[]>) {
     ...context,
     provide: () => provideLevelFilterContext(context),
   }
-}
-
-function filterNavByLevel (items: NavItem[], levels: Set<number>): NavItem[] {
-  const filtered = items
-    .map(item => {
-      if ('divider' in item) return item
-      if ('children' in item && item.children) {
-        const childFiltered = filterNavByLevel(item.children, levels)
-        if (childFiltered.length === 0) return null
-        return { ...item, children: childFiltered }
-      }
-      if ('to' in item) {
-        // Pages without level hidden when filtering
-        if (!item.level) return null
-        if (!levels.has(item.level)) return null
-      }
-      return item
-    })
-    .filter((item): item is NavItem => item !== null)
-
-  // Remove orphaned dividers (leading, trailing, consecutive)
-  return filtered.filter((item, i, arr) => {
-    if (!('divider' in item)) return true
-    const prev = arr[i - 1]
-    const next = arr[i + 1]
-    if (!prev || !next) return false
-    if ('divider' in prev || 'divider' in next) return false
-    return true
-  })
 }

--- a/apps/docs/src/composables/useNavConfig.ts
+++ b/apps/docs/src/composables/useNavConfig.ts
@@ -6,6 +6,7 @@ import { IN_BROWSER } from '@vuetify/v0/constants'
 import { useSettings } from '@/composables/useSettings'
 
 // Utilities
+import { filterNav } from '@/utilities/nav'
 import { toCamel } from '@/utilities/strings'
 import { computed, shallowRef, toRef, toValue, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -62,35 +63,6 @@ function matchesFeature (item: NavItemLink, features: Set<string>): boolean {
   return features.has(featureName)
 }
 
-/**
- * Filter nav items to only include those matching requested features
- * Preserves category structure if any children match
- */
-function filterNavByFeatures (items: NavItem[], features: Set<string>): NavItem[] {
-  const filtered = items
-    .map(item => {
-      if ('divider' in item) return item
-      if ('children' in item && item.children) {
-        const childFiltered = filterNavByFeatures(item.children, features)
-        if (childFiltered.length === 0) return null
-        return { ...item, children: childFiltered }
-      }
-      if ('to' in item && !matchesFeature(item, features)) return null
-      return item
-    })
-    .filter((item): item is NavItem => item !== null)
-
-  // Remove orphaned dividers
-  return filtered.filter((item, i, arr) => {
-    if (!('divider' in item)) return true
-    const prev = arr[i - 1]
-    const next = arr[i + 1]
-    if (!prev || !next) return false
-    if ('divider' in prev || 'divider' in next) return false
-    return true
-  })
-}
-
 // =============================================================================
 // Composable
 // =============================================================================
@@ -141,7 +113,8 @@ export function createNavConfig (nav: MaybeRefOrGetter<NavItem[]>) {
     const items = toValue(nav)
     const features = activeFeatures.value
     if (!features) return items
-    return filterNavByFeatures(items, new Set(features.map(f => f.toLowerCase())))
+    const set = new Set(features.map(f => f.toLowerCase()))
+    return filterNav(items, item => matchesFeature(item, set))
   })
 
   function clearFilter () {

--- a/apps/docs/src/composables/useSettings.ts
+++ b/apps/docs/src/composables/useSettings.ts
@@ -58,6 +58,8 @@ export interface SettingsContext {
   showMeshGrid: ShallowRef<boolean>
   showMeshTransition: ShallowRef<boolean>
   showBgGlass: ShallowRef<boolean>
+  /** Surface background class tracking the glass setting — bind it instead of re-deriving the ternary. */
+  surface: Ref<string>
   hasChanges: ShallowRef<boolean>
   open: () => void
   close: () => void
@@ -180,6 +182,8 @@ export function createSettingsContext (): SettingsContext {
     return userPrefersReducedMotion.value
   })
 
+  const surface = toRef(() => showBgGlass.value ? 'bg-glass-surface' : 'bg-surface')
+
   // Check if any setting differs from defaults
   const hasChanges = toRef(() => (
     lineWrap.value !== DEFAULTS.lineWrap ||
@@ -263,6 +267,7 @@ export function createSettingsContext (): SettingsContext {
     showMeshGrid,
     showMeshTransition,
     showBgGlass,
+    surface,
     hasChanges,
     open,
     close,

--- a/apps/docs/src/constants/maturity.ts
+++ b/apps/docs/src/constants/maturity.ts
@@ -30,6 +30,12 @@ export interface MaturityData {
 }
 
 /**
+ * The maturity inventory, typed once. Import this rather than re-importing
+ * `#v0/maturity.json` and re-casting it at each consumer.
+ */
+export const MATURITY = maturityData as MaturityData
+
+/**
  * Single source of truth for level display. Two color fields on purpose: the
  * roadmap matrix styles inline (and parses the hex for its blended group dot),
  * while the page chip applies a utility class through DocsMetaItem. Keep both in
@@ -51,10 +57,9 @@ function countShipped (bucket: Record<string, MaturityEntry>): number {
   return Object.values(bucket).filter(entry => entry.level !== 'draft').length
 }
 
-const data = maturityData as MaturityData
-const composable = countShipped(data.composables)
-const component = countShipped(data.components)
-const utility = countShipped(data.utilities)
+const composable = countShipped(MATURITY.composables)
+const component = countShipped(MATURITY.components)
+const utility = countShipped(MATURITY.utilities)
 
 /** Counts of shipped (non-draft) features by type, derived from `maturity.json` — the single inventory source. */
 export const MATURITY_COUNTS: Record<MaturityCountKey, number> = {

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -1,8 +1,8 @@
 // Vuetify0
-import maturityData from '#v0/maturity.json'
+import { MATURITY as data } from '@/constants/maturity'
 
 // Types
-import type { Level, MaturityData } from '@/constants/maturity'
+import type { Level } from '@/constants/maturity'
 
 export type FeatureType = 'composable' | 'component' | 'utility'
 
@@ -110,8 +110,6 @@ export interface ResolvedRelease {
 function kebab (name: string): string {
   return name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
 }
-
-const data = maturityData as MaturityData
 
 // Flatten maturity.json into a name -> feature lookup once at module load.
 const index = new Map<string, ResolvedFeature>()

--- a/apps/docs/src/pages/api/[name].vue
+++ b/apps/docs/src/pages/api/[name].vue
@@ -7,6 +7,8 @@
   import { useApiHelpers } from '@/composables/useApiHelpers'
   import { useParams } from '@/composables/useRoute'
 
+  import { MATURITY } from '@/constants/maturity'
+
   // Utilities
   import { renderInlineMarkdown } from '@/utilities/markdown'
   import { toCamel, toPascal } from '@/utilities/strings'
@@ -15,16 +17,9 @@
   // Types
   import type { ApiData, ComponentApi, ComposableApi } from '@build/generate-api'
 
-  // Maturity (relative path; #v0 alias also works)
-  import maturity from '../../../../../packages/0/src/maturity.json'
-
   const params = useParams<{ name: string }>()
   const data = apiData as ApiData
   const helpers = useApiHelpers()
-  const maturityRecord = maturity as {
-    components?: Record<string, { description?: string }>
-    composables?: Record<string, { description?: string }>
-  }
 
   const itemName = computed(() => {
     const slug = params.value.name
@@ -87,8 +82,8 @@
 
   const groupDescription = toRef(() => {
     if (!itemName.value) return undefined
-    if (isComponent.value) return maturityRecord.components?.[itemName.value]?.description || undefined
-    if (isComposable.value) return maturityRecord.composables?.[itemName.value]?.description || undefined
+    if (isComponent.value) return MATURITY.components?.[itemName.value]?.description || undefined
+    if (isComposable.value) return MATURITY.composables?.[itemName.value]?.description || undefined
     return undefined
   })
 

--- a/apps/docs/src/pages/skillz.[id].vue
+++ b/apps/docs/src/pages/skillz.[id].vue
@@ -165,7 +165,7 @@
 
         <div
           class="border border-divider rounded-xl p-4 md:p-6"
-          :class="settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface'"
+          :class="settings.surface.value"
         >
           <div class="flex items-center gap-2 mb-3">
             <SkillLevelBadge :level="tour.level" />

--- a/apps/docs/src/stores/app.ts
+++ b/apps/docs/src/stores/app.ts
@@ -1,6 +1,12 @@
 import navData from 'virtual:nav'
 
+// Framework
+import { createStorage, useLogger } from '@vuetify/v0'
+
+import { CACHE_TTL } from '@/constants/cache'
+
 // Utilities
+import { flatten } from '@/utilities/nav'
 import { defineStore } from 'pinia'
 
 // Types
@@ -19,19 +25,7 @@ interface Commit {
   }
 }
 
-function flattenRoutes (nav: NavItem): string[] {
-  const routes: string[] = []
-
-  if ('to' in nav && nav.to) {
-    routes.push(nav.to)
-  }
-
-  if ('children' in nav && nav.children) {
-    routes.push(...nav.children.flatMap(child => flattenRoutes(child)))
-  }
-
-  return routes
-}
+const storage = createStorage({ prefix: 'v0-commit:', ttl: CACHE_TTL })
 
 export const useAppStore = defineStore('app', {
   state: () => ({
@@ -48,10 +42,41 @@ export const useAppStore = defineStore('app', {
       for (const nav of state.nav) {
         if (!('children' in nav) && !('to' in nav)) continue
 
-        pages.push(...flattenRoutes(nav as NavItem))
+        pages.push(...flatten(nav as NavItem))
       }
 
       return pages
+    },
+  },
+  actions: {
+    /**
+     * Latest commit on master, cached for `CACHE_TTL`. Every caller shares the
+     * cache — the footer used to re-hit the API on each intersection.
+     */
+    async fetchCommit () {
+      if (this.stats.commit) return
+
+      const cached = storage.get<Commit | null>('latest', null)
+      if (cached.value) {
+        this.stats.commit = cached.value
+        return
+      }
+
+      try {
+        const octokit = await import('@/plugins/octokit').then(m => m.default)
+        const { data = [] } = await octokit.request('GET /repos/{owner}/{repo}/commits', {
+          owner: 'vuetifyjs',
+          repo: '0',
+          per_page: 1,
+        })
+
+        if (data.length === 0) return
+
+        this.stats.commit = data[0] as Commit
+        storage.set('latest', this.stats.commit)
+      } catch (error) {
+        useLogger().warn('Failed to fetch commit info', error)
+      }
     },
   },
 })

--- a/apps/docs/src/utilities/nav.ts
+++ b/apps/docs/src/utilities/nav.ts
@@ -1,0 +1,77 @@
+// Types
+import type { NavItem, NavItemCategory, NavItemLink } from '@/stores/app'
+
+/** A nav entry that carries a name — everything except a divider. */
+type Named = NavItemLink | NavItemCategory
+
+/**
+ * Filter a nav tree by a leaf predicate, keeping a category only while it still
+ * has children and dropping dividers that end up leading, trailing, or doubled.
+ *
+ * The feature filter and the skill-level filter differ only in `keep` — the
+ * structural walk and the divider cleanup are the same for both.
+ */
+export function filterNav (items: NavItem[], keep: (item: NavItemLink) => boolean): NavItem[] {
+  const filtered = items
+    .map(item => {
+      if ('divider' in item) return item
+      if ('children' in item && item.children) {
+        const children = filterNav(item.children, keep)
+        if (children.length === 0) return null
+        return { ...item, children }
+      }
+      if ('to' in item && !keep(item)) return null
+      return item
+    })
+    .filter((item): item is NavItem => item !== null)
+
+  return filtered.filter((item, index, arr) => {
+    if (!('divider' in item)) return true
+    const prev = arr[index - 1]
+    const next = arr[index + 1]
+    if (!prev || !next) return false
+    if ('divider' in prev || 'divider' in next) return false
+    return true
+  })
+}
+
+/** Every routable path in a nav subtree, parents before children. */
+export function flatten (item: NavItem): string[] {
+  const routes: string[] = []
+
+  if ('to' in item && item.to) {
+    routes.push(item.to)
+  }
+
+  if ('children' in item && item.children) {
+    routes.push(...item.children.flatMap(child => flatten(child)))
+  }
+
+  return routes
+}
+
+/**
+ * The trail of nav items leading to `path`, ancestors first and the matching
+ * link last, or `null` when the path is not in the tree. Callers wanting only
+ * the page itself read the last entry.
+ */
+export function findNav (items: NavItem[], path: string): Named[] | null {
+  for (const item of items) {
+    if ('divider' in item) continue
+
+    if ('to' in item && item.to === path) return [item]
+
+    if ('children' in item && item.children) {
+      const trail = findNav(item.children, path)
+      if (trail) return [item, ...trail]
+    }
+  }
+
+  return null
+}
+
+/** The nav link registered for `path`, or `null` when the tree has no such page. */
+export function findLink (items: NavItem[], path: string): NavItemLink | null {
+  const found = findNav(items, path)?.at(-1)
+  return found && 'to' in found ? found : null
+}


### PR DESCRIPTION
Step 3 (phase A) of the docs normalization audit — four consolidations, one commit each, net **−128 lines**:

1. **Glass surface token** — 11 templates re-derived `showBgGlass.value ? 'bg-glass-surface' : 'bg-surface'` by hand; that copy is what produced the silent always-glass bug fixed in #868. `settings.surface` now owns it. (The one `md:`-variant site in AppBar keeps its ternary — a prefixed class can't consume a plain token.)
2. **Commit fetch → app store** — with a real behavioral fix: AppFooter's copy had no TTL cache and re-hit the GitHub API on every intersection. Verified post-fix: one commits request across two page loads.
3. **Single typed `MATURITY` export** — kills 5 re-casts, 2 ad-hoc record types, and both 5-deep `../../../../..` relative imports.
4. **`utilities/nav.ts`** — seven walkers across six files (incl. a verbatim `flattenRoutes` copy) become `filterNav`/`flatten`/`findNav`/`findLink`. `filterDevmode` deliberately stays local (different empty-category semantics).

Verified: docs build green (301 pages); eslint clean; in-browser round-trips on every touched surface (glass toggle across six surfaces, footer commit chip + cache behavior, maturity matrix/API index counts, breadcrumbs + prev/next + level & feature nav filters). Differential typecheck vs master (`tsconfig.app.json`): zero new errors — and one finding for the audit: docs src carries **1,242 pre-existing type errors** that no CI gate sees.