### PR TITLE
docs(build): pick up named export lists in api-whitelist generator

### DIFF
--- a/apps/docs/build/generate-api-whitelist.ts
+++ b/apps/docs/build/generate-api-whitelist.ts
@@ -126,6 +126,19 @@ async function getComposableData (): Promise<{
       }
     }
 
+    // Find named export lists (value re-exports of module-private declarations)
+    // Matches: export { createPopoverContext, createPopoverPlugin }
+    const namedExports = content.matchAll(/export\s+\{([^}]+)\}/g)
+    for (const match of namedExports) {
+      const bindings = match[1].split(',').map(s => s.trim().split(/\s+as\s+/).pop()!)
+      for (const binding of bindings) {
+        if (COMPOSABLE_PATTERN.test(binding)) {
+          names.add(binding)
+          toDir[binding] = dir
+        }
+      }
+    }
+
     // Also add the directory name itself (the primary export)
     names.add(dir)
     toDir[dir] = dir


### PR DESCRIPTION
Follow-up from #916 (closed as duplicate of #917).

The API whitelist generator only scanned `export function` and `export const [a, b] =`. Plugin trinities that re-export as a named list — `export { createPopoverContext, createPopoverPlugin }` — never made it into `V0_COMPOSABLES`, so Shiki API hover missed them. Same hole for the logger trinity (`createLoggerContext` / `createLoggerPlugin`).

This is the 13-line parser from #916, cherry-picked onto `dev` after #917. No package API change; generated whitelist is gitignored and rebuilds on docs start.

Verified locally: `createPopoverPlugin`, `createPopoverContext`, `createLoggerPlugin`, `createLoggerContext`, and `toPlacement` now resolve to the correct directories.