### PR TITLE
chore(playground): carry example themes into Open in Playground

### DIFF
--- a/apps/docs/src/components/docs/DocsCodeActions.vue
+++ b/apps/docs/src/components/docs/DocsCodeActions.vue
@@ -9,6 +9,7 @@
   import { CODE_SIZES } from '@/composables/useSettings'
 
   // Types
+  import type { PlaygroundHashData } from '@/composables/usePlayground'
   import type { CodeSize } from '@/composables/useSettings'
 
   const props = defineProps<{
@@ -18,6 +19,7 @@
     title?: string
     binTitle?: string
     playground?: boolean
+    playgroundThemes?: Pick<PlaygroundHashData, 'theme' | 'themes'>
     bin?: boolean
     showCopy?: boolean
     showWrap?: boolean
@@ -44,7 +46,10 @@
   }
 
   async function openInPlayground () {
-    const url = await usePlayground([{ name: props.title ?? 'Example.vue', code: props.playgroundCode ?? props.code }])
+    const url = await usePlayground(
+      [{ name: props.title ?? 'Example.vue', code: props.playgroundCode ?? props.code }],
+      props.playgroundThemes,
+    )
     window.open(url, '_blank')
   }
 </script>

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -17,16 +17,18 @@
   import {
     playgroundRegistryUrl,
     registryRefFromExamplePath,
+    toPlaygroundThemes,
     usePlayground,
   } from '@/composables/usePlayground'
   import { useSettings } from '@/composables/useSettings'
   import { useSyncedRef } from '@/composables/useSyncedRef'
-  import { createThemeToggle, provideThemeToggle } from '@/composables/useThemeToggle'
+  import { PALETTE_THEMES, createThemeToggle, provideThemeToggle } from '@/composables/useThemeToggle'
 
   // Utilities
   import { computed, onMounted, toRef } from 'vue'
 
   // Types
+  import type { PlaygroundHashData } from '@/composables/usePlayground'
   import type { Palette } from '@/composables/useThemeToggle'
   import type { GnDocsExampleFile } from '@paper/genesis'
 
@@ -107,23 +109,45 @@
     useIdleCallback(warm)
   })
 
+  function playgroundThemes (): Pick<PlaygroundHashData, 'theme' | 'themes'> | undefined {
+    const id = props.theme ?? example.currentThemeId.value
+    const records: Record<string, { dark?: boolean, colors: Record<string, unknown> }> = {}
+
+    function add (themeId: string) {
+      const colors = example.theme.colors.value[themeId]
+      if (colors) records[themeId] = { dark: example.theme.get(themeId)?.dark, colors }
+    }
+
+    add(id)
+    const mapping = PALETTE_THEMES[example.palette.value]
+    if (mapping && (id === mapping.light || id === mapping.dark)) {
+      add(mapping.light)
+      add(mapping.dark)
+    }
+
+    return toPlaygroundThemes(id, records)
+  }
+
   async function onPlayground (list: GnDocsExampleFile[]) {
+    const packed = playgroundThemes()
     // Embed source in the hash by default — works without a live /registry/*
     // (PR #721). Opt into short registry URLs with VITE_PLAYGROUND_REGISTRY=1
     // once the seed is deployed; entry file is the last .vue (registry contract).
-    if (import.meta.env.VITE_PLAYGROUND_REGISTRY === '1' && !props.imports) {
+    // Theme tokens only travel in the hash payload.
+    const hasThemes = packed?.themes && Object.keys(packed.themes).length > 0
+    if (import.meta.env.VITE_PLAYGROUND_REGISTRY === '1' && !props.imports && !hasThemes) {
       const path = props.filePath
         ?? [...(props.filePaths ?? [])].toReversed().find(p => p.endsWith('.vue'))
         ?? props.filePaths?.[0]
       const ref = path ? registryRefFromExamplePath(path) : null
       if (ref) {
-        window.open(playgroundRegistryUrl(ref), '_blank')
+        window.open(playgroundRegistryUrl({ ...ref, theme: packed?.theme }), '_blank')
         return
       }
     }
 
     const files = list.map(f => ({ name: f.name, code: f.code }))
-    const url = await usePlayground(files, undefined, props.imports)
+    const url = await usePlayground(files, { imports: props.imports, ...packed })
     window.open(url, '_blank')
   }
 
@@ -212,6 +236,7 @@
             :code="paneCode ?? ''"
             :language="paneLanguage"
             :playground="!paneFile"
+            :playground-themes="playgroundThemes()"
             show-copy
             show-size
             show-wrap

--- a/apps/docs/src/composables/usePlayground.test.ts
+++ b/apps/docs/src/composables/usePlayground.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+// Composables
+import {
+  decodePlaygroundHash,
+  encodePlaygroundHash,
+  playgroundRegistryUrl,
+  toPlaygroundThemes,
+  type PlaygroundHashData,
+} from './usePlayground'
+
+const LIGHT = {
+  primary: '#111111',
+  background: '#ffffff',
+}
+
+const DARK = {
+  primary: '#eeeeee',
+  background: '#111111',
+}
+
+const TAILWIND = {
+  primary: '#0ea5e9',
+  background: '#0f172a',
+}
+
+const TAILWIND_LIGHT = {
+  primary: '#0284c7',
+  background: '#ffffff',
+}
+
+const HIGH_CONTRAST = {
+  primary: '#ffff00',
+  background: '#000000',
+}
+
+describe('toPlaygroundThemes', () => {
+  it('should pack a custom builder theme and its dark counterpart', () => {
+    const result = toPlaygroundThemes('brand-light', {
+      'brand-light': { dark: false, colors: LIGHT },
+      'brand-dark': { dark: true, colors: DARK },
+    })
+
+    expect(result?.theme).toBe('brand-light')
+    expect(result?.themes?.['brand-light']).toEqual({ dark: false, colors: LIGHT })
+    expect(result?.themes?.['brand-dark']).toEqual({ dark: true, colors: DARK })
+  })
+
+  it('should pack a selected palette and any extra records the caller includes', () => {
+    const result = toPlaygroundThemes('tailwind-light', {
+      'tailwind-light': { dark: false, colors: TAILWIND_LIGHT },
+      'tailwind': { dark: true, colors: TAILWIND },
+    })
+
+    expect(result?.theme).toBe('tailwind-light')
+    expect(result?.themes?.['tailwind-light']).toEqual({ dark: false, colors: TAILWIND_LIGHT })
+    expect(result?.themes?.tailwind).toEqual({ dark: true, colors: TAILWIND })
+  })
+
+  it('should pack a single custom theme', () => {
+    const result = toPlaygroundThemes('high-contrast', {
+      'high-contrast': { dark: true, colors: HIGH_CONTRAST },
+    })
+
+    expect(result?.theme).toBe('high-contrast')
+    expect(result?.themes).toEqual({
+      'high-contrast': { dark: true, colors: HIGH_CONTRAST },
+    })
+  })
+
+  it('should drop unsafe ids and css values', () => {
+    const result = toPlaygroundThemes('ok-theme', {
+      'ok-theme': {
+        dark: false,
+        colors: {
+          'primary': '#fff',
+          'evil': 'url(https://x)',
+          'bad;key': '#000',
+        },
+      },
+    })
+
+    expect(result?.theme).toBe('ok-theme')
+    expect(result?.themes?.['ok-theme']?.colors).toEqual({ primary: '#fff' })
+  })
+
+  it('should reject a non-identifier selected id', () => {
+    expect(toPlaygroundThemes('x\';alert(1)//', { light: { colors: LIGHT } })).toBeUndefined()
+  })
+
+  it('should still emit theme when colors are missing', () => {
+    expect(toPlaygroundThemes('light', {})).toEqual({
+      theme: 'light',
+    })
+  })
+})
+
+describe('playgroundRegistryUrl', () => {
+  it('should append a theme query param when provided', () => {
+    const url = playgroundRegistryUrl({ item: 'dialog', example: 'basic', theme: 'dark' })
+    expect(url).toContain('example=dialog%2Fbasic')
+    expect(url).toContain('theme=dark')
+  })
+})
+
+describe('encodePlaygroundHash', () => {
+  it('should round-trip top-level theme + themes', async () => {
+    const packed = toPlaygroundThemes('tailwind', {
+      'tailwind': { dark: true, colors: TAILWIND },
+      'tailwind-light': { dark: false, colors: TAILWIND_LIGHT },
+    })
+    const hash = await encodePlaygroundHash({
+      files: { 'src/App.vue': '<template>ok</template>' },
+      ...packed,
+    })
+    const decoded = await decodePlaygroundHash(hash)
+    expect(decoded?.theme).toBe('tailwind')
+    expect(decoded?.themes?.tailwind?.colors.primary).toBe('#0ea5e9')
+    expect(decoded?.themes?.['tailwind-light']?.dark).toBe(false)
+  })
+
+  it('should read a legacy settings.theme payload', async () => {
+    const hash = await encodePlaygroundHash({
+      files: { 'src/App.vue': '<template>ok</template>' },
+      settings: {
+        theme: 'brand',
+        themes: { brand: { dark: false, colors: LIGHT } },
+      },
+    } as PlaygroundHashData)
+    const decoded = await decodePlaygroundHash(hash)
+    expect(decoded?.theme).toBe('brand')
+    expect(decoded?.themes?.brand?.colors.primary).toBe('#111111')
+  })
+})

--- a/apps/docs/src/composables/usePlayground.test.ts
+++ b/apps/docs/src/composables/usePlayground.test.ts
@@ -70,17 +70,20 @@ describe('toPlaygroundThemes', () => {
 
   it('should drop unsafe ids and css values', () => {
     const result = toPlaygroundThemes('ok-theme', {
+      'constructor': { dark: true, colors: { primary: '#111' } },
       'ok-theme': {
         dark: false,
         colors: {
           'primary': '#fff',
           'evil': 'url(https://x)',
+          'comment': 'red /*',
           'bad;key': '#000',
         },
       },
     })
 
     expect(result?.theme).toBe('ok-theme')
+    expect(Object.hasOwn(result?.themes ?? {}, 'constructor')).toBe(false)
     expect(result?.themes?.['ok-theme']?.colors).toEqual({ primary: '#fff' })
   })
 

--- a/apps/docs/src/composables/usePlayground.ts
+++ b/apps/docs/src/composables/usePlayground.ts
@@ -1,5 +1,5 @@
 // Framework
-import { isObject, isString } from '@vuetify/v0'
+import { isBoolean, isObject, isString, isUndefined } from '@vuetify/v0'
 
 // Utilities
 import { toPascal } from '@/utilities/strings'
@@ -104,18 +104,53 @@ function playgroundBase () {
   return import.meta.env.VITE_PLAYGROUND_URL ?? 'https://v0play.vuetifyjs.com'
 }
 
+export interface UsePlaygroundOptions {
+  dir?: string
+  imports?: Record<string, string>
+  settings?: PlaygroundHashSettings
+  /** Selected sandbox theme id. */
+  theme?: string
+  /** Theme records merged into the sandbox `createThemePlugin`. */
+  themes?: Record<string, PlaygroundThemeDefinition>
+}
+
 /**
- * Get editor URL for multiple files.
- * When dir is provided, files are nested under src/{dir}/.
+ * Build a v0play URL for the given files.
+ *
+ * Pass `theme` + `themes` to install any theme in the sandbox — docs
+ * palettes, a builder export, or a one-off custom record. `dir` still
+ * accepted as a positional string for older callers.
+ *
+ * @example
+ * ```ts
+ * const url = await usePlayground(files, {
+ *   ...toPlaygroundThemes('brand-light', {
+ *     'brand-light': { dark: false, colors: { primary: '#7453ec', background: '#fff' } },
+ *     'brand-dark': { dark: true, colors: { primary: '#c4b5fd', background: '#121212' } },
+ *   }),
+ * })
+ * ```
  */
 export async function usePlayground (
   inputFiles: PlaygroundFile[],
-  dir?: string,
+  dirOrOptions?: string | UsePlaygroundOptions,
   imports?: Record<string, string>,
 ): Promise<string> {
-  const files = buildPlaygroundFiles(inputFiles, dir)
+  let options: UsePlaygroundOptions
+  if (isString(dirOrOptions)) {
+    options = { dir: dirOrOptions, imports }
+  } else if (isObject(dirOrOptions)) {
+    options = dirOrOptions
+  } else {
+    options = { imports }
+  }
+
+  const files = buildPlaygroundFiles(inputFiles, options.dir)
   const data: PlaygroundHashData = { files }
-  if (imports && Object.keys(imports).length > 0) data.imports = imports
+  if (options.imports && Object.keys(options.imports).length > 0) data.imports = options.imports
+  if (options.settings && Object.keys(options.settings).length > 0) data.settings = options.settings
+  if (options.theme) data.theme = options.theme
+  if (options.themes && Object.keys(options.themes).length > 0) data.themes = options.themes
   const hash = await encodePlaygroundHash(data)
   return `${playgroundBase()}/#${hash}`
 }
@@ -129,6 +164,8 @@ export interface PlaygroundRegistryRef {
   type?: 'components' | 'composables'
   /** Override docs registry origin. */
   registry?: string
+  /** Sandbox default theme id (`light` / `dark` / palette id). */
+  theme?: string
 }
 
 /**
@@ -158,6 +195,7 @@ export function playgroundRegistryUrl (ref: PlaygroundRegistryRef): string {
     params.set('example', ref.item)
   }
   if (ref.registry) params.set('registry', ref.registry)
+  if (ref.theme) params.set('theme', ref.theme)
   return `${playgroundBase()}/?${params}`
 }
 
@@ -189,10 +227,80 @@ function isFileRecord (v: unknown): v is Record<string, string> {
   return isObject(v) && Object.values(v).every(x => isString(x))
 }
 
+export interface PlaygroundThemeDefinition {
+  dark: boolean
+  colors: Record<string, string>
+}
+
+export interface PlaygroundHashSettings {
+  vue?: string
+  v0?: string
+  vuetify?: string
+  vuetifyNightly?: boolean
+  preset?: string
+  addons?: string
+}
+
 export interface PlaygroundHashData {
   files: Record<string, string>
   active?: string
   imports?: Record<string, string>
+  settings?: PlaygroundHashSettings
+  /** Selected sandbox theme id. */
+  theme?: string
+  /** Theme records merged into the sandbox `createThemePlugin`. */
+  themes?: Record<string, PlaygroundThemeDefinition>
+}
+
+const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
+
+const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+
+export function sanitizeThemeId (id: string): string | undefined {
+  return SAFE_THEME_ID.test(id) ? id : undefined
+}
+
+function sanitizeColors (colors: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(colors)) {
+    if (!SAFE_COLOR_KEY.test(key) || !isString(value) || UNSAFE_CSS.test(value)) continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Pack any theme records for a v0play hash. Docs, the builder, or a host
+ * app can call this — v0play merges `themes` into the sandbox plugin and
+ * selects `theme`. Color aliases must already be resolved.
+ *
+ * @example
+ * ```ts
+ * toPlaygroundThemes('brand-light', {
+ *   'brand-light': { dark: false, colors: { primary: '#7453ec', background: '#ffffff' } },
+ *   'brand-dark': { dark: true, colors: { primary: '#c4b5fd', background: '#121212' } },
+ * })
+ * ```
+ */
+export function toPlaygroundThemes (
+  selected: string,
+  records: Record<string, { dark?: boolean, colors?: Record<string, unknown> }>,
+): Pick<PlaygroundHashData, 'theme' | 'themes'> | undefined {
+  const theme = sanitizeThemeId(selected)
+  if (!theme) return undefined
+
+  const themes: Record<string, PlaygroundThemeDefinition> = {}
+  for (const [id, def] of Object.entries(records)) {
+    const safeId = sanitizeThemeId(id)
+    if (!safeId || !def.colors) continue
+    const colors = sanitizeColors(def.colors)
+    if (Object.keys(colors).length === 0) continue
+    themes[safeId] = { dark: def.dark === true, colors }
+  }
+
+  if (Object.keys(themes).length === 0) return { theme }
+  return { theme, themes }
 }
 
 /**
@@ -202,9 +310,45 @@ export async function encodePlaygroundHash (data: PlaygroundHashData): Promise<s
   return utoa(JSON.stringify(data))
 }
 
+function isPlaygroundTheme (v: unknown): v is PlaygroundThemeDefinition {
+  if (!isObject(v)) return false
+  const theme = v as Record<string, unknown>
+  if (!isBoolean(theme.dark) || !isObject(theme.colors)) return false
+  const colors = theme.colors as Record<string, unknown>
+  return Object.values(colors).every(x => isString(x))
+}
+
+function isThemeRecord (v: unknown): v is Record<string, PlaygroundThemeDefinition> {
+  return isObject(v) && Object.values(v as Record<string, unknown>).every(isPlaygroundTheme)
+}
+
+function isValidSettings (v: unknown): v is PlaygroundHashSettings {
+  if (!isObject(v)) return false
+  const settings = v as Record<string, unknown>
+  if (!(isUndefined(settings.vue) || isString(settings.vue))) return false
+  if (!(isUndefined(settings.v0) || isString(settings.v0))) return false
+  if (!(isUndefined(settings.vuetify) || isString(settings.vuetify))) return false
+  if (!(isUndefined(settings.vuetifyNightly) || isBoolean(settings.vuetifyNightly))) return false
+  if (!(isUndefined(settings.preset) || isString(settings.preset))) return false
+  if (!(isUndefined(settings.addons) || isString(settings.addons))) return false
+  return true
+}
+
+function readPlaygroundThemes (parsed: Record<string, unknown>): Pick<PlaygroundHashData, 'theme' | 'themes'> {
+  const settings = isObject(parsed.settings) ? parsed.settings as Record<string, unknown> : undefined
+  const theme = isString(parsed.theme)
+    ? parsed.theme
+    : (isString(settings?.theme) ? settings.theme : undefined)
+  const themesRaw = parsed.themes ?? settings?.themes
+  return {
+    theme,
+    themes: isThemeRecord(themesRaw) ? themesRaw : undefined,
+  }
+}
+
 /**
  * Decode an editor hash back to editor state.
- * Handles both the current { files, active } format and the legacy plain Record<string, string> format.
+ * Handles both the current { files, active, settings? } format and the legacy plain Record<string, string> format.
  */
 export async function decodePlaygroundHash (hash: string): Promise<PlaygroundHashData | null> {
   try {
@@ -218,11 +362,16 @@ export async function decodePlaygroundHash (hash: string): Promise<PlaygroundHas
       && 'files' in parsed
       && isFileRecord((parsed as { files: unknown }).files)
     ) {
-      const { files, active, imports } = parsed as { files: Record<string, string>, active?: unknown, imports?: unknown }
+      const record = parsed as Record<string, unknown>
+      const { files, active, imports, settings } = record
+      const packed = readPlaygroundThemes(record)
       return {
-        files,
+        files: files as Record<string, string>,
         active: isString(active) ? active : undefined,
         imports: isFileRecord(imports) ? imports : undefined,
+        settings: isValidSettings(settings) ? settings : undefined,
+        theme: packed.theme,
+        themes: packed.themes,
       }
     }
     return null

--- a/apps/docs/src/composables/usePlayground.ts
+++ b/apps/docs/src/composables/usePlayground.ts
@@ -253,18 +253,33 @@ export interface PlaygroundHashData {
 }
 
 const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
-
 const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
-const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]|\/\*/i
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+const MAX_THEME_ID = 64
+const MAX_THEMES = 32
+const MAX_COLORS = 64
+const MAX_COLOR_VALUE = 128
 
 export function sanitizeThemeId (id: string): string | undefined {
-  return SAFE_THEME_ID.test(id) ? id : undefined
+  return id.length <= MAX_THEME_ID && SAFE_THEME_ID.test(id) && !UNSAFE_OBJECT_KEYS.has(id)
+    ? id
+    : undefined
 }
 
 function sanitizeColors (colors: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {}
   for (const [key, value] of Object.entries(colors)) {
-    if (!SAFE_COLOR_KEY.test(key) || !isString(value) || UNSAFE_CSS.test(value)) continue
+    if (Object.keys(out).length >= MAX_COLORS) break
+    if (
+      key.length > MAX_THEME_ID
+      || !SAFE_COLOR_KEY.test(key)
+      || UNSAFE_OBJECT_KEYS.has(key)
+      || !isString(value)
+      || value.length === 0
+      || value.length > MAX_COLOR_VALUE
+      || UNSAFE_CSS.test(value)
+    ) continue
     out[key] = value
   }
   return out
@@ -292,6 +307,7 @@ export function toPlaygroundThemes (
 
   const themes: Record<string, PlaygroundThemeDefinition> = {}
   for (const [id, def] of Object.entries(records)) {
+    if (Object.keys(themes).length >= MAX_THEMES) break
     const safeId = sanitizeThemeId(id)
     if (!safeId || !def.colors) continue
     const colors = sanitizeColors(def.colors)

--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -1,5 +1,5 @@
 // Framework
-import { isArray, isObject, isString, isUndefined } from '@vuetify/v0'
+import { isArray, isBoolean, isObject, isString, isUndefined } from '@vuetify/v0'
 
 // Utilities
 import { toPascal } from '@/utilities/strings'
@@ -100,18 +100,51 @@ export function buildPlaygroundFiles (inputFiles: PlaygroundFile[], dir?: string
   return files
 }
 
+export interface UsePlaygroundOptions {
+  dir?: string
+  imports?: Record<string, string>
+  settings?: PlaygroundHashSettings
+  /** Selected sandbox theme id. */
+  theme?: string
+  /** Theme records merged into the sandbox `createThemePlugin`. */
+  themes?: Record<string, PlaygroundThemeDefinition>
+}
+
 /**
- * Get editor URL for multiple files.
- * When dir is provided, files are nested under src/{dir}/.
+ * Build a same-origin v0play hash URL for the given files.
+ *
+ * Pass `theme` + `themes` to install any theme in the sandbox.
+ *
+ * @example
+ * ```ts
+ * const url = await usePlayground(files, {
+ *   ...toPlaygroundThemes('brand-light', {
+ *     'brand-light': { dark: false, colors: { primary: '#7453ec', background: '#fff' } },
+ *     'brand-dark': { dark: true, colors: { primary: '#c4b5fd', background: '#121212' } },
+ *   }),
+ * })
+ * ```
  */
 export async function usePlayground (
   inputFiles: PlaygroundFile[],
-  dir?: string,
+  dirOrOptions?: string | UsePlaygroundOptions,
   imports?: Record<string, string>,
 ): Promise<string> {
-  const files = buildPlaygroundFiles(inputFiles, dir)
+  let options: UsePlaygroundOptions
+  if (isString(dirOrOptions)) {
+    options = { dir: dirOrOptions, imports }
+  } else if (isObject(dirOrOptions)) {
+    options = dirOrOptions
+  } else {
+    options = { imports }
+  }
+
+  const files = buildPlaygroundFiles(inputFiles, options.dir)
   const data: PlaygroundHashData = { files }
-  if (imports && Object.keys(imports).length > 0) data.imports = imports
+  if (options.imports && Object.keys(options.imports).length > 0) data.imports = options.imports
+  if (options.settings && Object.keys(options.settings).length > 0) data.settings = options.settings
+  if (options.theme) data.theme = options.theme
+  if (options.themes && Object.keys(options.themes).length > 0) data.themes = options.themes
   const hash = await encodePlaygroundHash(data)
   return `/#${hash}`
 }
@@ -209,18 +242,81 @@ export function parseVuetifyPlayTuple (parsed: unknown[]): { files: Record<strin
   }
 }
 
+export interface PlaygroundThemeDefinition {
+  dark: boolean
+  colors: Record<string, string>
+}
+
+export interface PlaygroundHashSettings {
+  vue?: string
+  v0?: string
+  vuetify?: string
+  vuetifyNightly?: boolean
+  preset?: string
+  addons?: string
+}
+
 export interface PlaygroundHashData {
   files: Record<string, string>
   active?: string
   imports?: Record<string, string>
-  settings?: {
-    vue?: string
-    v0?: string
-    vuetify?: string
-    vuetifyNightly?: boolean
-    preset?: string
-    addons?: string
+  settings?: PlaygroundHashSettings
+  /** Selected sandbox theme id. */
+  theme?: string
+  /** Theme records merged into the sandbox `createThemePlugin`. */
+  themes?: Record<string, PlaygroundThemeDefinition>
+}
+
+/** Theme ids written into generated `main.ts` / hash JSON. */
+export const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
+
+const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+
+function sanitizeThemeId (id: string): string | undefined {
+  return SAFE_THEME_ID.test(id) ? id : undefined
+}
+
+function sanitizeColors (colors: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(colors)) {
+    if (!SAFE_COLOR_KEY.test(key) || !isString(value) || UNSAFE_CSS.test(value)) continue
+    out[key] = value
   }
+  return out
+}
+
+/**
+ * Pack any theme records for a v0play hash. Docs, the builder, or a host
+ * app can call this — v0play merges `themes` into the sandbox plugin and
+ * selects `theme`. Color aliases must already be resolved.
+ *
+ * @example
+ * ```ts
+ * toPlaygroundThemes('brand-light', {
+ *   'brand-light': { dark: false, colors: { primary: '#7453ec', background: '#ffffff' } },
+ *   'brand-dark': { dark: true, colors: { primary: '#c4b5fd', background: '#121212' } },
+ * })
+ * ```
+ */
+export function toPlaygroundThemes (
+  selected: string,
+  records: Record<string, { dark?: boolean, colors?: Record<string, unknown> }>,
+): Pick<PlaygroundHashData, 'theme' | 'themes'> | undefined {
+  const theme = sanitizeThemeId(selected)
+  if (!theme) return undefined
+
+  const themes: Record<string, PlaygroundThemeDefinition> = {}
+  for (const [id, def] of Object.entries(records)) {
+    const safeId = sanitizeThemeId(id)
+    if (!safeId || !def.colors) continue
+    const colors = sanitizeColors(def.colors)
+    if (Object.keys(colors).length === 0) continue
+    themes[safeId] = { dark: def.dark === true, colors }
+  }
+
+  if (Object.keys(themes).length === 0) return { theme }
+  return { theme, themes }
 }
 
 /**
@@ -230,15 +326,40 @@ export async function encodePlaygroundHash (data: PlaygroundHashData): Promise<s
   return utoa(JSON.stringify(data))
 }
 
-function isValidSettings (v: unknown): v is PlaygroundHashData['settings'] {
+function isPlaygroundTheme (v: unknown): v is PlaygroundThemeDefinition {
   if (!isObject(v)) return false
-  const s = v as Record<string, unknown>
-  return (isUndefined(s.vue) || isString(s.vue))
-    && (isUndefined(s.v0) || isString(s.v0))
-    && (isUndefined(s.vuetify) || isString(s.vuetify))
-    && (isUndefined(s.vuetifyNightly) || typeof s.vuetifyNightly === 'boolean')
-    && (isUndefined(s.preset) || isString(s.preset))
-    && (isUndefined(s.addons) || isString(s.addons))
+  const theme = v as Record<string, unknown>
+  if (!isBoolean(theme.dark) || !isObject(theme.colors)) return false
+  const colors = theme.colors as Record<string, unknown>
+  return Object.values(colors).every(x => isString(x))
+}
+
+function isThemeRecord (v: unknown): v is Record<string, PlaygroundThemeDefinition> {
+  return isObject(v) && Object.values(v as Record<string, unknown>).every(isPlaygroundTheme)
+}
+
+function isValidSettings (v: unknown): v is PlaygroundHashSettings {
+  if (!isObject(v)) return false
+  const settings = v as Record<string, unknown>
+  if (!(isUndefined(settings.vue) || isString(settings.vue))) return false
+  if (!(isUndefined(settings.v0) || isString(settings.v0))) return false
+  if (!(isUndefined(settings.vuetify) || isString(settings.vuetify))) return false
+  if (!(isUndefined(settings.vuetifyNightly) || isBoolean(settings.vuetifyNightly))) return false
+  if (!(isUndefined(settings.preset) || isString(settings.preset))) return false
+  if (!(isUndefined(settings.addons) || isString(settings.addons))) return false
+  return true
+}
+
+function readPlaygroundThemes (parsed: Record<string, unknown>): Pick<PlaygroundHashData, 'theme' | 'themes'> {
+  const settings = isObject(parsed.settings) ? parsed.settings as Record<string, unknown> : undefined
+  const theme = isString(parsed.theme)
+    ? parsed.theme
+    : (isString(settings?.theme) ? settings.theme : undefined)
+  const themesRaw = parsed.themes ?? settings?.themes
+  return {
+    theme,
+    themes: isThemeRecord(themesRaw) ? themesRaw : undefined,
+  }
 }
 
 /**
@@ -275,17 +396,16 @@ export async function decodePlaygroundHash (hash: string): Promise<PlaygroundHas
       && 'files' in parsed
       && isFileRecord((parsed as { files: unknown }).files)
     ) {
-      const { files, active, imports, settings } = parsed as {
-        files: Record<string, string>
-        active?: unknown
-        imports?: unknown
-        settings?: unknown
-      }
+      const record = parsed as Record<string, unknown>
+      const { files, active, imports, settings } = record
+      const packed = readPlaygroundThemes(record)
       return {
-        files,
+        files: files as Record<string, string>,
         active: isString(active) ? active : undefined,
         imports: isFileRecord(imports) ? imports : undefined,
         settings: isValidSettings(settings) ? settings : undefined,
+        theme: packed.theme,
+        themes: packed.themes,
       }
     }
 

--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -271,16 +271,32 @@ export interface PlaygroundHashData {
 export const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
 
 const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
-const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]|\/\*/i
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+const MAX_THEME_ID = 64
+const MAX_THEMES = 32
+const MAX_COLORS = 64
+const MAX_COLOR_VALUE = 128
 
 function sanitizeThemeId (id: string): string | undefined {
-  return SAFE_THEME_ID.test(id) ? id : undefined
+  return id.length <= MAX_THEME_ID && SAFE_THEME_ID.test(id) && !UNSAFE_OBJECT_KEYS.has(id)
+    ? id
+    : undefined
 }
 
 function sanitizeColors (colors: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {}
   for (const [key, value] of Object.entries(colors)) {
-    if (!SAFE_COLOR_KEY.test(key) || !isString(value) || UNSAFE_CSS.test(value)) continue
+    if (Object.keys(out).length >= MAX_COLORS) break
+    if (
+      key.length > MAX_THEME_ID
+      || !SAFE_COLOR_KEY.test(key)
+      || UNSAFE_OBJECT_KEYS.has(key)
+      || !isString(value)
+      || value.length === 0
+      || value.length > MAX_COLOR_VALUE
+      || UNSAFE_CSS.test(value)
+    ) continue
     out[key] = value
   }
   return out
@@ -308,6 +324,7 @@ export function toPlaygroundThemes (
 
   const themes: Record<string, PlaygroundThemeDefinition> = {}
   for (const [id, def] of Object.entries(records)) {
+    if (Object.keys(themes).length >= MAX_THEMES) break
     const safeId = sanitizeThemeId(id)
     if (!safeId || !def.colors) continue
     const colors = sanitizeColors(def.colors)

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -3,7 +3,7 @@ import { IN_BROWSER, isArray, isObject, useTheme, useTimer } from '@vuetify/v0'
 
 // Composables
 import { readPlaygroundIdFromUrl, useOnePlaygrounds, usePlaygroundRouteId } from '@/composables/useOnePlaygrounds'
-import { decodePlaygroundHash, encodePlaygroundHash, isFileRecord, parseVuetifyPlayTuple } from '@/composables/usePlayground'
+import { decodePlaygroundHash, encodePlaygroundHash, isFileRecord, parseVuetifyPlayTuple, SAFE_THEME_ID } from '@/composables/usePlayground'
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
@@ -17,7 +17,7 @@ import { compileFile, useStore } from '@vue/repl/core'
 import { computed, onMounted, shallowRef, watch, watchEffect } from 'vue'
 
 // Types
-import type { PlaygroundHashData } from '@/composables/usePlayground'
+import type { PlaygroundHashData, PlaygroundThemeDefinition } from '@/composables/usePlayground'
 import type { RegistryExampleRef } from '@/data/registry'
 import type { VuetifyExampleRef } from '@/data/vuetify-examples'
 import type { ShallowRef } from 'vue'
@@ -75,6 +75,8 @@ export function usePlaygroundFiles () {
   const extraImports = shallowRef<Record<string, string>>()
   const activePreset = shallowRef('default')
   const activeAddons = shallowRef<string[]>([])
+  const extraThemes = shallowRef<Record<string, PlaygroundThemeDefinition>>()
+  const extraDefault = shallowRef<string>()
 
   function mergedMainOptions () {
     const preset = PRESETS.find(p => p.id === activePreset.value)
@@ -86,10 +88,46 @@ export function usePlaygroundFiles () {
     return result
   }
 
+  function applyIncomingTheme (data?: Pick<PlaygroundHashData, 'theme' | 'themes' | 'settings'>) {
+    const raw = data?.theme ?? (data?.settings as { theme?: string } | undefined)?.theme
+    const id = raw && SAFE_THEME_ID.test(raw) ? raw : undefined
+    extraDefault.value = id
+    extraThemes.value = data?.themes ?? (data?.settings as { themes?: Record<string, PlaygroundThemeDefinition> } | undefined)?.themes
+  }
+
+  function clearIncomingTheme () {
+    extraDefault.value = undefined
+    extraThemes.value = undefined
+  }
+
+  function sandboxThemeId (isDark: boolean): string {
+    const extra = extraThemes.value
+    const selected = extraDefault.value
+    if (selected && extra?.[selected]?.dark === isDark) {
+      return selected
+    }
+    if (extra) {
+      const match = Object.entries(extra).find(([, def]) => def.dark === isDark)
+      if (match) return match[0]
+    }
+    return isDark ? 'dark' : 'light'
+  }
+
+  function syncHostTheme (id: string | undefined, themes?: Record<string, PlaygroundThemeDefinition>) {
+    if (!id) return
+    const dark = themes?.[id]?.dark ?? id === 'dark'
+    theme.select(dark ? 'dark' : 'light')
+  }
+
+  function mainTs (defaultTheme?: string) {
+    const id = defaultTheme ?? sandboxThemeId(theme.isDark.value)
+    return createMainTs(id, mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value, extraThemes.value)
+  }
+
   function rebuildMain () {
     const file = store.files['src/main.ts']
     if (!file) return
-    file.code = createMainTs(theme.isDark.value ? 'dark' : 'light', mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value)
+    file.code = mainTs()
     compileFile(store, file)
   }
 
@@ -120,6 +158,7 @@ export function usePlaygroundFiles () {
     const search = (!oneId && !decoded) ? new URLSearchParams(window.location.search) : null
     const vuetifyRef = search ? parseVuetifyExampleQuery(search) : null
     const registryRef = search && !vuetifyRef ? parseRegistryQuery(search) : null
+    const themeQuery = search?.get('theme') ?? undefined
 
     if (oneId) {
       one.pauseAutosave()
@@ -157,7 +196,7 @@ export function usePlaygroundFiles () {
       }
     } else if (registryRef) {
       try {
-        await openRegistryExample(registryRef, { clearSearch: true })
+        await openRegistryExample(registryRef, { clearSearch: true, theme: themeQuery })
       } catch (error) {
         loadError.value = error instanceof Error ? error.message : String(error)
         // Drop ?example= so a later hash rewrite / reload does not re-hit a
@@ -201,6 +240,8 @@ export function usePlaygroundFiles () {
       decoded.files['src/setup.ts'] = `document.head.insertAdjacentHTML('afterbegin', '<style>@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;</style>')\n${decoded.files['src/setup.ts']}`
     }
 
+    applyIncomingTheme(decoded)
+    syncHostTheme(decoded.theme, decoded.themes)
     await loadExample(decoded.files, decoded.active)
     if (decoded.imports && Object.keys(decoded.imports).length > 0) {
       extraImports.value = decoded.imports
@@ -209,10 +250,9 @@ export function usePlaygroundFiles () {
   }
 
   async function seedDefault () {
-    const theme_ = theme.isDark.value ? 'dark' : 'light'
     await store.setFiles(
       {
-        'src/main.ts': createMainTs(theme_),
+        'src/main.ts': mainTs(),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'src/App.vue': DEFAULT_APP,
         'tsconfig.json': REPL_TSCONFIG,
@@ -233,6 +273,7 @@ export function usePlaygroundFiles () {
     activeAddons.value = []
     extraImports.value = undefined
     aliasMap.value = new Map()
+    clearIncomingTheme()
     rebuildImportMap()
     await seedDefault()
     filesVersion.value++
@@ -266,18 +307,18 @@ export function usePlaygroundFiles () {
 
     aliasMap.value = nextAliasMap
 
-    const theme_ = theme.isDark.value ? 'dark' : 'light'
     const options = mergedMainOptions()
+    const theme_ = extraDefault.value ?? (theme.isDark.value ? 'dark' : 'light')
     // Ensure bare-specifier imports (vuetify, pinia, …) are on the map before
     // compile. setFiles calls applyBuiltinImportMap which can drop them, so
     // callers still rebuildImportMap() after loadExample — and we seed here too.
     rebuildImportMap()
     await store.setFiles(
       {
-        'src/main.ts': createMainTs(theme_, options, vuetifyVersion.value, vuetifyNightly.value),
+        'src/main.ts': mainTs(theme_),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'tsconfig.json': REPL_TSCONFIG,
-        ...(options.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme_) } : {}),
+        ...(options.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme.isDark.value ? 'dark' : 'light') } : {}),
         ...files,
         ...aliases,
       },
@@ -320,6 +361,8 @@ export function usePlaygroundFiles () {
 
     const data: PlaygroundHashData = { files, active, imports: extraImports.value }
     if (Object.keys(settings).length > 0) data.settings = settings
+    if (extraDefault.value) data.theme = extraDefault.value
+    if (extraThemes.value) data.themes = extraThemes.value
     return data
   }
 
@@ -364,9 +407,10 @@ export function usePlaygroundFiles () {
   watch(theme.isDark, isDark => {
     if (!isReady.value) return
     const mode = isDark ? 'dark' : 'light'
+    extraDefault.value = sandboxThemeId(isDark)
     const main = store.files['src/main.ts']
     if (main) {
-      main.code = createMainTs(mode, mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value)
+      main.code = mainTs(extraDefault.value)
       compileFile(store, main)
     }
     // Keep sandbox Vuetify theme aligned with the host chrome toggle.
@@ -402,6 +446,7 @@ export function usePlaygroundFiles () {
     activeAddons.value = []
     extraImports.value = preset.imports ?? undefined
     aliasMap.value = new Map() // presets use direct paths, no aliases
+    clearIncomingTheme()
 
     // Import map must include bare `vuetify` *before* setFiles compiles main/vuetify.ts.
     // setFiles re-applies builtins, so rebuild again after to keep preset imports.
@@ -511,6 +556,8 @@ export function usePlaygroundFiles () {
         if (data.settings?.v0) v0Version.value = data.settings.v0
         if (data.settings?.vuetify) vuetifyVersion.value = data.settings.vuetify
         if (data.settings?.vuetifyNightly) vuetifyNightly.value = data.settings.vuetifyNightly
+        applyIncomingTheme(data)
+        syncHostTheme(data.theme, data.themes)
 
         await loadExample(data.files, data.active)
         rebuildImportMap()
@@ -531,6 +578,7 @@ export function usePlaygroundFiles () {
         activeAddons.value = []
         extraImports.value = Object.keys(imports).length > 0 ? imports : undefined
         aliasMap.value = new Map()
+        clearIncomingTheme()
 
         if (vue) vueVersion.value = vue
 
@@ -547,6 +595,7 @@ export function usePlaygroundFiles () {
         activeAddons.value = []
         extraImports.value = undefined
         aliasMap.value = new Map()
+        clearIncomingTheme()
         await loadExample(parsed)
         rebuildImportMap()
         filesVersion.value++
@@ -562,6 +611,7 @@ export function usePlaygroundFiles () {
     url.searchParams.delete('registry')
     url.searchParams.delete('vuetify')
     url.searchParams.delete('source')
+    url.searchParams.delete('theme')
     history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
   }
 
@@ -572,7 +622,7 @@ export function usePlaygroundFiles () {
    */
   async function openRegistryExample (
     ref: RegistryExampleRef,
-    options: { clearSearch?: boolean } = {},
+    options: { clearSearch?: boolean, theme?: string } = {},
   ) {
     loadError.value = undefined
     const resolved = await resolveRegistryExample(ref)
@@ -582,6 +632,8 @@ export function usePlaygroundFiles () {
     activeAddons.value = []
     extraImports.value = resolved.imports
     aliasMap.value = new Map()
+    applyIncomingTheme(options.theme ? { theme: options.theme } : undefined)
+    syncHostTheme(options.theme)
 
     await loadExample(resolved.files, resolved.active)
     rebuildImportMap()
@@ -616,6 +668,7 @@ export function usePlaygroundFiles () {
     activeAddons.value = []
     extraImports.value = preset?.imports ?? undefined
     aliasMap.value = new Map()
+    clearIncomingTheme()
 
     try {
       // Map first (bare `vuetify` → labs CDN), then compile main + vuetify.ts + App.

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -7,7 +7,7 @@ import { decodePlaygroundHash, encodePlaygroundHash, isFileRecord, parseVuetifyP
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
-import { createMainTs, createVuetifyTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS, vuetifyEsmUrl } from '@/data/playground-defaults'
+import { createMainTs, createVuetifyTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, sanitizePlaygroundThemes, UNO_CONFIG_TS, vuetifyEsmUrl } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
 import { parseRegistryQuery, resolveRegistryExample } from '@/data/registry'
 import { parseVuetifyExampleQuery, resolveVuetifyExample } from '@/data/vuetify-examples'
@@ -90,9 +90,13 @@ export function usePlaygroundFiles () {
 
   function applyIncomingTheme (data?: Pick<PlaygroundHashData, 'theme' | 'themes' | 'settings'>) {
     const raw = data?.theme ?? (data?.settings as { theme?: string } | undefined)?.theme
-    const id = raw && SAFE_THEME_ID.test(raw) ? raw : undefined
+    const id = raw && SAFE_THEME_ID.test(raw) && raw !== 'constructor' && raw !== 'prototype'
+      ? raw
+      : undefined
     extraDefault.value = id
-    extraThemes.value = data?.themes ?? (data?.settings as { themes?: Record<string, PlaygroundThemeDefinition> } | undefined)?.themes
+    extraThemes.value = sanitizePlaygroundThemes(
+      data?.themes ?? (data?.settings as { themes?: Record<string, PlaygroundThemeDefinition> } | undefined)?.themes,
+    )
   }
 
   function clearIncomingTheme () {

--- a/apps/playground/src/content/intro.md
+++ b/apps/playground/src/content/intro.md
@@ -47,6 +47,29 @@ Point `?registry=` at a custom origin when testing a local docs build.
 - **Vuetify One playgrounds** get a canonical URL: `/playgrounds/:id` (e.g. `/playgrounds/abc123`). The editor hash is preserved for sharing with content inline
 - Save to Vuetify One via **☰ → File → Save** to persist your work and get a shareable link
 
+## Sending a theme
+
+Any producer — docs, the builder, a host app — can ship a theme in the hash next to the files. v0play merges `themes` into the sandbox `createThemePlugin` and selects `theme`:
+
+```json
+{
+  "files": { "src/App.vue": "…" },
+  "theme": "brand-light",
+  "themes": {
+    "brand-light": {
+      "dark": false,
+      "colors": { "primary": "#7453ec", "background": "#ffffff" }
+    },
+    "brand-dark": {
+      "dark": true,
+      "colors": { "primary": "#c4b5fd", "background": "#121212" }
+    }
+  }
+}
+```
+
+Ids must be CSS identifiers. Light/dark pairs are `{name}-light` / `{name}-dark` — never a bare `{name}` for one side. Color values must be plain tokens (hex / rgb / names) — no `url()`, `expression()`, or braces. Include both records if the playground host toggle should stay on that palette; a single custom theme is enough when there is no pair.
+
 ## Tips
 
 - `Ctrl+B` toggles the file tree sidebar — or drag the panel edge to close it

--- a/apps/playground/src/data/playground-defaults.test.ts
+++ b/apps/playground/src/data/playground-defaults.test.ts
@@ -53,4 +53,23 @@ describe('createMainTs', () => {
     expect(source).toContain('default: \'light\'')
     expect(source).not.toContain('alert(1)')
   })
+
+  it('should drop constructor keys, url() values, and css comments', () => {
+    const source = createMainTs('ok-theme', undefined, 'latest', false, {
+      'constructor': { dark: true, colors: { primary: '#111111' } },
+      'ok-theme': {
+        dark: false,
+        colors: {
+          primary: 'url(javascript:alert(1))',
+          secondary: 'red /*',
+          accent: '#00ff00',
+        },
+      },
+    })
+    expect(source).toContain('default: \'ok-theme\'')
+    expect(source).not.toContain('constructor')
+    expect(source).not.toContain('javascript:alert')
+    expect(source).not.toContain('red /*')
+    expect(source).toContain('#00ff00')
+  })
 })

--- a/apps/playground/src/data/playground-defaults.test.ts
+++ b/apps/playground/src/data/playground-defaults.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+// Data
+import { createMainTs } from './playground-defaults'
+
+describe('createMainTs', () => {
+  it('should keep default light and dark themes', () => {
+    const source = createMainTs()
+    expect(source).toContain('default: \'light\'')
+    expect(source).toContain('#3b82f6')
+    expect(source).toContain('#c4b5fd')
+  })
+
+  it('should merge extra palettes and overwrite matching ids', () => {
+    const source = createMainTs('tailwind', undefined, 'latest', false, {
+      dark: { dark: true, colors: { primary: '#111111' } },
+      tailwind: { dark: true, colors: { primary: '#0ea5e9' } },
+    })
+    expect(source).toContain('default: \'tailwind\'')
+    expect(source).toContain('#111111')
+    expect(source).toContain('#0ea5e9')
+    expect(source).toContain('#3b82f6')
+  })
+
+  it('should drop unsafe ids and css values', () => {
+    const source = createMainTs('ok-theme', undefined, 'latest', false, {
+      'ok-theme': {
+        dark: false,
+        colors: {
+          primary: '#fff',
+          inject: 'url(javascript:alert(1))',
+        },
+      },
+      'bad id': { dark: true, colors: { primary: '#000' } },
+    })
+    expect(source).toContain('default: \'ok-theme\'')
+    expect(source).toContain('#fff')
+    expect(source).not.toContain('javascript:alert')
+    expect(source).not.toContain('bad id')
+  })
+
+  it('should set the plugin default to the selected extra theme', () => {
+    const source = createMainTs('tailwind-light', undefined, 'latest', false, {
+      'tailwind-light': { dark: false, colors: { primary: '#0284c7' } },
+    })
+    expect(source).toContain('default: \'tailwind-light\'')
+    expect(source).toContain('"tailwind-light"')
+    expect(source).toContain('#0284c7')
+  })
+
+  it('should fall back to light when the default id is unsafe', () => {
+    const source = createMainTs('x\';alert(1)//')
+    expect(source).toContain('default: \'light\'')
+    expect(source).not.toContain('alert(1)')
+  })
+})

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -98,7 +98,94 @@ function vuetifyCssUrl (version = 'latest', nightly = false): string {
   return `https://cdn.jsdelivr.net/npm/${pkg}@${version}/dist/vuetify-labs.css`
 }
 
-export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?: MainOptions, vuetifyVersion = 'latest', vuetifyNightly = false): string {
+interface SandboxTheme {
+  dark: boolean
+  colors: Record<string, string>
+}
+
+const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
+const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+
+const DEFAULT_SANDBOX_THEMES: { light: SandboxTheme, dark: SandboxTheme } = {
+  light: {
+    dark: false,
+    colors: {
+      'primary': '#3b82f6',
+      'secondary': '#64748b',
+      'accent': '#6366f1',
+      'error': '#ef4444',
+      'info': '#1867c0',
+      'success': '#22c55e',
+      'warning': '#f59e0b',
+      'background': '#ffffff',
+      'surface': '#ffffff',
+      'surface-tint': '#f5f5f5',
+      'surface-variant': '#e8e8e8',
+      'divider': '#e0e0e0',
+      'on-primary': '#ffffff',
+      'on-secondary': '#ffffff',
+      'on-accent': '#1a1a1a',
+      'on-error': '#ffffff',
+      'on-info': '#ffffff',
+      'on-success': '#1a1a1a',
+      'on-warning': '#1a1a1a',
+      'on-background': '#212121',
+      'on-surface': '#212121',
+      'on-surface-variant': '#666666',
+    },
+  },
+  dark: {
+    dark: true,
+    colors: {
+      'primary': '#c4b5fd',
+      'secondary': '#94a3b8',
+      'accent': '#c084fc',
+      'error': '#f87171',
+      'info': '#38bdf8',
+      'success': '#4ade80',
+      'warning': '#fb923c',
+      'background': '#121212',
+      'surface': '#1a1a1a',
+      'surface-tint': '#2a2a2a',
+      'surface-variant': '#1e1e1e',
+      'divider': '#404040',
+      'on-primary': '#1a1a1a',
+      'on-secondary': '#ffffff',
+      'on-accent': '#ffffff',
+      'on-error': '#1a1a1a',
+      'on-info': '#1a1a1a',
+      'on-success': '#1a1a1a',
+      'on-warning': '#1a1a1a',
+      'on-background': '#e0e0e0',
+      'on-surface': '#e0e0e0',
+      'on-surface-variant': '#a0a0a0',
+    },
+  },
+}
+
+function mergeSandboxThemes (
+  extra?: Record<string, SandboxTheme>,
+): Record<string, SandboxTheme> {
+  const merged: Record<string, SandboxTheme> = {
+    light: { dark: false, colors: { ...DEFAULT_SANDBOX_THEMES.light.colors } },
+    dark: { dark: true, colors: { ...DEFAULT_SANDBOX_THEMES.dark.colors } },
+  }
+  if (!extra) return merged
+
+  for (const [id, def] of Object.entries(extra)) {
+    if (!SAFE_THEME_ID.test(id)) continue
+    const colors: Record<string, string> = {}
+    for (const [key, value] of Object.entries(def.colors)) {
+      if (!SAFE_COLOR_KEY.test(key) || typeof value !== 'string' || UNSAFE_CSS.test(value)) continue
+      colors[key] = value
+    }
+    merged[id] = { dark: def.dark === true, colors }
+  }
+  return merged
+}
+
+export function createMainTs (defaultTheme = 'light', options?: MainOptions, vuetifyVersion = 'latest', vuetifyNightly = false, extraThemes?: Record<string, SandboxTheme>): string {
   const useV0 = options?.v0 !== false
   const extraImports: string[] = []
   const extraPlugins: string[] = []
@@ -145,6 +232,11 @@ export function createMainTs (defaultTheme: 'light' | 'dark' = 'light', options?
   const importBlock = extraImports.length > 0 ? '\n' + extraImports.join('\n') : ''
   const setupBlock = extraSetup.length > 0 ? '\n' + extraSetup.join('\n') + '\n' : ''
   const pluginBlock = extraPlugins.length > 0 ? extraPlugins.join('\n') + '\n' : ''
+  const mergedThemes = mergeSandboxThemes(extraThemes)
+  const safeDefault = SAFE_THEME_ID.test(defaultTheme) && defaultTheme in mergedThemes
+    ? defaultTheme
+    : 'light'
+  const themesJson = JSON.stringify(mergedThemes, null, 2).split('\n').join('\n  ')
 
   if (!useV0) {
     return `import { createApp } from 'vue'
@@ -162,63 +254,8 @@ import { createThemePlugin } from '@vuetify/v0'
 import './uno.config.ts'${importBlock}
 ${setupBlock}
 const theme = createThemePlugin({
-  default: '${defaultTheme}',
-  themes: {
-    light: {
-      dark: false,
-      colors: {
-        'primary': '#3b82f6',
-        'secondary': '#64748b',
-        'accent': '#6366f1',
-        'error': '#ef4444',
-        'info': '#1867c0',
-        'success': '#22c55e',
-        'warning': '#f59e0b',
-        'background': '#ffffff',
-        'surface': '#ffffff',
-        'surface-tint': '#f5f5f5',
-        'surface-variant': '#e8e8e8',
-        'divider': '#e0e0e0',
-        'on-primary': '#ffffff',
-        'on-secondary': '#ffffff',
-        'on-accent': '#1a1a1a',
-        'on-error': '#ffffff',
-        'on-info': '#ffffff',
-        'on-success': '#1a1a1a',
-        'on-warning': '#1a1a1a',
-        'on-background': '#212121',
-        'on-surface': '#212121',
-        'on-surface-variant': '#666666',
-      },
-    },
-    dark: {
-      dark: true,
-      colors: {
-        'primary': '#c4b5fd',
-        'secondary': '#94a3b8',
-        'accent': '#c084fc',
-        'error': '#f87171',
-        'info': '#38bdf8',
-        'success': '#4ade80',
-        'warning': '#fb923c',
-        'background': '#121212',
-        'surface': '#1a1a1a',
-        'surface-tint': '#2a2a2a',
-        'surface-variant': '#1e1e1e',
-        'divider': '#404040',
-        'on-primary': '#1a1a1a',
-        'on-secondary': '#ffffff',
-        'on-accent': '#ffffff',
-        'on-error': '#1a1a1a',
-        'on-info': '#1a1a1a',
-        'on-success': '#1a1a1a',
-        'on-warning': '#1a1a1a',
-        'on-background': '#e0e0e0',
-        'on-surface': '#e0e0e0',
-        'on-surface-variant': '#a0a0a0',
-      },
-    },
-  },
+  default: '${safeDefault}',
+  themes: ${themesJson},
 })
 
 const app = createApp(App)

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -105,7 +105,46 @@ interface SandboxTheme {
 
 const SAFE_THEME_ID = /^[a-zA-Z][\w-]*$/
 const SAFE_COLOR_KEY = /^[a-zA-Z0-9_-]+$/
-const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]/i
+const UNSAFE_CSS = /url\s*\(|src\s*\(|image\s*\(|image-set\s*\(|cross-fade\s*\(|@import|expression\s*\(|[;{}<>\\]|\/\*/i
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+const MAX_THEME_ID = 64
+const MAX_THEMES = 32
+const MAX_COLORS = 64
+const MAX_COLOR_VALUE = 128
+
+function isSafeThemeId (id: string): boolean {
+  return id.length <= MAX_THEME_ID && SAFE_THEME_ID.test(id) && !UNSAFE_OBJECT_KEYS.has(id)
+}
+
+function isSafeColorKey (key: string): boolean {
+  return key.length <= MAX_THEME_ID && SAFE_COLOR_KEY.test(key) && !UNSAFE_OBJECT_KEYS.has(key)
+}
+
+function isSafeColorValue (value: string): boolean {
+  return value.length > 0 && value.length <= MAX_COLOR_VALUE && !UNSAFE_CSS.test(value)
+}
+
+/** Strip attacker-controlled theme records down to ids/colors the sandbox will emit. */
+export function sanitizePlaygroundThemes (
+  extra?: Record<string, SandboxTheme>,
+): Record<string, SandboxTheme> | undefined {
+  if (!extra) return undefined
+
+  const out: Record<string, SandboxTheme> = {}
+  for (const [id, def] of Object.entries(extra)) {
+    if (!isSafeThemeId(id) || !def?.colors || Object.keys(out).length >= MAX_THEMES) continue
+    const colors: Record<string, string> = {}
+    for (const [key, value] of Object.entries(def.colors)) {
+      if (!isSafeColorKey(key) || typeof value !== 'string' || !isSafeColorValue(value)) continue
+      if (Object.keys(colors).length >= MAX_COLORS) break
+      colors[key] = value
+    }
+    if (Object.keys(colors).length === 0) continue
+    out[id] = { dark: def.dark === true, colors }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
 
 const DEFAULT_SANDBOX_THEMES: { light: SandboxTheme, dark: SandboxTheme } = {
   light: {
@@ -167,22 +206,11 @@ const DEFAULT_SANDBOX_THEMES: { light: SandboxTheme, dark: SandboxTheme } = {
 function mergeSandboxThemes (
   extra?: Record<string, SandboxTheme>,
 ): Record<string, SandboxTheme> {
-  const merged: Record<string, SandboxTheme> = {
+  return {
     light: { dark: false, colors: { ...DEFAULT_SANDBOX_THEMES.light.colors } },
     dark: { dark: true, colors: { ...DEFAULT_SANDBOX_THEMES.dark.colors } },
+    ...sanitizePlaygroundThemes(extra),
   }
-  if (!extra) return merged
-
-  for (const [id, def] of Object.entries(extra)) {
-    if (!SAFE_THEME_ID.test(id)) continue
-    const colors: Record<string, string> = {}
-    for (const [key, value] of Object.entries(def.colors)) {
-      if (!SAFE_COLOR_KEY.test(key) || typeof value !== 'string' || UNSAFE_CSS.test(value)) continue
-      colors[key] = value
-    }
-    merged[id] = { dark: def.dark === true, colors }
-  }
-  return merged
 }
 
 export function createMainTs (defaultTheme = 'light', options?: MainOptions, vuetifyVersion = 'latest', vuetifyNightly = false, extraThemes?: Record<string, SandboxTheme>): string {
@@ -233,7 +261,7 @@ export function createMainTs (defaultTheme = 'light', options?: MainOptions, vue
   const setupBlock = extraSetup.length > 0 ? '\n' + extraSetup.join('\n') + '\n' : ''
   const pluginBlock = extraPlugins.length > 0 ? extraPlugins.join('\n') + '\n' : ''
   const mergedThemes = mergeSandboxThemes(extraThemes)
-  const safeDefault = SAFE_THEME_ID.test(defaultTheme) && defaultTheme in mergedThemes
+  const safeDefault = isSafeThemeId(defaultTheme) && Object.hasOwn(mergedThemes, defaultTheme)
     ? defaultTheme
     : 'light'
   const themesJson = JSON.stringify(mergedThemes, null, 2).split('\n').join('\n  ')

--- a/apps/playground/vitest.config.ts
+++ b/apps/playground/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('src', import.meta.url)),
+      '@vuetify/v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
+      '#v0': fileURLToPath(new URL('../../packages/0/src', import.meta.url)),
+    },
+  },
+  define: {
+    __DEV__: 'process.env.NODE_ENV !== \'production\'',
+    __VERSION__: '"0.0.1"',
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       'packages/paper',
       'packages/emerald',
       'apps/docs',
+      'apps/playground',
     ],
     globals: true,
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],


### PR DESCRIPTION
Docs Open in Playground now ships the example's current theme to v0play. The hash carries top-level `theme` + `themes` so the sandbox `createThemePlugin` registers those records and selects the same default the reader saw.

Any producer can send the same payload — docs palettes today, builder custom pairs later. Light/dark pair keys are `{name}-light` / `{name}-dark`.