### PR TITLE
docs(DocsExampleThemeMenu): drop top-right radius on the activator

### DIFF
--- a/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
+++ b/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
@@ -24,7 +24,7 @@
     >
       <Popover.Activator
         aria-label="Example theme"
-        class="bg-surface-tint text-on-surface-tint hover:bg-surface-tint data-[state=open]:bg-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] cursor-pointer"
+        class="bg-surface-tint text-on-surface-tint hover:bg-surface-tint data-[state=open]:bg-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] cursor-pointer"
         :data-state="open ? 'open' : undefined"
       >
         <AppIcon :icon="toggle.icon.value" />


### PR DESCRIPTION
Square the example-preview theme toggle's top-right corner. It already sits in the card's 8px radius with a rounded bottom-left, so the extra `rounded-tr` read as a double-round against the chrome.