### PR TITLE
docs(DocsFaq): collapse long FAQ lists behind GnPeek

### DIFF
--- a/apps/docs/src/components/docs/DocsFaq.test.ts
+++ b/apps/docs/src/components/docs/DocsFaq.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Context
+import DocsFaq from './DocsFaq.vue'
+import DocsFaqItem from './DocsFaqItem.vue'
+
+// Utilities
+import { flushPromises, mount } from '@vue/test-utils'
+import { h } from 'vue'
+
+vi.mock('./DocsCallout.vue', () => ({
+  default: { name: 'DocsCallout', template: '<div />' },
+}))
+
+const stubs = {
+  DocsCallout: true,
+  DocsSearchInput: {
+    props: ['modelValue', 'placeholder'],
+    emits: ['update:modelValue'],
+    template: '<input class="faq-search" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+}
+
+function mountFaq (n: number) {
+  return mount(DocsFaq, {
+    global: { stubs },
+    slots: {
+      default: () => Array.from({ length: n }, (_, index) =>
+        h(DocsFaqItem, { question: `Question ${index + 1}` }, () => `Answer ${index + 1}`),
+      ),
+    },
+  })
+}
+
+function visibleQuestions (wrapper: ReturnType<typeof mountFaq>) {
+  return wrapper.findAllComponents(DocsFaqItem).filter(item => {
+    return (item.element as HTMLElement).style.display !== 'none'
+  })
+}
+
+describe('docsFaq', () => {
+  it('should not render search or peek below 5 items', () => {
+    const wrapper = mountFaq(4)
+    expect(wrapper.find('.faq-search').exists()).toBe(false)
+    expect(wrapper.find('.genesis-peek').exists()).toBe(false)
+    expect(visibleQuestions(wrapper)).toHaveLength(4)
+  })
+
+  it('should render search without peek at 5 and 6 items', () => {
+    for (const n of [5, 6]) {
+      const wrapper = mountFaq(n)
+      expect(wrapper.find('.faq-search').exists()).toBe(true)
+      expect(wrapper.find('.genesis-peek').exists()).toBe(false)
+      expect(visibleQuestions(wrapper)).toHaveLength(n)
+    }
+  })
+
+  it('should clip to the first 5 questions when there are 7 or more', () => {
+    const wrapper = mountFaq(7)
+    expect(wrapper.find('.faq-search').exists()).toBe(true)
+    expect(visibleQuestions(wrapper)).toHaveLength(5)
+    const peek = wrapper.get('.genesis-peek')
+    expect(peek.attributes('aria-expanded')).toBe('false')
+    expect(peek.attributes('aria-label')).toBe('Expand FAQ')
+    expect(peek.text()).toContain('Expand')
+  })
+
+  it('should reveal every question when Expand is clicked, and clip again on Collapse', async () => {
+    const wrapper = mountFaq(7)
+    await wrapper.get('.genesis-peek').trigger('click')
+    expect(visibleQuestions(wrapper)).toHaveLength(7)
+    expect(wrapper.get('.genesis-peek').attributes('aria-expanded')).toBe('true')
+    expect(wrapper.get('.genesis-peek').text()).toContain('Collapse')
+
+    await wrapper.get('.genesis-peek').trigger('click')
+    expect(visibleQuestions(wrapper)).toHaveLength(5)
+    expect(wrapper.get('.genesis-peek').attributes('aria-expanded')).toBe('false')
+  })
+
+  it('should unclip matching items and hide the pill while searching', async () => {
+    const wrapper = mountFaq(7)
+    await wrapper.get('.faq-search').setValue('Question 7')
+    await flushPromises()
+    expect(wrapper.find('.genesis-peek').exists()).toBe(false)
+    expect(visibleQuestions(wrapper)).toHaveLength(1)
+    expect(visibleQuestions(wrapper)[0].props('question')).toBe('Question 7')
+  })
+
+  it('should re-clip after the search query is cleared if Expand was never clicked', async () => {
+    const wrapper = mountFaq(7)
+    await wrapper.get('.faq-search').setValue('Question 7')
+    await flushPromises()
+    await wrapper.get('.faq-search').setValue('')
+    await flushPromises()
+    expect(wrapper.find('.genesis-peek').exists()).toBe(true)
+    expect(visibleQuestions(wrapper)).toHaveLength(5)
+  })
+})

--- a/apps/docs/src/components/docs/DocsFaq.vue
+++ b/apps/docs/src/components/docs/DocsFaq.vue
@@ -1,16 +1,35 @@
 <script lang="ts">
+  import { GnPeek } from '@paper/genesis'
+
   // Framework
-  import { createFilter, createFilterContext, ExpansionPanel } from '@vuetify/v0'
+  import { createContext, createFilter, createFilterContext, ExpansionPanel } from '@vuetify/v0'
 
   // Components
   import DocsCallout from '@/components/docs/DocsCallout.vue'
+  import DocsSearchInput from '@/components/docs/DocsSearchInput.vue'
 
   // Utilities
-  import { toRef, useSlots } from 'vue'
+  import { isString } from '#v0/utilities'
+  import { shallowRef, toRef, useSlots } from 'vue'
+
+  // Types
+  import type { Ref } from 'vue'
+
+  export interface FaqCollapse {
+    takeIndex: () => number
+    clipped: Ref<boolean>
+    preview: number
+  }
 
   export const [useFaqFilter, provideFaqFilter] = createFilterContext({
     namespace: 'docs:faq',
   })
+
+  export const [useFaqCollapse, provideFaqCollapse] = createContext<FaqCollapse>('docs:faq-collapse')
+
+  const SEARCH_AT = 5
+  const COLLAPSE_AT = 7
+  const PREVIEW = 5
 </script>
 
 <script setup lang="ts">
@@ -27,7 +46,20 @@
     return items.filter(v => (v.type as { __name?: string })?.__name === 'DocsFaqItem').length
   })
 
-  const show = toRef(() => count.value >= 5)
+  const show = toRef(() => count.value >= SEARCH_AT)
+  const shouldCollapse = toRef(() => count.value >= COLLAPSE_AT)
+  const expanded = shallowRef(false)
+  const searching = toRef(() => isString(filter.query.value) && filter.query.value.length > 0)
+  const clipped = toRef(() => shouldCollapse.value && !expanded.value && !searching.value)
+
+  let next = 0
+  provideFaqCollapse({
+    takeIndex () {
+      return next++
+    },
+    clipped,
+    preview: PREVIEW,
+  })
 </script>
 
 <template>
@@ -40,10 +72,41 @@
       @update:model-value="filter.query.value = $event"
     />
 
-    <ExpansionPanel.Group class="flex flex-col gap-3" :multiple>
-      <slot />
-    </ExpansionPanel.Group>
+    <div
+      class="relative"
+      :class="shouldCollapse && 'mb-8'"
+    >
+      <ExpansionPanel.Group
+        class="flex flex-col gap-3"
+        :class="shouldCollapse && expanded && 'pb-4'"
+        :multiple
+      >
+        <slot />
+      </ExpansionPanel.Group>
+
+      <div
+        v-if="clipped"
+        aria-hidden="true"
+        class="docs-faq-fade absolute inset-x-0 bottom-0 h-12 rounded-b-lg pointer-events-none"
+      />
+
+      <GnPeek
+        v-if="shouldCollapse && !searching"
+        v-slot="{ expanded: open }"
+        v-model:expanded="expanded"
+        collapsed-label="Expand FAQ"
+        expanded-label="Collapse FAQ"
+      >
+        {{ open ? 'Collapse' : 'Expand' }}
+      </GnPeek>
+    </div>
 
     <DocsCallout type="discord" />
   </div>
 </template>
+
+<style>
+  .docs-faq-fade {
+    background: linear-gradient(transparent, var(--v0-background, var(--v0-surface, #fff)));
+  }
+</style>

--- a/apps/docs/src/components/docs/DocsFaqItem.vue
+++ b/apps/docs/src/components/docs/DocsFaqItem.vue
@@ -3,7 +3,7 @@
   import { ExpansionPanel } from '@vuetify/v0'
 
   // Context
-  import { useFaqFilter } from './DocsFaq.vue'
+  import { useFaqCollapse, useFaqFilter } from './DocsFaq.vue'
 
   // Utilities
   import { toRef } from 'vue'
@@ -13,12 +13,15 @@
   }>()
 
   const filter = useFaqFilter()
+  const collapse = useFaqCollapse()
+  const index = collapse.takeIndex()
   const result = filter.apply(filter.query, () => [question])
   const visible = toRef(() => result.items.value.length > 0)
+  const clippedAway = toRef(() => collapse.clipped.value && index >= collapse.preview)
 </script>
 
 <template>
-  <ExpansionPanel.Root v-show="visible">
+  <ExpansionPanel.Root v-show="visible && !clippedAway">
     <ExpansionPanel.Activator
       v-slot="{ isSelected }"
       class="w-full list-item-bordered flex items-center gap-3 text-left"


### PR DESCRIPTION
FAQ sections with 7+ items collapse to the first 5 questions behind the same Expand/Collapse pill used on examples. Search still appears at 5 items and auto-expands so a match further down the list is not clipped.

Hits the long pages today: frequently-asked (16), roadmap (10), sponsor (7), create-tokens (7). Authoring (`::: faq`) and FAQPage JSON-LD are unchanged.