### PR TITLE
docs: copyable CLI command on the release notes page

### DIFF
--- a/apps/docs/src/pages/releases.md
+++ b/apps/docs/src/pages/releases.md
@@ -20,7 +20,29 @@ related:
 
 Stay up to date with the latest releases and changes in Vuetify v0. Select a version below to view its release notes.
 
-> [!TIP]
-> Prefer the terminal? Read any release without leaving your shell with the Vuetify CLI: `npx @vuetify/cli release-notes v0`. Add `-v <version>` for a specific release (defaults to the latest).
-
 <DocsReleases />
+
+## From the terminal
+
+> [!TIP]
+> Prefer the terminal? Read the notes for any release without leaving your shell with the Vuetify CLI. Add `-v <version>` for a specific release (defaults to the latest).
+>
+> ::: code-group no-filename
+>
+> ```bash pnpm
+> pnpm dlx @vuetify/cli release-notes v0
+> ```
+>
+> ```bash npm
+> npx @vuetify/cli release-notes v0
+> ```
+>
+> ```bash yarn
+> yarn dlx @vuetify/cli release-notes v0
+> ```
+>
+> ```bash bun
+> bunx @vuetify/cli release-notes v0
+> ```
+>
+> :::


### PR DESCRIPTION
The release notes tip used an inline command that you had to drag-select. It is now a package-manager code group (pnpm / npm / yarn / bun) under a **From the terminal** heading, so the notes stay at the top of the page and the command is copyable from the TOC.