### PR TITLE
docs: put DataTable/DataGrid/Alert on 1.2.0 in the roadmap

### DIFF
--- a/apps/docs/src/components/docs/DocsReleaseCalendar.vue
+++ b/apps/docs/src/components/docs/DocsReleaseCalendar.vue
@@ -217,7 +217,7 @@
         </div>
 
         <p v-if="selected.stabilizing.length === 0" class="text-sm text-on-surface-variant">
-          No stable graduations this release — the two-minor clock resets at v1.0, so the first stable wave lands in v1.2.0.
+          No stable graduations this release — the two-minor clock resets at v1.0, so the first stable wave lands in v1.3.0.
         </p>
       </div>
     </div>

--- a/apps/docs/src/constants/roadmap-buckets.ts
+++ b/apps/docs/src/constants/roadmap-buckets.ts
@@ -56,24 +56,27 @@ export const ROADMAP_BUCKETS: Record<string, ReleaseBucket> = {
     ],
   },
   'v1.1.0': {
-    date: '2026-08-25',
-    features: ['DataTable', 'DataGrid', 'Alert'],
+    // Shipped 2026-08-26: Splitter pending-intent + @vuetify/play. No new maturity chips.
+    date: '2026-08-26',
+    features: [],
     stabilizing: [],
   },
   'v1.2.0': {
-    date: '2026-09-22',
-    features: ['Tour'],
+    // Shipped 2026-08-26: DataTable/DataGrid/Alert were planned for 1.1.0; a
+    // master-side minor consumed 1.1.0 first. Tour and the first stable wave
+    // slip to v1.3.0.
+    date: '2026-08-26',
+    features: ['DataTable', 'DataGrid', 'Alert'],
+    stabilizing: [],
+  },
+  'v1.3.0': {
+    date: '2026-10-20',
+    features: ['Tour', 'Virtualizer', 'Kanban', 'Otp'],
     stabilizing: [
       'createValidation', 'createForm', 'createInput', 'usePopover', 'usePresence',
       'useRovingFocus', 'useVirtualFocus', 'createFilter', 'createPagination', 'useRtl',
       'useLocale', 'useStack',
       'Single', 'Step', 'Selection', 'Group', 'Theme', 'Locale', 'Scrim',
-    ],
-  },
-  'v1.3.0': {
-    date: '2026-10-20',
-    features: ['Virtualizer', 'Kanban', 'Otp'],
-    stabilizing: [
       'useClickOutside', 'useEventListener', 'useHotkey', 'useMediaQuery', 'useToggleScope',
       'useRaf', 'useTimer', 'useProxyModel', 'useProxyRegistry', 'toArray', 'toElement',
       'toReactive', 'useDelay', 'useHydration',

--- a/apps/docs/src/pages/roadmap.md
+++ b/apps/docs/src/pages/roadmap.md
@@ -26,7 +26,7 @@ Track the development of @vuetify/v0. Milestones are organized by time horizon:
 
 ## Release Calendar
 
-Expected dates for the v1.1–v1.5 minor releases, the net-new features landing in each, and the existing preview features on track to graduate to stable as of that release.
+Expected dates for the v1.1–v1.5 minor releases, the net-new features landing in each, and the existing preview features on track to graduate to stable as of that release. v1.1.0 shipped Splitter pending-intent and `@vuetify/play`; DataTable, DataGrid, and Alert shipped in v1.2.0.
 
 <DocsReleaseCalendar />
 
@@ -51,7 +51,7 @@ This isn't a proof of concept. v0 is feature-complete for v1 and ready to build 
 
 - **The stable set is locked.** 16 composables and 17 utilities are marked stable — breaking changes require a major version. See the [maturity matrix](#maturity-matrix) below for the full breakdown.
 - **v0 is being built directly into Vuetify.** The composables and patterns here are the same ones powering Vuetify's next generation — `vuetify` takes `@vuetify/v0` as a runtime dependency from 4.2.0, starting with the utility layer, and adopts more of the surface each minor. This isn't a side project — it's the core.
-- **Development continues.** v1.1 and beyond are on the roadmap above, and preview APIs graduate to stable release by release. Every regression, gap, or rough edge you report still gets priority — if something feels wrong, say so.
+- **Development continues.** v1.3 and beyond are on the roadmap above, and preview APIs graduate to stable release by release. Every regression, gap, or rough edge you report still gets priority — if something feels wrong, say so.
 
 ### Try v0
 


### PR DESCRIPTION
Roadmap calendar still listed DataTable/DataGrid/Alert under v1.1.0 (Aug 25) and Tour under v1.2.0 (Sep 22).

- v1.1.0: shipped 2026-08-26 (Splitter + play) — no new maturity chips
- v1.2.0: shipped 2026-08-26 with DataTable, DataGrid, Alert
- Tour + the first stable wave slip to v1.3.0

GitHub milestones v1.1.0 / v1.2.0 closed; leftover issues (Tour epic, PR 383, etc.) moved to v1.3.0.