### PR TITLE
chore(bench): regenerate metrics

### DIFF
--- a/apps/docs/src/data/metrics/1.0.5.json
+++ b/apps/docs/src/data/metrics/1.0.5.json
@@ -1,0 +1,9987 @@
+{
+  "version": "1.0.5",
+  "generatedAt": "2026-08-21T00:53:54.313Z",
+  "env": {
+    "cpu": "Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz",
+    "cores": 36,
+    "arch": "x64",
+    "platform": "linux",
+    "node": "v26.0.0",
+    "pnpm": null,
+    "imageOs": null,
+    "imageVersion": null,
+    "ci": false,
+    "busy": 0.000832870627429206,
+    "peak": 0.01,
+    "governor": "performance"
+  },
+  "items": {
+    "helpers": {
+      "benchmarks": {
+        "_groups": {
+          "mergeDeep benchmarks": {
+            "shallow merge (2 objects, 5 keys each)": {
+              "name": "shallow merge (2 objects, 5 keys each)",
+              "hz": 667621,
+              "hzLabel": "667.6k ops/s",
+              "mean": 0.0014978560413124724,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "deep nested merge (3 levels)": {
+              "name": "deep nested merge (3 levels)",
+              "hz": 340941,
+              "hzLabel": "340.9k ops/s",
+              "mean": 0.002933060303520706,
+              "meanLabel": "2.9μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "many sources (5 objects)": {
+              "name": "many sources (5 objects)",
+              "hz": 804932,
+              "hzLabel": "804.9k ops/s",
+              "mean": 0.0012423402192108372,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "realistic theme merge": {
+              "name": "realistic theme merge",
+              "hz": 366404,
+              "hzLabel": "366.4k ops/s",
+              "mean": 0.0027292305870279558,
+              "meanLabel": "2.7μs",
+              "rme": 44.9,
+              "tier": "blazing"
+            },
+            "large flat object (50 keys)": {
+              "name": "large flat object (50 keys)",
+              "hz": 59259,
+              "hzLabel": "59.3k ops/s",
+              "mean": 0.016875170030454478,
+              "meanLabel": "16.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "many sources (5 objects)",
+              "hz": 804932,
+              "hzLabel": "804.9k ops/s",
+              "mean": 0.0012423402192108372,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "large flat object (50 keys)",
+              "hz": 59259,
+              "hzLabel": "59.3k ops/s",
+              "mean": 0.016875170030454478,
+              "meanLabel": "16.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "shallow merge (2 objects, 5 keys each)": {
+          "name": "shallow merge (2 objects, 5 keys each)",
+          "hz": 667621,
+          "hzLabel": "667.6k ops/s",
+          "mean": 0.0014978560413124724,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "deep nested merge (3 levels)": {
+          "name": "deep nested merge (3 levels)",
+          "hz": 340941,
+          "hzLabel": "340.9k ops/s",
+          "mean": 0.002933060303520706,
+          "meanLabel": "2.9μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "many sources (5 objects)": {
+          "name": "many sources (5 objects)",
+          "hz": 804932,
+          "hzLabel": "804.9k ops/s",
+          "mean": 0.0012423402192108372,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "realistic theme merge": {
+          "name": "realistic theme merge",
+          "hz": 366404,
+          "hzLabel": "366.4k ops/s",
+          "mean": 0.0027292305870279558,
+          "meanLabel": "2.7μs",
+          "rme": 44.9,
+          "tier": "blazing"
+        },
+        "large flat object (50 keys)": {
+          "name": "large flat object (50 keys)",
+          "hz": 59259,
+          "hzLabel": "59.3k ops/s",
+          "mean": 0.016875170030454478,
+          "meanLabel": "16.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "many sources (5 objects)",
+          "hz": 804932,
+          "hzLabel": "804.9k ops/s",
+          "mean": 0.0012423402192108372,
+          "meanLabel": "1.2μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "large flat object (50 keys)",
+          "hz": 59259,
+          "hzLabel": "59.3k ops/s",
+          "mean": 0.016875170030454478,
+          "meanLabel": "16.9μs",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createDataTable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create table (1,000 items)": {
+              "name": "Create table (1,000 items)",
+              "hz": 1160,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8617826883566447,
+              "meanLabel": "861.8μs",
+              "rme": 9.3,
+              "tier": "blazing"
+            },
+            "Create table (10,000 items)": {
+              "name": "Create table (10,000 items)",
+              "hz": 98,
+              "hzLabel": "98 ops/s",
+              "mean": 10.200775780001422,
+              "meanLabel": "10.20ms",
+              "rme": 25.2,
+              "tier": "fast"
+            },
+            "Create table with groupBy (1,000 items)": {
+              "name": "Create table with groupBy (1,000 items)",
+              "hz": 994,
+              "hzLabel": "994 ops/s",
+              "mean": 1.0061568289740053,
+              "meanLabel": "1.01ms",
+              "rme": 15,
+              "tier": "fast"
+            },
+            "Create table with all options (1,000 items)": {
+              "name": "Create table with all options (1,000 items)",
+              "hz": 687,
+              "hzLabel": "687 ops/s",
+              "mean": 1.4549777441861806,
+              "meanLabel": "1.45ms",
+              "rme": 6.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create table (1,000 items)",
+              "hz": 1160,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8617826883566447,
+              "meanLabel": "861.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create table (10,000 items)",
+              "hz": 98,
+              "hzLabel": "98 ops/s",
+              "mean": 10.200775780001422,
+              "meanLabel": "10.20ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1556,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6424738549421619,
+              "meanLabel": "642.5μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 155,
+              "hzLabel": "155 ops/s",
+              "mean": 6.451071064103953,
+              "meanLabel": "6.45ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (1,000 items)": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1650,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.6059650060532835,
+              "meanLabel": "606.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (10,000 items)": {
+              "name": "Search with custom column filter (10,000 items)",
+              "hz": 164,
+              "hzLabel": "164 ops/s",
+              "mean": 6.089549710843832,
+              "meanLabel": "6.09ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Update search 10 times (1,000 items)": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 157,
+              "hzLabel": "157 ops/s",
+              "mean": 6.376135506328082,
+              "meanLabel": "6.38ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1650,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.6059650060532835,
+              "meanLabel": "606.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 155,
+              "hzLabel": "155 ops/s",
+              "mean": 6.451071064103953,
+              "meanLabel": "6.45ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3098,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3228119238221289,
+              "meanLabel": "322.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 377,
+              "hzLabel": "377 ops/s",
+              "mean": 2.650950883597563,
+              "meanLabel": "2.65ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3050,
+              "hzLabel": "3.0k ops/s",
+              "mean": 0.32788723081989657,
+              "meanLabel": "327.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 102,
+              "hzLabel": "102 ops/s",
+              "mean": 9.782894653846597,
+              "meanLabel": "9.78ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Multi-sort two columns (1,000 items)": {
+              "name": "Multi-sort two columns (1,000 items)",
+              "hz": 954,
+              "hzLabel": "954 ops/s",
+              "mean": 1.0477381087867612,
+              "meanLabel": "1.05ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Multi-sort two columns (10,000 items)": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.05803149999923,
+              "meanLabel": "11.06ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Toggle sort cycle 3 times (1,000 items)": {
+              "name": "Toggle sort cycle 3 times (1,000 items)",
+              "hz": 1266,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7899548846760788,
+              "meanLabel": "790.0μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3098,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3228119238221289,
+              "meanLabel": "322.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.05803149999923,
+              "meanLabel": "11.06ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 842698,
+              "hzLabel": "842.7k ops/s",
+              "mean": 0.0011866643859216473,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select all items (1,000 items)": {
+              "name": "Select all items (1,000 items)",
+              "hz": 1754,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5702682805017196,
+              "meanLabel": "570.3μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Select all items (10,000 items)": {
+              "name": "Select all items (10,000 items)",
+              "hz": 172,
+              "hzLabel": "172 ops/s",
+              "mean": 5.817123976743714,
+              "meanLabel": "5.82ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Select all with itemSelectable (1,000 items)": {
+              "name": "Select all with itemSelectable (1,000 items)",
+              "hz": 2251,
+              "hzLabel": "2.3k ops/s",
+              "mean": 0.4443148605683135,
+              "meanLabel": "444.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle all then check isAllSelected (1,000 items)": {
+              "name": "Toggle all then check isAllSelected (1,000 items)",
+              "hz": 865,
+              "hzLabel": "865 ops/s",
+              "mean": 1.1555684226326854,
+              "meanLabel": "1.16ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle 100 individual rows (1,000 items)": {
+              "name": "Toggle 100 individual rows (1,000 items)",
+              "hz": 8260,
+              "hzLabel": "8.3k ops/s",
+              "mean": 0.1210595076250559,
+              "meanLabel": "121.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 842698,
+              "hzLabel": "842.7k ops/s",
+              "mean": 0.0011866643859216473,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all items (10,000 items)",
+              "hz": 172,
+              "hzLabel": "172 ops/s",
+              "mean": 5.817123976743714,
+              "meanLabel": "5.82ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "grouping": {
+            "Compute groups (1,000 items, 8 groups)": {
+              "name": "Compute groups (1,000 items, 8 groups)",
+              "hz": 974,
+              "hzLabel": "974 ops/s",
+              "mean": 1.0268805316975946,
+              "meanLabel": "1.03ms",
+              "rme": 11.1,
+              "tier": "fast"
+            },
+            "Compute groups (10,000 items, 8 groups)": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 95,
+              "hzLabel": "95 ops/s",
+              "mean": 10.550375229167003,
+              "meanLabel": "10.55ms",
+              "rme": 11.3,
+              "tier": "fast"
+            },
+            "Open all then close all groups (1,000 items)": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 195064,
+              "hzLabel": "195.1k ops/s",
+              "mean": 0.0051265313742990684,
+              "meanLabel": "5.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Create with openAll (1,000 items)": {
+              "name": "Create with openAll (1,000 items)",
+              "hz": 695,
+              "hzLabel": "695 ops/s",
+              "mean": 1.438845603448227,
+              "meanLabel": "1.44ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 195064,
+              "hzLabel": "195.1k ops/s",
+              "mean": 0.0051265313742990684,
+              "meanLabel": "5.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 95,
+              "hzLabel": "95 ops/s",
+              "mean": 10.550375229167003,
+              "meanLabel": "10.55ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 731250,
+              "hzLabel": "731.2k ops/s",
+              "mean": 0.001367522133325354,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 675419,
+              "hzLabel": "675.4k ops/s",
+              "mean": 0.0014805620058632488,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 808737,
+              "hzLabel": "808.7k ops/s",
+              "mean": 0.0012364959752055571,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access total 100 times (1,000 items, cached)": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 556855,
+              "hzLabel": "556.9k ops/s",
+              "mean": 0.0017957986445291164,
+              "meanLabel": "1.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 808737,
+              "hzLabel": "808.7k ops/s",
+              "mean": 0.0012364959752055571,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 556855,
+              "hzLabel": "556.9k ops/s",
+              "mean": 0.0017957986445291164,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1318,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7588638786038772,
+              "meanLabel": "758.9μs",
+              "rme": 9.8,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 150,
+              "hzLabel": "150 ops/s",
+              "mean": 6.6701530266669575,
+              "meanLabel": "6.67ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Search + multi-sort + paginate (1,000 items)": {
+              "name": "Search + multi-sort + paginate (1,000 items)",
+              "hz": 569,
+              "hzLabel": "569 ops/s",
+              "mean": 1.7560429263159965,
+              "meanLabel": "1.76ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1318,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7588638786038772,
+              "meanLabel": "758.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 150,
+              "hzLabel": "150 ops/s",
+              "mean": 6.6701530266669575,
+              "meanLabel": "6.67ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "adapter comparison": {
+            "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 378,
+              "hzLabel": "378 ops/s",
+              "mean": 2.6450711315797983,
+              "meanLabel": "2.65ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 379,
+              "hzLabel": "379 ops/s",
+              "mean": 2.6390809473681176,
+              "meanLabel": "2.64ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "ClientDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 150,
+              "hzLabel": "150 ops/s",
+              "mean": 6.653651407894933,
+              "meanLabel": "6.65ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 150,
+              "hzLabel": "150 ops/s",
+              "mean": 6.684391266666741,
+              "meanLabel": "6.68ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 379,
+              "hzLabel": "379 ops/s",
+              "mean": 2.6390809473681176,
+              "meanLabel": "2.64ms",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 150,
+              "hzLabel": "150 ops/s",
+              "mean": 6.684391266666741,
+              "meanLabel": "6.68ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create table (1,000 items)": {
+          "name": "Create table (1,000 items)",
+          "hz": 1160,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8617826883566447,
+          "meanLabel": "861.8μs",
+          "rme": 9.3,
+          "tier": "blazing"
+        },
+        "Create table (10,000 items)": {
+          "name": "Create table (10,000 items)",
+          "hz": 98,
+          "hzLabel": "98 ops/s",
+          "mean": 10.200775780001422,
+          "meanLabel": "10.20ms",
+          "rme": 25.2,
+          "tier": "fast"
+        },
+        "Create table with groupBy (1,000 items)": {
+          "name": "Create table with groupBy (1,000 items)",
+          "hz": 994,
+          "hzLabel": "994 ops/s",
+          "mean": 1.0061568289740053,
+          "meanLabel": "1.01ms",
+          "rme": 15,
+          "tier": "fast"
+        },
+        "Create table with all options (1,000 items)": {
+          "name": "Create table with all options (1,000 items)",
+          "hz": 687,
+          "hzLabel": "687 ops/s",
+          "mean": 1.4549777441861806,
+          "meanLabel": "1.45ms",
+          "rme": 6.4,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1556,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6424738549421619,
+          "meanLabel": "642.5μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 155,
+          "hzLabel": "155 ops/s",
+          "mean": 6.451071064103953,
+          "meanLabel": "6.45ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (1,000 items)": {
+          "name": "Search with custom column filter (1,000 items)",
+          "hz": 1650,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.6059650060532835,
+          "meanLabel": "606.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (10,000 items)": {
+          "name": "Search with custom column filter (10,000 items)",
+          "hz": 164,
+          "hzLabel": "164 ops/s",
+          "mean": 6.089549710843832,
+          "meanLabel": "6.09ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Update search 10 times (1,000 items)": {
+          "name": "Update search 10 times (1,000 items)",
+          "hz": 157,
+          "hzLabel": "157 ops/s",
+          "mean": 6.376135506328082,
+          "meanLabel": "6.38ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3098,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.3228119238221289,
+          "meanLabel": "322.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 377,
+          "hzLabel": "377 ops/s",
+          "mean": 2.650950883597563,
+          "meanLabel": "2.65ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 3050,
+          "hzLabel": "3.0k ops/s",
+          "mean": 0.32788723081989657,
+          "meanLabel": "327.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 102,
+          "hzLabel": "102 ops/s",
+          "mean": 9.782894653846597,
+          "meanLabel": "9.78ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Multi-sort two columns (1,000 items)": {
+          "name": "Multi-sort two columns (1,000 items)",
+          "hz": 954,
+          "hzLabel": "954 ops/s",
+          "mean": 1.0477381087867612,
+          "meanLabel": "1.05ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Multi-sort two columns (10,000 items)": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 90,
+          "hzLabel": "90 ops/s",
+          "mean": 11.05803149999923,
+          "meanLabel": "11.06ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Toggle sort cycle 3 times (1,000 items)": {
+          "name": "Toggle sort cycle 3 times (1,000 items)",
+          "hz": 1266,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7899548846760788,
+          "meanLabel": "790.0μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 842698,
+          "hzLabel": "842.7k ops/s",
+          "mean": 0.0011866643859216473,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all items (1,000 items)": {
+          "name": "Select all items (1,000 items)",
+          "hz": 1754,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5702682805017196,
+          "meanLabel": "570.3μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Select all items (10,000 items)": {
+          "name": "Select all items (10,000 items)",
+          "hz": 172,
+          "hzLabel": "172 ops/s",
+          "mean": 5.817123976743714,
+          "meanLabel": "5.82ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Select all with itemSelectable (1,000 items)": {
+          "name": "Select all with itemSelectable (1,000 items)",
+          "hz": 2251,
+          "hzLabel": "2.3k ops/s",
+          "mean": 0.4443148605683135,
+          "meanLabel": "444.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle all then check isAllSelected (1,000 items)": {
+          "name": "Toggle all then check isAllSelected (1,000 items)",
+          "hz": 865,
+          "hzLabel": "865 ops/s",
+          "mean": 1.1555684226326854,
+          "meanLabel": "1.16ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle 100 individual rows (1,000 items)": {
+          "name": "Toggle 100 individual rows (1,000 items)",
+          "hz": 8260,
+          "hzLabel": "8.3k ops/s",
+          "mean": 0.1210595076250559,
+          "meanLabel": "121.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Compute groups (1,000 items, 8 groups)": {
+          "name": "Compute groups (1,000 items, 8 groups)",
+          "hz": 974,
+          "hzLabel": "974 ops/s",
+          "mean": 1.0268805316975946,
+          "meanLabel": "1.03ms",
+          "rme": 11.1,
+          "tier": "fast"
+        },
+        "Compute groups (10,000 items, 8 groups)": {
+          "name": "Compute groups (10,000 items, 8 groups)",
+          "hz": 95,
+          "hzLabel": "95 ops/s",
+          "mean": 10.550375229167003,
+          "meanLabel": "10.55ms",
+          "rme": 11.3,
+          "tier": "fast"
+        },
+        "Open all then close all groups (1,000 items)": {
+          "name": "Open all then close all groups (1,000 items)",
+          "hz": 195064,
+          "hzLabel": "195.1k ops/s",
+          "mean": 0.0051265313742990684,
+          "meanLabel": "5.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Create with openAll (1,000 items)": {
+          "name": "Create with openAll (1,000 items)",
+          "hz": 695,
+          "hzLabel": "695 ops/s",
+          "mean": 1.438845603448227,
+          "meanLabel": "1.44ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 731250,
+          "hzLabel": "731.2k ops/s",
+          "mean": 0.001367522133325354,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 675419,
+          "hzLabel": "675.4k ops/s",
+          "mean": 0.0014805620058632488,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 808737,
+          "hzLabel": "808.7k ops/s",
+          "mean": 0.0012364959752055571,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access total 100 times (1,000 items, cached)": {
+          "name": "Access total 100 times (1,000 items, cached)",
+          "hz": 556855,
+          "hzLabel": "556.9k ops/s",
+          "mean": 0.0017957986445291164,
+          "meanLabel": "1.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1318,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7588638786038772,
+          "meanLabel": "758.9μs",
+          "rme": 9.8,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 150,
+          "hzLabel": "150 ops/s",
+          "mean": 6.6701530266669575,
+          "meanLabel": "6.67ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Search + multi-sort + paginate (1,000 items)": {
+          "name": "Search + multi-sort + paginate (1,000 items)",
+          "hz": 569,
+          "hzLabel": "569 ops/s",
+          "mean": 1.7560429263159965,
+          "meanLabel": "1.76ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+          "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+          "hz": 378,
+          "hzLabel": "378 ops/s",
+          "mean": 2.6450711315797983,
+          "meanLabel": "2.65ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+          "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+          "hz": 379,
+          "hzLabel": "379 ops/s",
+          "mean": 2.6390809473681176,
+          "meanLabel": "2.64ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "ClientDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 150,
+          "hzLabel": "150 ops/s",
+          "mean": 6.653651407894933,
+          "meanLabel": "6.65ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 150,
+          "hzLabel": "150 ops/s",
+          "mean": 6.684391266666741,
+          "meanLabel": "6.68ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Select single item (1,000 items)",
+          "hz": 842698,
+          "hzLabel": "842.7k ops/s",
+          "mean": 0.0011866643859216473,
+          "meanLabel": "1.2μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 90,
+          "hzLabel": "90 ops/s",
+          "mean": 11.05803149999923,
+          "meanLabel": "11.06ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createDataGrid": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create grid (1,000 items)": {
+              "name": "Create grid (1,000 items)",
+              "hz": 284,
+              "hzLabel": "284 ops/s",
+              "mean": 3.526405957746474,
+              "meanLabel": "3.53ms",
+              "rme": 5.9,
+              "tier": "fast"
+            },
+            "Create grid (10,000 items)": {
+              "name": "Create grid (10,000 items)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.190238666666694,
+              "meanLabel": "35.19ms",
+              "rme": 12.9,
+              "tier": "good"
+            },
+            "Create grid with pinned columns (1,000 items)": {
+              "name": "Create grid with pinned columns (1,000 items)",
+              "hz": 306,
+              "hzLabel": "306 ops/s",
+              "mean": 3.27028592156862,
+              "meanLabel": "3.27ms",
+              "rme": 5.2,
+              "tier": "fast"
+            },
+            "Create grid with editable columns (1,000 items)": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 238,
+              "hzLabel": "238 ops/s",
+              "mean": 4.207721974789916,
+              "meanLabel": "4.21ms",
+              "rme": 8.9,
+              "tier": "fast"
+            },
+            "Create grid with all options (1,000 items)": {
+              "name": "Create grid with all options (1,000 items)",
+              "hz": 288,
+              "hzLabel": "288 ops/s",
+              "mean": 3.4780733263888552,
+              "meanLabel": "3.48ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create grid with pinned columns (1,000 items)",
+              "hz": 306,
+              "hzLabel": "306 ops/s",
+              "mean": 3.27028592156862,
+              "meanLabel": "3.27ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create grid (10,000 items)",
+              "hz": 28,
+              "hzLabel": "28 ops/s",
+              "mean": 35.190238666666694,
+              "meanLabel": "35.19ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1610,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6211880310559078,
+              "meanLabel": "621.2μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.405345075949345,
+              "meanLabel": "6.41ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1610,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6211880310559078,
+              "meanLabel": "621.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.405345075949345,
+              "meanLabel": "6.41ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3526,
+              "hzLabel": "3.5k ops/s",
+              "mean": 0.2836230805445299,
+              "meanLabel": "283.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 448,
+              "hzLabel": "448 ops/s",
+              "mean": 2.2344938660714724,
+              "meanLabel": "2.23ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3077,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3249494437946618,
+              "meanLabel": "324.9μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 105,
+              "hzLabel": "105 ops/s",
+              "mean": 9.479860339622595,
+              "meanLabel": "9.48ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3526,
+              "hzLabel": "3.5k ops/s",
+              "mean": 0.2836230805445299,
+              "meanLabel": "283.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 105,
+              "hzLabel": "105 ops/s",
+              "mean": 9.479860339622595,
+              "meanLabel": "9.48ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "column layout": {
+            "Pin column (1,000 items)": {
+              "name": "Pin column (1,000 items)",
+              "hz": 15817,
+              "hzLabel": "15.8k ops/s",
+              "mean": 0.06322303123024056,
+              "meanLabel": "63.2μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Resize column (1,000 items)": {
+              "name": "Resize column (1,000 items)",
+              "hz": 13400,
+              "hzLabel": "13.4k ops/s",
+              "mean": 0.07462483599462649,
+              "meanLabel": "74.6μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Resize column 10 times (1,000 items)": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5240,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.19085510916029239,
+              "meanLabel": "190.9μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Reorder column (1,000 items)": {
+              "name": "Reorder column (1,000 items)",
+              "hz": 11614,
+              "hzLabel": "11.6k ops/s",
+              "mean": 0.08610596986395172,
+              "meanLabel": "86.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Reset layout (1,000 items)": {
+              "name": "Reset layout (1,000 items)",
+              "hz": 13270,
+              "hzLabel": "13.3k ops/s",
+              "mean": 0.07535859306707536,
+              "meanLabel": "75.4μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Pin column (1,000 items)",
+              "hz": 15817,
+              "hzLabel": "15.8k ops/s",
+              "mean": 0.06322303123024056,
+              "meanLabel": "63.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5240,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.19085510916029239,
+              "meanLabel": "190.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "cell editing": {
+            "Edit cell (1,000 items)": {
+              "name": "Edit cell (1,000 items)",
+              "hz": 252321,
+              "hzLabel": "252.3k ops/s",
+              "mean": 0.003963208083320477,
+              "meanLabel": "4.0μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Edit then commit (1,000 items)": {
+              "name": "Edit then commit (1,000 items)",
+              "hz": 143003,
+              "hzLabel": "143.0k ops/s",
+              "mean": 0.006992872660906761,
+              "meanLabel": "7.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit then cancel (1,000 items)": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 255831,
+              "hzLabel": "255.8k ops/s",
+              "mean": 0.0039088347978372675,
+              "meanLabel": "3.9μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Edit with validation failure (1,000 items)": {
+              "name": "Edit with validation failure (1,000 items)",
+              "hz": 141311,
+              "hzLabel": "141.3k ops/s",
+              "mean": 0.007076566519472698,
+              "meanLabel": "7.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit 10 cells sequentially (1,000 items)": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14406,
+              "hzLabel": "14.4k ops/s",
+              "mean": 0.06941458634093522,
+              "meanLabel": "69.4μs",
+              "rme": 0.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 255831,
+              "hzLabel": "255.8k ops/s",
+              "mean": 0.0039088347978372675,
+              "meanLabel": "3.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 14406,
+              "hzLabel": "14.4k ops/s",
+              "mean": 0.06941458634093522,
+              "meanLabel": "69.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row ordering": {
+            "Move row (1,000 items)": {
+              "name": "Move row (1,000 items)",
+              "hz": 1079,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.926852009259225,
+              "meanLabel": "926.9μs",
+              "rme": 1.4,
+              "tier": "blazing"
+            },
+            "Move 10 rows (1,000 items)": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1087,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9195689227941356,
+              "meanLabel": "919.6μs",
+              "rme": 1.4,
+              "tier": "blazing"
+            },
+            "Reset row order (1,000 items)": {
+              "name": "Reset row order (1,000 items)",
+              "hz": 1080,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.926105040740721,
+              "meanLabel": "926.1μs",
+              "rme": 1.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1087,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9195689227941356,
+              "meanLabel": "919.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move row (1,000 items)",
+              "hz": 1079,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.926852009259225,
+              "meanLabel": "926.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row spanning": {
+            "Compute spans (1,000 items, 1 column)": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 264,
+              "hzLabel": "264 ops/s",
+              "mean": 3.794439969697068,
+              "meanLabel": "3.79ms",
+              "rme": 6.6,
+              "tier": "fast"
+            },
+            "Compute spans (10,000 items, 1 column)": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 27,
+              "hzLabel": "27 ops/s",
+              "mean": 36.789091142857224,
+              "meanLabel": "36.79ms",
+              "rme": 4,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 264,
+              "hzLabel": "264 ops/s",
+              "mean": 3.794439969697068,
+              "meanLabel": "3.79ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 27,
+              "hzLabel": "27 ops/s",
+              "mean": 36.789091142857224,
+              "meanLabel": "36.79ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 487233,
+              "hzLabel": "487.2k ops/s",
+              "mean": 0.002052405016890194,
+              "meanLabel": "2.1μs",
+              "rme": 16.8,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 476871,
+              "hzLabel": "476.9k ops/s",
+              "mean": 0.002097002189266641,
+              "meanLabel": "2.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 792940,
+              "hzLabel": "792.9k ops/s",
+              "mean": 0.0012611287408172843,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access layout.columns 100 times (1,000 items, cached)": {
+              "name": "Access layout.columns 100 times (1,000 items, cached)",
+              "hz": 768813,
+              "hzLabel": "768.8k ops/s",
+              "mean": 0.0013007064517493612,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access layout.pinned 100 times (1,000 items, cached)": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 795612,
+              "hzLabel": "795.6k ops/s",
+              "mean": 0.0012568938153446256,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 795612,
+              "hzLabel": "795.6k ops/s",
+              "mean": 0.0012568938153446256,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 476871,
+              "hzLabel": "476.9k ops/s",
+              "mean": 0.002097002189266641,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1338,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.747656720478377,
+              "meanLabel": "747.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 142,
+              "hzLabel": "142 ops/s",
+              "mean": 7.063401704225277,
+              "meanLabel": "7.06ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (1,000 items)": {
+              "name": "Search + sort + paginate + layout (1,000 items)",
+              "hz": 1161,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8615865903613757,
+              "meanLabel": "861.6μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (10,000 items)": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 137,
+              "hzLabel": "137 ops/s",
+              "mean": 7.308754231884107,
+              "meanLabel": "7.31ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1338,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.747656720478377,
+              "meanLabel": "747.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 137,
+              "hzLabel": "137 ops/s",
+              "mean": 7.308754231884107,
+              "meanLabel": "7.31ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create grid (1,000 items)": {
+          "name": "Create grid (1,000 items)",
+          "hz": 284,
+          "hzLabel": "284 ops/s",
+          "mean": 3.526405957746474,
+          "meanLabel": "3.53ms",
+          "rme": 5.9,
+          "tier": "fast"
+        },
+        "Create grid (10,000 items)": {
+          "name": "Create grid (10,000 items)",
+          "hz": 28,
+          "hzLabel": "28 ops/s",
+          "mean": 35.190238666666694,
+          "meanLabel": "35.19ms",
+          "rme": 12.9,
+          "tier": "good"
+        },
+        "Create grid with pinned columns (1,000 items)": {
+          "name": "Create grid with pinned columns (1,000 items)",
+          "hz": 306,
+          "hzLabel": "306 ops/s",
+          "mean": 3.27028592156862,
+          "meanLabel": "3.27ms",
+          "rme": 5.2,
+          "tier": "fast"
+        },
+        "Create grid with editable columns (1,000 items)": {
+          "name": "Create grid with editable columns (1,000 items)",
+          "hz": 238,
+          "hzLabel": "238 ops/s",
+          "mean": 4.207721974789916,
+          "meanLabel": "4.21ms",
+          "rme": 8.9,
+          "tier": "fast"
+        },
+        "Create grid with all options (1,000 items)": {
+          "name": "Create grid with all options (1,000 items)",
+          "hz": 288,
+          "hzLabel": "288 ops/s",
+          "mean": 3.4780733263888552,
+          "meanLabel": "3.48ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1610,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6211880310559078,
+          "meanLabel": "621.2μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.405345075949345,
+          "meanLabel": "6.41ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3526,
+          "hzLabel": "3.5k ops/s",
+          "mean": 0.2836230805445299,
+          "meanLabel": "283.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 448,
+          "hzLabel": "448 ops/s",
+          "mean": 2.2344938660714724,
+          "meanLabel": "2.23ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 3077,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.3249494437946618,
+          "meanLabel": "324.9μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 105,
+          "hzLabel": "105 ops/s",
+          "mean": 9.479860339622595,
+          "meanLabel": "9.48ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Pin column (1,000 items)": {
+          "name": "Pin column (1,000 items)",
+          "hz": 15817,
+          "hzLabel": "15.8k ops/s",
+          "mean": 0.06322303123024056,
+          "meanLabel": "63.2μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Resize column (1,000 items)": {
+          "name": "Resize column (1,000 items)",
+          "hz": 13400,
+          "hzLabel": "13.4k ops/s",
+          "mean": 0.07462483599462649,
+          "meanLabel": "74.6μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Resize column 10 times (1,000 items)": {
+          "name": "Resize column 10 times (1,000 items)",
+          "hz": 5240,
+          "hzLabel": "5.2k ops/s",
+          "mean": 0.19085510916029239,
+          "meanLabel": "190.9μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Reorder column (1,000 items)": {
+          "name": "Reorder column (1,000 items)",
+          "hz": 11614,
+          "hzLabel": "11.6k ops/s",
+          "mean": 0.08610596986395172,
+          "meanLabel": "86.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Reset layout (1,000 items)": {
+          "name": "Reset layout (1,000 items)",
+          "hz": 13270,
+          "hzLabel": "13.3k ops/s",
+          "mean": 0.07535859306707536,
+          "meanLabel": "75.4μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Edit cell (1,000 items)": {
+          "name": "Edit cell (1,000 items)",
+          "hz": 252321,
+          "hzLabel": "252.3k ops/s",
+          "mean": 0.003963208083320477,
+          "meanLabel": "4.0μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Edit then commit (1,000 items)": {
+          "name": "Edit then commit (1,000 items)",
+          "hz": 143003,
+          "hzLabel": "143.0k ops/s",
+          "mean": 0.006992872660906761,
+          "meanLabel": "7.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit then cancel (1,000 items)": {
+          "name": "Edit then cancel (1,000 items)",
+          "hz": 255831,
+          "hzLabel": "255.8k ops/s",
+          "mean": 0.0039088347978372675,
+          "meanLabel": "3.9μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Edit with validation failure (1,000 items)": {
+          "name": "Edit with validation failure (1,000 items)",
+          "hz": 141311,
+          "hzLabel": "141.3k ops/s",
+          "mean": 0.007076566519472698,
+          "meanLabel": "7.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit 10 cells sequentially (1,000 items)": {
+          "name": "Edit 10 cells sequentially (1,000 items)",
+          "hz": 14406,
+          "hzLabel": "14.4k ops/s",
+          "mean": 0.06941458634093522,
+          "meanLabel": "69.4μs",
+          "rme": 0.9,
+          "tier": "blazing"
+        },
+        "Move row (1,000 items)": {
+          "name": "Move row (1,000 items)",
+          "hz": 1079,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.926852009259225,
+          "meanLabel": "926.9μs",
+          "rme": 1.4,
+          "tier": "blazing"
+        },
+        "Move 10 rows (1,000 items)": {
+          "name": "Move 10 rows (1,000 items)",
+          "hz": 1087,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9195689227941356,
+          "meanLabel": "919.6μs",
+          "rme": 1.4,
+          "tier": "blazing"
+        },
+        "Reset row order (1,000 items)": {
+          "name": "Reset row order (1,000 items)",
+          "hz": 1080,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.926105040740721,
+          "meanLabel": "926.1μs",
+          "rme": 1.6,
+          "tier": "blazing"
+        },
+        "Compute spans (1,000 items, 1 column)": {
+          "name": "Compute spans (1,000 items, 1 column)",
+          "hz": 264,
+          "hzLabel": "264 ops/s",
+          "mean": 3.794439969697068,
+          "meanLabel": "3.79ms",
+          "rme": 6.6,
+          "tier": "fast"
+        },
+        "Compute spans (10,000 items, 1 column)": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 27,
+          "hzLabel": "27 ops/s",
+          "mean": 36.789091142857224,
+          "meanLabel": "36.79ms",
+          "rme": 4,
+          "tier": "good"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 487233,
+          "hzLabel": "487.2k ops/s",
+          "mean": 0.002052405016890194,
+          "meanLabel": "2.1μs",
+          "rme": 16.8,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 476871,
+          "hzLabel": "476.9k ops/s",
+          "mean": 0.002097002189266641,
+          "meanLabel": "2.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 792940,
+          "hzLabel": "792.9k ops/s",
+          "mean": 0.0012611287408172843,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access layout.columns 100 times (1,000 items, cached)": {
+          "name": "Access layout.columns 100 times (1,000 items, cached)",
+          "hz": 768813,
+          "hzLabel": "768.8k ops/s",
+          "mean": 0.0013007064517493612,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access layout.pinned 100 times (1,000 items, cached)": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 795612,
+          "hzLabel": "795.6k ops/s",
+          "mean": 0.0012568938153446256,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1338,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.747656720478377,
+          "meanLabel": "747.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 142,
+          "hzLabel": "142 ops/s",
+          "mean": 7.063401704225277,
+          "meanLabel": "7.06ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (1,000 items)": {
+          "name": "Search + sort + paginate + layout (1,000 items)",
+          "hz": 1161,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8615865903613757,
+          "meanLabel": "861.6μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (10,000 items)": {
+          "name": "Search + sort + paginate + layout (10,000 items)",
+          "hz": 137,
+          "hzLabel": "137 ops/s",
+          "mean": 7.308754231884107,
+          "meanLabel": "7.31ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 795612,
+          "hzLabel": "795.6k ops/s",
+          "mean": 0.0012568938153446256,
+          "meanLabel": "1.3μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 27,
+          "hzLabel": "27 ops/s",
+          "mean": 36.789091142857224,
+          "meanLabel": "36.79ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createFilter": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty filter": {
+              "name": "Create empty filter",
+              "hz": 7279003,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001373814519011799,
+              "meanLabel": "137ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Create filter with keys constraint": {
+              "name": "Create filter with keys constraint",
+              "hz": 7211736,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001386628731236546,
+              "meanLabel": "139ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Create filter with custom matcher": {
+              "name": "Create filter with custom matcher",
+              "hz": 6419546,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015577424360397804,
+              "meanLabel": "156ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty filter",
+              "hz": 7279003,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001373814519011799,
+              "meanLabel": "137ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create filter with custom matcher",
+              "hz": 6419546,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015577424360397804,
+              "meanLabel": "156ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "primitive filtering": {
+            "Filter 1,000 string primitives with single query": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 7020126,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.0001424475939565726,
+              "meanLabel": "142ns",
+              "rme": 4.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 string primitives with single query": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 7243027,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013806383269464675,
+              "meanLabel": "138ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 7243027,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013806383269464675,
+              "meanLabel": "138ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 7020126,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.0001424475939565726,
+              "meanLabel": "142ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "object filtering": {
+            "Filter 1,000 objects across all keys": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 7231965,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001382750131757258,
+              "meanLabel": "138ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with single key constraint": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 7211744,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013866272152793655,
+              "meanLabel": "139ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects across all keys": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 6963326,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014360954234683533,
+              "meanLabel": "144ns",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with single key constraint": {
+              "name": "Filter 10,000 objects with single key constraint",
+              "hz": 7202034,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013884966385972972,
+              "meanLabel": "139ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 7231965,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001382750131757258,
+              "meanLabel": "138ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 6963326,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014360954234683533,
+              "meanLabel": "144ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "filter modes": {
+            "Filter 1,000 objects with some mode": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 7168827,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013949283619995995,
+              "meanLabel": "139ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with every mode": {
+              "name": "Filter 1,000 objects with every mode",
+              "hz": 7029084,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014226605260323172,
+              "meanLabel": "142ns",
+              "rme": 4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with union mode (2 queries)": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 6456449,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.00015488390523273954,
+              "meanLabel": "155ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with intersection mode (2 queries)": {
+              "name": "Filter 1,000 objects with intersection mode (2 queries)",
+              "hz": 7084021,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014116277221625607,
+              "meanLabel": "141ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with some mode": {
+              "name": "Filter 10,000 objects with some mode",
+              "hz": 7018490,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.0001424807821996448,
+              "meanLabel": "142ns",
+              "rme": 4.2,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with every mode": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 7087843,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014108665174114874,
+              "meanLabel": "141ns",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 7168827,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013949283619995995,
+              "meanLabel": "139ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 6456449,
+              "hzLabel": "6.5M ops/s",
+              "mean": 0.00015488390523273954,
+              "meanLabel": "155ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Access filtered 100 times (1,000 items, cached)": {
+              "name": "Access filtered 100 times (1,000 items, cached)",
+              "hz": 1107077,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009032791601151661,
+              "meanLabel": "903ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Access filtered 100 times (10,000 items, cached)": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 1103600,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009061250480324502,
+              "meanLabel": "906ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Update query 10 times (1,000 items)": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 534890,
+              "hzLabel": "534.9k ops/s",
+              "mean": 0.0018695445717393316,
+              "meanLabel": "1.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Update query 10 times (10,000 items)": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 503605,
+              "hzLabel": "503.6k ops/s",
+              "mean": 0.0019856826011136817,
+              "meanLabel": "2.0μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access filtered 100 times (1,000 items, cached)",
+              "hz": 1107077,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009032791601151661,
+              "meanLabel": "903ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 503605,
+              "hzLabel": "503.6k ops/s",
+              "mean": 0.0019856826011136817,
+              "meanLabel": "2.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "native comparison": {
+            "Native Array.filter 1,000 objects": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1774,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5637325264932561,
+              "meanLabel": "563.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Native Array.filter 10,000 objects": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 177,
+              "hzLabel": "177 ops/s",
+              "mean": 5.636683786515502,
+              "meanLabel": "5.64ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1774,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5637325264932561,
+              "meanLabel": "563.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 177,
+              "hzLabel": "177 ops/s",
+              "mean": 5.636683786515502,
+              "meanLabel": "5.64ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty filter": {
+          "name": "Create empty filter",
+          "hz": 7279003,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001373814519011799,
+          "meanLabel": "137ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Create filter with keys constraint": {
+          "name": "Create filter with keys constraint",
+          "hz": 7211736,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.0001386628731236546,
+          "meanLabel": "139ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Create filter with custom matcher": {
+          "name": "Create filter with custom matcher",
+          "hz": 6419546,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.00015577424360397804,
+          "meanLabel": "156ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 1,000 string primitives with single query": {
+          "name": "Filter 1,000 string primitives with single query",
+          "hz": 7020126,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.0001424475939565726,
+          "meanLabel": "142ns",
+          "rme": 4.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 string primitives with single query": {
+          "name": "Filter 10,000 string primitives with single query",
+          "hz": 7243027,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013806383269464675,
+          "meanLabel": "138ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects across all keys": {
+          "name": "Filter 1,000 objects across all keys",
+          "hz": 7231965,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.0001382750131757258,
+          "meanLabel": "138ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with single key constraint": {
+          "name": "Filter 1,000 objects with single key constraint",
+          "hz": 7211744,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013866272152793655,
+          "meanLabel": "139ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects across all keys": {
+          "name": "Filter 10,000 objects across all keys",
+          "hz": 6963326,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014360954234683533,
+          "meanLabel": "144ns",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with single key constraint": {
+          "name": "Filter 10,000 objects with single key constraint",
+          "hz": 7202034,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013884966385972972,
+          "meanLabel": "139ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with some mode": {
+          "name": "Filter 1,000 objects with some mode",
+          "hz": 7168827,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013949283619995995,
+          "meanLabel": "139ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with every mode": {
+          "name": "Filter 1,000 objects with every mode",
+          "hz": 7029084,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014226605260323172,
+          "meanLabel": "142ns",
+          "rme": 4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with union mode (2 queries)": {
+          "name": "Filter 1,000 objects with union mode (2 queries)",
+          "hz": 6456449,
+          "hzLabel": "6.5M ops/s",
+          "mean": 0.00015488390523273954,
+          "meanLabel": "155ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with intersection mode (2 queries)": {
+          "name": "Filter 1,000 objects with intersection mode (2 queries)",
+          "hz": 7084021,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014116277221625607,
+          "meanLabel": "141ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with some mode": {
+          "name": "Filter 10,000 objects with some mode",
+          "hz": 7018490,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.0001424807821996448,
+          "meanLabel": "142ns",
+          "rme": 4.2,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with every mode": {
+          "name": "Filter 10,000 objects with every mode",
+          "hz": 7087843,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014108665174114874,
+          "meanLabel": "141ns",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (1,000 items, cached)": {
+          "name": "Access filtered 100 times (1,000 items, cached)",
+          "hz": 1107077,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009032791601151661,
+          "meanLabel": "903ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (10,000 items, cached)": {
+          "name": "Access filtered 100 times (10,000 items, cached)",
+          "hz": 1103600,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009061250480324502,
+          "meanLabel": "906ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Update query 10 times (1,000 items)": {
+          "name": "Update query 10 times (1,000 items)",
+          "hz": 534890,
+          "hzLabel": "534.9k ops/s",
+          "mean": 0.0018695445717393316,
+          "meanLabel": "1.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Update query 10 times (10,000 items)": {
+          "name": "Update query 10 times (10,000 items)",
+          "hz": 503605,
+          "hzLabel": "503.6k ops/s",
+          "mean": 0.0019856826011136817,
+          "meanLabel": "2.0μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Native Array.filter 1,000 objects": {
+          "name": "Native Array.filter 1,000 objects",
+          "hz": 1774,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5637325264932561,
+          "meanLabel": "563.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Native Array.filter 10,000 objects": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 177,
+          "hzLabel": "177 ops/s",
+          "mean": 5.636683786515502,
+          "meanLabel": "5.64ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Create empty filter",
+          "hz": 7279003,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001373814519011799,
+          "meanLabel": "137ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 177,
+          "hzLabel": "177 ops/s",
+          "mean": 5.636683786515502,
+          "meanLabel": "5.64ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createGroup": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty group": {
+              "name": "Create empty group",
+              "hz": 28201,
+              "hzLabel": "28.2k ops/s",
+              "mean": 0.035459278845468005,
+              "meanLabel": "35.5μs",
+              "rme": 10.6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 437,
+              "hzLabel": "437 ops/s",
+              "mean": 2.287312566213146,
+              "meanLabel": "2.29ms",
+              "rme": 12.1,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.10025577273601,
+              "meanLabel": "23.10ms",
+              "rme": 4.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 465,
+              "hzLabel": "465 ops/s",
+              "mean": 2.1513757381976437,
+              "meanLabel": "2.15ms",
+              "rme": 11.4,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 39,
+              "hzLabel": "39 ops/s",
+              "mean": 25.927794899998116,
+              "meanLabel": "25.93ms",
+              "rme": 10,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty group",
+              "hz": 28201,
+              "hzLabel": "28.2k ops/s",
+              "mean": 0.035459278845468005,
+              "meanLabel": "35.5μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 39,
+              "hzLabel": "39 ops/s",
+              "mean": 25.927794899998116,
+              "meanLabel": "25.93ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2293798,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043595810709184994,
+              "meanLabel": "436ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2302614,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004342891079624143,
+              "meanLabel": "434ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2302614,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004342891079624143,
+              "meanLabel": "434ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2293798,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043595810709184994,
+              "meanLabel": "436ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 965792,
+              "hzLabel": "965.8k ops/s",
+              "mean": 0.001035419474519129,
+              "meanLabel": "1.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 941091,
+              "hzLabel": "941.1k ops/s",
+              "mean": 0.0010625959629289973,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 528847,
+              "hzLabel": "528.8k ops/s",
+              "mean": 0.0018909075386233317,
+              "meanLabel": "1.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 522068,
+              "hzLabel": "522.1k ops/s",
+              "mean": 0.0019154594381861798,
+              "meanLabel": "1.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 678929,
+              "hzLabel": "678.9k ops/s",
+              "mean": 0.0014729086650716015,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 666695,
+              "hzLabel": "666.7k ops/s",
+              "mean": 0.0014999352538677853,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 965792,
+              "hzLabel": "965.8k ops/s",
+              "mean": 0.001035419474519129,
+              "meanLabel": "1.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 522068,
+              "hzLabel": "522.1k ops/s",
+              "mean": 0.0019154594381861798,
+              "meanLabel": "1.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mixed state": {
+            "Mix single item (1,000 items)": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 414794,
+              "hzLabel": "414.8k ops/s",
+              "mean": 0.0024108352868660123,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unmix single item (1,000 items)": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 574799,
+              "hzLabel": "574.8k ops/s",
+              "mean": 0.0017397396033992307,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 574799,
+              "hzLabel": "574.8k ops/s",
+              "mean": 0.0017397396033992307,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 414794,
+              "hzLabel": "414.8k ops/s",
+              "mean": 0.0024108352868660123,
+              "meanLabel": "2.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 975,
+              "hzLabel": "975 ops/s",
+              "mean": 1.025196014341925,
+              "meanLabel": "1.03ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.063204782615092,
+              "meanLabel": "11.06ms",
+              "rme": 0.6,
+              "tier": "fast"
+            },
+            "Unselect all 1,000 items (from full)": {
+              "name": "Unselect all 1,000 items (from full)",
+              "hz": 904,
+              "hzLabel": "904 ops/s",
+              "mean": 1.1055975761590937,
+              "meanLabel": "1.11ms",
+              "rme": 4.1,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (none→all)": {
+              "name": "Toggle all 1,000 items (none→all)",
+              "hz": 892,
+              "hzLabel": "892 ops/s",
+              "mean": 1.1215845156966597,
+              "meanLabel": "1.12ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (all→none)": {
+              "name": "Toggle all 1,000 items (all→none)",
+              "hz": 632,
+              "hzLabel": "632 ops/s",
+              "mean": 1.5813904952699296,
+              "meanLabel": "1.58ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 975,
+              "hzLabel": "975 ops/s",
+              "mean": 1.025196014341925,
+              "meanLabel": "1.03ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Select all 10,000 items",
+              "hz": 90,
+              "hzLabel": "90 ops/s",
+              "mean": 11.063204782615092,
+              "meanLabel": "11.06ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 831054,
+              "hzLabel": "831.1k ops/s",
+              "mean": 0.0012032905748812384,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 828515,
+              "hzLabel": "828.5k ops/s",
+              "mean": 0.001206978503623741,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isAllSelected 100 times (partial, cached)": {
+              "name": "Access isAllSelected 100 times (partial, cached)",
+              "hz": 757901,
+              "hzLabel": "757.9k ops/s",
+              "mean": 0.0013194340746447645,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isNoneSelected 100 times (partial, cached)": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 42334,
+              "hzLabel": "42.3k ops/s",
+              "mean": 0.023621779279080376,
+              "meanLabel": "23.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isMixed 100 times (partial, cached)": {
+              "name": "Access isMixed 100 times (partial, cached)",
+              "hz": 824515,
+              "hzLabel": "824.5k ops/s",
+              "mean": 0.001212834057752733,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 831054,
+              "hzLabel": "831.1k ops/s",
+              "mean": 0.0012032905748812384,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 42334,
+              "hzLabel": "42.3k ops/s",
+              "mean": 0.023621779279080376,
+              "meanLabel": "23.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty group": {
+          "name": "Create empty group",
+          "hz": 28201,
+          "hzLabel": "28.2k ops/s",
+          "mean": 0.035459278845468005,
+          "meanLabel": "35.5μs",
+          "rme": 10.6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 437,
+          "hzLabel": "437 ops/s",
+          "mean": 2.287312566213146,
+          "meanLabel": "2.29ms",
+          "rme": 12.1,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.10025577273601,
+          "meanLabel": "23.10ms",
+          "rme": 4.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 465,
+          "hzLabel": "465 ops/s",
+          "mean": 2.1513757381976437,
+          "meanLabel": "2.15ms",
+          "rme": 11.4,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 39,
+          "hzLabel": "39 ops/s",
+          "mean": 25.927794899998116,
+          "meanLabel": "25.93ms",
+          "rme": 10,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2293798,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00043595810709184994,
+          "meanLabel": "436ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2302614,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.0004342891079624143,
+          "meanLabel": "434ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 965792,
+          "hzLabel": "965.8k ops/s",
+          "mean": 0.001035419474519129,
+          "meanLabel": "1.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 941091,
+          "hzLabel": "941.1k ops/s",
+          "mean": 0.0010625959629289973,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 528847,
+          "hzLabel": "528.8k ops/s",
+          "mean": 0.0018909075386233317,
+          "meanLabel": "1.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 522068,
+          "hzLabel": "522.1k ops/s",
+          "mean": 0.0019154594381861798,
+          "meanLabel": "1.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 678929,
+          "hzLabel": "678.9k ops/s",
+          "mean": 0.0014729086650716015,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 666695,
+          "hzLabel": "666.7k ops/s",
+          "mean": 0.0014999352538677853,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Mix single item (1,000 items)": {
+          "name": "Mix single item (1,000 items)",
+          "hz": 414794,
+          "hzLabel": "414.8k ops/s",
+          "mean": 0.0024108352868660123,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unmix single item (1,000 items)": {
+          "name": "Unmix single item (1,000 items)",
+          "hz": 574799,
+          "hzLabel": "574.8k ops/s",
+          "mean": 0.0017397396033992307,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 975,
+          "hzLabel": "975 ops/s",
+          "mean": 1.025196014341925,
+          "meanLabel": "1.03ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 90,
+          "hzLabel": "90 ops/s",
+          "mean": 11.063204782615092,
+          "meanLabel": "11.06ms",
+          "rme": 0.6,
+          "tier": "fast"
+        },
+        "Unselect all 1,000 items (from full)": {
+          "name": "Unselect all 1,000 items (from full)",
+          "hz": 904,
+          "hzLabel": "904 ops/s",
+          "mean": 1.1055975761590937,
+          "meanLabel": "1.11ms",
+          "rme": 4.1,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (none→all)": {
+          "name": "Toggle all 1,000 items (none→all)",
+          "hz": 892,
+          "hzLabel": "892 ops/s",
+          "mean": 1.1215845156966597,
+          "meanLabel": "1.12ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (all→none)": {
+          "name": "Toggle all 1,000 items (all→none)",
+          "hz": 632,
+          "hzLabel": "632 ops/s",
+          "mean": 1.5813904952699296,
+          "meanLabel": "1.58ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+          "hz": 831054,
+          "hzLabel": "831.1k ops/s",
+          "mean": 0.0012032905748812384,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 828515,
+          "hzLabel": "828.5k ops/s",
+          "mean": 0.001206978503623741,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isAllSelected 100 times (partial, cached)": {
+          "name": "Access isAllSelected 100 times (partial, cached)",
+          "hz": 757901,
+          "hzLabel": "757.9k ops/s",
+          "mean": 0.0013194340746447645,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isNoneSelected 100 times (partial, cached)": {
+          "name": "Access isNoneSelected 100 times (partial, cached)",
+          "hz": 42334,
+          "hzLabel": "42.3k ops/s",
+          "mean": 0.023621779279080376,
+          "meanLabel": "23.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isMixed 100 times (partial, cached)": {
+          "name": "Access isMixed 100 times (partial, cached)",
+          "hz": 824515,
+          "hzLabel": "824.5k ops/s",
+          "mean": 0.001212834057752733,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2302614,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.0004342891079624143,
+          "meanLabel": "434ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 39,
+          "hzLabel": "39 ops/s",
+          "mean": 25.927794899998116,
+          "meanLabel": "25.93ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createNested": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty nested": {
+              "name": "Create empty nested",
+              "hz": 16778,
+              "hzLabel": "16.8k ops/s",
+              "mean": 0.0596035883895888,
+              "meanLabel": "59.6μs",
+              "rme": 8.8,
+              "tier": "fast"
+            },
+            "Onboard 1,000 flat items": {
+              "name": "Onboard 1,000 flat items",
+              "hz": 149,
+              "hzLabel": "149 ops/s",
+              "mean": 6.7098703733330085,
+              "meanLabel": "6.71ms",
+              "rme": 7.1,
+              "tier": "fast"
+            },
+            "Onboard 10,000 flat items": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 12,
+              "hzLabel": "12 ops/s",
+              "mean": 81.53279430000002,
+              "meanLabel": "81.53ms",
+              "rme": 36.9,
+              "tier": "good"
+            },
+            "Onboard ~1,000 tree items (depth 3)": {
+              "name": "Onboard ~1,000 tree items (depth 3)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.426972961538456,
+              "meanLabel": "6.43ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Onboard ~10,000 tree items (depth 4)": {
+              "name": "Onboard ~10,000 tree items (depth 4)",
+              "hz": 15,
+              "hzLabel": "15 ops/s",
+              "mean": 66.50827330000102,
+              "meanLabel": "66.51ms",
+              "rme": 2.3,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Create empty nested",
+              "hz": 16778,
+              "hzLabel": "16.8k ops/s",
+              "mean": 0.0596035883895888,
+              "meanLabel": "59.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 12,
+              "hzLabel": "12 ops/s",
+              "mean": 81.53279430000002,
+              "meanLabel": "81.53ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "lookup operations": {
+            "Get by id (1,000 flat items)": {
+              "name": "Get by id (1,000 flat items)",
+              "hz": 8316182,
+              "hzLabel": "8.3M ops/s",
+              "mean": 0.00012024748346071751,
+              "meanLabel": "120ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 flat items)": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 8336853,
+              "hzLabel": "8.3M ops/s",
+              "mean": 0.00011994933172650862,
+              "meanLabel": "120ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check isLeaf (1,000 tree items)": {
+              "name": "Check isLeaf (1,000 tree items)",
+              "hz": 1707686,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005855877649666853,
+              "meanLabel": "586ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check isLeaf (10,000 tree items)": {
+              "name": "Check isLeaf (10,000 tree items)",
+              "hz": 1706771,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005859017361453777,
+              "meanLabel": "586ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get depth (1,000 tree items)": {
+              "name": "Get depth (1,000 tree items)",
+              "hz": 575038,
+              "hzLabel": "575.0k ops/s",
+              "mean": 0.0017390160545925491,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get depth (10,000 tree items)": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 449326,
+              "hzLabel": "449.3k ops/s",
+              "mean": 0.002225553266214439,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check opened state (1,000 items)": {
+              "name": "Check opened state (1,000 items)",
+              "hz": 2307302,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043340654547707264,
+              "meanLabel": "433ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected state (1,000 items)": {
+              "name": "Check selected state (1,000 items)",
+              "hz": 2230536,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00044832279685457654,
+              "meanLabel": "448ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 8336853,
+              "hzLabel": "8.3M ops/s",
+              "mean": 0.00011994933172650862,
+              "meanLabel": "120ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 449326,
+              "hzLabel": "449.3k ops/s",
+              "mean": 0.002225553266214439,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "traversal operations": {
+            "Get path to deep node (1,000 tree items)": {
+              "name": "Get path to deep node (1,000 tree items)",
+              "hz": 588169,
+              "hzLabel": "588.2k ops/s",
+              "mean": 0.0017001927877953794,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get path to deep node (10,000 tree items)": {
+              "name": "Get path to deep node (10,000 tree items)",
+              "hz": 457118,
+              "hzLabel": "457.1k ops/s",
+              "mean": 0.002187616704597195,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (1,000 tree items)": {
+              "name": "Get ancestors of deep node (1,000 tree items)",
+              "hz": 578517,
+              "hzLabel": "578.5k ops/s",
+              "mean": 0.0017285574415989457,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (10,000 tree items)": {
+              "name": "Get ancestors of deep node (10,000 tree items)",
+              "hz": 438549,
+              "hzLabel": "438.5k ops/s",
+              "mean": 0.002280246001595467,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (1,000 tree items)": {
+              "name": "Get descendants of root node (1,000 tree items)",
+              "hz": 18887,
+              "hzLabel": "18.9k ops/s",
+              "mean": 0.05294681787379394,
+              "meanLabel": "52.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (10,000 tree items)": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1822,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5487353234648253,
+              "meanLabel": "548.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access roots (1,000 tree items)": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7823281,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012782360114179178,
+              "meanLabel": "128ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access leaves (1,000 tree items)": {
+              "name": "Access leaves (1,000 tree items)",
+              "hz": 7801569,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012817934031097641,
+              "meanLabel": "128ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7823281,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012782360114179178,
+              "meanLabel": "128ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1822,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5487353234648253,
+              "meanLabel": "548.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open/close operations": {
+            "Open single node (1,000 tree items)": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1576389,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006343611466714733,
+              "meanLabel": "634ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open single node (10,000 tree items)": {
+              "name": "Open single node (10,000 tree items)",
+              "hz": 1565501,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006387731411413405,
+              "meanLabel": "639ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Close single node (1,000 tree items)": {
+              "name": "Close single node (1,000 tree items)",
+              "hz": 609186,
+              "hzLabel": "609.2k ops/s",
+              "mean": 0.001641535553995863,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle open (1,000 tree items)": {
+              "name": "Toggle open (1,000 tree items)",
+              "hz": 782776,
+              "hzLabel": "782.8k ops/s",
+              "mean": 0.0012775044878608794,
+              "meanLabel": "1.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Expand all (1,000 tree items)": {
+              "name": "Expand all (1,000 tree items)",
+              "hz": 20678,
+              "hzLabel": "20.7k ops/s",
+              "mean": 0.04836040967121287,
+              "meanLabel": "48.4μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Expand all (10,000 tree items)": {
+              "name": "Expand all (10,000 tree items)",
+              "hz": 2083,
+              "hzLabel": "2.1k ops/s",
+              "mean": 0.48007961612278793,
+              "meanLabel": "480.1μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Collapse all (1,000 tree items)": {
+              "name": "Collapse all (1,000 tree items)",
+              "hz": 15400,
+              "hzLabel": "15.4k ops/s",
+              "mean": 0.0649337680821151,
+              "meanLabel": "64.9μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Collapse all (10,000 tree items)": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1507,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6634967533155187,
+              "meanLabel": "663.5μs",
+              "rme": 1.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1576389,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006343611466714733,
+              "meanLabel": "634ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1507,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6634967533155187,
+              "meanLabel": "663.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select leaf node (1,000 tree items)": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 71199,
+              "hzLabel": "71.2k ops/s",
+              "mean": 0.01404516682585892,
+              "meanLabel": "14.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (1,000 tree items)": {
+              "name": "Select root node with cascade (1,000 tree items)",
+              "hz": 7254,
+              "hzLabel": "7.3k ops/s",
+              "mean": 0.13785246306507934,
+              "meanLabel": "137.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (10,000 tree items)": {
+              "name": "Select root node with cascade (10,000 tree items)",
+              "hz": 723,
+              "hzLabel": "723 ops/s",
+              "mean": 1.3826357762431023,
+              "meanLabel": "1.38ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Unselect root node with cascade (1,000 tree items)": {
+              "name": "Unselect root node with cascade (1,000 tree items)",
+              "hz": 3305,
+              "hzLabel": "3.3k ops/s",
+              "mean": 0.3025343841500024,
+              "meanLabel": "302.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle selection (1,000 tree items)": {
+              "name": "Toggle selection (1,000 tree items)",
+              "hz": 6577,
+              "hzLabel": "6.6k ops/s",
+              "mean": 0.1520448090605692,
+              "meanLabel": "152.0μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (1,000 tree items)": {
+              "name": "Select all via selectAll (1,000 tree items)",
+              "hz": 1941,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5151200823893605,
+              "meanLabel": "515.1μs",
+              "rme": 41.8,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (10,000 tree items)": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 247,
+              "hzLabel": "247 ops/s",
+              "mean": 4.040758233871055,
+              "meanLabel": "4.04ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 71199,
+              "hzLabel": "71.2k ops/s",
+              "mean": 0.01404516682585892,
+              "meanLabel": "14.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 247,
+              "hzLabel": "247 ops/s",
+              "mean": 4.040758233871055,
+              "meanLabel": "4.04ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single root item": {
+              "name": "Register single root item",
+              "hz": 14773,
+              "hzLabel": "14.8k ops/s",
+              "mean": 0.06768982907374779,
+              "meanLabel": "67.7μs",
+              "rme": 8.8,
+              "tier": "fast"
+            },
+            "Register item with parent (1,000 items)": {
+              "name": "Register item with parent (1,000 items)",
+              "hz": 156,
+              "hzLabel": "156 ops/s",
+              "mean": 6.416909961539018,
+              "meanLabel": "6.42ms",
+              "rme": 6.1,
+              "tier": "fast"
+            },
+            "Unregister leaf node (1,000 tree items)": {
+              "name": "Unregister leaf node (1,000 tree items)",
+              "hz": 142,
+              "hzLabel": "142 ops/s",
+              "mean": 7.066699549296303,
+              "meanLabel": "7.07ms",
+              "rme": 6.9,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (1,000 tree items)": {
+              "name": "Unregister root with cascade (1,000 tree items)",
+              "hz": 130,
+              "hzLabel": "130 ops/s",
+              "mean": 7.6783191363636325,
+              "meanLabel": "7.68ms",
+              "rme": 6,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (10,000 tree items)": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 11,
+              "hzLabel": "11 ops/s",
+              "mean": 88.76774430000005,
+              "meanLabel": "88.77ms",
+              "rme": 26.1,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Register single root item",
+              "hz": 14773,
+              "hzLabel": "14.8k ops/s",
+              "mean": 0.06768982907374779,
+              "meanLabel": "67.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 11,
+              "hzLabel": "11 ops/s",
+              "mean": 88.76774430000005,
+              "meanLabel": "88.77ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 tree items": {
+              "name": "Onboard then clear 1,000 tree items",
+              "hz": 185,
+              "hzLabel": "185 ops/s",
+              "mean": 5.412283860215221,
+              "meanLabel": "5.41ms",
+              "rme": 1.9,
+              "tier": "fast"
+            },
+            "Onboard then clear 10,000 tree items": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 15,
+              "hzLabel": "15 ops/s",
+              "mean": 67.6417346000031,
+              "meanLabel": "67.64ms",
+              "rme": 2.5,
+              "tier": "good"
+            },
+            "toFlat conversion (1,000 tree items)": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 1995,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.5011311042085098,
+              "meanLabel": "501.1μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "toFlat conversion (10,000 tree items)": {
+              "name": "toFlat conversion (10,000 tree items)",
+              "hz": 187,
+              "hzLabel": "187 ops/s",
+              "mean": 5.347542255318989,
+              "meanLabel": "5.35ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 1995,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.5011311042085098,
+              "meanLabel": "501.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 15,
+              "hzLabel": "15 ops/s",
+              "mean": 67.6417346000031,
+              "meanLabel": "67.64ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "selection mode comparison": {
+            "Select root - cascade mode (1,000 tree items)": {
+              "name": "Select root - cascade mode (1,000 tree items)",
+              "hz": 7371,
+              "hzLabel": "7.4k ops/s",
+              "mean": 0.1356689940314626,
+              "meanLabel": "135.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root - independent mode (1,000 tree items)": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 860700,
+              "hzLabel": "860.7k ops/s",
+              "mean": 0.0011618454258093204,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select root - leaf mode (1,000 tree items)": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5189,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.1927188420037325,
+              "meanLabel": "192.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 860700,
+              "hzLabel": "860.7k ops/s",
+              "mean": 0.0011618454258093204,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5189,
+              "hzLabel": "5.2k ops/s",
+              "mean": 0.1927188420037325,
+              "meanLabel": "192.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open mode comparison": {
+            "Open 3 nodes - multiple mode (1,000 tree items)": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 592362,
+              "hzLabel": "592.4k ops/s",
+              "mean": 0.0016881577751197364,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open 3 nodes - single mode (1,000 tree items)": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 109532,
+              "hzLabel": "109.5k ops/s",
+              "mean": 0.009129769674628517,
+              "meanLabel": "9.1μs",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 592362,
+              "hzLabel": "592.4k ops/s",
+              "mean": 0.0016881577751197364,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 109532,
+              "hzLabel": "109.5k ops/s",
+              "mean": 0.009129769674628517,
+              "meanLabel": "9.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty nested": {
+          "name": "Create empty nested",
+          "hz": 16778,
+          "hzLabel": "16.8k ops/s",
+          "mean": 0.0596035883895888,
+          "meanLabel": "59.6μs",
+          "rme": 8.8,
+          "tier": "fast"
+        },
+        "Onboard 1,000 flat items": {
+          "name": "Onboard 1,000 flat items",
+          "hz": 149,
+          "hzLabel": "149 ops/s",
+          "mean": 6.7098703733330085,
+          "meanLabel": "6.71ms",
+          "rme": 7.1,
+          "tier": "fast"
+        },
+        "Onboard 10,000 flat items": {
+          "name": "Onboard 10,000 flat items",
+          "hz": 12,
+          "hzLabel": "12 ops/s",
+          "mean": 81.53279430000002,
+          "meanLabel": "81.53ms",
+          "rme": 36.9,
+          "tier": "good"
+        },
+        "Onboard ~1,000 tree items (depth 3)": {
+          "name": "Onboard ~1,000 tree items (depth 3)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.426972961538456,
+          "meanLabel": "6.43ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Onboard ~10,000 tree items (depth 4)": {
+          "name": "Onboard ~10,000 tree items (depth 4)",
+          "hz": 15,
+          "hzLabel": "15 ops/s",
+          "mean": 66.50827330000102,
+          "meanLabel": "66.51ms",
+          "rme": 2.3,
+          "tier": "good"
+        },
+        "Get by id (1,000 flat items)": {
+          "name": "Get by id (1,000 flat items)",
+          "hz": 8316182,
+          "hzLabel": "8.3M ops/s",
+          "mean": 0.00012024748346071751,
+          "meanLabel": "120ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 flat items)": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 8336853,
+          "hzLabel": "8.3M ops/s",
+          "mean": 0.00011994933172650862,
+          "meanLabel": "120ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check isLeaf (1,000 tree items)": {
+          "name": "Check isLeaf (1,000 tree items)",
+          "hz": 1707686,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005855877649666853,
+          "meanLabel": "586ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check isLeaf (10,000 tree items)": {
+          "name": "Check isLeaf (10,000 tree items)",
+          "hz": 1706771,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005859017361453777,
+          "meanLabel": "586ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get depth (1,000 tree items)": {
+          "name": "Get depth (1,000 tree items)",
+          "hz": 575038,
+          "hzLabel": "575.0k ops/s",
+          "mean": 0.0017390160545925491,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get depth (10,000 tree items)": {
+          "name": "Get depth (10,000 tree items)",
+          "hz": 449326,
+          "hzLabel": "449.3k ops/s",
+          "mean": 0.002225553266214439,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check opened state (1,000 items)": {
+          "name": "Check opened state (1,000 items)",
+          "hz": 2307302,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00043340654547707264,
+          "meanLabel": "433ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected state (1,000 items)": {
+          "name": "Check selected state (1,000 items)",
+          "hz": 2230536,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00044832279685457654,
+          "meanLabel": "448ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get path to deep node (1,000 tree items)": {
+          "name": "Get path to deep node (1,000 tree items)",
+          "hz": 588169,
+          "hzLabel": "588.2k ops/s",
+          "mean": 0.0017001927877953794,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get path to deep node (10,000 tree items)": {
+          "name": "Get path to deep node (10,000 tree items)",
+          "hz": 457118,
+          "hzLabel": "457.1k ops/s",
+          "mean": 0.002187616704597195,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (1,000 tree items)": {
+          "name": "Get ancestors of deep node (1,000 tree items)",
+          "hz": 578517,
+          "hzLabel": "578.5k ops/s",
+          "mean": 0.0017285574415989457,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (10,000 tree items)": {
+          "name": "Get ancestors of deep node (10,000 tree items)",
+          "hz": 438549,
+          "hzLabel": "438.5k ops/s",
+          "mean": 0.002280246001595467,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (1,000 tree items)": {
+          "name": "Get descendants of root node (1,000 tree items)",
+          "hz": 18887,
+          "hzLabel": "18.9k ops/s",
+          "mean": 0.05294681787379394,
+          "meanLabel": "52.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (10,000 tree items)": {
+          "name": "Get descendants of root node (10,000 tree items)",
+          "hz": 1822,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5487353234648253,
+          "meanLabel": "548.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access roots (1,000 tree items)": {
+          "name": "Access roots (1,000 tree items)",
+          "hz": 7823281,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012782360114179178,
+          "meanLabel": "128ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access leaves (1,000 tree items)": {
+          "name": "Access leaves (1,000 tree items)",
+          "hz": 7801569,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012817934031097641,
+          "meanLabel": "128ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open single node (1,000 tree items)": {
+          "name": "Open single node (1,000 tree items)",
+          "hz": 1576389,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006343611466714733,
+          "meanLabel": "634ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open single node (10,000 tree items)": {
+          "name": "Open single node (10,000 tree items)",
+          "hz": 1565501,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006387731411413405,
+          "meanLabel": "639ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Close single node (1,000 tree items)": {
+          "name": "Close single node (1,000 tree items)",
+          "hz": 609186,
+          "hzLabel": "609.2k ops/s",
+          "mean": 0.001641535553995863,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle open (1,000 tree items)": {
+          "name": "Toggle open (1,000 tree items)",
+          "hz": 782776,
+          "hzLabel": "782.8k ops/s",
+          "mean": 0.0012775044878608794,
+          "meanLabel": "1.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Expand all (1,000 tree items)": {
+          "name": "Expand all (1,000 tree items)",
+          "hz": 20678,
+          "hzLabel": "20.7k ops/s",
+          "mean": 0.04836040967121287,
+          "meanLabel": "48.4μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Expand all (10,000 tree items)": {
+          "name": "Expand all (10,000 tree items)",
+          "hz": 2083,
+          "hzLabel": "2.1k ops/s",
+          "mean": 0.48007961612278793,
+          "meanLabel": "480.1μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Collapse all (1,000 tree items)": {
+          "name": "Collapse all (1,000 tree items)",
+          "hz": 15400,
+          "hzLabel": "15.4k ops/s",
+          "mean": 0.0649337680821151,
+          "meanLabel": "64.9μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Collapse all (10,000 tree items)": {
+          "name": "Collapse all (10,000 tree items)",
+          "hz": 1507,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6634967533155187,
+          "meanLabel": "663.5μs",
+          "rme": 1.2,
+          "tier": "blazing"
+        },
+        "Select leaf node (1,000 tree items)": {
+          "name": "Select leaf node (1,000 tree items)",
+          "hz": 71199,
+          "hzLabel": "71.2k ops/s",
+          "mean": 0.01404516682585892,
+          "meanLabel": "14.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (1,000 tree items)": {
+          "name": "Select root node with cascade (1,000 tree items)",
+          "hz": 7254,
+          "hzLabel": "7.3k ops/s",
+          "mean": 0.13785246306507934,
+          "meanLabel": "137.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (10,000 tree items)": {
+          "name": "Select root node with cascade (10,000 tree items)",
+          "hz": 723,
+          "hzLabel": "723 ops/s",
+          "mean": 1.3826357762431023,
+          "meanLabel": "1.38ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Unselect root node with cascade (1,000 tree items)": {
+          "name": "Unselect root node with cascade (1,000 tree items)",
+          "hz": 3305,
+          "hzLabel": "3.3k ops/s",
+          "mean": 0.3025343841500024,
+          "meanLabel": "302.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle selection (1,000 tree items)": {
+          "name": "Toggle selection (1,000 tree items)",
+          "hz": 6577,
+          "hzLabel": "6.6k ops/s",
+          "mean": 0.1520448090605692,
+          "meanLabel": "152.0μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (1,000 tree items)": {
+          "name": "Select all via selectAll (1,000 tree items)",
+          "hz": 1941,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5151200823893605,
+          "meanLabel": "515.1μs",
+          "rme": 41.8,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (10,000 tree items)": {
+          "name": "Select all via selectAll (10,000 tree items)",
+          "hz": 247,
+          "hzLabel": "247 ops/s",
+          "mean": 4.040758233871055,
+          "meanLabel": "4.04ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Register single root item": {
+          "name": "Register single root item",
+          "hz": 14773,
+          "hzLabel": "14.8k ops/s",
+          "mean": 0.06768982907374779,
+          "meanLabel": "67.7μs",
+          "rme": 8.8,
+          "tier": "fast"
+        },
+        "Register item with parent (1,000 items)": {
+          "name": "Register item with parent (1,000 items)",
+          "hz": 156,
+          "hzLabel": "156 ops/s",
+          "mean": 6.416909961539018,
+          "meanLabel": "6.42ms",
+          "rme": 6.1,
+          "tier": "fast"
+        },
+        "Unregister leaf node (1,000 tree items)": {
+          "name": "Unregister leaf node (1,000 tree items)",
+          "hz": 142,
+          "hzLabel": "142 ops/s",
+          "mean": 7.066699549296303,
+          "meanLabel": "7.07ms",
+          "rme": 6.9,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (1,000 tree items)": {
+          "name": "Unregister root with cascade (1,000 tree items)",
+          "hz": 130,
+          "hzLabel": "130 ops/s",
+          "mean": 7.6783191363636325,
+          "meanLabel": "7.68ms",
+          "rme": 6,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (10,000 tree items)": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 11,
+          "hzLabel": "11 ops/s",
+          "mean": 88.76774430000005,
+          "meanLabel": "88.77ms",
+          "rme": 26.1,
+          "tier": "good"
+        },
+        "Onboard then clear 1,000 tree items": {
+          "name": "Onboard then clear 1,000 tree items",
+          "hz": 185,
+          "hzLabel": "185 ops/s",
+          "mean": 5.412283860215221,
+          "meanLabel": "5.41ms",
+          "rme": 1.9,
+          "tier": "fast"
+        },
+        "Onboard then clear 10,000 tree items": {
+          "name": "Onboard then clear 10,000 tree items",
+          "hz": 15,
+          "hzLabel": "15 ops/s",
+          "mean": 67.6417346000031,
+          "meanLabel": "67.64ms",
+          "rme": 2.5,
+          "tier": "good"
+        },
+        "toFlat conversion (1,000 tree items)": {
+          "name": "toFlat conversion (1,000 tree items)",
+          "hz": 1995,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.5011311042085098,
+          "meanLabel": "501.1μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "toFlat conversion (10,000 tree items)": {
+          "name": "toFlat conversion (10,000 tree items)",
+          "hz": 187,
+          "hzLabel": "187 ops/s",
+          "mean": 5.347542255318989,
+          "meanLabel": "5.35ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Select root - cascade mode (1,000 tree items)": {
+          "name": "Select root - cascade mode (1,000 tree items)",
+          "hz": 7371,
+          "hzLabel": "7.4k ops/s",
+          "mean": 0.1356689940314626,
+          "meanLabel": "135.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root - independent mode (1,000 tree items)": {
+          "name": "Select root - independent mode (1,000 tree items)",
+          "hz": 860700,
+          "hzLabel": "860.7k ops/s",
+          "mean": 0.0011618454258093204,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select root - leaf mode (1,000 tree items)": {
+          "name": "Select root - leaf mode (1,000 tree items)",
+          "hz": 5189,
+          "hzLabel": "5.2k ops/s",
+          "mean": 0.1927188420037325,
+          "meanLabel": "192.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - multiple mode (1,000 tree items)": {
+          "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+          "hz": 592362,
+          "hzLabel": "592.4k ops/s",
+          "mean": 0.0016881577751197364,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - single mode (1,000 tree items)": {
+          "name": "Open 3 nodes - single mode (1,000 tree items)",
+          "hz": 109532,
+          "hzLabel": "109.5k ops/s",
+          "mean": 0.009129769674628517,
+          "meanLabel": "9.1μs",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 8336853,
+          "hzLabel": "8.3M ops/s",
+          "mean": 0.00011994933172650862,
+          "meanLabel": "120ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 11,
+          "hzLabel": "11 ops/s",
+          "mean": 88.76774430000005,
+          "meanLabel": "88.77ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createModel": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty model": {
+              "name": "Create empty model",
+              "hz": 83150,
+              "hzLabel": "83.1k ops/s",
+              "mean": 0.012026490487118537,
+              "meanLabel": "12.0μs",
+              "rme": 12.4,
+              "tier": "fast"
+            },
+            "Register 1,000 items": {
+              "name": "Register 1,000 items",
+              "hz": 410,
+              "hzLabel": "410 ops/s",
+              "mean": 2.4419717463426203,
+              "meanLabel": "2.44ms",
+              "rme": 5.6,
+              "tier": "fast"
+            },
+            "Register 10,000 items": {
+              "name": "Register 10,000 items",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.863404857144424,
+              "meanLabel": "23.86ms",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Register 1,000 items (disabled)": {
+              "name": "Register 1,000 items (disabled)",
+              "hz": 890,
+              "hzLabel": "890 ops/s",
+              "mean": 1.123915728091346,
+              "meanLabel": "1.12ms",
+              "rme": 7.5,
+              "tier": "fast"
+            },
+            "Register 10,000 items (disabled)": {
+              "name": "Register 10,000 items (disabled)",
+              "hz": 78,
+              "hzLabel": "78 ops/s",
+              "mean": 12.757345174998772,
+              "meanLabel": "12.76ms",
+              "rme": 9.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty model",
+              "hz": 83150,
+              "hzLabel": "83.1k ops/s",
+              "mean": 0.012026490487118537,
+              "meanLabel": "12.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.863404857144424,
+              "meanLabel": "23.86ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2286315,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043738513834976766,
+              "meanLabel": "437ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2258376,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004427960181954736,
+              "meanLabel": "443ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8076242,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012381996673639973,
+              "meanLabel": "124ns",
+              "rme": 3.6,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8076993,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.0001238084492772943,
+              "meanLabel": "124ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6064048,
+              "hzLabel": "6.1M ops/s",
+              "mean": 0.0001649063572676489,
+              "meanLabel": "165ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 5847768,
+              "hzLabel": "5.8M ops/s",
+              "mean": 0.00017100540411654235,
+              "meanLabel": "171ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8076993,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.0001238084492772943,
+              "meanLabel": "124ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2258376,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004427960181954736,
+              "meanLabel": "443ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 814870,
+              "hzLabel": "814.9k ops/s",
+              "mean": 0.0012271902414104105,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 800518,
+              "hzLabel": "800.5k ops/s",
+              "mean": 0.0012491916059815388,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 575018,
+              "hzLabel": "575.0k ops/s",
+              "mean": 0.0017390773993426864,
+              "meanLabel": "1.7μs",
+              "rme": 4.6,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 619392,
+              "hzLabel": "619.4k ops/s",
+              "mean": 0.0016144857457048314,
+              "meanLabel": "1.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 809493,
+              "hzLabel": "809.5k ops/s",
+              "mean": 0.0012353414108527611,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 777865,
+              "hzLabel": "777.9k ops/s",
+              "mean": 0.001285569905347658,
+              "meanLabel": "1.3μs",
+              "rme": 3.6,
+              "tier": "blazing"
+            },
+            "Select disabled item (1,000 items)": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 6659167,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00015016892470725128,
+              "meanLabel": "150ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 6659167,
+              "hzLabel": "6.7M ops/s",
+              "mean": 0.00015016892470725128,
+              "meanLabel": "150ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 575018,
+              "hzLabel": "575.0k ops/s",
+              "mean": 0.0017390773993426864,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "apply operations": {
+            "Apply static value (1,000 items)": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 260751,
+              "hzLabel": "260.8k ops/s",
+              "mean": 0.0038350756888097257,
+              "meanLabel": "3.8μs",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "Apply static value (10,000 items)": {
+              "name": "Apply static value (10,000 items)",
+              "hz": 247816,
+              "hzLabel": "247.8k ops/s",
+              "mean": 0.004035259612027959,
+              "meanLabel": "4.0μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "Apply ref value (1,000 items)": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 53631,
+              "hzLabel": "53.6k ops/s",
+              "mean": 0.018645912253674148,
+              "meanLabel": "18.6μs",
+              "rme": 7.9,
+              "tier": "blazing"
+            },
+            "Apply undefined (1,000 items)": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 242960,
+              "hzLabel": "243.0k ops/s",
+              "mean": 0.0041159088744780825,
+              "meanLabel": "4.1μs",
+              "rme": 6.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 260751,
+              "hzLabel": "260.8k ops/s",
+              "mean": 0.0038350756888097257,
+              "meanLabel": "3.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 53631,
+              "hzLabel": "53.6k ops/s",
+              "mean": 0.018645912253674148,
+              "meanLabel": "18.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 1,000 then offboard 100 items": {
+              "name": "Onboard 1,000 then offboard 100 items",
+              "hz": 408,
+              "hzLabel": "408 ops/s",
+              "mean": 2.453590642153251,
+              "meanLabel": "2.45ms",
+              "rme": 4.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 then offboard 1,000 items": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 38,
+              "hzLabel": "38 ops/s",
+              "mean": 26.386883105261642,
+              "meanLabel": "26.39ms",
+              "rme": 5.1,
+              "tier": "fast"
+            },
+            "Reset (1,000 items)": {
+              "name": "Reset (1,000 items)",
+              "hz": 620218,
+              "hzLabel": "620.2k ops/s",
+              "mean": 0.001612335219769325,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Reset (10,000 items)": {
+              "name": "Reset (10,000 items)",
+              "hz": 621033,
+              "hzLabel": "621.0k ops/s",
+              "mean": 0.0016102210893424254,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reset (10,000 items)",
+              "hz": 621033,
+              "hzLabel": "621.0k ops/s",
+              "mean": 0.0016102210893424254,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 38,
+              "hzLabel": "38 ops/s",
+              "mean": 26.386883105261642,
+              "meanLabel": "26.39ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 774731,
+              "hzLabel": "774.7k ops/s",
+              "mean": 0.001290770774961072,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+              "hz": 806802,
+              "hzLabel": "806.8k ops/s",
+              "mean": 0.001239461674610653,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 806724,
+              "hzLabel": "806.7k ops/s",
+              "mean": 0.0012395807721321493,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 817763,
+              "hzLabel": "817.8k ops/s",
+              "mean": 0.0012228475990720157,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 817763,
+              "hzLabel": "817.8k ops/s",
+              "mean": 0.0012228475990720157,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 774731,
+              "hzLabel": "774.7k ops/s",
+              "mean": 0.001290770774961072,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty model": {
+          "name": "Create empty model",
+          "hz": 83150,
+          "hzLabel": "83.1k ops/s",
+          "mean": 0.012026490487118537,
+          "meanLabel": "12.0μs",
+          "rme": 12.4,
+          "tier": "fast"
+        },
+        "Register 1,000 items": {
+          "name": "Register 1,000 items",
+          "hz": 410,
+          "hzLabel": "410 ops/s",
+          "mean": 2.4419717463426203,
+          "meanLabel": "2.44ms",
+          "rme": 5.6,
+          "tier": "fast"
+        },
+        "Register 10,000 items": {
+          "name": "Register 10,000 items",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.863404857144424,
+          "meanLabel": "23.86ms",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Register 1,000 items (disabled)": {
+          "name": "Register 1,000 items (disabled)",
+          "hz": 890,
+          "hzLabel": "890 ops/s",
+          "mean": 1.123915728091346,
+          "meanLabel": "1.12ms",
+          "rme": 7.5,
+          "tier": "fast"
+        },
+        "Register 10,000 items (disabled)": {
+          "name": "Register 10,000 items (disabled)",
+          "hz": 78,
+          "hzLabel": "78 ops/s",
+          "mean": 12.757345174998772,
+          "meanLabel": "12.76ms",
+          "rme": 9.5,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2286315,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00043738513834976766,
+          "meanLabel": "437ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2258376,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.0004427960181954736,
+          "meanLabel": "443ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8076242,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012381996673639973,
+          "meanLabel": "124ns",
+          "rme": 3.6,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8076993,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.0001238084492772943,
+          "meanLabel": "124ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6064048,
+          "hzLabel": "6.1M ops/s",
+          "mean": 0.0001649063572676489,
+          "meanLabel": "165ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 5847768,
+          "hzLabel": "5.8M ops/s",
+          "mean": 0.00017100540411654235,
+          "meanLabel": "171ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 814870,
+          "hzLabel": "814.9k ops/s",
+          "mean": 0.0012271902414104105,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 800518,
+          "hzLabel": "800.5k ops/s",
+          "mean": 0.0012491916059815388,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 575018,
+          "hzLabel": "575.0k ops/s",
+          "mean": 0.0017390773993426864,
+          "meanLabel": "1.7μs",
+          "rme": 4.6,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 619392,
+          "hzLabel": "619.4k ops/s",
+          "mean": 0.0016144857457048314,
+          "meanLabel": "1.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 809493,
+          "hzLabel": "809.5k ops/s",
+          "mean": 0.0012353414108527611,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 777865,
+          "hzLabel": "777.9k ops/s",
+          "mean": 0.001285569905347658,
+          "meanLabel": "1.3μs",
+          "rme": 3.6,
+          "tier": "blazing"
+        },
+        "Select disabled item (1,000 items)": {
+          "name": "Select disabled item (1,000 items)",
+          "hz": 6659167,
+          "hzLabel": "6.7M ops/s",
+          "mean": 0.00015016892470725128,
+          "meanLabel": "150ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Apply static value (1,000 items)": {
+          "name": "Apply static value (1,000 items)",
+          "hz": 260751,
+          "hzLabel": "260.8k ops/s",
+          "mean": 0.0038350756888097257,
+          "meanLabel": "3.8μs",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "Apply static value (10,000 items)": {
+          "name": "Apply static value (10,000 items)",
+          "hz": 247816,
+          "hzLabel": "247.8k ops/s",
+          "mean": 0.004035259612027959,
+          "meanLabel": "4.0μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Apply ref value (1,000 items)": {
+          "name": "Apply ref value (1,000 items)",
+          "hz": 53631,
+          "hzLabel": "53.6k ops/s",
+          "mean": 0.018645912253674148,
+          "meanLabel": "18.6μs",
+          "rme": 7.9,
+          "tier": "blazing"
+        },
+        "Apply undefined (1,000 items)": {
+          "name": "Apply undefined (1,000 items)",
+          "hz": 242960,
+          "hzLabel": "243.0k ops/s",
+          "mean": 0.0041159088744780825,
+          "meanLabel": "4.1μs",
+          "rme": 6.5,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 100 items": {
+          "name": "Onboard 1,000 then offboard 100 items",
+          "hz": 408,
+          "hzLabel": "408 ops/s",
+          "mean": 2.453590642153251,
+          "meanLabel": "2.45ms",
+          "rme": 4.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 then offboard 1,000 items": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 38,
+          "hzLabel": "38 ops/s",
+          "mean": 26.386883105261642,
+          "meanLabel": "26.39ms",
+          "rme": 5.1,
+          "tier": "fast"
+        },
+        "Reset (1,000 items)": {
+          "name": "Reset (1,000 items)",
+          "hz": 620218,
+          "hzLabel": "620.2k ops/s",
+          "mean": 0.001612335219769325,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Reset (10,000 items)": {
+          "name": "Reset (10,000 items)",
+          "hz": 621033,
+          "hzLabel": "621.0k ops/s",
+          "mean": 0.0016102210893424254,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+          "hz": 774731,
+          "hzLabel": "774.7k ops/s",
+          "mean": 0.001290770774961072,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+          "hz": 806802,
+          "hzLabel": "806.8k ops/s",
+          "mean": 0.001239461674610653,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+          "hz": 806724,
+          "hzLabel": "806.7k ops/s",
+          "mean": 0.0012395807721321493,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+          "hz": 817763,
+          "hzLabel": "817.8k ops/s",
+          "mean": 0.0012228475990720157,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8076993,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.0001238084492772943,
+          "meanLabel": "124ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 38,
+          "hzLabel": "38 ops/s",
+          "mean": 26.386883105261642,
+          "meanLabel": "26.39ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty registry": {
+              "name": "Create empty registry",
+              "hz": 281499,
+              "hzLabel": "281.5k ops/s",
+              "mean": 0.0035524075950329856,
+              "meanLabel": "3.6μs",
+              "rme": 12.5,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 1833,
+              "hzLabel": "1.8k ops/s",
+              "mean": 0.5455002562707719,
+              "meanLabel": "545.5μs",
+              "rme": 10,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 139,
+              "hzLabel": "139 ops/s",
+              "mean": 7.195196225351538,
+              "meanLabel": "7.20ms",
+              "rme": 12.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty registry",
+              "hz": 281499,
+              "hzLabel": "281.5k ops/s",
+              "mean": 0.0035524075950329856,
+              "meanLabel": "3.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 139,
+              "hzLabel": "139 ops/s",
+              "mean": 7.195196225351538,
+              "meanLabel": "7.20ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8286649,
+              "hzLabel": "8.3M ops/s",
+              "mean": 0.00012067604810624977,
+              "meanLabel": "121ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8168941,
+              "hzLabel": "8.2M ops/s",
+              "mean": 0.00012241488407912607,
+              "meanLabel": "122ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Lookup by index (1,000 items)": {
+              "name": "Lookup by index (1,000 items)",
+              "hz": 8009182,
+              "hzLabel": "8.0M ops/s",
+              "mean": 0.00012485669002016016,
+              "meanLabel": "125ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Lookup by index (10,000 items)": {
+              "name": "Lookup by index (10,000 items)",
+              "hz": 8208082,
+              "hzLabel": "8.2M ops/s",
+              "mean": 0.0001218311374450967,
+              "meanLabel": "122ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 5967344,
+              "hzLabel": "6.0M ops/s",
+              "mean": 0.00016757874424084271,
+              "meanLabel": "168ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 5832007,
+              "hzLabel": "5.8M ops/s",
+              "mean": 0.00017146755217545907,
+              "meanLabel": "171ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (1,000 items)": {
+              "name": "Check has (1,000 items)",
+              "hz": 8056219,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.0001241277018269874,
+              "meanLabel": "124ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Check has (10,000 items)": {
+              "name": "Check has (10,000 items)",
+              "hz": 8135894,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012291212323931874,
+              "meanLabel": "123ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8286649,
+              "hzLabel": "8.3M ops/s",
+              "mean": 0.00012067604810624977,
+              "meanLabel": "121ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 5832007,
+              "hzLabel": "5.8M ops/s",
+              "mean": 0.00017146755217545907,
+              "meanLabel": "171ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 1702507,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.000587369128376992,
+              "meanLabel": "587ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 1568332,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006376201148748028,
+              "meanLabel": "638ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Register single item": {
+              "name": "Register single item",
+              "hz": 234441,
+              "hzLabel": "234.4k ops/s",
+              "mean": 0.004265469711057428,
+              "meanLabel": "4.3μs",
+              "rme": 11.1,
+              "tier": "blazing"
+            },
+            "Register then unregister single item": {
+              "name": "Register then unregister single item",
+              "hz": 213748,
+              "hzLabel": "213.7k ops/s",
+              "mean": 0.0046784137582732395,
+              "meanLabel": "4.7μs",
+              "rme": 9.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 1702507,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.000587369128376992,
+              "meanLabel": "587ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register then unregister single item",
+              "hz": 213748,
+              "hzLabel": "213.7k ops/s",
+              "mean": 0.0046784137582732395,
+              "meanLabel": "4.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 items": {
+              "name": "Onboard then clear 1,000 items",
+              "hz": 2542,
+              "hzLabel": "2.5k ops/s",
+              "mean": 0.39331396855365863,
+              "meanLabel": "393.3μs",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Onboard then clear 10,000 items": {
+              "name": "Onboard then clear 10,000 items",
+              "hz": 208,
+              "hzLabel": "208 ops/s",
+              "mean": 4.812999471154119,
+              "meanLabel": "4.81ms",
+              "rme": 2.7,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 1,000 items": {
+              "name": "Onboard then reindex 1,000 items",
+              "hz": 1575,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6349770837562384,
+              "meanLabel": "635.0μs",
+              "rme": 7.9,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 10,000 items": {
+              "name": "Onboard then reindex 10,000 items",
+              "hz": 119,
+              "hzLabel": "119 ops/s",
+              "mean": 8.428138933332956,
+              "meanLabel": "8.43ms",
+              "rme": 13.4,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 then offboard 500 items": {
+              "name": "Onboard 1,000 then offboard 500 items",
+              "hz": 1322,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7561980422960201,
+              "meanLabel": "756.2μs",
+              "rme": 4.1,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 then offboard 5,000 items": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 104,
+              "hzLabel": "104 ops/s",
+              "mean": 9.649570365382925,
+              "meanLabel": "9.65ms",
+              "rme": 4.3,
+              "tier": "blazing"
+            },
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 4411,
+              "hzLabel": "4.4k ops/s",
+              "mean": 0.22669536773321156,
+              "meanLabel": "226.7μs",
+              "rme": 10.5,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 293,
+              "hzLabel": "293 ops/s",
+              "mean": 3.410915659863912,
+              "meanLabel": "3.41ms",
+              "rme": 13.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 4411,
+              "hzLabel": "4.4k ops/s",
+              "mean": 0.22669536773321156,
+              "meanLabel": "226.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 104,
+              "hzLabel": "104 ops/s",
+              "mean": 9.649570365382925,
+              "meanLabel": "9.65ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access keys 100 times (1,000 items, cached)": {
+              "name": "Access keys 100 times (1,000 items, cached)",
+              "hz": 797185,
+              "hzLabel": "797.2k ops/s",
+              "mean": 0.0012544136374766277,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, cached)": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 785195,
+              "hzLabel": "785.2k ops/s",
+              "mean": 0.0012735690579320936,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, cached)": {
+              "name": "Access values 100 times (1,000 items, cached)",
+              "hz": 811265,
+              "hzLabel": "811.3k ops/s",
+              "mean": 0.0012326428200020755,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, cached)": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 825482,
+              "hzLabel": "825.5k ops/s",
+              "mean": 0.0012114140223441856,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, cached)": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 829338,
+              "hzLabel": "829.3k ops/s",
+              "mean": 0.0012057808715396257,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, cached)": {
+              "name": "Access entries 100 times (10,000 items, cached)",
+              "hz": 789381,
+              "hzLabel": "789.4k ops/s",
+              "mean": 0.0012668154151052227,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 829338,
+              "hzLabel": "829.3k ops/s",
+              "mean": 0.0012057808715396257,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 785195,
+              "hzLabel": "785.2k ops/s",
+              "mean": 0.0012735690579320936,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reactive access": {
+            "Access keys 100 times (1,000 items, reactive)": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 718003,
+              "hzLabel": "718.0k ops/s",
+              "mean": 0.0013927522214396543,
+              "meanLabel": "1.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, reactive)": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 717837,
+              "hzLabel": "717.8k ops/s",
+              "mean": 0.001393073584852799,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, reactive)": {
+              "name": "Access values 100 times (1,000 items, reactive)",
+              "hz": 683902,
+              "hzLabel": "683.9k ops/s",
+              "mean": 0.0014621984495173763,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, reactive)": {
+              "name": "Access values 100 times (10,000 items, reactive)",
+              "hz": 695315,
+              "hzLabel": "695.3k ops/s",
+              "mean": 0.0014381968141250943,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, reactive)": {
+              "name": "Access entries 100 times (1,000 items, reactive)",
+              "hz": 703116,
+              "hzLabel": "703.1k ops/s",
+              "mean": 0.0014222412717254597,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, reactive)": {
+              "name": "Access entries 100 times (10,000 items, reactive)",
+              "hz": 697181,
+              "hzLabel": "697.2k ops/s",
+              "mean": 0.0014343486177047404,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (1,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 210034,
+              "hzLabel": "210.0k ops/s",
+              "mean": 0.0047611426245353266,
+              "meanLabel": "4.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (10,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 214368,
+              "hzLabel": "214.4k ops/s",
+              "mean": 0.004664883881936288,
+              "meanLabel": "4.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 718003,
+              "hzLabel": "718.0k ops/s",
+              "mean": 0.0013927522214396543,
+              "meanLabel": "1.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 210034,
+              "hzLabel": "210.0k ops/s",
+              "mean": 0.0047611426245353266,
+              "meanLabel": "4.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "seek operations": {
+            "Seek first (1,000 items)": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7211913,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013865946155071793,
+              "meanLabel": "139ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek first (10,000 items)": {
+              "name": "Seek first (10,000 items)",
+              "hz": 7746551,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012908971087858864,
+              "meanLabel": "129ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek last (1,000 items)": {
+              "name": "Seek last (1,000 items)",
+              "hz": 7916796,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012631372329466613,
+              "meanLabel": "126ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek last (10,000 items)": {
+              "name": "Seek last (10,000 items)",
+              "hz": 7703521,
+              "hzLabel": "7.7M ops/s",
+              "mean": 0.00012981076498332243,
+              "meanLabel": "130ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (1,000 items)": {
+              "name": "Seek with predicate (1,000 items)",
+              "hz": 838910,
+              "hzLabel": "838.9k ops/s",
+              "mean": 0.0011920226722074482,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (10,000 items)": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 43456,
+              "hzLabel": "43.5k ops/s",
+              "mean": 0.02301204445860326,
+              "meanLabel": "23.0μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Seek last (1,000 items)",
+              "hz": 7916796,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012631372329466613,
+              "meanLabel": "126ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 43456,
+              "hzLabel": "43.5k ops/s",
+              "mean": 0.02301204445860326,
+              "meanLabel": "23.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty registry": {
+          "name": "Create empty registry",
+          "hz": 281499,
+          "hzLabel": "281.5k ops/s",
+          "mean": 0.0035524075950329856,
+          "meanLabel": "3.6μs",
+          "rme": 12.5,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 1833,
+          "hzLabel": "1.8k ops/s",
+          "mean": 0.5455002562707719,
+          "meanLabel": "545.5μs",
+          "rme": 10,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 139,
+          "hzLabel": "139 ops/s",
+          "mean": 7.195196225351538,
+          "meanLabel": "7.20ms",
+          "rme": 12.5,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8286649,
+          "hzLabel": "8.3M ops/s",
+          "mean": 0.00012067604810624977,
+          "meanLabel": "121ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8168941,
+          "hzLabel": "8.2M ops/s",
+          "mean": 0.00012241488407912607,
+          "meanLabel": "122ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Lookup by index (1,000 items)": {
+          "name": "Lookup by index (1,000 items)",
+          "hz": 8009182,
+          "hzLabel": "8.0M ops/s",
+          "mean": 0.00012485669002016016,
+          "meanLabel": "125ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Lookup by index (10,000 items)": {
+          "name": "Lookup by index (10,000 items)",
+          "hz": 8208082,
+          "hzLabel": "8.2M ops/s",
+          "mean": 0.0001218311374450967,
+          "meanLabel": "122ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 5967344,
+          "hzLabel": "6.0M ops/s",
+          "mean": 0.00016757874424084271,
+          "meanLabel": "168ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 5832007,
+          "hzLabel": "5.8M ops/s",
+          "mean": 0.00017146755217545907,
+          "meanLabel": "171ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (1,000 items)": {
+          "name": "Check has (1,000 items)",
+          "hz": 8056219,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.0001241277018269874,
+          "meanLabel": "124ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Check has (10,000 items)": {
+          "name": "Check has (10,000 items)",
+          "hz": 8135894,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012291212323931874,
+          "meanLabel": "123ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 1702507,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.000587369128376992,
+          "meanLabel": "587ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 1568332,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006376201148748028,
+          "meanLabel": "638ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Register single item": {
+          "name": "Register single item",
+          "hz": 234441,
+          "hzLabel": "234.4k ops/s",
+          "mean": 0.004265469711057428,
+          "meanLabel": "4.3μs",
+          "rme": 11.1,
+          "tier": "blazing"
+        },
+        "Register then unregister single item": {
+          "name": "Register then unregister single item",
+          "hz": 213748,
+          "hzLabel": "213.7k ops/s",
+          "mean": 0.0046784137582732395,
+          "meanLabel": "4.7μs",
+          "rme": 9.6,
+          "tier": "blazing"
+        },
+        "Onboard then clear 1,000 items": {
+          "name": "Onboard then clear 1,000 items",
+          "hz": 2542,
+          "hzLabel": "2.5k ops/s",
+          "mean": 0.39331396855365863,
+          "meanLabel": "393.3μs",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Onboard then clear 10,000 items": {
+          "name": "Onboard then clear 10,000 items",
+          "hz": 208,
+          "hzLabel": "208 ops/s",
+          "mean": 4.812999471154119,
+          "meanLabel": "4.81ms",
+          "rme": 2.7,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 1,000 items": {
+          "name": "Onboard then reindex 1,000 items",
+          "hz": 1575,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6349770837562384,
+          "meanLabel": "635.0μs",
+          "rme": 7.9,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 10,000 items": {
+          "name": "Onboard then reindex 10,000 items",
+          "hz": 119,
+          "hzLabel": "119 ops/s",
+          "mean": 8.428138933332956,
+          "meanLabel": "8.43ms",
+          "rme": 13.4,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 500 items": {
+          "name": "Onboard 1,000 then offboard 500 items",
+          "hz": 1322,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7561980422960201,
+          "meanLabel": "756.2μs",
+          "rme": 4.1,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 then offboard 5,000 items": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 104,
+          "hzLabel": "104 ops/s",
+          "mean": 9.649570365382925,
+          "meanLabel": "9.65ms",
+          "rme": 4.3,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 4411,
+          "hzLabel": "4.4k ops/s",
+          "mean": 0.22669536773321156,
+          "meanLabel": "226.7μs",
+          "rme": 10.5,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 293,
+          "hzLabel": "293 ops/s",
+          "mean": 3.410915659863912,
+          "meanLabel": "3.41ms",
+          "rme": 13.4,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, cached)": {
+          "name": "Access keys 100 times (1,000 items, cached)",
+          "hz": 797185,
+          "hzLabel": "797.2k ops/s",
+          "mean": 0.0012544136374766277,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, cached)": {
+          "name": "Access keys 100 times (10,000 items, cached)",
+          "hz": 785195,
+          "hzLabel": "785.2k ops/s",
+          "mean": 0.0012735690579320936,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, cached)": {
+          "name": "Access values 100 times (1,000 items, cached)",
+          "hz": 811265,
+          "hzLabel": "811.3k ops/s",
+          "mean": 0.0012326428200020755,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, cached)": {
+          "name": "Access values 100 times (10,000 items, cached)",
+          "hz": 825482,
+          "hzLabel": "825.5k ops/s",
+          "mean": 0.0012114140223441856,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, cached)": {
+          "name": "Access entries 100 times (1,000 items, cached)",
+          "hz": 829338,
+          "hzLabel": "829.3k ops/s",
+          "mean": 0.0012057808715396257,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, cached)": {
+          "name": "Access entries 100 times (10,000 items, cached)",
+          "hz": 789381,
+          "hzLabel": "789.4k ops/s",
+          "mean": 0.0012668154151052227,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, reactive)": {
+          "name": "Access keys 100 times (1,000 items, reactive)",
+          "hz": 718003,
+          "hzLabel": "718.0k ops/s",
+          "mean": 0.0013927522214396543,
+          "meanLabel": "1.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, reactive)": {
+          "name": "Access keys 100 times (10,000 items, reactive)",
+          "hz": 717837,
+          "hzLabel": "717.8k ops/s",
+          "mean": 0.001393073584852799,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, reactive)": {
+          "name": "Access values 100 times (1,000 items, reactive)",
+          "hz": 683902,
+          "hzLabel": "683.9k ops/s",
+          "mean": 0.0014621984495173763,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, reactive)": {
+          "name": "Access values 100 times (10,000 items, reactive)",
+          "hz": 695315,
+          "hzLabel": "695.3k ops/s",
+          "mean": 0.0014381968141250943,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, reactive)": {
+          "name": "Access entries 100 times (1,000 items, reactive)",
+          "hz": 703116,
+          "hzLabel": "703.1k ops/s",
+          "mean": 0.0014222412717254597,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, reactive)": {
+          "name": "Access entries 100 times (10,000 items, reactive)",
+          "hz": 697181,
+          "hzLabel": "697.2k ops/s",
+          "mean": 0.0014343486177047404,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (1,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+          "hz": 210034,
+          "hzLabel": "210.0k ops/s",
+          "mean": 0.0047611426245353266,
+          "meanLabel": "4.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (10,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+          "hz": 214368,
+          "hzLabel": "214.4k ops/s",
+          "mean": 0.004664883881936288,
+          "meanLabel": "4.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek first (1,000 items)": {
+          "name": "Seek first (1,000 items)",
+          "hz": 7211913,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013865946155071793,
+          "meanLabel": "139ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek first (10,000 items)": {
+          "name": "Seek first (10,000 items)",
+          "hz": 7746551,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012908971087858864,
+          "meanLabel": "129ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek last (1,000 items)": {
+          "name": "Seek last (1,000 items)",
+          "hz": 7916796,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012631372329466613,
+          "meanLabel": "126ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek last (10,000 items)": {
+          "name": "Seek last (10,000 items)",
+          "hz": 7703521,
+          "hzLabel": "7.7M ops/s",
+          "mean": 0.00012981076498332243,
+          "meanLabel": "130ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (1,000 items)": {
+          "name": "Seek with predicate (1,000 items)",
+          "hz": 838910,
+          "hzLabel": "838.9k ops/s",
+          "mean": 0.0011920226722074482,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (10,000 items)": {
+          "name": "Seek with predicate (10,000 items)",
+          "hz": 43456,
+          "hzLabel": "43.5k ops/s",
+          "mean": 0.02301204445860326,
+          "meanLabel": "23.0μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8286649,
+          "hzLabel": "8.3M ops/s",
+          "mean": 0.00012067604810624977,
+          "meanLabel": "121ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 104,
+          "hzLabel": "104 ops/s",
+          "mean": 9.649570365382925,
+          "meanLabel": "9.65ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createSelection": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty selection": {
+              "name": "Create empty selection",
+              "hz": 53088,
+              "hzLabel": "53.1k ops/s",
+              "mean": 0.018836684373188205,
+              "meanLabel": "18.8μs",
+              "rme": 7,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 681,
+              "hzLabel": "681 ops/s",
+              "mean": 1.4687200029315073,
+              "meanLabel": "1.47ms",
+              "rme": 10.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 63,
+              "hzLabel": "63 ops/s",
+              "mean": 15.78929243749917,
+              "meanLabel": "15.79ms",
+              "rme": 10.9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (enroll)": {
+              "name": "Onboard 1,000 items (enroll)",
+              "hz": 483,
+              "hzLabel": "483 ops/s",
+              "mean": 2.0706883539089267,
+              "meanLabel": "2.07ms",
+              "rme": 6.7,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (enroll)": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.924233318179507,
+              "meanLabel": "23.92ms",
+              "rme": 9.7,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory: force)": {
+              "name": "Onboard 1,000 items (mandatory: force)",
+              "hz": 520,
+              "hzLabel": "520 ops/s",
+              "mean": 1.9239264600760855,
+              "meanLabel": "1.92ms",
+              "rme": 9.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory: force)": {
+              "name": "Onboard 10,000 items (mandatory: force)",
+              "hz": 54,
+              "hzLabel": "54 ops/s",
+              "mean": 18.380369714287685,
+              "meanLabel": "18.38ms",
+              "rme": 6.4,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty selection",
+              "hz": 53088,
+              "hzLabel": "53.1k ops/s",
+              "mean": 0.018836684373188205,
+              "meanLabel": "18.8μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.924233318179507,
+              "meanLabel": "23.92ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2237792,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004468689718665388,
+              "meanLabel": "447ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2267629,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00044098926104174673,
+              "meanLabel": "441ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2267629,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00044098926104174673,
+              "meanLabel": "441ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2237792,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.0004468689718665388,
+              "meanLabel": "447ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1873983,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005336227822647863,
+              "meanLabel": "534ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 1864069,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005364609354802118,
+              "meanLabel": "536ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 790366,
+              "hzLabel": "790.4k ops/s",
+              "mean": 0.0012652363026072599,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 818264,
+              "hzLabel": "818.3k ops/s",
+              "mean": 0.001222099275776167,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 964192,
+              "hzLabel": "964.2k ops/s",
+              "mean": 0.0010371379600725443,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 936986,
+              "hzLabel": "937.0k ops/s",
+              "mean": 0.0010672515741890088,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1873983,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005336227822647863,
+              "meanLabel": "534ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 790366,
+              "hzLabel": "790.4k ops/s",
+              "mean": 0.0012652363026072599,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mandatory enforcement": {
+            "Select with mandatory (1,000 items)": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 855261,
+              "hzLabel": "855.3k ops/s",
+              "mean": 0.0011692343959618442,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect blocked by mandatory (1,000 items)": {
+              "name": "Unselect blocked by mandatory (1,000 items)",
+              "hz": 633765,
+              "hzLabel": "633.8k ops/s",
+              "mean": 0.0015778711259426135,
+              "meanLabel": "1.6μs",
+              "rme": 5.8,
+              "tier": "blazing"
+            },
+            "Mandate on empty (1,000 items)": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 505862,
+              "hzLabel": "505.9k ops/s",
+              "mean": 0.0019768235771148186,
+              "meanLabel": "2.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 855261,
+              "hzLabel": "855.3k ops/s",
+              "mean": 0.0011692343959618442,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 505862,
+              "hzLabel": "505.9k ops/s",
+              "mean": 0.0019768235771148186,
+              "meanLabel": "2.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1516,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6594180013175823,
+              "meanLabel": "659.4μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 141,
+              "hzLabel": "141 ops/s",
+              "mean": 7.0915547605627705,
+              "meanLabel": "7.09ms",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Select then unselect all 1,000 items": {
+              "name": "Select then unselect all 1,000 items",
+              "hz": 868,
+              "hzLabel": "868 ops/s",
+              "mean": 1.1523064216585457,
+              "meanLabel": "1.15ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Reset selection (1,000 items)": {
+              "name": "Reset selection (1,000 items)",
+              "hz": 447,
+              "hzLabel": "447 ops/s",
+              "mean": 2.2353272946421776,
+              "meanLabel": "2.24ms",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "Reset selection (10,000 items)": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.545843272727904,
+              "meanLabel": "23.55ms",
+              "rme": 6.6,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 1516,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6594180013175823,
+              "meanLabel": "659.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.545843272727904,
+              "meanLabel": "23.55ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+              "hz": 773438,
+              "hzLabel": "773.4k ops/s",
+              "mean": 0.0012929276297989623,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 825617,
+              "hzLabel": "825.6k ops/s",
+              "mean": 0.0012112146464791432,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 813747,
+              "hzLabel": "813.7k ops/s",
+              "mean": 0.0012288833054027114,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 832649,
+              "hzLabel": "832.6k ops/s",
+              "mean": 0.0012009860902099474,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 821677,
+              "hzLabel": "821.7k ops/s",
+              "mean": 0.0012170234544167222,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 772574,
+              "hzLabel": "772.6k ops/s",
+              "mean": 0.001294374501325559,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 832649,
+              "hzLabel": "832.6k ops/s",
+              "mean": 0.0012009860902099474,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 772574,
+              "hzLabel": "772.6k ops/s",
+              "mean": 0.001294374501325559,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty selection": {
+          "name": "Create empty selection",
+          "hz": 53088,
+          "hzLabel": "53.1k ops/s",
+          "mean": 0.018836684373188205,
+          "meanLabel": "18.8μs",
+          "rme": 7,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 681,
+          "hzLabel": "681 ops/s",
+          "mean": 1.4687200029315073,
+          "meanLabel": "1.47ms",
+          "rme": 10.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 63,
+          "hzLabel": "63 ops/s",
+          "mean": 15.78929243749917,
+          "meanLabel": "15.79ms",
+          "rme": 10.9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (enroll)": {
+          "name": "Onboard 1,000 items (enroll)",
+          "hz": 483,
+          "hzLabel": "483 ops/s",
+          "mean": 2.0706883539089267,
+          "meanLabel": "2.07ms",
+          "rme": 6.7,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (enroll)": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.924233318179507,
+          "meanLabel": "23.92ms",
+          "rme": 9.7,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory: force)": {
+          "name": "Onboard 1,000 items (mandatory: force)",
+          "hz": 520,
+          "hzLabel": "520 ops/s",
+          "mean": 1.9239264600760855,
+          "meanLabel": "1.92ms",
+          "rme": 9.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory: force)": {
+          "name": "Onboard 10,000 items (mandatory: force)",
+          "hz": 54,
+          "hzLabel": "54 ops/s",
+          "mean": 18.380369714287685,
+          "meanLabel": "18.38ms",
+          "rme": 6.4,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2237792,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.0004468689718665388,
+          "meanLabel": "447ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2267629,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00044098926104174673,
+          "meanLabel": "441ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 1873983,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005336227822647863,
+          "meanLabel": "534ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 1864069,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005364609354802118,
+          "meanLabel": "536ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 790366,
+          "hzLabel": "790.4k ops/s",
+          "mean": 0.0012652363026072599,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 818264,
+          "hzLabel": "818.3k ops/s",
+          "mean": 0.001222099275776167,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 964192,
+          "hzLabel": "964.2k ops/s",
+          "mean": 0.0010371379600725443,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 936986,
+          "hzLabel": "937.0k ops/s",
+          "mean": 0.0010672515741890088,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select with mandatory (1,000 items)": {
+          "name": "Select with mandatory (1,000 items)",
+          "hz": 855261,
+          "hzLabel": "855.3k ops/s",
+          "mean": 0.0011692343959618442,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect blocked by mandatory (1,000 items)": {
+          "name": "Unselect blocked by mandatory (1,000 items)",
+          "hz": 633765,
+          "hzLabel": "633.8k ops/s",
+          "mean": 0.0015778711259426135,
+          "meanLabel": "1.6μs",
+          "rme": 5.8,
+          "tier": "blazing"
+        },
+        "Mandate on empty (1,000 items)": {
+          "name": "Mandate on empty (1,000 items)",
+          "hz": 505862,
+          "hzLabel": "505.9k ops/s",
+          "mean": 0.0019768235771148186,
+          "meanLabel": "2.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1516,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6594180013175823,
+          "meanLabel": "659.4μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 141,
+          "hzLabel": "141 ops/s",
+          "mean": 7.0915547605627705,
+          "meanLabel": "7.09ms",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Select then unselect all 1,000 items": {
+          "name": "Select then unselect all 1,000 items",
+          "hz": 868,
+          "hzLabel": "868 ops/s",
+          "mean": 1.1523064216585457,
+          "meanLabel": "1.15ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Reset selection (1,000 items)": {
+          "name": "Reset selection (1,000 items)",
+          "hz": 447,
+          "hzLabel": "447 ops/s",
+          "mean": 2.2353272946421776,
+          "meanLabel": "2.24ms",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Reset selection (10,000 items)": {
+          "name": "Reset selection (10,000 items)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.545843272727904,
+          "meanLabel": "23.55ms",
+          "rme": 6.6,
+          "tier": "fast"
+        },
+        "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+          "hz": 773438,
+          "hzLabel": "773.4k ops/s",
+          "mean": 0.0012929276297989623,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 825617,
+          "hzLabel": "825.6k ops/s",
+          "mean": 0.0012112146464791432,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 813747,
+          "hzLabel": "813.7k ops/s",
+          "mean": 0.0012288833054027114,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+          "hz": 832649,
+          "hzLabel": "832.6k ops/s",
+          "mean": 0.0012009860902099474,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 821677,
+          "hzLabel": "821.7k ops/s",
+          "mean": 0.0012170234544167222,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 772574,
+          "hzLabel": "772.6k ops/s",
+          "mean": 0.001294374501325559,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2267629,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00044098926104174673,
+          "meanLabel": "441ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.924233318179507,
+          "meanLabel": "23.92ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSingle": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty single": {
+              "name": "Create empty single",
+              "hz": 35536,
+              "hzLabel": "35.5k ops/s",
+              "mean": 0.028140445797966256,
+              "meanLabel": "28.1μs",
+              "rme": 8.8,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 721,
+              "hzLabel": "721 ops/s",
+              "mean": 1.3877148808870488,
+              "meanLabel": "1.39ms",
+              "rme": 8.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 65,
+              "hzLabel": "65 ops/s",
+              "mean": 15.407596636371277,
+              "meanLabel": "15.41ms",
+              "rme": 9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 710,
+              "hzLabel": "710 ops/s",
+              "mean": 1.4085861971839593,
+              "meanLabel": "1.41ms",
+              "rme": 9.1,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 64,
+              "hzLabel": "64 ops/s",
+              "mean": 15.648297303028151,
+              "meanLabel": "15.65ms",
+              "rme": 9.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty single",
+              "hz": 35536,
+              "hzLabel": "35.5k ops/s",
+              "mean": 0.028140445797966256,
+              "meanLabel": "28.1μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 64,
+              "hzLabel": "64 ops/s",
+              "mean": 15.648297303028151,
+              "meanLabel": "15.65ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2236909,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00044704538936992424,
+              "meanLabel": "447ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2210171,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045245368596698624,
+              "meanLabel": "452ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2236909,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00044704538936992424,
+              "meanLabel": "447ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2210171,
+              "hzLabel": "2.2M ops/s",
+              "mean": 0.00045245368596698624,
+              "meanLabel": "452ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 840694,
+              "hzLabel": "840.7k ops/s",
+              "mean": 0.0011894929010799837,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 838909,
+              "hzLabel": "838.9k ops/s",
+              "mean": 0.0011920243840362673,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 567495,
+              "hzLabel": "567.5k ops/s",
+              "mean": 0.0017621314828687633,
+              "meanLabel": "1.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 597012,
+              "hzLabel": "597.0k ops/s",
+              "mean": 0.0016750087803556566,
+              "meanLabel": "1.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 780276,
+              "hzLabel": "780.3k ops/s",
+              "mean": 0.0012815985574663445,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 779445,
+              "hzLabel": "779.4k ops/s",
+              "mean": 0.0012829639487182654,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 840694,
+              "hzLabel": "840.7k ops/s",
+              "mean": 0.0011894929010799837,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 567495,
+              "hzLabel": "567.5k ops/s",
+              "mean": 0.0017621314828687633,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 5910,
+              "hzLabel": "5.9k ops/s",
+              "mean": 0.16921055702267643,
+              "meanLabel": "169.2μs",
+              "rme": 4.7,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (10,000 items, cached)": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 5359,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1866079302408546,
+              "meanLabel": "186.6μs",
+              "rme": 9.3,
+              "tier": "blazing"
+            },
+            "Access selectedItem 100 times (1,000 items, cached)": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 336765,
+              "hzLabel": "336.8k ops/s",
+              "mean": 0.0029694292356780886,
+              "meanLabel": "3.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 297399,
+              "hzLabel": "297.4k ops/s",
+              "mean": 0.003362481008742879,
+              "meanLabel": "3.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 252957,
+              "hzLabel": "253.0k ops/s",
+              "mean": 0.003953236537374381,
+              "meanLabel": "4.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 336765,
+              "hzLabel": "336.8k ops/s",
+              "mean": 0.0029694292356780886,
+              "meanLabel": "3.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 5359,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1866079302408546,
+              "meanLabel": "186.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty single": {
+          "name": "Create empty single",
+          "hz": 35536,
+          "hzLabel": "35.5k ops/s",
+          "mean": 0.028140445797966256,
+          "meanLabel": "28.1μs",
+          "rme": 8.8,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 721,
+          "hzLabel": "721 ops/s",
+          "mean": 1.3877148808870488,
+          "meanLabel": "1.39ms",
+          "rme": 8.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 65,
+          "hzLabel": "65 ops/s",
+          "mean": 15.407596636371277,
+          "meanLabel": "15.41ms",
+          "rme": 9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 710,
+          "hzLabel": "710 ops/s",
+          "mean": 1.4085861971839593,
+          "meanLabel": "1.41ms",
+          "rme": 9.1,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 64,
+          "hzLabel": "64 ops/s",
+          "mean": 15.648297303028151,
+          "meanLabel": "15.65ms",
+          "rme": 9.1,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2236909,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00044704538936992424,
+          "meanLabel": "447ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2210171,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00045245368596698624,
+          "meanLabel": "452ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 840694,
+          "hzLabel": "840.7k ops/s",
+          "mean": 0.0011894929010799837,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 838909,
+          "hzLabel": "838.9k ops/s",
+          "mean": 0.0011920243840362673,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 567495,
+          "hzLabel": "567.5k ops/s",
+          "mean": 0.0017621314828687633,
+          "meanLabel": "1.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 597012,
+          "hzLabel": "597.0k ops/s",
+          "mean": 0.0016750087803556566,
+          "meanLabel": "1.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 780276,
+          "hzLabel": "780.3k ops/s",
+          "mean": 0.0012815985574663445,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 779445,
+          "hzLabel": "779.4k ops/s",
+          "mean": 0.0012829639487182654,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 5910,
+          "hzLabel": "5.9k ops/s",
+          "mean": 0.16921055702267643,
+          "meanLabel": "169.2μs",
+          "rme": 4.7,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (10,000 items, cached)": {
+          "name": "Access selectedId 100 times (10,000 items, cached)",
+          "hz": 5359,
+          "hzLabel": "5.4k ops/s",
+          "mean": 0.1866079302408546,
+          "meanLabel": "186.6μs",
+          "rme": 9.3,
+          "tier": "blazing"
+        },
+        "Access selectedItem 100 times (1,000 items, cached)": {
+          "name": "Access selectedItem 100 times (1,000 items, cached)",
+          "hz": 336765,
+          "hzLabel": "336.8k ops/s",
+          "mean": 0.0029694292356780886,
+          "meanLabel": "3.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 297399,
+          "hzLabel": "297.4k ops/s",
+          "mean": 0.003362481008742879,
+          "meanLabel": "3.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 252957,
+          "hzLabel": "253.0k ops/s",
+          "mean": 0.003953236537374381,
+          "meanLabel": "4.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2236909,
+          "hzLabel": "2.2M ops/s",
+          "mean": 0.00044704538936992424,
+          "meanLabel": "447ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 64,
+          "hzLabel": "64 ops/s",
+          "mean": 15.648297303028151,
+          "meanLabel": "15.65ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSortable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty sortable": {
+              "name": "Create empty sortable",
+              "hz": 49195,
+              "hzLabel": "49.2k ops/s",
+              "mean": 0.02032740125220656,
+              "meanLabel": "20.3μs",
+              "rme": 8.4,
+              "tier": "fast"
+            },
+            "Create empty sortable (disabled)": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 47608,
+              "hzLabel": "47.6k ops/s",
+              "mean": 0.02100492455049723,
+              "meanLabel": "21.0μs",
+              "rme": 13,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty sortable",
+              "hz": 49195,
+              "hzLabel": "49.2k ops/s",
+              "mean": 0.02032740125220656,
+              "meanLabel": "20.3μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 47608,
+              "hzLabel": "47.6k ops/s",
+              "mean": 0.02100492455049723,
+              "meanLabel": "21.0μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7993338,
+              "hzLabel": "8.0M ops/s",
+              "mean": 0.0001251041880098429,
+              "meanLabel": "125ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8104593,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012338682356777364,
+              "meanLabel": "123ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Values snapshot (10,000 items)": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 6970714,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014345731859205713,
+              "meanLabel": "143ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8104593,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012338682356777364,
+              "meanLabel": "123ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 6970714,
+              "hzLabel": "7.0M ops/s",
+              "mean": 0.00014345731859205713,
+              "meanLabel": "143ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "move operations": {
+            "Move first to last (1,000 items)": {
+              "name": "Move first to last (1,000 items)",
+              "hz": 8477,
+              "hzLabel": "8.5k ops/s",
+              "mean": 0.11796070912933185,
+              "meanLabel": "118.0μs",
+              "rme": 7.3,
+              "tier": "blazing"
+            },
+            "Move first to last (10,000 items)": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 511,
+              "hzLabel": "511 ops/s",
+              "mean": 1.9581622226563695,
+              "meanLabel": "1.96ms",
+              "rme": 8.5,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (1,000 items)": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 241768,
+              "hzLabel": "241.8k ops/s",
+              "mean": 0.004136199488717142,
+              "meanLabel": "4.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (10,000 items)": {
+              "name": "Move mid by 1 (10,000 items)",
+              "hz": 29356,
+              "hzLabel": "29.4k ops/s",
+              "mean": 0.03406458137475874,
+              "meanLabel": "34.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 241768,
+              "hzLabel": "241.8k ops/s",
+              "mean": 0.004136199488717142,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 511,
+              "hzLabel": "511 ops/s",
+              "mean": 1.9581622226563695,
+              "meanLabel": "1.96ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "swap operations": {
+            "Swap two tickets (1,000 items)": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 6629,
+              "hzLabel": "6.6k ops/s",
+              "mean": 0.1508454343892787,
+              "meanLabel": "150.8μs",
+              "rme": 2.1,
+              "tier": "blazing"
+            },
+            "Swap two tickets (10,000 items)": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 373,
+              "hzLabel": "373 ops/s",
+              "mean": 2.6795017165765302,
+              "meanLabel": "2.68ms",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 6629,
+              "hzLabel": "6.6k ops/s",
+              "mean": 0.1508454343892787,
+              "meanLabel": "150.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 373,
+              "hzLabel": "373 ops/s",
+              "mean": 2.6795017165765302,
+              "meanLabel": "2.68ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reorder operations": {
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2585,
+              "hzLabel": "2.6k ops/s",
+              "mean": 0.3868262250578866,
+              "meanLabel": "386.8μs",
+              "rme": 7.2,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 166,
+              "hzLabel": "166 ops/s",
+              "mean": 6.02921918072143,
+              "meanLabel": "6.03ms",
+              "rme": 7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2585,
+              "hzLabel": "2.6k ops/s",
+              "mean": 0.3868262250578866,
+              "meanLabel": "386.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 166,
+              "hzLabel": "166 ops/s",
+              "mean": 6.02921918072143,
+              "meanLabel": "6.03ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 100 items": {
+              "name": "Onboard 100 items",
+              "hz": 4337,
+              "hzLabel": "4.3k ops/s",
+              "mean": 0.23059803734471981,
+              "meanLabel": "230.6μs",
+              "rme": 5.3,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 471,
+              "hzLabel": "471 ops/s",
+              "mean": 2.1213760254242393,
+              "meanLabel": "2.12ms",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 43,
+              "hzLabel": "43 ops/s",
+              "mean": 23.203239363635394,
+              "meanLabel": "23.20ms",
+              "rme": 4.5,
+              "tier": "fast"
+            },
+            "Register then move to mid (1,000 items)": {
+              "name": "Register then move to mid (1,000 items)",
+              "hz": 455,
+              "hzLabel": "455 ops/s",
+              "mean": 2.199674188596219,
+              "meanLabel": "2.20ms",
+              "rme": 4.5,
+              "tier": "fast"
+            },
+            "Register then move to mid (10,000 items)": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.597162636359414,
+              "meanLabel": "23.60ms",
+              "rme": 4.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Onboard 100 items",
+              "hz": 4337,
+              "hzLabel": "4.3k ops/s",
+              "mean": 0.23059803734471981,
+              "meanLabel": "230.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 42,
+              "hzLabel": "42 ops/s",
+              "mean": 23.597162636359414,
+              "meanLabel": "23.60ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "events overhead": {
+            "Move with no listeners (1,000 items)": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 243852,
+              "hzLabel": "243.9k ops/s",
+              "mean": 0.004100853271666938,
+              "meanLabel": "4.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Move with listener attached (1,000 items)": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 243170,
+              "hzLabel": "243.2k ops/s",
+              "mean": 0.004112344751814893,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Move with no listeners (10,000 items)": {
+              "name": "Move with no listeners (10,000 items)",
+              "hz": 29617,
+              "hzLabel": "29.6k ops/s",
+              "mean": 0.03376390492284224,
+              "meanLabel": "33.8μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Move with listener attached (10,000 items)": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29545,
+              "hzLabel": "29.5k ops/s",
+              "mean": 0.03384681208954856,
+              "meanLabel": "33.8μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 243852,
+              "hzLabel": "243.9k ops/s",
+              "mean": 0.004100853271666938,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29545,
+              "hzLabel": "29.5k ops/s",
+              "mean": 0.03384681208954856,
+              "meanLabel": "33.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty sortable": {
+          "name": "Create empty sortable",
+          "hz": 49195,
+          "hzLabel": "49.2k ops/s",
+          "mean": 0.02032740125220656,
+          "meanLabel": "20.3μs",
+          "rme": 8.4,
+          "tier": "fast"
+        },
+        "Create empty sortable (disabled)": {
+          "name": "Create empty sortable (disabled)",
+          "hz": 47608,
+          "hzLabel": "47.6k ops/s",
+          "mean": 0.02100492455049723,
+          "meanLabel": "21.0μs",
+          "rme": 13,
+          "tier": "fast"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7993338,
+          "hzLabel": "8.0M ops/s",
+          "mean": 0.0001251041880098429,
+          "meanLabel": "125ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8104593,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012338682356777364,
+          "meanLabel": "123ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Values snapshot (10,000 items)": {
+          "name": "Values snapshot (10,000 items)",
+          "hz": 6970714,
+          "hzLabel": "7.0M ops/s",
+          "mean": 0.00014345731859205713,
+          "meanLabel": "143ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Move first to last (1,000 items)": {
+          "name": "Move first to last (1,000 items)",
+          "hz": 8477,
+          "hzLabel": "8.5k ops/s",
+          "mean": 0.11796070912933185,
+          "meanLabel": "118.0μs",
+          "rme": 7.3,
+          "tier": "blazing"
+        },
+        "Move first to last (10,000 items)": {
+          "name": "Move first to last (10,000 items)",
+          "hz": 511,
+          "hzLabel": "511 ops/s",
+          "mean": 1.9581622226563695,
+          "meanLabel": "1.96ms",
+          "rme": 8.5,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (1,000 items)": {
+          "name": "Move mid by 1 (1,000 items)",
+          "hz": 241768,
+          "hzLabel": "241.8k ops/s",
+          "mean": 0.004136199488717142,
+          "meanLabel": "4.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (10,000 items)": {
+          "name": "Move mid by 1 (10,000 items)",
+          "hz": 29356,
+          "hzLabel": "29.4k ops/s",
+          "mean": 0.03406458137475874,
+          "meanLabel": "34.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Swap two tickets (1,000 items)": {
+          "name": "Swap two tickets (1,000 items)",
+          "hz": 6629,
+          "hzLabel": "6.6k ops/s",
+          "mean": 0.1508454343892787,
+          "meanLabel": "150.8μs",
+          "rme": 2.1,
+          "tier": "blazing"
+        },
+        "Swap two tickets (10,000 items)": {
+          "name": "Swap two tickets (10,000 items)",
+          "hz": 373,
+          "hzLabel": "373 ops/s",
+          "mean": 2.6795017165765302,
+          "meanLabel": "2.68ms",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 2585,
+          "hzLabel": "2.6k ops/s",
+          "mean": 0.3868262250578866,
+          "meanLabel": "386.8μs",
+          "rme": 7.2,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 166,
+          "hzLabel": "166 ops/s",
+          "mean": 6.02921918072143,
+          "meanLabel": "6.03ms",
+          "rme": 7,
+          "tier": "blazing"
+        },
+        "Onboard 100 items": {
+          "name": "Onboard 100 items",
+          "hz": 4337,
+          "hzLabel": "4.3k ops/s",
+          "mean": 0.23059803734471981,
+          "meanLabel": "230.6μs",
+          "rme": 5.3,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 471,
+          "hzLabel": "471 ops/s",
+          "mean": 2.1213760254242393,
+          "meanLabel": "2.12ms",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 43,
+          "hzLabel": "43 ops/s",
+          "mean": 23.203239363635394,
+          "meanLabel": "23.20ms",
+          "rme": 4.5,
+          "tier": "fast"
+        },
+        "Register then move to mid (1,000 items)": {
+          "name": "Register then move to mid (1,000 items)",
+          "hz": 455,
+          "hzLabel": "455 ops/s",
+          "mean": 2.199674188596219,
+          "meanLabel": "2.20ms",
+          "rme": 4.5,
+          "tier": "fast"
+        },
+        "Register then move to mid (10,000 items)": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.597162636359414,
+          "meanLabel": "23.60ms",
+          "rme": 4.2,
+          "tier": "fast"
+        },
+        "Move with no listeners (1,000 items)": {
+          "name": "Move with no listeners (1,000 items)",
+          "hz": 243852,
+          "hzLabel": "243.9k ops/s",
+          "mean": 0.004100853271666938,
+          "meanLabel": "4.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Move with listener attached (1,000 items)": {
+          "name": "Move with listener attached (1,000 items)",
+          "hz": 243170,
+          "hzLabel": "243.2k ops/s",
+          "mean": 0.004112344751814893,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move with no listeners (10,000 items)": {
+          "name": "Move with no listeners (10,000 items)",
+          "hz": 29617,
+          "hzLabel": "29.6k ops/s",
+          "mean": 0.03376390492284224,
+          "meanLabel": "33.8μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Move with listener attached (10,000 items)": {
+          "name": "Move with listener attached (10,000 items)",
+          "hz": 29545,
+          "hzLabel": "29.5k ops/s",
+          "mean": 0.03384681208954856,
+          "meanLabel": "33.8μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8104593,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012338682356777364,
+          "meanLabel": "123ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 42,
+          "hzLabel": "42 ops/s",
+          "mean": 23.597162636359414,
+          "meanLabel": "23.60ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createStep": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty step": {
+              "name": "Create empty step",
+              "hz": 25882,
+              "hzLabel": "25.9k ops/s",
+              "mean": 0.03863645418035773,
+              "meanLabel": "38.6μs",
+              "rme": 9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 672,
+              "hzLabel": "672 ops/s",
+              "mean": 1.4883236577379215,
+              "meanLabel": "1.49ms",
+              "rme": 10.4,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 63,
+              "hzLabel": "63 ops/s",
+              "mean": 15.7678409062446,
+              "meanLabel": "15.77ms",
+              "rme": 9.5,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (circular)": {
+              "name": "Onboard 1,000 items (circular)",
+              "hz": 706,
+              "hzLabel": "706 ops/s",
+              "mean": 1.4158834789914512,
+              "meanLabel": "1.42ms",
+              "rme": 8.8,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 699,
+              "hzLabel": "699 ops/s",
+              "mean": 1.4306455714298811,
+              "meanLabel": "1.43ms",
+              "rme": 9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty step",
+              "hz": 25882,
+              "hzLabel": "25.9k ops/s",
+              "mean": 0.03863645418035773,
+              "meanLabel": "38.6μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 63,
+              "hzLabel": "63 ops/s",
+              "mean": 15.7678409062446,
+              "meanLabel": "15.77ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation operations (linear)": {
+            "next() from mid-point (1,000 items)": {
+              "name": "next() from mid-point (1,000 items)",
+              "hz": 110468,
+              "hzLabel": "110.5k ops/s",
+              "mean": 0.00905238591482245,
+              "meanLabel": "9.1μs",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "next() from mid-point (10,000 items)": {
+              "name": "next() from mid-point (10,000 items)",
+              "hz": 113084,
+              "hzLabel": "113.1k ops/s",
+              "mean": 0.008842982951085265,
+              "meanLabel": "8.8μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (1,000 items)": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 114873,
+              "hzLabel": "114.9k ops/s",
+              "mean": 0.008705263001187381,
+              "meanLabel": "8.7μs",
+              "rme": 2.6,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (10,000 items)": {
+              "name": "prev() from mid-point (10,000 items)",
+              "hz": 112259,
+              "hzLabel": "112.3k ops/s",
+              "mean": 0.008907936362048743,
+              "meanLabel": "8.9μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "first() (1,000 items)": {
+              "name": "first() (1,000 items)",
+              "hz": 378598,
+              "hzLabel": "378.6k ops/s",
+              "mean": 0.002641325152224815,
+              "meanLabel": "2.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "last() (1,000 items)": {
+              "name": "last() (1,000 items)",
+              "hz": 381732,
+              "hzLabel": "381.7k ops/s",
+              "mean": 0.00261963557353455,
+              "meanLabel": "2.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "step(+5) from mid-point (1,000 items)": {
+              "name": "step(+5) from mid-point (1,000 items)",
+              "hz": 108386,
+              "hzLabel": "108.4k ops/s",
+              "mean": 0.009226287361868606,
+              "meanLabel": "9.2μs",
+              "rme": 4.5,
+              "tier": "blazing"
+            },
+            "step(+50) from mid-point (1,000 items)": {
+              "name": "step(+50) from mid-point (1,000 items)",
+              "hz": 112822,
+              "hzLabel": "112.8k ops/s",
+              "mean": 0.008863554484023541,
+              "meanLabel": "8.9μs",
+              "rme": 2.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "last() (1,000 items)",
+              "hz": 381732,
+              "hzLabel": "381.7k ops/s",
+              "mean": 0.00261963557353455,
+              "meanLabel": "2.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "step(+5) from mid-point (1,000 items)",
+              "hz": 108386,
+              "hzLabel": "108.4k ops/s",
+              "mean": 0.009226287361868606,
+              "meanLabel": "9.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "navigation operations (circular)": {
+            "next() from mid-point circular (1,000 items)": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 110678,
+              "hzLabel": "110.7k ops/s",
+              "mean": 0.00903522470675689,
+              "meanLabel": "9.0μs",
+              "rme": 3.1,
+              "tier": "blazing"
+            },
+            "next() wrapping past end circular (1,000 items)": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 137216,
+              "hzLabel": "137.2k ops/s",
+              "mean": 0.007287798113860567,
+              "meanLabel": "7.3μs",
+              "rme": 2.3,
+              "tier": "blazing"
+            },
+            "prev() wrapping past start circular (1,000 items)": {
+              "name": "prev() wrapping past start circular (1,000 items)",
+              "hz": 131745,
+              "hzLabel": "131.7k ops/s",
+              "mean": 0.00759043435088749,
+              "meanLabel": "7.6μs",
+              "rme": 1.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 137216,
+              "hzLabel": "137.2k ops/s",
+              "mean": 0.007287798113860567,
+              "meanLabel": "7.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 110678,
+              "hzLabel": "110.7k ops/s",
+              "mean": 0.00903522470675689,
+              "meanLabel": "9.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "boundary conditions": {
+            "next() at last item — no-op (1,000 items)": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 219822,
+              "hzLabel": "219.8k ops/s",
+              "mean": 0.004549128484700879,
+              "meanLabel": "4.5μs",
+              "rme": 4,
+              "tier": "blazing"
+            },
+            "prev() at first item — no-op (1,000 items)": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 249239,
+              "hzLabel": "249.2k ops/s",
+              "mean": 0.004012210375556482,
+              "meanLabel": "4.0μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 249239,
+              "hzLabel": "249.2k ops/s",
+              "mean": 0.004012210375556482,
+              "meanLabel": "4.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 219822,
+              "hzLabel": "219.8k ops/s",
+              "mean": 0.004549128484700879,
+              "meanLabel": "4.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 301044,
+              "hzLabel": "301.0k ops/s",
+              "mean": 0.0033217707592435607,
+              "meanLabel": "3.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (10,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (10,000 items, cached)",
+              "hz": 303040,
+              "hzLabel": "303.0k ops/s",
+              "mean": 0.0032998898568160143,
+              "meanLabel": "3.3μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 5561,
+              "hzLabel": "5.6k ops/s",
+              "mean": 0.17983171844673945,
+              "meanLabel": "179.8μs",
+              "rme": 8.7,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 283889,
+              "hzLabel": "283.9k ops/s",
+              "mean": 0.0035225034837678337,
+              "meanLabel": "3.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndex 100 times (10,000 items, cached)",
+              "hz": 303040,
+              "hzLabel": "303.0k ops/s",
+              "mean": 0.0032998898568160143,
+              "meanLabel": "3.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 5561,
+              "hzLabel": "5.6k ops/s",
+              "mean": 0.17983171844673945,
+              "meanLabel": "179.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty step": {
+          "name": "Create empty step",
+          "hz": 25882,
+          "hzLabel": "25.9k ops/s",
+          "mean": 0.03863645418035773,
+          "meanLabel": "38.6μs",
+          "rme": 9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 672,
+          "hzLabel": "672 ops/s",
+          "mean": 1.4883236577379215,
+          "meanLabel": "1.49ms",
+          "rme": 10.4,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 63,
+          "hzLabel": "63 ops/s",
+          "mean": 15.7678409062446,
+          "meanLabel": "15.77ms",
+          "rme": 9.5,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (circular)": {
+          "name": "Onboard 1,000 items (circular)",
+          "hz": 706,
+          "hzLabel": "706 ops/s",
+          "mean": 1.4158834789914512,
+          "meanLabel": "1.42ms",
+          "rme": 8.8,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 699,
+          "hzLabel": "699 ops/s",
+          "mean": 1.4306455714298811,
+          "meanLabel": "1.43ms",
+          "rme": 9,
+          "tier": "fast"
+        },
+        "next() from mid-point (1,000 items)": {
+          "name": "next() from mid-point (1,000 items)",
+          "hz": 110468,
+          "hzLabel": "110.5k ops/s",
+          "mean": 0.00905238591482245,
+          "meanLabel": "9.1μs",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "next() from mid-point (10,000 items)": {
+          "name": "next() from mid-point (10,000 items)",
+          "hz": 113084,
+          "hzLabel": "113.1k ops/s",
+          "mean": 0.008842982951085265,
+          "meanLabel": "8.8μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (1,000 items)": {
+          "name": "prev() from mid-point (1,000 items)",
+          "hz": 114873,
+          "hzLabel": "114.9k ops/s",
+          "mean": 0.008705263001187381,
+          "meanLabel": "8.7μs",
+          "rme": 2.6,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (10,000 items)": {
+          "name": "prev() from mid-point (10,000 items)",
+          "hz": 112259,
+          "hzLabel": "112.3k ops/s",
+          "mean": 0.008907936362048743,
+          "meanLabel": "8.9μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "first() (1,000 items)": {
+          "name": "first() (1,000 items)",
+          "hz": 378598,
+          "hzLabel": "378.6k ops/s",
+          "mean": 0.002641325152224815,
+          "meanLabel": "2.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "last() (1,000 items)": {
+          "name": "last() (1,000 items)",
+          "hz": 381732,
+          "hzLabel": "381.7k ops/s",
+          "mean": 0.00261963557353455,
+          "meanLabel": "2.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "step(+5) from mid-point (1,000 items)": {
+          "name": "step(+5) from mid-point (1,000 items)",
+          "hz": 108386,
+          "hzLabel": "108.4k ops/s",
+          "mean": 0.009226287361868606,
+          "meanLabel": "9.2μs",
+          "rme": 4.5,
+          "tier": "blazing"
+        },
+        "step(+50) from mid-point (1,000 items)": {
+          "name": "step(+50) from mid-point (1,000 items)",
+          "hz": 112822,
+          "hzLabel": "112.8k ops/s",
+          "mean": 0.008863554484023541,
+          "meanLabel": "8.9μs",
+          "rme": 2.6,
+          "tier": "blazing"
+        },
+        "next() from mid-point circular (1,000 items)": {
+          "name": "next() from mid-point circular (1,000 items)",
+          "hz": 110678,
+          "hzLabel": "110.7k ops/s",
+          "mean": 0.00903522470675689,
+          "meanLabel": "9.0μs",
+          "rme": 3.1,
+          "tier": "blazing"
+        },
+        "next() wrapping past end circular (1,000 items)": {
+          "name": "next() wrapping past end circular (1,000 items)",
+          "hz": 137216,
+          "hzLabel": "137.2k ops/s",
+          "mean": 0.007287798113860567,
+          "meanLabel": "7.3μs",
+          "rme": 2.3,
+          "tier": "blazing"
+        },
+        "prev() wrapping past start circular (1,000 items)": {
+          "name": "prev() wrapping past start circular (1,000 items)",
+          "hz": 131745,
+          "hzLabel": "131.7k ops/s",
+          "mean": 0.00759043435088749,
+          "meanLabel": "7.6μs",
+          "rme": 1.8,
+          "tier": "blazing"
+        },
+        "next() at last item — no-op (1,000 items)": {
+          "name": "next() at last item — no-op (1,000 items)",
+          "hz": 219822,
+          "hzLabel": "219.8k ops/s",
+          "mean": 0.004549128484700879,
+          "meanLabel": "4.5μs",
+          "rme": 4,
+          "tier": "blazing"
+        },
+        "prev() at first item — no-op (1,000 items)": {
+          "name": "prev() at first item — no-op (1,000 items)",
+          "hz": 249239,
+          "hzLabel": "249.2k ops/s",
+          "mean": 0.004012210375556482,
+          "meanLabel": "4.0μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 301044,
+          "hzLabel": "301.0k ops/s",
+          "mean": 0.0033217707592435607,
+          "meanLabel": "3.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (10,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (10,000 items, cached)",
+          "hz": 303040,
+          "hzLabel": "303.0k ops/s",
+          "mean": 0.0032998898568160143,
+          "meanLabel": "3.3μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 5561,
+          "hzLabel": "5.6k ops/s",
+          "mean": 0.17983171844673945,
+          "meanLabel": "179.8μs",
+          "rme": 8.7,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 283889,
+          "hzLabel": "283.9k ops/s",
+          "mean": 0.0035225034837678337,
+          "meanLabel": "3.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "last() (1,000 items)",
+          "hz": 381732,
+          "hzLabel": "381.7k ops/s",
+          "mean": 0.00261963557353455,
+          "meanLabel": "2.6μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 63,
+          "hzLabel": "63 ops/s",
+          "mean": 15.7678409062446,
+          "meanLabel": "15.77ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createTokens": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create tokens (~100 tokens)": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6277,
+              "hzLabel": "6.3k ops/s",
+              "mean": 0.1593093622176053,
+              "meanLabel": "159.3μs",
+              "rme": 6.9,
+              "tier": "fast"
+            },
+            "Create tokens (1,000 tokens)": {
+              "name": "Create tokens (1,000 tokens)",
+              "hz": 821,
+              "hzLabel": "821 ops/s",
+              "mean": 1.2179176496340975,
+              "meanLabel": "1.22ms",
+              "rme": 5.3,
+              "tier": "fast"
+            },
+            "Create tokens (10,000 tokens)": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 67,
+              "hzLabel": "67 ops/s",
+              "mean": 15.002147970589302,
+              "meanLabel": "15.00ms",
+              "rme": 7.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 6277,
+              "hzLabel": "6.3k ops/s",
+              "mean": 0.1593093622176053,
+              "meanLabel": "159.3μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 67,
+              "hzLabel": "67 ops/s",
+              "mean": 15.002147970589302,
+              "meanLabel": "15.00ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Resolve primitive token": {
+              "name": "Resolve primitive token",
+              "hz": 4074640,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024542047050627586,
+              "meanLabel": "245ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve nested path (3 levels)": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 4024284,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002484914069360894,
+              "meanLabel": "248ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve deep nested path (5 levels)": {
+              "name": "Resolve deep nested path (5 levels)",
+              "hz": 4014678,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00024908596651532493,
+              "meanLabel": "249ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Resolve by id (1,000 tokens)": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 4004132,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002497419941281376,
+              "meanLabel": "250ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve by id (10,000 tokens)": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 4090544,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.0002444662836963383,
+              "meanLabel": "244ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 4090544,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.0002444662836963383,
+              "meanLabel": "244ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 4004132,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002497419941281376,
+              "meanLabel": "250ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "alias resolution": {
+            "Resolve single alias": {
+              "name": "Resolve single alias",
+              "hz": 4006496,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.0002495946430078078,
+              "meanLabel": "250ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve chained alias (2 levels)": {
+              "name": "Resolve chained alias (2 levels)",
+              "hz": 4010289,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00024935861346898013,
+              "meanLabel": "249ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve component alias reference": {
+              "name": "Resolve component alias reference",
+              "hz": 3954138,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00025289959178991303,
+              "meanLabel": "253ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (1,000 tokens)": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 4017572,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.000248906523731372,
+              "meanLabel": "249ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (10,000 tokens)": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 4055633,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024657060920450877,
+              "meanLabel": "247ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 4055633,
+              "hzLabel": "4.1M ops/s",
+              "mean": 0.00024657060920450877,
+              "meanLabel": "247ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve component alias reference",
+              "hz": 3954138,
+              "hzLabel": "4.0M ops/s",
+              "mean": 0.00025289959178991303,
+              "meanLabel": "253ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch resolution": {
+            "Resolve 5 different paths sequentially": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1313263,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007614621386477932,
+              "meanLabel": "761ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve 100 paths (20 unique, repeated)": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 79426,
+              "hzLabel": "79.4k ops/s",
+              "mean": 0.012590404578143647,
+              "meanLabel": "12.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1313263,
+              "hzLabel": "1.3M ops/s",
+              "mean": 0.0007614621386477932,
+              "meanLabel": "761ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 79426,
+              "hzLabel": "79.4k ops/s",
+              "mean": 0.012590404578143647,
+              "meanLabel": "12.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access token 100 times (fixture, cached)": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 86649,
+              "hzLabel": "86.6k ops/s",
+              "mean": 0.011540753467784215,
+              "meanLabel": "11.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access token 100 times (1,000 tokens, cached)": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 75006,
+              "hzLabel": "75.0k ops/s",
+              "mean": 0.013332203391674263,
+              "meanLabel": "13.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access token 100 times (10,000 tokens, cached)": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 86565,
+              "hzLabel": "86.6k ops/s",
+              "mean": 0.011551989141405218,
+              "meanLabel": "11.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 86649,
+              "hzLabel": "86.6k ops/s",
+              "mean": 0.011540753467784215,
+              "meanLabel": "11.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 75006,
+              "hzLabel": "75.0k ops/s",
+              "mean": 0.013332203391674263,
+              "meanLabel": "13.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create tokens (~100 tokens)": {
+          "name": "Create tokens (~100 tokens)",
+          "hz": 6277,
+          "hzLabel": "6.3k ops/s",
+          "mean": 0.1593093622176053,
+          "meanLabel": "159.3μs",
+          "rme": 6.9,
+          "tier": "fast"
+        },
+        "Create tokens (1,000 tokens)": {
+          "name": "Create tokens (1,000 tokens)",
+          "hz": 821,
+          "hzLabel": "821 ops/s",
+          "mean": 1.2179176496340975,
+          "meanLabel": "1.22ms",
+          "rme": 5.3,
+          "tier": "fast"
+        },
+        "Create tokens (10,000 tokens)": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 67,
+          "hzLabel": "67 ops/s",
+          "mean": 15.002147970589302,
+          "meanLabel": "15.00ms",
+          "rme": 7.1,
+          "tier": "fast"
+        },
+        "Resolve primitive token": {
+          "name": "Resolve primitive token",
+          "hz": 4074640,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.00024542047050627586,
+          "meanLabel": "245ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve nested path (3 levels)": {
+          "name": "Resolve nested path (3 levels)",
+          "hz": 4024284,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002484914069360894,
+          "meanLabel": "248ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve deep nested path (5 levels)": {
+          "name": "Resolve deep nested path (5 levels)",
+          "hz": 4014678,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00024908596651532493,
+          "meanLabel": "249ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Resolve by id (1,000 tokens)": {
+          "name": "Resolve by id (1,000 tokens)",
+          "hz": 4004132,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002497419941281376,
+          "meanLabel": "250ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve by id (10,000 tokens)": {
+          "name": "Resolve by id (10,000 tokens)",
+          "hz": 4090544,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.0002444662836963383,
+          "meanLabel": "244ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve single alias": {
+          "name": "Resolve single alias",
+          "hz": 4006496,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.0002495946430078078,
+          "meanLabel": "250ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve chained alias (2 levels)": {
+          "name": "Resolve chained alias (2 levels)",
+          "hz": 4010289,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00024935861346898013,
+          "meanLabel": "249ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve component alias reference": {
+          "name": "Resolve component alias reference",
+          "hz": 3954138,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.00025289959178991303,
+          "meanLabel": "253ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (1,000 tokens)": {
+          "name": "Resolve alias (1,000 tokens)",
+          "hz": 4017572,
+          "hzLabel": "4.0M ops/s",
+          "mean": 0.000248906523731372,
+          "meanLabel": "249ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (10,000 tokens)": {
+          "name": "Resolve alias (10,000 tokens)",
+          "hz": 4055633,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.00024657060920450877,
+          "meanLabel": "247ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve 5 different paths sequentially": {
+          "name": "Resolve 5 different paths sequentially",
+          "hz": 1313263,
+          "hzLabel": "1.3M ops/s",
+          "mean": 0.0007614621386477932,
+          "meanLabel": "761ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve 100 paths (20 unique, repeated)": {
+          "name": "Resolve 100 paths (20 unique, repeated)",
+          "hz": 79426,
+          "hzLabel": "79.4k ops/s",
+          "mean": 0.012590404578143647,
+          "meanLabel": "12.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (fixture, cached)": {
+          "name": "Access token 100 times (fixture, cached)",
+          "hz": 86649,
+          "hzLabel": "86.6k ops/s",
+          "mean": 0.011540753467784215,
+          "meanLabel": "11.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (1,000 tokens, cached)": {
+          "name": "Access token 100 times (1,000 tokens, cached)",
+          "hz": 75006,
+          "hzLabel": "75.0k ops/s",
+          "mean": 0.013332203391674263,
+          "meanLabel": "13.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (10,000 tokens, cached)": {
+          "name": "Access token 100 times (10,000 tokens, cached)",
+          "hz": 86565,
+          "hzLabel": "86.6k ops/s",
+          "mean": 0.011551989141405218,
+          "meanLabel": "11.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Resolve by id (10,000 tokens)",
+          "hz": 4090544,
+          "hzLabel": "4.1M ops/s",
+          "mean": 0.0002444662836963383,
+          "meanLabel": "244ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 67,
+          "hzLabel": "67 ops/s",
+          "mean": 15.002147970589302,
+          "meanLabel": "15.00ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createVirtual": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create virtual (1,000 items)": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8578,
+              "hzLabel": "8.6k ops/s",
+              "mean": 0.11657800559552106,
+              "meanLabel": "116.6μs",
+              "rme": 5.3,
+              "tier": "blazing"
+            },
+            "Create virtual (10,000 items)": {
+              "name": "Create virtual (10,000 items)",
+              "hz": 989,
+              "hzLabel": "989 ops/s",
+              "mean": 1.0112816060606316,
+              "meanLabel": "1.01ms",
+              "rme": 5,
+              "tier": "blazing"
+            },
+            "Create virtual (100,000 items)": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 95,
+              "hzLabel": "95 ops/s",
+              "mean": 10.574433666666664,
+              "meanLabel": "10.57ms",
+              "rme": 8.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8578,
+              "hzLabel": "8.6k ops/s",
+              "mean": 0.11657800559552106,
+              "meanLabel": "116.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 95,
+              "hzLabel": "95 ops/s",
+              "mean": 10.574433666666664,
+              "meanLabel": "10.57ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scroll operations": {
+            "Scroll to start position (1,000 items)": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 465333,
+              "hzLabel": "465.3k ops/s",
+              "mean": 0.0021489985172111854,
+              "meanLabel": "2.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Scroll to start position (10,000 items)": {
+              "name": "Scroll to start position (10,000 items)",
+              "hz": 455112,
+              "hzLabel": "455.1k ops/s",
+              "mean": 0.0021972616674667466,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (1,000 items)": {
+              "name": "Scroll to middle position (1,000 items)",
+              "hz": 438483,
+              "hzLabel": "438.5k ops/s",
+              "mean": 0.0022805899508113827,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (10,000 items)": {
+              "name": "Scroll to middle position (10,000 items)",
+              "hz": 437178,
+              "hzLabel": "437.2k ops/s",
+              "mean": 0.0022873965277172624,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (1,000 items)": {
+              "name": "Scroll to end position (1,000 items)",
+              "hz": 439369,
+              "hzLabel": "439.4k ops/s",
+              "mean": 0.0022759909369982523,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (10,000 items)": {
+              "name": "Scroll to end position (10,000 items)",
+              "hz": 438703,
+              "hzLabel": "438.7k ops/s",
+              "mean": 0.0022794487535882308,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (1,000 items)": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4572,
+              "hzLabel": "4.6k ops/s",
+              "mean": 0.2187018001750355,
+              "meanLabel": "218.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (10,000 items)": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4551,
+              "hzLabel": "4.6k ops/s",
+              "mean": 0.21970924253067134,
+              "meanLabel": "219.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 465333,
+              "hzLabel": "465.3k ops/s",
+              "mean": 0.0021489985172111854,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4551,
+              "hzLabel": "4.6k ops/s",
+              "mean": 0.21970924253067134,
+              "meanLabel": "219.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "resize operations": {
+            "Resize single item (1,000 items)": {
+              "name": "Resize single item (1,000 items)",
+              "hz": 1018083,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009822378114229132,
+              "meanLabel": "982ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize single item (10,000 items)": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1027365,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009733641292396667,
+              "meanLabel": "973ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (1,000 items)": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 11747,
+              "hzLabel": "11.7k ops/s",
+              "mean": 0.0851244994894451,
+              "meanLabel": "85.1μs",
+              "rme": 5.7,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (10,000 items)": {
+              "name": "Resize 100 items sequentially (10,000 items)",
+              "hz": 12263,
+              "hzLabel": "12.3k ops/s",
+              "mean": 0.08154381017617708,
+              "meanLabel": "81.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize with variable heights (1,000 items)": {
+              "name": "Resize with variable heights (1,000 items)",
+              "hz": 12085,
+              "hzLabel": "12.1k ops/s",
+              "mean": 0.08274795697501701,
+              "meanLabel": "82.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1027365,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009733641292396667,
+              "meanLabel": "973ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 11747,
+              "hzLabel": "11.7k ops/s",
+              "mean": 0.0851244994894451,
+              "meanLabel": "85.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scrollTo operations": {
+            "ScrollTo start (1,000 items)": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 445183,
+              "hzLabel": "445.2k ops/s",
+              "mean": 0.0022462653778967637,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo start (10,000 items)": {
+              "name": "ScrollTo start (10,000 items)",
+              "hz": 434072,
+              "hzLabel": "434.1k ops/s",
+              "mean": 0.002303766278374454,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (1,000 items)": {
+              "name": "ScrollTo middle (1,000 items)",
+              "hz": 432311,
+              "hzLabel": "432.3k ops/s",
+              "mean": 0.002313150678255455,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (10,000 items)": {
+              "name": "ScrollTo middle (10,000 items)",
+              "hz": 423514,
+              "hzLabel": "423.5k ops/s",
+              "mean": 0.002361198283845621,
+              "meanLabel": "2.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (1,000 items)": {
+              "name": "ScrollTo end (1,000 items)",
+              "hz": 429730,
+              "hzLabel": "429.7k ops/s",
+              "mean": 0.0023270441905486167,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo end (10,000 items)": {
+              "name": "ScrollTo end (10,000 items)",
+              "hz": 423713,
+              "hzLabel": "423.7k ops/s",
+              "mean": 0.00236008786114966,
+              "meanLabel": "2.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "ScrollTo 5 positions (10,000 items)": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 82110,
+              "hzLabel": "82.1k ops/s",
+              "mean": 0.012178753702344633,
+              "meanLabel": "12.2μs",
+              "rme": 1.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 445183,
+              "hzLabel": "445.2k ops/s",
+              "mean": 0.0022462653778967637,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 82110,
+              "hzLabel": "82.1k ops/s",
+              "mean": 0.012178753702344633,
+              "meanLabel": "12.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 1903702,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005252924239147382,
+              "meanLabel": "525ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1899811,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005263682869707148,
+              "meanLabel": "526ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (1,000 items, cached)": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 51022,
+              "hzLabel": "51.0k ops/s",
+              "mean": 0.01959942859944555,
+              "meanLabel": "19.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (10,000 items, cached)": {
+              "name": "Access offset 100 times (10,000 items, cached)",
+              "hz": 51131,
+              "hzLabel": "51.1k ops/s",
+              "mean": 0.019557425447842825,
+              "meanLabel": "19.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (1,000 items, cached)": {
+              "name": "Access size 100 times (1,000 items, cached)",
+              "hz": 51057,
+              "hzLabel": "51.1k ops/s",
+              "mean": 0.019585901249492985,
+              "meanLabel": "19.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (10,000 items, cached)": {
+              "name": "Access size 100 times (10,000 items, cached)",
+              "hz": 51115,
+              "hzLabel": "51.1k ops/s",
+              "mean": 0.01956357238447402,
+              "meanLabel": "19.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 1903702,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005252924239147382,
+              "meanLabel": "525ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 51022,
+              "hzLabel": "51.0k ops/s",
+              "mean": 0.01959942859944555,
+              "meanLabel": "19.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create virtual (1,000 items)": {
+          "name": "Create virtual (1,000 items)",
+          "hz": 8578,
+          "hzLabel": "8.6k ops/s",
+          "mean": 0.11657800559552106,
+          "meanLabel": "116.6μs",
+          "rme": 5.3,
+          "tier": "blazing"
+        },
+        "Create virtual (10,000 items)": {
+          "name": "Create virtual (10,000 items)",
+          "hz": 989,
+          "hzLabel": "989 ops/s",
+          "mean": 1.0112816060606316,
+          "meanLabel": "1.01ms",
+          "rme": 5,
+          "tier": "blazing"
+        },
+        "Create virtual (100,000 items)": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 95,
+          "hzLabel": "95 ops/s",
+          "mean": 10.574433666666664,
+          "meanLabel": "10.57ms",
+          "rme": 8.5,
+          "tier": "blazing"
+        },
+        "Scroll to start position (1,000 items)": {
+          "name": "Scroll to start position (1,000 items)",
+          "hz": 465333,
+          "hzLabel": "465.3k ops/s",
+          "mean": 0.0021489985172111854,
+          "meanLabel": "2.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Scroll to start position (10,000 items)": {
+          "name": "Scroll to start position (10,000 items)",
+          "hz": 455112,
+          "hzLabel": "455.1k ops/s",
+          "mean": 0.0021972616674667466,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (1,000 items)": {
+          "name": "Scroll to middle position (1,000 items)",
+          "hz": 438483,
+          "hzLabel": "438.5k ops/s",
+          "mean": 0.0022805899508113827,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (10,000 items)": {
+          "name": "Scroll to middle position (10,000 items)",
+          "hz": 437178,
+          "hzLabel": "437.2k ops/s",
+          "mean": 0.0022873965277172624,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (1,000 items)": {
+          "name": "Scroll to end position (1,000 items)",
+          "hz": 439369,
+          "hzLabel": "439.4k ops/s",
+          "mean": 0.0022759909369982523,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (10,000 items)": {
+          "name": "Scroll to end position (10,000 items)",
+          "hz": 438703,
+          "hzLabel": "438.7k ops/s",
+          "mean": 0.0022794487535882308,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (1,000 items)": {
+          "name": "Process 100 scroll events (1,000 items)",
+          "hz": 4572,
+          "hzLabel": "4.6k ops/s",
+          "mean": 0.2187018001750355,
+          "meanLabel": "218.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (10,000 items)": {
+          "name": "Process 100 scroll events (10,000 items)",
+          "hz": 4551,
+          "hzLabel": "4.6k ops/s",
+          "mean": 0.21970924253067134,
+          "meanLabel": "219.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize single item (1,000 items)": {
+          "name": "Resize single item (1,000 items)",
+          "hz": 1018083,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.0009822378114229132,
+          "meanLabel": "982ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize single item (10,000 items)": {
+          "name": "Resize single item (10,000 items)",
+          "hz": 1027365,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.0009733641292396667,
+          "meanLabel": "973ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (1,000 items)": {
+          "name": "Resize 100 items sequentially (1,000 items)",
+          "hz": 11747,
+          "hzLabel": "11.7k ops/s",
+          "mean": 0.0851244994894451,
+          "meanLabel": "85.1μs",
+          "rme": 5.7,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (10,000 items)": {
+          "name": "Resize 100 items sequentially (10,000 items)",
+          "hz": 12263,
+          "hzLabel": "12.3k ops/s",
+          "mean": 0.08154381017617708,
+          "meanLabel": "81.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize with variable heights (1,000 items)": {
+          "name": "Resize with variable heights (1,000 items)",
+          "hz": 12085,
+          "hzLabel": "12.1k ops/s",
+          "mean": 0.08274795697501701,
+          "meanLabel": "82.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "ScrollTo start (1,000 items)": {
+          "name": "ScrollTo start (1,000 items)",
+          "hz": 445183,
+          "hzLabel": "445.2k ops/s",
+          "mean": 0.0022462653778967637,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo start (10,000 items)": {
+          "name": "ScrollTo start (10,000 items)",
+          "hz": 434072,
+          "hzLabel": "434.1k ops/s",
+          "mean": 0.002303766278374454,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (1,000 items)": {
+          "name": "ScrollTo middle (1,000 items)",
+          "hz": 432311,
+          "hzLabel": "432.3k ops/s",
+          "mean": 0.002313150678255455,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (10,000 items)": {
+          "name": "ScrollTo middle (10,000 items)",
+          "hz": 423514,
+          "hzLabel": "423.5k ops/s",
+          "mean": 0.002361198283845621,
+          "meanLabel": "2.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (1,000 items)": {
+          "name": "ScrollTo end (1,000 items)",
+          "hz": 429730,
+          "hzLabel": "429.7k ops/s",
+          "mean": 0.0023270441905486167,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo end (10,000 items)": {
+          "name": "ScrollTo end (10,000 items)",
+          "hz": 423713,
+          "hzLabel": "423.7k ops/s",
+          "mean": 0.00236008786114966,
+          "meanLabel": "2.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "ScrollTo 5 positions (10,000 items)": {
+          "name": "ScrollTo 5 positions (10,000 items)",
+          "hz": 82110,
+          "hzLabel": "82.1k ops/s",
+          "mean": 0.012178753702344633,
+          "meanLabel": "12.2μs",
+          "rme": 1.5,
+          "tier": "blazing"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 1903702,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005252924239147382,
+          "meanLabel": "525ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1899811,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005263682869707148,
+          "meanLabel": "526ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (1,000 items, cached)": {
+          "name": "Access offset 100 times (1,000 items, cached)",
+          "hz": 51022,
+          "hzLabel": "51.0k ops/s",
+          "mean": 0.01959942859944555,
+          "meanLabel": "19.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (10,000 items, cached)": {
+          "name": "Access offset 100 times (10,000 items, cached)",
+          "hz": 51131,
+          "hzLabel": "51.1k ops/s",
+          "mean": 0.019557425447842825,
+          "meanLabel": "19.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (1,000 items, cached)": {
+          "name": "Access size 100 times (1,000 items, cached)",
+          "hz": 51057,
+          "hzLabel": "51.1k ops/s",
+          "mean": 0.019585901249492985,
+          "meanLabel": "19.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (10,000 items, cached)": {
+          "name": "Access size 100 times (10,000 items, cached)",
+          "hz": 51115,
+          "hzLabel": "51.1k ops/s",
+          "mean": 0.01956357238447402,
+          "meanLabel": "19.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 1903702,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005252924239147382,
+          "meanLabel": "525ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 95,
+          "hzLabel": "95 ops/s",
+          "mean": 10.574433666666664,
+          "meanLabel": "10.57ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "useDate": {
+      "benchmarks": {
+        "_groups": {
+          "construction": {
+            "create date from null (now)": {
+              "name": "create date from null (now)",
+              "hz": 662843,
+              "hzLabel": "662.8k ops/s",
+              "mean": 0.0015086529107630874,
+              "meanLabel": "1.5μs",
+              "rme": 13.7,
+              "tier": "blazing"
+            },
+            "create date from ISO string": {
+              "name": "create date from ISO string",
+              "hz": 1579331,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006331793479551319,
+              "meanLabel": "633ns",
+              "rme": 23.5,
+              "tier": "blazing"
+            },
+            "create date from timestamp": {
+              "name": "create date from timestamp",
+              "hz": 847126,
+              "hzLabel": "847.1k ops/s",
+              "mean": 0.0011804623468059136,
+              "meanLabel": "1.2μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "create 1000 dates": {
+              "name": "create 1000 dates",
+              "hz": 1622,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6165423734174483,
+              "meanLabel": "616.5μs",
+              "rme": 40.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "create date from ISO string",
+              "hz": 1579331,
+              "hzLabel": "1.6M ops/s",
+              "mean": 0.0006331793479551319,
+              "meanLabel": "633ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "create 1000 dates",
+              "hz": 1622,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6165423734174483,
+              "meanLabel": "616.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "formatting": {
+            "format fullDate": {
+              "name": "format fullDate",
+              "hz": 466993,
+              "hzLabel": "467.0k ops/s",
+              "mean": 0.002141358098803932,
+              "meanLabel": "2.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format shortDate": {
+              "name": "format shortDate",
+              "hz": 446168,
+              "hzLabel": "446.2k ops/s",
+              "mean": 0.002241310645359771,
+              "meanLabel": "2.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format 1000 dates": {
+              "name": "format 1000 dates",
+              "hz": 483,
+              "hzLabel": "483 ops/s",
+              "mean": 2.070356330578889,
+              "meanLabel": "2.07ms",
+              "rme": 5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "format fullDate",
+              "hz": 466993,
+              "hzLabel": "467.0k ops/s",
+              "mean": 0.002141358098803932,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "format 1000 dates",
+              "hz": 483,
+              "hzLabel": "483 ops/s",
+              "mean": 2.070356330578889,
+              "meanLabel": "2.07ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation": {
+            "startOfDay": {
+              "name": "startOfDay",
+              "hz": 1142051,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0008756175217744847,
+              "meanLabel": "876ns",
+              "rme": 9.6,
+              "tier": "blazing"
+            },
+            "startOfWeek": {
+              "name": "startOfWeek",
+              "hz": 493747,
+              "hzLabel": "493.7k ops/s",
+              "mean": 0.0020253275637865257,
+              "meanLabel": "2.0μs",
+              "rme": 20.7,
+              "tier": "blazing"
+            },
+            "startOfMonth": {
+              "name": "startOfMonth",
+              "hz": 585476,
+              "hzLabel": "585.5k ops/s",
+              "mean": 0.0017080128749408748,
+              "meanLabel": "1.7μs",
+              "rme": 16,
+              "tier": "blazing"
+            },
+            "getWeekArray": {
+              "name": "getWeekArray",
+              "hz": 17789,
+              "hzLabel": "17.8k ops/s",
+              "mean": 0.05621465283854089,
+              "meanLabel": "56.2μs",
+              "rme": 33.8,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "startOfDay",
+              "hz": 1142051,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0008756175217744847,
+              "meanLabel": "876ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "getWeekArray",
+              "hz": 17789,
+              "hzLabel": "17.8k ops/s",
+              "mean": 0.05621465283854089,
+              "meanLabel": "56.2μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "arithmetic": {
+            "addDays": {
+              "name": "addDays",
+              "hz": 967652,
+              "hzLabel": "967.7k ops/s",
+              "mean": 0.0010334295904496943,
+              "meanLabel": "1.0μs",
+              "rme": 8.4,
+              "tier": "blazing"
+            },
+            "addMonths": {
+              "name": "addMonths",
+              "hz": 811875,
+              "hzLabel": "811.9k ops/s",
+              "mean": 0.0012317166833405255,
+              "meanLabel": "1.2μs",
+              "rme": 28,
+              "tier": "blazing"
+            },
+            "chain 10 additions": {
+              "name": "chain 10 additions",
+              "hz": 92002,
+              "hzLabel": "92.0k ops/s",
+              "mean": 0.010869346870685873,
+              "meanLabel": "10.9μs",
+              "rme": 37.6,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "addDays",
+              "hz": 967652,
+              "hzLabel": "967.7k ops/s",
+              "mean": 0.0010334295904496943,
+              "meanLabel": "1.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "chain 10 additions",
+              "hz": 92002,
+              "hzLabel": "92.0k ops/s",
+              "mean": 0.010869346870685873,
+              "meanLabel": "10.9μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "comparison": {
+            "isAfter": {
+              "name": "isAfter",
+              "hz": 1501577,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006659663207590514,
+              "meanLabel": "666ns",
+              "rme": 30,
+              "tier": "blazing"
+            },
+            "isSameDay": {
+              "name": "isSameDay",
+              "hz": 751207,
+              "hzLabel": "751.2k ops/s",
+              "mean": 0.001331190365417322,
+              "meanLabel": "1.3μs",
+              "rme": 40,
+              "tier": "blazing"
+            },
+            "compare 1000 pairs": {
+              "name": "compare 1000 pairs",
+              "hz": 1645,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6078837873645575,
+              "meanLabel": "607.9μs",
+              "rme": 54.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "isAfter",
+              "hz": 1501577,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006659663207590514,
+              "meanLabel": "666ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "compare 1000 pairs",
+              "hz": 1645,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6078837873645575,
+              "meanLabel": "607.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "getters/setters": {
+            "get components": {
+              "name": "get components",
+              "hz": 6138993,
+              "hzLabel": "6.1M ops/s",
+              "mean": 0.0001628931681689823,
+              "meanLabel": "163ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "set components": {
+              "name": "set components",
+              "hz": 458928,
+              "hzLabel": "458.9k ops/s",
+              "mean": 0.002178988760820966,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "get components",
+              "hz": 6138993,
+              "hzLabel": "6.1M ops/s",
+              "mean": 0.0001628931681689823,
+              "meanLabel": "163ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "set components",
+              "hz": 458928,
+              "hzLabel": "458.9k ops/s",
+              "mean": 0.002178988760820966,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "locale switching": {
+            "locale change + reformat": {
+              "name": "locale change + reformat",
+              "hz": 19968,
+              "hzLabel": "20.0k ops/s",
+              "mean": 0.05008043895845041,
+              "meanLabel": "50.1μs",
+              "rme": 0.7,
+              "tier": "fast"
+            },
+            "toggle locale 10 times": {
+              "name": "toggle locale 10 times",
+              "hz": 1504,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6647207490034008,
+              "meanLabel": "664.7μs",
+              "rme": 1.1,
+              "tier": "fast"
+            },
+            "cache eviction (60 unique formats)": {
+              "name": "cache eviction (60 unique formats)",
+              "hz": 14385,
+              "hzLabel": "14.4k ops/s",
+              "mean": 0.06951775545690102,
+              "meanLabel": "69.5μs",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "locale change + reformat",
+              "hz": 19968,
+              "hzLabel": "20.0k ops/s",
+              "mean": 0.05008043895845041,
+              "meanLabel": "50.1μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "toggle locale 10 times",
+              "hz": 1504,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6647207490034008,
+              "meanLabel": "664.7μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          }
+        },
+        "create date from null (now)": {
+          "name": "create date from null (now)",
+          "hz": 662843,
+          "hzLabel": "662.8k ops/s",
+          "mean": 0.0015086529107630874,
+          "meanLabel": "1.5μs",
+          "rme": 13.7,
+          "tier": "blazing"
+        },
+        "create date from ISO string": {
+          "name": "create date from ISO string",
+          "hz": 1579331,
+          "hzLabel": "1.6M ops/s",
+          "mean": 0.0006331793479551319,
+          "meanLabel": "633ns",
+          "rme": 23.5,
+          "tier": "blazing"
+        },
+        "create date from timestamp": {
+          "name": "create date from timestamp",
+          "hz": 847126,
+          "hzLabel": "847.1k ops/s",
+          "mean": 0.0011804623468059136,
+          "meanLabel": "1.2μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "create 1000 dates": {
+          "name": "create 1000 dates",
+          "hz": 1622,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6165423734174483,
+          "meanLabel": "616.5μs",
+          "rme": 40.5,
+          "tier": "blazing"
+        },
+        "format fullDate": {
+          "name": "format fullDate",
+          "hz": 466993,
+          "hzLabel": "467.0k ops/s",
+          "mean": 0.002141358098803932,
+          "meanLabel": "2.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format shortDate": {
+          "name": "format shortDate",
+          "hz": 446168,
+          "hzLabel": "446.2k ops/s",
+          "mean": 0.002241310645359771,
+          "meanLabel": "2.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format 1000 dates": {
+          "name": "format 1000 dates",
+          "hz": 483,
+          "hzLabel": "483 ops/s",
+          "mean": 2.070356330578889,
+          "meanLabel": "2.07ms",
+          "rme": 5,
+          "tier": "fast"
+        },
+        "startOfDay": {
+          "name": "startOfDay",
+          "hz": 1142051,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0008756175217744847,
+          "meanLabel": "876ns",
+          "rme": 9.6,
+          "tier": "blazing"
+        },
+        "startOfWeek": {
+          "name": "startOfWeek",
+          "hz": 493747,
+          "hzLabel": "493.7k ops/s",
+          "mean": 0.0020253275637865257,
+          "meanLabel": "2.0μs",
+          "rme": 20.7,
+          "tier": "blazing"
+        },
+        "startOfMonth": {
+          "name": "startOfMonth",
+          "hz": 585476,
+          "hzLabel": "585.5k ops/s",
+          "mean": 0.0017080128749408748,
+          "meanLabel": "1.7μs",
+          "rme": 16,
+          "tier": "blazing"
+        },
+        "getWeekArray": {
+          "name": "getWeekArray",
+          "hz": 17789,
+          "hzLabel": "17.8k ops/s",
+          "mean": 0.05621465283854089,
+          "meanLabel": "56.2μs",
+          "rme": 33.8,
+          "tier": "fast"
+        },
+        "addDays": {
+          "name": "addDays",
+          "hz": 967652,
+          "hzLabel": "967.7k ops/s",
+          "mean": 0.0010334295904496943,
+          "meanLabel": "1.0μs",
+          "rme": 8.4,
+          "tier": "blazing"
+        },
+        "addMonths": {
+          "name": "addMonths",
+          "hz": 811875,
+          "hzLabel": "811.9k ops/s",
+          "mean": 0.0012317166833405255,
+          "meanLabel": "1.2μs",
+          "rme": 28,
+          "tier": "blazing"
+        },
+        "chain 10 additions": {
+          "name": "chain 10 additions",
+          "hz": 92002,
+          "hzLabel": "92.0k ops/s",
+          "mean": 0.010869346870685873,
+          "meanLabel": "10.9μs",
+          "rme": 37.6,
+          "tier": "fast"
+        },
+        "isAfter": {
+          "name": "isAfter",
+          "hz": 1501577,
+          "hzLabel": "1.5M ops/s",
+          "mean": 0.0006659663207590514,
+          "meanLabel": "666ns",
+          "rme": 30,
+          "tier": "blazing"
+        },
+        "isSameDay": {
+          "name": "isSameDay",
+          "hz": 751207,
+          "hzLabel": "751.2k ops/s",
+          "mean": 0.001331190365417322,
+          "meanLabel": "1.3μs",
+          "rme": 40,
+          "tier": "blazing"
+        },
+        "compare 1000 pairs": {
+          "name": "compare 1000 pairs",
+          "hz": 1645,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6078837873645575,
+          "meanLabel": "607.9μs",
+          "rme": 54.5,
+          "tier": "blazing"
+        },
+        "get components": {
+          "name": "get components",
+          "hz": 6138993,
+          "hzLabel": "6.1M ops/s",
+          "mean": 0.0001628931681689823,
+          "meanLabel": "163ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "set components": {
+          "name": "set components",
+          "hz": 458928,
+          "hzLabel": "458.9k ops/s",
+          "mean": 0.002178988760820966,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "locale change + reformat": {
+          "name": "locale change + reformat",
+          "hz": 19968,
+          "hzLabel": "20.0k ops/s",
+          "mean": 0.05008043895845041,
+          "meanLabel": "50.1μs",
+          "rme": 0.7,
+          "tier": "fast"
+        },
+        "toggle locale 10 times": {
+          "name": "toggle locale 10 times",
+          "hz": 1504,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6647207490034008,
+          "meanLabel": "664.7μs",
+          "rme": 1.1,
+          "tier": "fast"
+        },
+        "cache eviction (60 unique formats)": {
+          "name": "cache eviction (60 unique formats)",
+          "hz": 14385,
+          "hzLabel": "14.4k ops/s",
+          "mean": 0.06951775545690102,
+          "meanLabel": "69.5μs",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "_fastest": {
+          "name": "get components",
+          "hz": 6138993,
+          "hzLabel": "6.1M ops/s",
+          "mean": 0.0001628931681689823,
+          "meanLabel": "163ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "format 1000 dates",
+          "hz": 483,
+          "hzLabel": "483 ops/s",
+          "mean": 2.070356330578889,
+          "meanLabel": "2.07ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "useProxyRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty proxy": {
+              "name": "Create empty proxy",
+              "hz": 108505,
+              "hzLabel": "108.5k ops/s",
+              "mean": 0.009216143254679425,
+              "meanLabel": "9.2μs",
+              "rme": 15.6,
+              "tier": "blazing"
+            },
+            "Create proxy (1,000 items)": {
+              "name": "Create proxy (1,000 items)",
+              "hz": 1747,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5723978981700165,
+              "meanLabel": "572.4μs",
+              "rme": 9.5,
+              "tier": "blazing"
+            },
+            "Create proxy (10,000 items)": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 133,
+              "hzLabel": "133 ops/s",
+              "mean": 7.518455985076934,
+              "meanLabel": "7.52ms",
+              "rme": 11.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty proxy",
+              "hz": 108505,
+              "hzLabel": "108.5k ops/s",
+              "mean": 0.009216143254679425,
+              "meanLabel": "9.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 133,
+              "hzLabel": "133 ops/s",
+              "mean": 7.518455985076934,
+              "meanLabel": "7.52ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "registry.keys() (1,000 items)": {
+              "name": "registry.keys() (1,000 items)",
+              "hz": 7160230,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.0001396603254338298,
+              "meanLabel": "140ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "proxy.keys (1,000 items)": {
+              "name": "proxy.keys (1,000 items)",
+              "hz": 3045228,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.00032838266955433987,
+              "meanLabel": "328ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.keys() (10,000 items)": {
+              "name": "registry.keys() (10,000 items)",
+              "hz": 7184656,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013918550919300816,
+              "meanLabel": "139ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.keys (10,000 items)": {
+              "name": "proxy.keys (10,000 items)",
+              "hz": 3018480,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.0003312925298546492,
+              "meanLabel": "331ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.values() (1,000 items)": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7122296,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001404041696685588,
+              "meanLabel": "140ns",
+              "rme": 1.8,
+              "tier": "blazing"
+            },
+            "proxy.values (1,000 items)": {
+              "name": "proxy.values (1,000 items)",
+              "hz": 2986132,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.00033488139438640204,
+              "meanLabel": "335ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "registry.values() (10,000 items)": {
+              "name": "registry.values() (10,000 items)",
+              "hz": 6784647,
+              "hzLabel": "6.8M ops/s",
+              "mean": 0.00014739160498381592,
+              "meanLabel": "147ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.values (10,000 items)": {
+              "name": "proxy.values (10,000 items)",
+              "hz": 3035039,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.00032948508223984316,
+              "meanLabel": "329ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.entries() (1,000 items)": {
+              "name": "registry.entries() (1,000 items)",
+              "hz": 7255618,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001378242355011588,
+              "meanLabel": "138ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.entries (1,000 items)": {
+              "name": "proxy.entries (1,000 items)",
+              "hz": 2977068,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.00033590090459178763,
+              "meanLabel": "336ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.entries() (10,000 items)": {
+              "name": "registry.entries() (10,000 items)",
+              "hz": 7295208,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013707627416527515,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.entries (10,000 items)": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 2956440,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.0003382446488265654,
+              "meanLabel": "338ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "proxy.size (1,000 items)": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 3029629,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.00033007341423238516,
+              "meanLabel": "330ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "proxy.size (10,000 items)": {
+              "name": "proxy.size (10,000 items)",
+              "hz": 3004429,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.0003328419973143316,
+              "meanLabel": "333ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "registry.entries() (10,000 items)",
+              "hz": 7295208,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013707627416527515,
+              "meanLabel": "137ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 2956440,
+              "hzLabel": "3.0M ops/s",
+              "mean": 0.0003382446488265654,
+              "meanLabel": "338ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single item (1,000 items)": {
+              "name": "Register single item (1,000 items)",
+              "hz": 134674,
+              "hzLabel": "134.7k ops/s",
+              "mean": 0.007425364326264451,
+              "meanLabel": "7.4μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Register single item (10,000 items)": {
+              "name": "Register single item (10,000 items)",
+              "hz": 21631,
+              "hzLabel": "21.6k ops/s",
+              "mean": 0.04622950855108491,
+              "meanLabel": "46.2μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Unregister single item (1,000 items)": {
+              "name": "Unregister single item (1,000 items)",
+              "hz": 1604,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6234442707048574,
+              "meanLabel": "623.4μs",
+              "rme": 10.6,
+              "tier": "blazing"
+            },
+            "Unregister single item (10,000 items)": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 135,
+              "hzLabel": "135 ops/s",
+              "mean": 7.4249405294120905,
+              "meanLabel": "7.42ms",
+              "rme": 10.5,
+              "tier": "blazing"
+            },
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 554666,
+              "hzLabel": "554.7k ops/s",
+              "mean": 0.0018028872659332266,
+              "meanLabel": "1.8μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 47704,
+              "hzLabel": "47.7k ops/s",
+              "mean": 0.02096261986434903,
+              "meanLabel": "21.0μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 554666,
+              "hzLabel": "554.7k ops/s",
+              "mean": 0.0018028872659332266,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 135,
+              "hzLabel": "135 ops/s",
+              "mean": 7.4249405294120905,
+              "meanLabel": "7.42ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "bulk registration": {
+            "Onboard 1,000 items (proxy attached)": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1430,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6994000209798268,
+              "meanLabel": "699.4μs",
+              "rme": 9.1,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items (proxy attached)": {
+              "name": "Onboard 10,000 items (proxy attached)",
+              "hz": 114,
+              "hzLabel": "114 ops/s",
+              "mean": 8.75157563793192,
+              "meanLabel": "8.75ms",
+              "rme": 9.9,
+              "tier": "blazing"
+            },
+            "Register 1,000 items one-by-one (proxy attached)": {
+              "name": "Register 1,000 items one-by-one (proxy attached)",
+              "hz": 1237,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8084379450719155,
+              "meanLabel": "808.4μs",
+              "rme": 8.4,
+              "tier": "blazing"
+            },
+            "Register 10,000 items one-by-one (proxy attached)": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 101,
+              "hzLabel": "101 ops/s",
+              "mean": 9.85677069230811,
+              "meanLabel": "9.86ms",
+              "rme": 10.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1430,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6994000209798268,
+              "meanLabel": "699.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 101,
+              "hzLabel": "101 ops/s",
+              "mean": 9.85677069230811,
+              "meanLabel": "9.86ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty proxy": {
+          "name": "Create empty proxy",
+          "hz": 108505,
+          "hzLabel": "108.5k ops/s",
+          "mean": 0.009216143254679425,
+          "meanLabel": "9.2μs",
+          "rme": 15.6,
+          "tier": "blazing"
+        },
+        "Create proxy (1,000 items)": {
+          "name": "Create proxy (1,000 items)",
+          "hz": 1747,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.5723978981700165,
+          "meanLabel": "572.4μs",
+          "rme": 9.5,
+          "tier": "blazing"
+        },
+        "Create proxy (10,000 items)": {
+          "name": "Create proxy (10,000 items)",
+          "hz": 133,
+          "hzLabel": "133 ops/s",
+          "mean": 7.518455985076934,
+          "meanLabel": "7.52ms",
+          "rme": 11.2,
+          "tier": "blazing"
+        },
+        "registry.keys() (1,000 items)": {
+          "name": "registry.keys() (1,000 items)",
+          "hz": 7160230,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.0001396603254338298,
+          "meanLabel": "140ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "proxy.keys (1,000 items)": {
+          "name": "proxy.keys (1,000 items)",
+          "hz": 3045228,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.00032838266955433987,
+          "meanLabel": "328ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.keys() (10,000 items)": {
+          "name": "registry.keys() (10,000 items)",
+          "hz": 7184656,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013918550919300816,
+          "meanLabel": "139ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.keys (10,000 items)": {
+          "name": "proxy.keys (10,000 items)",
+          "hz": 3018480,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.0003312925298546492,
+          "meanLabel": "331ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.values() (1,000 items)": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7122296,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.0001404041696685588,
+          "meanLabel": "140ns",
+          "rme": 1.8,
+          "tier": "blazing"
+        },
+        "proxy.values (1,000 items)": {
+          "name": "proxy.values (1,000 items)",
+          "hz": 2986132,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.00033488139438640204,
+          "meanLabel": "335ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "registry.values() (10,000 items)": {
+          "name": "registry.values() (10,000 items)",
+          "hz": 6784647,
+          "hzLabel": "6.8M ops/s",
+          "mean": 0.00014739160498381592,
+          "meanLabel": "147ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.values (10,000 items)": {
+          "name": "proxy.values (10,000 items)",
+          "hz": 3035039,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.00032948508223984316,
+          "meanLabel": "329ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.entries() (1,000 items)": {
+          "name": "registry.entries() (1,000 items)",
+          "hz": 7255618,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001378242355011588,
+          "meanLabel": "138ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.entries (1,000 items)": {
+          "name": "proxy.entries (1,000 items)",
+          "hz": 2977068,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.00033590090459178763,
+          "meanLabel": "336ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.entries() (10,000 items)": {
+          "name": "registry.entries() (10,000 items)",
+          "hz": 7295208,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013707627416527515,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.entries (10,000 items)": {
+          "name": "proxy.entries (10,000 items)",
+          "hz": 2956440,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.0003382446488265654,
+          "meanLabel": "338ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "proxy.size (1,000 items)": {
+          "name": "proxy.size (1,000 items)",
+          "hz": 3029629,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.00033007341423238516,
+          "meanLabel": "330ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "proxy.size (10,000 items)": {
+          "name": "proxy.size (10,000 items)",
+          "hz": 3004429,
+          "hzLabel": "3.0M ops/s",
+          "mean": 0.0003328419973143316,
+          "meanLabel": "333ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single item (1,000 items)": {
+          "name": "Register single item (1,000 items)",
+          "hz": 134674,
+          "hzLabel": "134.7k ops/s",
+          "mean": 0.007425364326264451,
+          "meanLabel": "7.4μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Register single item (10,000 items)": {
+          "name": "Register single item (10,000 items)",
+          "hz": 21631,
+          "hzLabel": "21.6k ops/s",
+          "mean": 0.04622950855108491,
+          "meanLabel": "46.2μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Unregister single item (1,000 items)": {
+          "name": "Unregister single item (1,000 items)",
+          "hz": 1604,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6234442707048574,
+          "meanLabel": "623.4μs",
+          "rme": 10.6,
+          "tier": "blazing"
+        },
+        "Unregister single item (10,000 items)": {
+          "name": "Unregister single item (10,000 items)",
+          "hz": 135,
+          "hzLabel": "135 ops/s",
+          "mean": 7.4249405294120905,
+          "meanLabel": "7.42ms",
+          "rme": 10.5,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 554666,
+          "hzLabel": "554.7k ops/s",
+          "mean": 0.0018028872659332266,
+          "meanLabel": "1.8μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 47704,
+          "hzLabel": "47.7k ops/s",
+          "mean": 0.02096261986434903,
+          "meanLabel": "21.0μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items (proxy attached)": {
+          "name": "Onboard 1,000 items (proxy attached)",
+          "hz": 1430,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.6994000209798268,
+          "meanLabel": "699.4μs",
+          "rme": 9.1,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items (proxy attached)": {
+          "name": "Onboard 10,000 items (proxy attached)",
+          "hz": 114,
+          "hzLabel": "114 ops/s",
+          "mean": 8.75157563793192,
+          "meanLabel": "8.75ms",
+          "rme": 9.9,
+          "tier": "blazing"
+        },
+        "Register 1,000 items one-by-one (proxy attached)": {
+          "name": "Register 1,000 items one-by-one (proxy attached)",
+          "hz": 1237,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8084379450719155,
+          "meanLabel": "808.4μs",
+          "rme": 8.4,
+          "tier": "blazing"
+        },
+        "Register 10,000 items one-by-one (proxy attached)": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 101,
+          "hzLabel": "101 ops/s",
+          "mean": 9.85677069230811,
+          "meanLabel": "9.86ms",
+          "rme": 10.7,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "registry.entries() (10,000 items)",
+          "hz": 7295208,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013707627416527515,
+          "meanLabel": "137ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 101,
+          "hzLabel": "101 ops/s",
+          "mean": 9.85677069230811,
+          "meanLabel": "9.86ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the missing published 1.0.5 history snapshot (series had 1.0.0 through 1.0.4 only).
- Measured on the i9-7980XE reference host, current bench suite, 16 items / 433 benches.
- Does not touch apps/docs/public/benchmarks.json.

## Test plan

- 1.0.5.json has items and env.cpu is the i9-7980XE (not an error stub).
- apps/docs/public/benchmarks.json is unchanged in this PR.
- Docs metrics history includes 1.0.5 next to 1.0.0-1.0.4.
