### PR TITLE
docs(nuxt): explain stable keys in dynamic lists

### DIFF
--- a/apps/docs/src/pages/guide/integration/nuxt.md
+++ b/apps/docs/src/pages/guide/integration/nuxt.md
@@ -292,7 +292,10 @@ export default defineNuxtConfig({
    - Wrap browser-dependent content in `<ClientOnly>` or `v-if="isHydrated"`
    - Use `useId()` from Vue for SSR-safe unique IDs
    - Avoid `new Date()`, `Math.random()`, or `window` access during initial render
-   - Ensure v-for keys are deterministic (not index-based for dynamic lists)
+   - Ensure the initial list items and their keys match between the server and client
+
+> [!NOTE]
+> Array indexes identify positions rather than items. When items are inserted, removed, or reordered, Vue can reuse DOM or component state for a different item. Prefer a stable identifier from the item, such as `:key="item.id"`. This does not replace the hydration requirement above: the server and client must still render the same initial list. The contributor maintains an optional [worked `v-for` key exercise](https://frontendatlas.com/vue/trivia/vue-v-for-keys-why-not-index) on FrontendAtlas.
 
 ### useHydration vs ClientOnly
 


### PR DESCRIPTION
## Documentation gap

The “Avoiding Hydration Mismatch” section already recommends deterministic
`v-for` keys and warns against index-based keys for dynamic lists. It does not
explain an important distinction: an array index may be identical during the
initial server and client render, yet still represent the wrong logical item
after an insertion, removal, or reorder.

That can cause Vue to reuse component or DOM identity for a different item,
allowing local state, focus, or uncontrolled input values to appear on the
wrong row.

## Proposed documentation change

Add a short explanation and a minimal before/after example:

- Avoid `:key="index"` when the list can change order or membership.
- Prefer a stable identifier owned by the item, such as `:key="item.id"`.
- Clarify that stable keys do not repair mismatched server/client data; the
  initial item sequence and keys must still agree during hydration.

This would expand the existing recommendation without changing any Vuetify0
API or runtime behavior.

## Optional reader exercise

For readers who want to reproduce the identity problem with insertion and
reordering, this focused exercise may be useful:
https://frontendatlas.com/vue/trivia/vue-v-for-keys-why-not-index

Disclosure: I maintain FrontendAtlas. The external exercise is optional and can
be omitted if the project prefers to keep the explanation self-contained.