### PR TITLE
fix(EmKanban): announce rejected drops instead of leaving the live region stale

### DIFF
--- a/packages/emerald/changesets-parked/emkanban-reject-announce.md
+++ b/packages/emerald/changesets-parked/emkanban-reject-announce.md
@@ -1,0 +1,9 @@
+---
+'@paper/emerald': patch
+---
+
+fix(EmKanban): announce rejected drops instead of leaving the live region stale
+
+A drop gated by `disabled`, `accept`, or an unknown id used to bail silently,
+so keyboard and screen-reader users still heard the pickup message. The board
+now announces "Move not allowed, the card stayed where it was."

--- a/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
+++ b/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
@@ -68,7 +68,14 @@
     const target = from?.column === column.id && from.index < to ? to - 1 : to
     const moved = kanban.transfer(card, column.id, target)
 
-    if (!moved || !from) return
+    // A gated transfer returns undefined with no event — without an
+    // announcement the live region keeps the stale pickup message.
+    if (!moved) {
+      context.announce('Move not allowed, the card stayed where it was.')
+      return
+    }
+
+    if (!from) return
 
     if (focus) context.dropped.value = card
 


### PR DESCRIPTION
From the kanban dogfood memo's verified defects: `kanban.transfer` returns `undefined` for eight gated cases and `onDrop` bailed silently — a rejected keyboard drop left the live region holding the stale pickup message, so a screen-reader user got no feedback at all. The rejection now announces ('Move not allowed, the card stayed where it was.', mirroring the existing cancel wording); same-column no-op drops can't false-positive since `sortable.move` returns the ticket even when the index is unchanged.

Changeset parked in `packages/emerald/changesets-parked/` per the private-package convention.

Verified: emerald typecheck + build green; the announcement chain is source-verified (onDrop → context.announce → message ref → `role=status` region). A live browser repro is currently impossible by construction — no shipped example can reach a rejection because per-column `disabled`/`accept` aren't surfaced as DS props (already a listed gap in the memo) and board-level disabled gates pickup before any drop. That gap is exactly why this went unnoticed.