### PR TITLE
docs(DocsFaq): render inline code in FAQ toggle titles

### DIFF
--- a/apps/docs/build/markdown.test.ts
+++ b/apps/docs/build/markdown.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMarkdownIt } from './markdown'
+
+describe('faq container', () => {
+  it('should compile inline code in FAQ question titles', async () => {
+    const md = await createMarkdownIt()
+    const html = md.render(`::: faq
+??? What's the difference between \`foo\` and \`bar\`?
+
+Answer with \`baz\`.
+:::`)
+
+    expect(html).toContain('<template #question>')
+    expect(html).toMatch(/<template #question>[\s\S]*<code[^>]*>foo<\/code>[\s\S]*<code[^>]*>bar<\/code>/)
+    expect(html).not.toMatch(/<template #question>[^<]*`foo`/)
+  })
+})

--- a/apps/docs/build/markdown.ts
+++ b/apps/docs/build/markdown.ts
@@ -281,7 +281,10 @@ export function applyMarkdownPlugins (md: MarkdownIt, highlighter: DocsHighlight
       env._faqQuestionPara = true
       inlineToken.content = ''
       inlineToken.children = []
-      return `${closeTag}<DocsFaqItem question="${md.utils.escapeHtml(question)}">\n`
+      // `question` stays plain text for search/filter; the slot is the same
+      // inline pipeline as body markdown (`code`, API hover, links).
+      const title = md.renderInline(question, env)
+      return `${closeTag}<DocsFaqItem question="${md.utils.escapeHtml(question)}">\n<template #question>${title}</template>\n`
     }
     return defaultParagraphOpen
       ? defaultParagraphOpen(tokens, index, options, env, self)

--- a/apps/docs/src/components/docs/DocsFaq.test.ts
+++ b/apps/docs/src/components/docs/DocsFaq.test.ts
@@ -95,4 +95,29 @@ describe('docsFaq', () => {
     expect(wrapper.find('.genesis-peek').exists()).toBe(true)
     expect(visibleQuestions(wrapper)).toHaveLength(5)
   })
+
+  it('should render inline code in the question instead of raw backticks', () => {
+    const wrapper = mount(DocsFaq, {
+      global: { stubs },
+      slots: {
+        default: () => h(DocsFaqItem, { question: 'What is `foo`?' }, () => 'Answer'),
+      },
+    })
+    expect(wrapper.find('code').text()).toBe('foo')
+    expect(wrapper.text()).not.toContain('`foo`')
+  })
+
+  it('should prefer the question slot over the raw question string', () => {
+    const wrapper = mount(DocsFaq, {
+      global: { stubs },
+      slots: {
+        default: () => h(DocsFaqItem, { question: 'What is `foo`?' }, {
+          question: () => h('code', { class: 'from-slot' }, 'foo'),
+          default: () => 'Answer',
+        }),
+      },
+    })
+    expect(wrapper.find('code.from-slot').text()).toBe('foo')
+    expect(wrapper.findAll('code')).toHaveLength(1)
+  })
 })

--- a/apps/docs/src/components/docs/DocsFaqItem.vue
+++ b/apps/docs/src/components/docs/DocsFaqItem.vue
@@ -6,6 +6,7 @@
   import { useFaqCollapse, useFaqFilter } from './DocsFaq.vue'
 
   // Utilities
+  import { renderInlineMarkdown } from '@/utilities/markdown'
   import { toRef } from 'vue'
 
   const { question } = defineProps<{
@@ -18,6 +19,7 @@
   const result = filter.apply(filter.query, () => [question])
   const visible = toRef(() => result.items.value.length > 0)
   const clippedAway = toRef(() => collapse.clipped.value && index >= collapse.preview)
+  const html = renderInlineMarkdown(question)
 </script>
 
 <template>
@@ -33,7 +35,11 @@
         {{ isSelected ? '−' : '?' }}
       </span>
 
-      <span class="font-medium">{{ question }}</span>
+      <span class="font-medium [&_code]:font-normal">
+        <slot name="question">
+          <span v-html="html" />
+        </slot>
+      </span>
     </ExpansionPanel.Activator>
 
     <ExpansionPanel.Content class="px-4 pb-4 pt-3 text-on-surface-variant [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:opacity-80 [&_p]:my-2 first:[&_p]:mt-0 [&_ul]:my-2 [&_ul]:ml-4 [&_ul]:list-disc [&_li]:my-1">


### PR DESCRIPTION
FAQ `???` questions were interpolated as a plain string, so backticks showed as literal `` `code` `` instead of a chip. Titles now run through the same inline markdown pipeline as body copy (`<code>`, API hover, links). Search still matches on the raw question text.