### PR TITLE
test(vapor): pin injection-context guarantees on vue 3.6.0-rc.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,7 +453,7 @@ importers:
         version: 2.1.15(vue@3.5.39(typescript@6.0.3))
       '@vue/test-utils':
         specifier: 'catalog:'
-        version: 2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
+        version: 2.4.11(@vue/compiler-dom@3.6.0-rc.5)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       markdown-it:
         specifier: 'catalog:'
         version: 14.3.0
@@ -783,7 +783,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: 'catalog:'
-        version: 7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(vue@3.6.0-rc.2(typescript@6.0.3))(yaml@2.9.0)
+        version: 7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(vue@3.6.0-rc.5(typescript@6.0.3))(yaml@2.9.0)
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.7(typescript@6.0.3)
@@ -796,10 +796,10 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.5(typescript@6.0.3))
       '@vue/runtime-vapor':
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)
+        specifier: 3.6.0-rc.5
+        version: 3.6.0-rc.5(@vue/runtime-dom@3.6.0-rc.5)
       happy-dom:
         specifier: 'catalog:'
         version: 20.10.6
@@ -810,8 +810,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@28.1.0(supports-color@8.1.1))(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.5
+        version: 3.6.0-rc.5(typescript@6.0.3)
 
 packages:
 
@@ -990,6 +990,11 @@ packages:
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1394,6 +1399,10 @@ packages:
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0':
@@ -3623,29 +3632,29 @@ packages:
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
-  '@vue/compiler-core@3.6.0-rc.2':
-    resolution: {integrity: sha512-Xx79h4EpJktQBShelXNKaRuvn9N6YsYL1j+RXdvPKzI+8tohYziBJbxOFGAkdcOKBwKc2SIWV4DOlTAMhE96yQ==}
+  '@vue/compiler-core@3.6.0-rc.5':
+    resolution: {integrity: sha512-OSOzR/4Mk8TMStNxFLFwcVjgFvvMGvlKEpboxv9W4ikQhsVLKEMTtzBVY5A11qwb6zGuwWJdCOeME5npmpURiQ==}
 
   '@vue/compiler-dom@3.5.39':
     resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
 
-  '@vue/compiler-dom@3.6.0-rc.2':
-    resolution: {integrity: sha512-dRTdTdi/KXzHYIkHtyjGxepTIxnsZ/hB3v1osnS8c4MeycAyzkSoZW6OZkXXN4oVVVU6NKXds1XtKAEKVVw7nA==}
+  '@vue/compiler-dom@3.6.0-rc.5':
+    resolution: {integrity: sha512-QBONzGYH7o448rwz+8FUWW4Gm4Zw0EtNhtRooOw/KDFF+/hWz1VlGIpvU9Hjv5MXDMMCu+UsLXEYFtXTSHgIwg==}
 
   '@vue/compiler-sfc@3.5.39':
     resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
 
-  '@vue/compiler-sfc@3.6.0-rc.2':
-    resolution: {integrity: sha512-EZWTNh0UwdxvrBJkFc6+dqfwuUSdTVHDIohQcGDPCqGaYTHOfUL20b+grEAzlyxB741KrVBUb7qqpes92hAh2w==}
+  '@vue/compiler-sfc@3.6.0-rc.5':
+    resolution: {integrity: sha512-o/IH60kRS8C06ek3tullJhm4sK3T6aDXQa8Dgq7qLxRCa5gXrIZMDO9+mZYy0THxAiTZs2tc/XwnKu0JqmSKRw==}
 
   '@vue/compiler-ssr@3.5.39':
     resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
-  '@vue/compiler-ssr@3.6.0-rc.2':
-    resolution: {integrity: sha512-lqHSdQTmlhKX3dNEvR1TcspUzDlTR82T7BYLDzfvTwAqGXxAI2WJfyGJPcNpPjPKYEMI9JRGF32DU8TlHLx1AA==}
+  '@vue/compiler-ssr@3.6.0-rc.5':
+    resolution: {integrity: sha512-KBsxaO538LZeNARcaYeEwOE0Fl/gw2mEYB9+hK/Hrk7yUCq4WeS9V32HL84SiTY4S6WXrcKP0pXB6zW6zvjB6w==}
 
-  '@vue/compiler-vapor@3.6.0-rc.2':
-    resolution: {integrity: sha512-QbrA01pbj9xemF2McgBopyaOwj3kQGN0W1GW5EdFXORIT4fQQJpmUOj40h99S3bk09gLs5bFTRS4YE+Oyw/F9w==}
+  '@vue/compiler-vapor@3.6.0-rc.5':
+    resolution: {integrity: sha512-UXnYH+4NhPmEmlWcHuiR+KjfpZCuG1CBkWXTSH5720p2jRGzuEGiMUAx7CtMXyIJ0QZwdzDV09xFs35zsgJeYA==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -3674,8 +3683,8 @@ packages:
   '@vue/reactivity@3.5.39':
     resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
 
-  '@vue/reactivity@3.6.0-rc.2':
-    resolution: {integrity: sha512-B01EoSTcaVQiJwZDoSoeKYClVgj60BHN43oHEcxXhPVLdxsXI0SOiQuskUskQDZn2ma08llICKJohL60o+UamA==}
+  '@vue/reactivity@3.6.0-rc.5':
+    resolution: {integrity: sha512-FcTNjZwCU4VPAv7W/EJD/ckatgxFJ20jU6S2dGmJC9RS08HAvKB/IjtCQaE7HBuIC4oXQnnahkNuilrDFt0BWA==}
 
   '@vue/repl@4.7.1':
     resolution: {integrity: sha512-8w5Z3cyqBJ5ufzXO2eut2stzb7aX/ZnSva2d3ee8eEINEB7FG2JYwc14eAHHHGGuoXOGN5v4cyb5ti/YZGcwlg==}
@@ -3683,33 +3692,33 @@ packages:
   '@vue/runtime-core@3.5.39':
     resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
 
-  '@vue/runtime-core@3.6.0-rc.2':
-    resolution: {integrity: sha512-qFV61Hbg6LyEGxJiVRJYuiIfryxrfO4+cgW1esxtkR1/pvemULwG6KpFImsJDwcC+YxrtvndXGM5PRVwUCGuiA==}
+  '@vue/runtime-core@3.6.0-rc.5':
+    resolution: {integrity: sha512-NiT9xl/ndkTHASfQ9AjxDjTiClIZRmsIWb0orlKNnjHn6C09PNZX4V/c0Aewtlg8bouarpnV6JLbpg16gYMBJA==}
 
   '@vue/runtime-dom@3.5.39':
     resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
 
-  '@vue/runtime-dom@3.6.0-rc.2':
-    resolution: {integrity: sha512-clIE/xk0b61t30BPKoOXZep253nhWdjyw7iac53yy2KN0nxAupkb6x3ImOI9iljjXqOW5lYdNVHNxNlcx3iA1Q==}
+  '@vue/runtime-dom@3.6.0-rc.5':
+    resolution: {integrity: sha512-E5A1z7UEoPvAmIpZopSJ5ji8A1wuP2cFHVc41ZN2w32FWV3CxFQVJG3VNSHwFs8lBQ8Ji5SDnkMCfJXHVzt0iQ==}
 
-  '@vue/runtime-vapor@3.6.0-rc.2':
-    resolution: {integrity: sha512-8EpxbNyT629k/52el4D7PxXmZtiYhJRBHPXJR7CZw0OluiADtT9W8J+XB83EVlzHmFUysXcd+mGWmuHwIhuHZA==}
+  '@vue/runtime-vapor@3.6.0-rc.5':
+    resolution: {integrity: sha512-OmBf4R/SJ11h9ZXrpPThddh2SqTmyc9eCBLFSmH1rhfr/sVFMrrcxMXjFOX1Rn+Nlqiuf9pUx/hYwG2gY2uJHA==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-rc.2
+      '@vue/runtime-dom': 3.6.0-rc.5
 
   '@vue/server-renderer@3.5.39':
     resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
     peerDependencies:
       vue: 3.5.39
 
-  '@vue/server-renderer@3.6.0-rc.2':
-    resolution: {integrity: sha512-TIsqoYljs6b0wfoCDhv4EeU3Du2a8gTadkaTGMjIYLTLlO4p8r4VdDqfNp/ZMAm87bW4ST1naBMRe+bXQBpAeQ==}
+  '@vue/server-renderer@3.6.0-rc.5':
+    resolution: {integrity: sha512-esb8yrZjymuMO7Wqjp62B2cFCGvL1AkmlIp8KBsKowG+BOqzemOJHz1yhK7Tf3KE0LIEatDP/Gb4FZo+S/LwyQ==}
 
   '@vue/shared@3.5.39':
     resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
-  '@vue/shared@3.6.0-rc.2':
-    resolution: {integrity: sha512-Tz44lKLjxhWRu3GJ38768dc2hW4XhDtTB5aUo5fCMis6YDyFzwQYkrD/B9SuQ1v/ailv6UVR3wSHiujNXSjMCQ==}
+  '@vue/shared@3.6.0-rc.5':
+    resolution: {integrity: sha512-2dQ2+xAv7USEKgM5ckB2PrNc4pBcqYNCmkk8/RQtbpxpNDK0RvH0c9vG4rgqsvFS4wy3RXyj2ZfoAhldkgZ2dw==}
 
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
@@ -7306,8 +7315,8 @@ packages:
       typescript:
         optional: true
 
-  vue@3.6.0-rc.2:
-    resolution: {integrity: sha512-pBgoISqETcufJ1e92vVW2/D5MEbCm2XHlC/5dq3hWq8s17tx9v5BEdYv4hojJ0yEEDidYxUL7itS+vV32wfZrw==}
+  vue@3.6.0-rc.5:
+    resolution: {integrity: sha512-yM+CHEWSTc9FjJGIeViI86VVheHvJ3YaZrrXqlD7wX3S+8tNPR/vDMviGOv4ULIMTkzWWKWVRvylsytXbHBbNA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -7759,6 +7768,10 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.0':
     dependencies:
@@ -8269,6 +8282,11 @@ snapshots:
       - supports-color
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -10158,11 +10176,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.6.0-rc.5(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.5(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.0)(vite@8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -10292,10 +10310,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-rc.2':
+  '@vue/compiler-core@3.6.0-rc.5':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/shared': 3.6.0-rc.2
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.6.0-rc.5
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -10305,10 +10323,10 @@ snapshots:
       '@vue/compiler-core': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/compiler-dom@3.6.0-rc.2':
+  '@vue/compiler-dom@3.6.0-rc.5':
     dependencies:
-      '@vue/compiler-core': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-core': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
 
   '@vue/compiler-sfc@3.5.39':
     dependencies:
@@ -10322,14 +10340,14 @@ snapshots:
       postcss: 8.5.19
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-rc.2':
+  '@vue/compiler-sfc@3.6.0-rc.5':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.6.0-rc.2
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/compiler-ssr': 3.6.0-rc.2
-      '@vue/compiler-vapor': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.6.0-rc.5
+      '@vue/compiler-dom': 3.6.0-rc.5
+      '@vue/compiler-ssr': 3.6.0-rc.5
+      '@vue/compiler-vapor': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.19
@@ -10340,16 +10358,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/compiler-ssr@3.6.0-rc.2':
+  '@vue/compiler-ssr@3.6.0-rc.5':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
 
-  '@vue/compiler-vapor@3.6.0-rc.2':
+  '@vue/compiler-vapor@3.6.0-rc.5':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@babel/parser': 7.29.8
+      '@vue/compiler-dom': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -10400,9 +10418,9 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.39
 
-  '@vue/reactivity@3.6.0-rc.2':
+  '@vue/reactivity@3.6.0-rc.5':
     dependencies:
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.5
 
   '@vue/repl@4.7.1(patch_hash=fc29a8ded97d1a89f3c3a420fabdefb4950b13833ca6b61fbd67bca26f408d33)': {}
 
@@ -10411,10 +10429,10 @@ snapshots:
       '@vue/reactivity': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/runtime-core@3.6.0-rc.2':
+  '@vue/runtime-core@3.6.0-rc.5':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
 
   '@vue/runtime-dom@3.5.39':
     dependencies:
@@ -10423,18 +10441,18 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/runtime-dom@3.6.0-rc.2':
+  '@vue/runtime-dom@3.6.0-rc.5':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/runtime-core': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.5
+      '@vue/runtime-core': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)':
+  '@vue/runtime-vapor@3.6.0-rc.5(@vue/runtime-dom@3.6.0-rc.5)':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.5
+      '@vue/runtime-dom': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
 
   '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -10442,15 +10460,15 @@ snapshots:
       '@vue/shared': 3.5.39
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vue/server-renderer@3.6.0-rc.2':
+  '@vue/server-renderer@3.6.0-rc.5':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-ssr': 3.6.0-rc.5
+      '@vue/runtime-dom': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
 
   '@vue/shared@3.5.39': {}
 
-  '@vue/shared@3.6.0-rc.2': {}
+  '@vue/shared@3.6.0-rc.5': {}
 
   '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -10461,9 +10479,9 @@ snapshots:
     optionalDependencies:
       '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.5)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.5
       js-beautify: 1.15.4
       vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.2.8
@@ -14199,7 +14217,7 @@ snapshots:
       - tsx
       - yaml
 
-  unplugin-vue@7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(vue@3.6.0-rc.2(typescript@6.0.3))(yaml@2.9.0):
+  unplugin-vue@7.2.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(vue@3.6.0-rc.5(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -14207,7 +14225,7 @@ snapshots:
       obug: 2.1.3
       unplugin: 3.0.0
       vite: 8.1.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.5(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -14437,14 +14455,14 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vue@3.6.0-rc.2(typescript@6.0.3):
+  vue@3.6.0-rc.5(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/compiler-sfc': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/runtime-vapor': 3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)
-      '@vue/server-renderer': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.5
+      '@vue/compiler-sfc': 3.6.0-rc.5
+      '@vue/runtime-dom': 3.6.0-rc.5
+      '@vue/runtime-vapor': 3.6.0-rc.5(@vue/runtime-dom@3.6.0-rc.5)
+      '@vue/server-renderer': 3.6.0-rc.5
+      '@vue/shared': 3.6.0-rc.5
     optionalDependencies:
       typescript: 6.0.3
 

--- a/tests/vapor/README.md
+++ b/tests/vapor/README.md
@@ -12,7 +12,7 @@ feature-complete as of rc.1). The rest of the monorepo is pinned to Vue 3.5 via
 the catalog, and we don't want a pre-release Vue in the default test run. So
 this package:
 
-- Declares its **own** `vue@3.6.0-rc.2` + `@vue/runtime-vapor@3.6.0-rc.2`
+- Declares its **own** `vue@3.6.0-rc.5` + `@vue/runtime-vapor@3.6.0-rc.5`
   devDependencies. pnpm installs them alongside the 3.5 copy; `packages/0`
   is untouched.
 - Lives under `tests/*`, which the root `vitest.config.ts`
@@ -34,6 +34,7 @@ pnpm --filter @vuetify-private/vapor-tests test
 | `test/instance.vapor.test.ts` | `utilities/instance.ts` works under a real Vapor render: `getCurrentInstance()` is genuinely `null`, yet the `currentInstance` shim still detects the instance and `useId()` resolves. `instance.test.ts` can only mock this. |
 | `test/composables.vapor.test.ts` | `createSelection` (registry + reactive tickets + computed Set) runs in a Vapor setup and drives Vapor DOM updates. |
 | `test/context.vapor.test.ts` | `createContext` carries a value from a Vapor ancestor to a Vapor descendant — the provide/inject substrate beneath every v0 compound component. |
+| `test/injection.vapor.test.ts` | `hasInjectionContext()` is vapor-aware and app-level provides resolve via `inject()` inside a Vapor setup — the gate `createPlugin` puts in front of every generated `useX()` consumer, exercised through a real `createLoggerPlugin` install (provided context resolves, fallback resolves when absent, no throws). |
 | `test/interop.vapor.test.ts` | A classic (vdom) v0 component renders inside a Vapor root via `vaporInteropPlugin`, including slot content forwarded from the Vapor parent. |
 
 ## Why the vitest config is unusual
@@ -54,7 +55,7 @@ Two toolchain traps, both handled in `vitest.config.ts`:
 
 ## RC pin
 
-`3.6.0-rc.2` is the newest 3.6 release candidate. RCs land faster than the
+`3.6.0-rc.5` is the newest 3.6 release candidate. RCs land faster than the
 workspace's `minimumReleaseAge` (14 days) clears them, so `vue` and `@vue/*`
 sit in `minimumReleaseAgeExclude` — safe because both are exact-pinned
 everywhere (default catalog + this package), so no floating range can pull an

--- a/tests/vapor/package.json
+++ b/tests/vapor/package.json
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
-    "@vue/runtime-vapor": "3.6.0-rc.2",
+    "@vue/runtime-vapor": "3.6.0-rc.5",
     "happy-dom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vue": "3.6.0-rc.2"
+    "vue": "3.6.0-rc.5"
   }
 }

--- a/tests/vapor/src/InjectionProbe.vue
+++ b/tests/vapor/src/InjectionProbe.vue
@@ -1,0 +1,43 @@
+<script setup vapor lang="ts">
+  // Composables
+  import { useLogger } from '#v0/composables'
+
+  // Utilities
+  import { isNull } from '#v0/utilities'
+  import { getCurrentInstance, hasInjectionContext, inject } from 'vue'
+
+  // createPlugin/index.ts gates every generated useX() consumer on
+  // hasInjectionContext(). Under Vapor that guarantee comes from Vue's
+  // getCurrentGenericInstance() accessor, not getCurrentInstance() — this
+  // probe pins it against a real Vapor render.
+  const has = hasInjectionContext()
+
+  // App-level provide → component-level inject is how every v0 plugin
+  // delivers its context. Resolve one provided via app.provide().
+  const injected = inject<string>('vapor-probe', '<missing>')
+
+  // For contrast, mirror InstanceProbe: the vdom accessor stays null by
+  // design, so hasInjectionContext() must NOT be built on it.
+  const rawNull = isNull(getCurrentInstance())
+
+  // A real createPluginContext consumer: with createLoggerPlugin installed,
+  // inject() resolves the provided context; without it, the fallback logger
+  // resolves instead of throwing. current() discriminates the two.
+  let level = ''
+  let loggerError = ''
+  try {
+    level = useLogger().current()
+  } catch (error) {
+    loggerError = (error as Error).message
+  }
+</script>
+
+<template>
+  <div
+    :data-has-injection-context="String(has)"
+    :data-injected="injected"
+    :data-logger-error="loggerError"
+    :data-logger-level="level"
+    :data-raw-null="String(rawNull)"
+  />
+</template>

--- a/tests/vapor/src/InjectionProbe.vue
+++ b/tests/vapor/src/InjectionProbe.vue
@@ -23,8 +23,8 @@
   // A real createPluginContext consumer: with createLoggerPlugin installed,
   // inject() resolves the provided context; without it, the fallback logger
   // resolves instead of throwing. current() discriminates the two.
-  let level = ''
-  let loggerError = ''
+  let level: string | undefined
+  let loggerError: string | undefined
   try {
     level = useLogger().current()
   } catch (error) {
@@ -36,8 +36,8 @@
   <div
     :data-has-injection-context="String(has)"
     :data-injected="injected"
-    :data-logger-error="loggerError"
-    :data-logger-level="level"
+    :data-logger-error="loggerError ?? ''"
+    :data-logger-level="level ?? ''"
     :data-raw-null="String(rawNull)"
   />
 </template>

--- a/tests/vapor/test/injection.vapor.test.ts
+++ b/tests/vapor/test/injection.vapor.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createLoggerPlugin } from '#v0/composables'
+
+import { mountVapor } from './mount'
+
+// Types
+import type { MountOptions, VaporMount } from './mount'
+
+import InjectionProbe from '../src/InjectionProbe.vue'
+
+// createPlugin/index.ts gates every generated useX() consumer on
+// hasInjectionContext() before inject()ing the plugin context. The whole v0
+// plugin family (useLogger, useTheme, useLocale, …) therefore depends on
+// hasInjectionContext() being vapor-aware — in Vue 3.6 it reads
+// getCurrentGenericInstance() || currentApp, NOT the vdom-only
+// getCurrentInstance(). These tests pin that guarantee against a real Vapor
+// render so an upstream regression fails loudly here instead of silently
+// downgrading every plugin consumer to its fallback.
+describe('injection context under vapor', () => {
+  let wrapper: VaporMount
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  function probe (options: MountOptions = {}) {
+    wrapper = mountVapor(InjectionProbe, options)
+    return wrapper.host.firstElementChild as HTMLElement
+  }
+
+  it('should report hasInjectionContext() true inside vapor setup', () => {
+    const el = probe()
+
+    expect(el.dataset.hasInjectionContext).toBe('true')
+    // ...even though the vdom accessor is genuinely null — proving the
+    // guarantee does not come from getCurrentInstance().
+    expect(el.dataset.rawNull).toBe('true')
+  })
+
+  it('should resolve an app-level provide via inject()', () => {
+    const el = probe({ provide: { 'vapor-probe': 'from-app' } })
+
+    expect(el.dataset.injected).toBe('from-app')
+  })
+
+  it('should resolve a provided plugin context through the createPlugin consumer', () => {
+    // The real createPlugin path: app.use(createXPlugin()) provides at the
+    // app level, useX() inside the vapor component injects it back. current()
+    // returning the configured level proves the PROVIDED context resolved,
+    // not the fallback (which always reports 'info' and ignores level()).
+    const el = probe({ plugins: [createLoggerPlugin({ level: 'debug' })] })
+
+    expect(el.dataset.loggerError).toBe('')
+    expect(el.dataset.loggerLevel).toBe('debug')
+  })
+
+  it('should resolve the fallback without throwing when the plugin is absent', () => {
+    const el = probe()
+
+    expect(el.dataset.loggerError).toBe('')
+    expect(el.dataset.loggerLevel).toBe('info')
+  })
+})

--- a/tests/vapor/test/mount.ts
+++ b/tests/vapor/test/mount.ts
@@ -2,7 +2,7 @@
 import { createVaporApp, vaporInteropPlugin } from '@vue/runtime-vapor'
 
 // Types
-import type { Component } from 'vue'
+import type { Component, Plugin } from 'vue'
 
 export interface VaporMount {
   host: HTMLElement
@@ -16,6 +16,12 @@ export interface MountOptions {
   // Install vaporInteropPlugin so classic (vdom) v0 components can render
   // inside this Vapor app — required for any test that mounts a v0 SFC.
   interop?: boolean
+  // App plugins to install before mount — v0's createXPlugin() objects go
+  // through the same app.use() path they take in a real app.
+  plugins?: Plugin[]
+  // App-level provides, applied before mount the way v0 plugins provide
+  // their contexts.
+  provide?: Record<string, unknown>
 }
 
 // @vue/test-utils has no Vapor support yet (vuejs/core#13687), so mount
@@ -28,6 +34,12 @@ export function mountVapor (component: Component, options: MountOptions = {}): V
   const app = createVaporApp(component as Parameters<typeof createVaporApp>[0], options.props)
   if (options.interop) {
     app.use(vaporInteropPlugin)
+  }
+  for (const plugin of options.plugins ?? []) {
+    app.use(plugin)
+  }
+  for (const [key, value] of Object.entries(options.provide ?? {})) {
+    app.provide(key, value)
   }
   app.mount(host)
 


### PR DESCRIPTION
The #845 review surfaced the load-bearing assumption: `createPlugin`'s generated `useX()` consumers gate on `hasInjectionContext()`, so the entire v0 plugin family depends on that check being Vapor-aware — `instanceExists()` was the shim we own, but injection context is Vue's to break. This bumps the vapor harness rc.2 → rc.5 (three RCs of drift, pre-existing suite still green) and adds an `InjectionProbe` that pins the guarantee with a test we own: `hasInjectionContext()` true inside a real Vapor setup while `getCurrentInstance()` is null, app-level provides resolving via `inject()`, and a real `createLoggerPlugin` install resolving its provided context (fallback when absent) through the `createPlugin` consumer path.

The rc.5 implementation remains vapor-aware:

```js
function hasInjectionContext() {
	return !!(getCurrentGenericInstance() || currentApp);
}
```

Tests-only — no changeset.