### PR TITLE
docs(playground): add Swetrix pageview/error tracking

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -17,6 +17,7 @@
     "client-zip": "catalog:",
     "fflate": "catalog:",
     "pinia": "catalog:",
+    "swetrix": "catalog:",
     "vue": "catalog:"
   },
   "devDependencies": {

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -99,6 +99,7 @@ export const createApp = ViteSSG(
       pinia.state.value = initialState.pinia || {}
 
     if (!import.meta.env.SSR) {
+      await import('./plugins/analytics')
       const { useAuthStore } = await import('@vuetify/auth')
       useAuthStore().verify()
     }

--- a/apps/playground/src/plugins/analytics.ts
+++ b/apps/playground/src/plugins/analytics.ts
@@ -1,0 +1,20 @@
+// Framework
+import { IN_BROWSER } from '@vuetify/v0/constants'
+
+async function initAnalytics () {
+  const Swetrix = await import('swetrix')
+  Swetrix.init('NYQnHCV4oCFA', {
+    apiURL: 'https://swetrix-api.vuetifyjs.com/log',
+  })
+  Swetrix.trackViews()
+  Swetrix.trackErrors()
+}
+
+if (IN_BROWSER) {
+  const timeout = 2000
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(() => initAnalytics(), { timeout })
+  } else {
+    setTimeout(initAnalytics, timeout)
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       pinia:
         specifier: 'catalog:'
         version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
+      swetrix:
+        specifier: 'catalog:'
+        version: 4.4.0
       vue:
         specifier: 'catalog:'
         version: 3.5.39(typescript@6.0.3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Swetrix analytics to the v0play app (`apps/playground`) to track pageviews and errors on https://v0play.vuetifyjs.com.

**Changes:**
- Created `apps/playground/src/plugins/analytics.ts` with Swetrix initialization for pid `NYQnHCV4oCFA` using the Vuetify Swetrix API endpoint
- Imported the analytics plugin in `main.ts` inside the existing `if (!import.meta.env.SSR)` block to ensure tracking only runs in the browser
- Added `swetrix` dependency to playground using the workspace catalog (`"swetrix": "catalog:"`)

The implementation mirrors the existing docs analytics pattern but uses `requestIdleCallback` with a 2s timeout fallback instead of `useIdleCallback` (which playground doesn't have).

## Test plan

- Load https://v0play.vuetifyjs.com (or local playground) and confirm a hit appears on https://swetrix.vuetifyjs.com/projects/NYQnHCV4oCFA
- SSR/build still succeeds; tracker only runs in the browser (guarded by `IN_BROWSER` and `!import.meta.env.SSR`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-796f9d04-e35b-4258-b5db-4c522b1a8bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-796f9d04-e35b-4258-b5db-4c522b1a8bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

