### PR TITLE
chore: publish @paper/emerald so Version Packages can run

### DIFF
--- a/packages/bulma/package.json
+++ b/packages/bulma/package.json
@@ -35,6 +35,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": "./dist/index.mjs",
       "./package.json": "./package.json"

--- a/packages/emerald/package.json
+++ b/packages/emerald/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@paper/emerald",
   "version": "0.0.0",
-  "private": true,
   "description": "Emerald design system — Wave 1–4 (v0-composed, Figma-tokened)",
   "license": "MIT",
   "repository": {
@@ -34,6 +33,7 @@
     "./theme.css": "./dist/theme.css"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": "./dist/index.mjs",
       "./package.json": "./package.json",


### PR DESCRIPTION
Release after #925 failed:

\`Mixed changesets that contain both ignored and not ignored packages are not allowed\`

\`@paper/emerald\` is \`private\` (\`privatePackages.version: false\` → ignored). This cut already has Wave 1–4 emerald changesets. Un-private it and mark first publish public instead of stripping emerald from the mixed changeset.

Also \`publishConfig.access: public\` on \`@paper/bulma\` — first create on the same train.

After merge, master Release should open the 1.2.0 Version Packages PR (\`@vuetify/v0@1.2.0\`, \`@paper/emerald@0.1.0\`, \`@paper/bulma@0.1.0\`, play if still unpublished).

Same OIDC first-create 404 risk as play. If publish dies on PUT 404:

\`\`\`bash
pnpm --filter @paper/emerald build
cd packages/emerald && npm publish --access public
\`\`\`