### PR TITLE
chore(play): mark first publish public

### DIFF
--- a/packages/play/package.json
+++ b/packages/play/package.json
@@ -26,6 +26,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": "./dist/index.mjs",
       "./package.json": "./package.json"


### PR DESCRIPTION
\`@vuetify/play@0.1.0\` never landed: Release #895 404'd on first PUT of a new scoped package.

\`publishConfig.access: public\` matches changesets \`access: public\` and is required for the first create. v0@1.1.0 is already on npm and tagged; the recovery run skips it and publishes play, then mints \`@vuetify/play@0.1.0\`.