### PR TITLE
docs: record why 1.1.0 skipped tables and harden the cut process

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -16,7 +16,24 @@ pnpm changeset         # Author a changeset — once per change
 pnpm release:prepare   # Pre-release validation (validate + build)
 ```
 
-Publishing is automated via the Version Packages PR on `master` — do not `npm publish` by hand.
+Publishing is automated via the Version Packages PR on `master` — do not `npm publish` by hand except the **first create** of a new scoped package (OIDC cannot PUT a name that does not exist yet). That one-shot is `npm publish --access public` from a logged-in human, then add a trusted publisher (GitHub Actions / org `vuetifyjs` / repo `0` / workflow `release.yml` / environment empty). Every package needs `publishConfig.access: public` before that PUT.
+
+`npm view` 404 on a brand-new name after a successful `+ pkg@version` is packument lag — the version URL can 200 while the packument is still 404. Do not abort the GitHub-release step on that.
+
+A changeset file must not mix a public package with a `private` one (`privatePackages.version: false` treats private as ignored; changesets rejects mixed files). Un-private the DS if this cut is meant to ship it; do not strip it from the changeset as a workaround unless it should stay unpublished.
+
+## Version Packages review (before merge)
+
+The bump in that PR **is** the next published version. It is not held for a milestone.
+
+1. Read the title (`1.1.0` vs `1.0.6`).
+2. Every pending `.changeset/*.md` on `master` — any `"@vuetify/v0": minor` (or `major`) *is* that bump.
+3. What is still on `dev` that you wanted in this minor?
+4. If (2) and (3) disagree: **do not merge**. Retarget the stray `feat` PRs to `dev`, or accept this minor is the master feats and the `dev` train is the *next* minor.
+
+`dev` → `master` is a **merge commit**, never squash. Do not unpublish if another published package depends on v0 with a caret range.
+
+Agents do not merge this PR or cut `dev`→`master` unless John says so.
 
 ## Changeset content contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,12 @@ Three long-lived branches; a PR's base is chosen by the semver impact of the cha
 | `next` | breaking changes | major | anything with a `BREAKING CHANGE:` footer |
 
 - **Only `master` publishes.** `dev` and `next` accumulate work and merge **into `master`** at the next minor / major cut — that merge is what triggers the changesets release. Never publish from `dev`/`next` directly.
+- **The next minor number is not reserved.** Any `"@vuetify/v0": minor` changeset that is already on `master` when Version Packages merges *is* that minor (1.1.0 was Splitter + play because those `feat`s landed on `master` while DataTable/DataGrid were still on `dev`). Before merging Version Packages: read the bump in the PR title, list pending `.changeset/*.md` bump types on `master`, and check what is still queued on `dev`. If they disagree, stop.
+- **`dev`/`next` → `master` is a merge commit** (`git merge --no-ff`), never squash or rebase. Squash rewrites SHAs so the next cut treats the same history as new. GitHub may have merge commits disabled — enable for that PR only.
+- **Do not unpublish** a version any published package depends on with a range (`@paper/genesis` is `^1.0.5`). npm returns 405.
 - **`feat`/`fix` are still reserved for `packages/*` source.** A `feat(docs)` / `feat(playground)` / app-only change ships no package version, so it targets `master` (patch train) regardless of the `feat` label — prefer `docs`/`chore` for those.
 - **Design systems** (`@paper/*`) version independently; a DS feature still targets `dev` (it's a minor bump for that package).
+- **Agents do not merge Version Packages or cut `dev`→`master` unless John explicitly says so.**
 - CI (`pr-checks.yml`) and the changeset reminder (`changeset-reminder.yml`) run on PRs into all three branches; `release.yml` triggers on `master` pushes only.
 
 ### Authoring a changeset / cutting a release

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -124,7 +124,9 @@ pnpm build            # Build packages
 | `dev` | New features that add public API (a component, composable, prop, or option) | Minor |
 | `next` | Breaking changes (anything with a `BREAKING CHANGE:` footer) | Major |
 
-Only `master` publishes to npm. Work on `dev` and `next` merges into `master` at the next minor or major release, and that merge is what ships it. If you're unsure which base fits, open against `master` — a maintainer will retarget it.
+Only `master` publishes to npm. Work on `dev` and `next` merges into `master` at the next minor or major release, and that merge is what ships it. That join is a **merge commit**, not squash or rebase — squashing rewrites the `dev` SHAs and the next cut treats the same history as new. If you're unsure which base fits, open against `master` — a maintainer will retarget it.
+
+A `feat` PR that adds public API **must** target `dev`. If it lands on `master` with a `minor` changeset, the next Version Packages merge *is* that minor, even if larger features are still queued on `dev`. The version number is not reserved for a milestone.
 
 > [!TIP]
 > A `feat` that only touches the docs site, playground, or other tooling (not `packages/*` source) ships no package version, so it targets `master` — prefer a `docs`/`chore` prefix for those.

--- a/packages/0/CHANGELOG.md
+++ b/packages/0/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.2.0
 
+DataTable, DataGrid, and Alert ship in this minor, not 1.1.0. 1.1.0 went out earlier with Splitter pending-intent and `@vuetify/play` after those `feat`s landed on `master`.
+
 ### Minor Changes
 
 - [#826](https://github.com/vuetifyjs/0/pull/826) [`bcc509c`](https://github.com/vuetifyjs/0/commit/bcc509c909404443dfff098ef0b0bc73e206da93) Thanks [@johnleider](https://github.com/johnleider)! - feat(DataGrid): headless compound with column layout, editing, and spanning


### PR DESCRIPTION
1.1.0 shipped Splitter + play because those \`minor\` changesets were on \`master\` when Version Packages merged; DataTable/DataGrid/Alert were still on \`dev\` and became 1.2.0. Cannot unpublish (genesis \`^1.0.5\`).

Codifies:
- Version Packages bump *is* the next number — not reserved for a milestone
- \`dev\`→\`master\` is a merge commit
- no unpublish when a published package has a caret range
- first-create OIDC / \`access: public\` / mixed private+public changesets
- agents do not cut the train unless asked

Also prepends a note on the 1.1.0 / 1.2.0 GitHub releases (already live).