### PR TITLE
fix(createKanban): add dispose() to tear down the second tier

### DIFF
--- a/.changeset/fix-kanban-dispose.md
+++ b/.changeset/fix-kanban-dispose.md
@@ -1,0 +1,5 @@
+---
+'@vuetify/v0': patch
+---
+
+fix(createKanban): contexts can now be disposed — `kanban.dispose()` tears down every column's inner sortable, the internal id → column lookup, and the transfer event bus, so boards no longer leak listeners and stale lookup entries

--- a/.changeset/fix-kanban-dispose.md
+++ b/.changeset/fix-kanban-dispose.md
@@ -2,4 +2,4 @@
 '@vuetify/v0': patch
 ---
 
-fix(createKanban): contexts can now be disposed — `kanban.dispose()` tears down every column's inner sortable, the internal id → column lookup, and the transfer event bus, so boards no longer leak listeners and stale lookup entries
+fix(createKanban): contexts can now be disposed — `kanban.dispose()` (and `kanban.columns.dispose`) tears down every column's inner sortable, the internal id → column lookup, and the transfer event bus, so boards no longer leak listeners and stale lookup entries

--- a/packages/0/src/composables/createKanban/index.test.ts
+++ b/packages/0/src/composables/createKanban/index.test.ts
@@ -567,4 +567,105 @@ describe('createKanban', () => {
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown ticket id'))
     })
   })
+
+  describe('emission sequence', () => {
+    function record () {
+      const kanban = createKanban<CardInput, ColumnInput>()
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      const done = kanban.columns.register({ value: { title: 'Done' } })
+      const a = todo.items.register({ value: { title: 'a' } })
+
+      const events: string[] = []
+
+      function listen () {
+        todo.items.on('unregister:ticket', () => events.push('unregister'))
+        done.items.on('register:ticket', () => events.push('register'))
+        done.items.on('move:ticket', () => events.push('move'))
+        kanban.on('transfer:ticket', () => events.push('transfer'))
+      }
+
+      return { kanban, todo, done, a, events, listen }
+    }
+
+    it('should emit unregister → register → transfer for an append-position transfer (no move:ticket)', () => {
+      const { kanban, done, a, events, listen } = record()
+      listen()
+
+      // Empty destination: index 0 is the natural landing spot, so the
+      // register lands in place and no move-correction (or move:ticket) fires.
+      kanban.transfer(a.id, done.id, 0)
+
+      expect(events).toEqual(['unregister', 'register', 'transfer'])
+    })
+
+    it('should emit unregister → register → move → transfer for a mid-position transfer', () => {
+      const { kanban, done, a, events, listen } = record()
+
+      done.items.register({ value: { title: 'x' } })
+      done.items.register({ value: { title: 'y' } })
+      listen()
+
+      kanban.transfer(a.id, done.id, 1)
+
+      expect(events).toEqual(['unregister', 'register', 'move', 'transfer'])
+    })
+  })
+
+  describe('dispose', () => {
+    it('should tear down inner sortables and empty the lookup', () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const kanban = createKanban<CardInput, ColumnInput>()
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      const done = kanban.columns.register({ value: { title: 'Done' } })
+      const a = todo.items.register({ value: { title: 'a' } })
+
+      const registerHandler = vi.fn()
+      todo.items.on('register:ticket', registerHandler)
+      todo.items.register({ value: { title: 'b' } })
+      expect(registerHandler).toHaveBeenCalledTimes(1)
+
+      kanban.dispose()
+
+      // Columns registry cleared.
+      expect(kanban.columns.size).toBe(0)
+
+      // Inner sortable disposed: prior listeners no longer fire.
+      todo.items.register({ value: { title: 'c' } })
+      expect(registerHandler).toHaveBeenCalledTimes(1)
+
+      // Lookup emptied: transfer of a previously-known ticket warns as unknown.
+      expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown ticket id'))
+    })
+
+    it('should silence the kanban transfer:ticket bus after dispose', () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const kanban = createKanban<CardInput, ColumnInput>()
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      const done = kanban.columns.register({ value: { title: 'Done' } })
+      const a = todo.items.register({ value: { title: 'a' } })
+
+      const handler = vi.fn()
+      kanban.on('transfer:ticket', handler)
+
+      kanban.dispose()
+
+      expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
+      expect(handler).not.toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should be idempotent', () => {
+      const kanban = createKanban<CardInput, ColumnInput>()
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      todo.items.register({ value: { title: 'a' } })
+
+      kanban.dispose()
+      expect(() => kanban.dispose()).not.toThrow()
+      expect(kanban.columns.size).toBe(0)
+    })
+  })
 })

--- a/packages/0/src/composables/createKanban/index.test.ts
+++ b/packages/0/src/composables/createKanban/index.test.ts
@@ -24,7 +24,7 @@ describe('createKanban', () => {
   })
 
   describe('shape', () => {
-    it('should expose columns sortable, transfer, on, off', () => {
+    it('should expose columns sortable, transfer, on, off, dispose', () => {
       const kanban = createKanban()
 
       expect(typeof kanban.columns.register).toBe('function')
@@ -32,6 +32,8 @@ describe('createKanban', () => {
       expect(typeof kanban.transfer).toBe('function')
       expect(typeof kanban.on).toBe('function')
       expect(typeof kanban.off).toBe('function')
+      expect(typeof kanban.dispose).toBe('function')
+      expect(kanban.columns.dispose).toBe(kanban.dispose)
     })
 
     it('should expose a live kanban.columns.size getter', () => {
@@ -591,8 +593,8 @@ describe('createKanban', () => {
       const { kanban, done, a, events, listen } = record()
       listen()
 
-      // Empty destination: index 0 is the natural landing spot, so the
-      // register lands in place and no move-correction (or move:ticket) fires.
+      // register always appends; empty dest lands at 0. transfer(..., 0)
+      // matches that index, so move() (and move:ticket) are skipped.
       kanban.transfer(a.id, done.id, 0)
 
       expect(events).toEqual(['unregister', 'register', 'transfer'])
@@ -620,19 +622,24 @@ describe('createKanban', () => {
       const done = kanban.columns.register({ value: { title: 'Done' } })
       const a = todo.items.register({ value: { title: 'a' } })
 
-      const registerHandler = vi.fn()
-      todo.items.on('register:ticket', registerHandler)
+      const todoHandler = vi.fn()
+      const doneHandler = vi.fn()
+      todo.items.on('register:ticket', todoHandler)
+      done.items.on('register:ticket', doneHandler)
       todo.items.register({ value: { title: 'b' } })
-      expect(registerHandler).toHaveBeenCalledTimes(1)
+      done.items.register({ value: { title: 'd' } })
+      expect(todoHandler).toHaveBeenCalledTimes(1)
+      expect(doneHandler).toHaveBeenCalledTimes(1)
 
       kanban.dispose()
 
-      // Columns registry cleared.
       expect(kanban.columns.size).toBe(0)
 
-      // Inner sortable disposed: prior listeners no longer fire.
+      // Inner sortables disposed: prior listeners no longer fire.
       todo.items.register({ value: { title: 'c' } })
-      expect(registerHandler).toHaveBeenCalledTimes(1)
+      done.items.register({ value: { title: 'e' } })
+      expect(todoHandler).toHaveBeenCalledTimes(1)
+      expect(doneHandler).toHaveBeenCalledTimes(1)
 
       // Lookup emptied: transfer of a previously-known ticket warns as unknown.
       expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
@@ -641,24 +648,29 @@ describe('createKanban', () => {
     })
 
     it('should silence the kanban transfer:ticket bus after dispose', () => {
-      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
-      const done = kanban.columns.register({ value: { title: 'Done' } })
-      const a = todo.items.register({ value: { title: 'a' } })
+      kanban.columns.register({ value: { title: 'Done' } })
+      todo.items.register({ value: { title: 'a' } })
 
       const handler = vi.fn()
       kanban.on('transfer:ticket', handler)
 
       kanban.dispose()
 
-      expect(kanban.transfer(a.id, done.id, 0)).toBeUndefined()
+      const todo2 = kanban.columns.register({ value: { title: 'Todo' } })
+      const done2 = kanban.columns.register({ value: { title: 'Done' } })
+      const c = todo2.items.register({ value: { title: 'c' } })
+
+      expect(kanban.transfer(c.id, done2.id, 0)).toBeDefined()
       expect(handler).not.toHaveBeenCalled()
-      expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('should be idempotent', () => {
+    it('should be safe on an empty board and idempotent', () => {
+      const empty = createKanban<CardInput, ColumnInput>()
+      expect(() => empty.dispose()).not.toThrow()
+      expect(empty.columns.size).toBe(0)
+
       const kanban = createKanban<CardInput, ColumnInput>()
       const todo = kanban.columns.register({ value: { title: 'Todo' } })
       todo.items.register({ value: { title: 'a' } })
@@ -666,6 +678,41 @@ describe('createKanban', () => {
       kanban.dispose()
       expect(() => kanban.dispose()).not.toThrow()
       expect(kanban.columns.size).toBe(0)
+    })
+
+    it('should tear down a rebuilt board on a second dispose', () => {
+      const kanban = createKanban<CardInput, ColumnInput>()
+      kanban.columns.register({ value: { title: 'Todo' } })
+      kanban.dispose()
+
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      const handler = vi.fn()
+      todo.items.on('register:ticket', handler)
+      todo.items.register({ value: { title: 'a' } })
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      kanban.dispose()
+
+      expect(kanban.columns.size).toBe(0)
+      todo.items.register({ value: { title: 'b' } })
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should still dispose a column inner sortable after a rebuild', () => {
+      const kanban = createKanban<CardInput, ColumnInput>()
+      kanban.columns.register({ value: { title: 'Old' } })
+      kanban.dispose()
+
+      const todo = kanban.columns.register({ value: { title: 'Todo' } })
+      const handler = vi.fn()
+      todo.items.on('register:ticket', handler)
+      todo.items.register({ value: { title: 'a' } })
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      todo.unregister()
+
+      todo.items.register({ value: { title: 'b' } })
+      expect(handler).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/0/src/composables/createKanban/index.ts
+++ b/packages/0/src/composables/createKanban/index.ts
@@ -240,6 +240,9 @@ export interface KanbanContext<
    * `unregister:ticket` handlers, so you cannot rescue items from inside that
    * callback. To preserve items, move them before calling `unregister`.
    *
+   * `columns.dispose` is the board cascade — the same function as
+   * `kanban.dispose()` — not a columns-only wipe.
+   *
    * @example
    * ```ts
    * import { createKanban } from '@vuetify/v0'
@@ -327,13 +330,16 @@ export interface KanbanContext<
   /**
    * Tear down the entire board: every column's inner `items` sortable, the
    * internal id → column lookup, the `transfer:ticket` event bus, and the
-   * columns registry itself. Idempotent — subsequent calls no-op.
+   * columns registry itself. `kanban.columns.dispose` is the same function.
+   * Repeatable — a later call after `columns.register` tears down the rebuilt
+   * board the same way.
    *
    * @remarks
-   * `columns.dispose()` alone is not enough: registry disposal clears
-   * listeners before clearing tickets, so the kanban's per-column
-   * `unregister:ticket` cleanup never runs and each column's inner sortable
-   * would stay alive. Use this method to release a board.
+   * Registry `dispose()` clears listeners then `clear()`, and `clear()` never
+   * emits `unregister:ticket`, so the per-column cleanup subscribed on that
+   * event would not run. This method walks current columns and disposes each
+   * inner sortable first, then re-binds that cleanup so a rebuilt board still
+   * cascades on column unregister.
    *
    * @example
    * ```ts
@@ -433,6 +439,27 @@ export function createKanban<
     },
   }
 
+  function onColumnUnregister (column: KanbanColumnTicket<ItemZ, ColZ>) {
+    column.items.dispose()
+    for (const t of lookup.values()) {
+      if (t.value === column.id) t.unregister()
+    }
+  }
+
+  function dispose (): void {
+    // Walk inners first. Registry dispose() clears listeners then clear(),
+    // and clear() never emits unregister:ticket, so the per-column cleanup
+    // subscribed on that event would not run.
+    for (const column of _columns.values()) column.items.dispose()
+    lookup.dispose()
+    bus.dispose()
+    _columns.dispose()
+    columns.on('unregister:ticket', onColumnUnregister)
+  }
+
+  columns.dispose = dispose
+  columns.on('unregister:ticket', onColumnUnregister)
+
   function isAccepted (
     accept: ColZ['accept'],
     ticket: SortableTicket<ItemZ>,
@@ -452,13 +479,6 @@ export function createKanban<
       return false
     }
   }
-
-  columns.on('unregister:ticket', column => {
-    column.items.dispose()
-    for (const t of lookup.values()) {
-      if (t.value === column.id) t.unregister()
-    }
-  })
 
   function transfer (id: ID, toColumnId: ID, toIndex: number): SortableTicket<ItemZ> | undefined {
     const fromColumnId = lookup.get(id)?.value
@@ -529,19 +549,6 @@ export function createKanban<
     }
 
     return final
-  }
-
-  let disposed = false
-
-  function dispose (): void {
-    if (disposed) return
-    disposed = true
-    // Inner sortables first — registry disposal clears listeners before
-    // tickets, so the unregister-driven per-column cleanup never fires here.
-    for (const column of _columns.values()) column.items.dispose()
-    lookup.dispose()
-    bus.dispose()
-    _columns.dispose()
   }
 
   return {

--- a/packages/0/src/composables/createKanban/index.ts
+++ b/packages/0/src/composables/createKanban/index.ts
@@ -324,6 +324,28 @@ export interface KanbanContext<
    * ```
    */
   off: KanbanEventListener<ItemZ>
+  /**
+   * Tear down the entire board: every column's inner `items` sortable, the
+   * internal id → column lookup, the `transfer:ticket` event bus, and the
+   * columns registry itself. Idempotent — subsequent calls no-op.
+   *
+   * @remarks
+   * `columns.dispose()` alone is not enough: registry disposal clears
+   * listeners before clearing tickets, so the kanban's per-column
+   * `unregister:ticket` cleanup never runs and each column's inner sortable
+   * would stay alive. Use this method to release a board.
+   *
+   * @example
+   * ```ts
+   * import { createKanban } from '@vuetify/v0'
+   *
+   * const kanban = createKanban()
+   * kanban.columns.register({ value: { title: 'Todo' } })
+   * // later
+   * kanban.dispose()
+   * ```
+   */
+  dispose: () => void
 }
 
 /**
@@ -509,10 +531,24 @@ export function createKanban<
     return final
   }
 
+  let disposed = false
+
+  function dispose (): void {
+    if (disposed) return
+    disposed = true
+    // Inner sortables first — registry disposal clears listeners before
+    // tickets, so the unregister-driven per-column cleanup never fires here.
+    for (const column of _columns.values()) column.items.dispose()
+    lookup.dispose()
+    bus.dispose()
+    _columns.dispose()
+  }
+
   return {
     columns,
     transfer,
     on,
     off,
+    dispose,
   }
 }


### PR DESCRIPTION
From the kanban dogfood memo's verified defects: `createRegistry.dispose()` clears listeners before `clear()`, so kanban's unregister-driven per-column cleanup never fires on disposal — every inner column sortable stayed alive and the internal id→column lookup kept stale entries, and the returned context had no `dispose()` at all.

`kanban.dispose()` now tears down every column's inner sortable first (the event path can't), then the lookup and transfer bus, then the columns registry; idempotent. Patch changeset included.

Tests: 5 new — teardown observed via behavior (listeners stop firing, post-dispose transfer warns and no-ops), bus silenced, idempotency — plus two pinning the transfer **emission sequence** (append-position transfer emits no `move:ticket`; mid-position does), which the docs page contradicts and nothing covered; the docs correction rides a separate md-only PR.

**Flagged design question, deliberately not addressed here:** registry disposal silently skips all listener notification (listeners cleared before clear()) — any composable layering per-ticket cleanup on registry events has the same blind spot; kanban is just the first bitten. Whether disposal should emit before wiping listeners is a base-primitive semantics ruling with blast radius across every `events: true` consumer.

createKanban suite 44/44; full composables sweep 4,064 green; typecheck clean.