### PR TITLE
docs: enable UnoCSS icons in example previews

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,6 +10,8 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.examples.json"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "catalog:",
+    "@iconify-json/mdi": "catalog:",
     "@octokit/openapi-types": "catalog:",
     "@resvg/resvg-js": "catalog:",
     "@shikijs/langs": "catalog:",

--- a/apps/docs/uno.config.ts
+++ b/apps/docs/uno.config.ts
@@ -1,8 +1,17 @@
-import { defineConfig, presetWind4 } from 'unocss'
+import { defineConfig, presetIcons, presetWind4 } from 'unocss'
 
 export default defineConfig({
   presets: [
     presetWind4(),
+    // Example previews use Iconify classes (`i-mdi-*`, `i-lucide-*`). Play
+    // already has this preset; without it the same source renders empty spans.
+    presetIcons({
+      scale: 1.2,
+      extraProperties: {
+        'display': 'inline-block',
+        'vertical-align': 'middle',
+      },
+    }),
   ],
   // Wind4 uses color-mix with oklch - opacity modifiers (bg-surface/50)
   // don't work with CSS variables. Color-mix utilities are in tokens.css.

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,10 @@
       ]
     },
     "apps/docs": {
+      "ignoreDependencies": [
+        "@iconify-json/lucide",
+        "@iconify-json/mdi"
+      ],
       "entry": [
         "src/App.vue",
         "src/components/**/*.vue",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ catalogs:
     '@flagsmith/flagsmith':
       specifier: ^11.0.0
       version: 11.0.0
+    '@iconify-json/lucide':
+      specifier: 1.2.121
+      version: 1.2.121
+    '@iconify-json/mdi':
+      specifier: ^1.2.3
+      version: 1.2.3
     '@js-temporal/polyfill':
       specifier: 0.5.1
       version: 0.5.1
@@ -409,6 +415,12 @@ importers:
         specifier: 'catalog:'
         version: 3.5.39(typescript@6.0.3)
     devDependencies:
+      '@iconify-json/lucide':
+        specifier: 'catalog:'
+        version: 1.2.121
+      '@iconify-json/mdi':
+        specifier: 'catalog:'
+        version: 1.2.3
       '@octokit/openapi-types':
         specifier: 'catalog:'
         version: 27.0.0
@@ -1920,6 +1932,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.121':
+    resolution: {integrity: sha512-zSoQQSmsyFaeTpSwURHJ9PIrsDcGFpDNhGlpiTrs+Ua4uFeH5UsE26L4OEBLrgLWoSK0UO+JhsO8yehSw0403g==}
+
+  '@iconify-json/mdi@1.2.3':
+    resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -8729,6 +8747,14 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/lucide@1.2.121':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/mdi@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ catalog:
   '@changesets/changelog-github': ^0.7.0
   '@changesets/cli': ^2.31.0
   '@flagsmith/flagsmith': ^11.0.0
+  '@iconify-json/lucide': 1.2.121
+  '@iconify-json/mdi': ^1.2.3
   '@js-temporal/polyfill': 0.5.1
   '@material/material-color-utilities': ^0.4.0
   '@mdi/js': npm:mdi-js-es@7.4.47


### PR DESCRIPTION
Docs example previews use Iconify classes (`i-mdi-*`, `i-lucide-*`) that Play already renders via `presetIcons`. The docs host did not, so those spans were empty — the `useProxyRegistry` notification-center example was the visible case.

Adds `presetIcons` to the docs UnoCSS config with local `@iconify-json/mdi` and `@iconify-json/lucide` collections so example icons match Play.