### PR TITLE
fix(EmKanban): announce rejected drops instead of leaving the live region stale

### DIFF
--- a/packages/emerald/changesets-parked/emkanban-reject-announce.md
+++ b/packages/emerald/changesets-parked/emkanban-reject-announce.md
@@ -1,0 +1,9 @@
+---
+'@paper/emerald': patch
+---
+
+fix(EmKanban): announce rejected drops instead of leaving the live region stale
+
+A drop gated by `disabled`, `accept`, or an unknown id used to bail silently,
+so keyboard and screen-reader users still heard the pickup message. The board
+now announces "Move not allowed, the card stayed where it was."

--- a/packages/emerald/changesets-parked/emkanban-reject-announce.md
+++ b/packages/emerald/changesets-parked/emkanban-reject-announce.md
@@ -4,6 +4,5 @@
 
 fix(EmKanban): announce rejected drops instead of leaving the live region stale
 
-A drop gated by `disabled`, `accept`, or an unknown id used to bail silently,
-so keyboard and screen-reader users still heard the pickup message. The board
-now announces "Move not allowed, the card stayed where it was."
+Rejected drops now announce "Move not allowed, the card stayed where it was."
+instead of leaving the pickup line in the live region with no new feedback.

--- a/packages/emerald/src/components/EmKanban/EmKanban.test.ts
+++ b/packages/emerald/src/components/EmKanban/EmKanban.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Context
+import EmKanban from './EmKanban.vue'
+import EmKanbanColumn from './EmKanbanColumn.vue'
+
+// Utilities
+import { createApp, h, nextTick, shallowRef } from 'vue'
+
+// Types
+import type { EmKanbanContext, EmKanbanDrag } from './context'
+import type { ActiveDrag } from '@vuetify/v0'
+import type { App } from 'vue'
+
+const apps: App[] = []
+
+interface Board {
+  kanban: EmKanbanContext['kanban']
+  dnd: EmKanbanContext['dnd']
+  announce: EmKanbanContext['announce']
+}
+
+function mountBoard () {
+  const onMove = vi.fn()
+  const board = shallowRef<Board>()
+  const host = document.createElement('div')
+
+  document.body.append(host)
+
+  const app = createApp({
+    setup () {
+      return () => h(EmKanban, { ref: board, onMove }, () => [
+        h(EmKanbanColumn, {
+          id: 'todo',
+          title: 'Todo',
+          cards: [{ id: 'c1', value: 'Alpha' }],
+        }),
+        h(EmKanbanColumn, { id: 'done', title: 'Done' }),
+      ])
+    },
+  })
+
+  apps.push(app)
+  app.mount(host)
+
+  return { host, onMove, board: () => board.value! }
+}
+
+function status (host: HTMLElement) {
+  return host.querySelector('[role="status"]')?.textContent
+}
+
+function drop (board: Board, column: string, card: string, index: number) {
+  const zone = board.dnd.zones.get(column)
+  const drag: ActiveDrag<EmKanbanDrag> = {
+    id: card,
+    type: 'card',
+    value: undefined,
+    origin: { x: 0, y: 0 },
+    current: { x: 0, y: 0 },
+    delta: { x: 0, y: 0 },
+    over: column,
+    willAccept: true,
+    via: 'keyboard',
+  }
+
+  expect(zone?.onDrop).toBeTypeOf('function')
+  zone!.onDrop!(drag, { index, pointer: { x: 0, y: 0 } })
+}
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.unmount()
+
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('emKanban', () => {
+  describe('rejected drop announcement', () => {
+    it('should announce a rejected drop instead of leaving the pickup message', async () => {
+      const { host, board, onMove } = mountBoard()
+
+      await nextTick()
+
+      board().kanban.columns.upsert('done', { accept: () => false })
+      board().announce('Picked up card 1 in Todo.')
+
+      await nextTick()
+
+      expect(status(host)).toBe('Picked up card 1 in Todo.')
+
+      drop(board(), 'done', 'c1', 0)
+
+      await nextTick()
+
+      expect(status(host)).toBe('Move not allowed, the card stayed where it was.')
+      expect(board().kanban.columns.get('todo')!.items.get('c1')).toBeDefined()
+      expect(board().kanban.columns.get('done')!.items.size).toBe(0)
+      expect(onMove).not.toHaveBeenCalled()
+    })
+
+    it('should not treat a same-column stay as a rejected move', async () => {
+      const { host, board } = mountBoard()
+
+      await nextTick()
+
+      drop(board(), 'todo', 'c1', 0)
+
+      await nextTick()
+
+      expect(status(host)).toBe('Moved card to Todo, position 1 of 1.')
+      expect(board().kanban.columns.get('todo')!.items.get('c1')).toBeDefined()
+    })
+  })
+})

--- a/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
+++ b/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
@@ -68,7 +68,14 @@
     const target = from?.column === column.id && from.index < to ? to - 1 : to
     const moved = kanban.transfer(card, column.id, target)
 
-    if (!moved || !from) return
+    // A gated transfer returns undefined with no event — without an
+    // announcement the live region keeps the stale pickup message.
+    if (!moved) {
+      context.announce('Move not allowed, the card stayed where it was.')
+      return
+    }
+
+    if (!from) return
 
     if (focus) context.dropped.value = card
 

--- a/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
+++ b/packages/emerald/src/components/EmKanban/EmKanbanColumn.vue
@@ -68,8 +68,7 @@
     const target = from?.column === column.id && from.index < to ? to - 1 : to
     const moved = kanban.transfer(card, column.id, target)
 
-    // A gated transfer returns undefined with no event — without an
-    // announcement the live region keeps the stale pickup message.
+    // Without an announcement the live region keeps the stale pickup message.
     if (!moved) {
       context.announce('Move not allowed, the card stayed where it was.')
       return


### PR DESCRIPTION
Supersedes #891 (that PR targeted `dev`; this is a patch fix and lands on `master`). Cherry-picked `f86d3d2` and added coverage.

From the kanban dogfood memo's verified defects: `kanban.transfer` returns `undefined` for gated cases and `onDrop` bailed silently — a rejected keyboard drop left the live region holding the stale pickup message, so a screen-reader user got no feedback at all. The rejection now announces ("Move not allowed, the card stayed where it was.", mirroring the existing cancel wording); same-column no-op drops can't false-positive since `sortable.move` returns the ticket even when the index is unchanged.

Changeset parked in `packages/emerald/changesets-parked/` per the private-package convention.

Verified: emerald typecheck + the full pre-push suite (lint, typecheck, 4924 tests, knip/sherif). The announcement chain is source-verified (`onDrop` → `context.announce` → `message` ref → `role=status` region). Happy-dom covers the contract: a gated `accept` drop replaces the pickup string and does not emit `move`; a same-column stay announces success, not rejection.

A live browser repro is currently impossible by construction — no shipped example can reach a rejection because per-column `disabled`/`accept` aren't surfaced as DS props (already a listed gap in the memo) and board-level disabled gates pickup before any drop. That gap is exactly why this went unnoticed.