### PR TITLE
chore(play): mark first publish public so OIDC can create the package

### DIFF
--- a/packages/play/package.json
+++ b/packages/play/package.json
@@ -26,6 +26,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": "./dist/index.mjs",
       "./package.json": "./package.json"


### PR DESCRIPTION
Release #895 published `@vuetify/v0@1.1.0` then died on `@vuetify/play@0.1.0`:

`404 Not Found - PUT https://registry.npmjs.org/@vuetify%2fplay`

New scoped packages default to restricted; a 404 is what npm returns when the package does not exist yet. `publishConfig.access: public` lets the next master Release run create it.

`v1.1.0` GitHub release is already minted. This unblocks the play publish + `@vuetify/play@0.1.0` GitHub release on the recovery run (v0 is skipped as already on npm).