### PR TITLE
feat(forms): expose AtomExpose on control roots and focus() on groups

### DIFF
--- a/.changeset/form-focus-expose.md
+++ b/.changeset/form-focus-expose.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": minor
+---
+
+feat(forms): expose AtomExpose on control roots and focus() on groups
+
+`Checkbox.Root`, `Radio.Root`, `Switch.Root`, `Toggle.Root`, and `Button.Root` now expose the rendered host via `AtomExpose.element`, so a template ref can call `.focus()`. `Radio.Group`, `Checkbox.Group`, `Switch.Group`, `Toggle.Group`, and `Button.Group` expose `focus(options?: FocusOptions)` which focuses the selected item, or the first if none is selected.

--- a/apps/docs/src/pages/components/actions/button.md
+++ b/apps/docs/src/pages/components/actions/button.md
@@ -209,6 +209,28 @@ Set the `grace` prop (milliseconds, default `0`) to delay the indicator. If the 
 
 Put a `Button.HiddenInput` inside each `Button.Root`. It renders a visually hidden checkbox that reflects the button's selected state, so the group's value posts with the form.
 
+??? How do I focus this control programmatically?
+
+Hold a template ref on `Button.Root` typed as `AtomExpose` — `ref.value?.element` is the host; call `.focus()` on it. On `Button.Group`, type the ref as `ButtonGroupExpose` and call `ref.value?.focus()` — that focuses the selected item, or the first if none is selected. Pass DOM `FocusOptions` (`preventScroll`, `focusVisible`); `focusVisible` is pass-through only, not emulated. Renderless roots expose `element: null` — there is no host to focus.
+
+```vue
+<script setup lang="ts">
+  import { Button } from '@vuetify/v0'
+  import type { AtomExpose, ButtonGroupExpose } from '@vuetify/v0'
+  import { useTemplateRef } from 'vue'
+
+  const root = useTemplateRef<AtomExpose>('root')
+  const group = useTemplateRef<ButtonGroupExpose>('group')
+</script>
+
+<template>
+  <Button.Root ref="root">Click</Button.Root>
+  <Button.Group ref="group">
+    <Button.Root value="a">A</Button.Root>
+  </Button.Group>
+</template>
+```
+
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/components/actions/toggle.md
+++ b/apps/docs/src/pages/components/actions/toggle.md
@@ -121,7 +121,29 @@ Yes. Standalone Toggle.Root manages a boolean `v-model` and works independently.
 
 ??? Why is there no roving focus in Toggle.Group?
 
-Roving focus is a separate concern. Toggle.Group manages selection state. Focus management can be layered on top with a separate composable when needed.
+Arrow-key roving is a separate concern — Toggle.Group manages selection state, not a tab-stop ring. For programmatic focus, `ToggleGroupExpose.focus()` moves to the selected item (or the first if none is selected); layer `useRovingFocus` only if you need arrow navigation.
+
+??? How do I focus this control programmatically?
+
+Hold a template ref on `Toggle.Root` typed as `AtomExpose` — `ref.value?.element` is the host; call `.focus()` on it. On `Toggle.Group`, type the ref as `ToggleGroupExpose` and call `ref.value?.focus()` — that focuses the selected item, or the first if none is selected. Pass DOM `FocusOptions` (`preventScroll`, `focusVisible`); `focusVisible` is pass-through only, not emulated. Renderless roots expose `element: null` — there is no host to focus.
+
+```vue
+<script setup lang="ts">
+  import { Toggle } from '@vuetify/v0'
+  import type { AtomExpose, ToggleGroupExpose } from '@vuetify/v0'
+  import { useTemplateRef } from 'vue'
+
+  const root = useTemplateRef<AtomExpose>('root')
+  const group = useTemplateRef<ToggleGroupExpose>('group')
+</script>
+
+<template>
+  <Toggle.Root ref="root" />
+  <Toggle.Group ref="group">
+    <Toggle.Root value="a" />
+  </Toggle.Group>
+</template>
+```
 
 :::
 

--- a/apps/docs/src/pages/components/forms/checkbox.md
+++ b/apps/docs/src/pages/components/forms/checkbox.md
@@ -148,6 +148,28 @@ Pass the `disabled` prop on `Checkbox.Root`. The component sets `aria-disabled`,
 
 Yes. `Checkbox.Indicator` is purely cosmetic — it reads checkbox state from context to render a checkmark. You can omit it entirely and render your own visual using the `attrs` slot prop on `Checkbox.Root`, or use `renderless` mode for full control over the rendered element.
 
+??? How do I focus this control programmatically?
+
+Hold a template ref on `Checkbox.Root` typed as `AtomExpose` — `ref.value?.element` is the host; call `.focus()` on it. On `Checkbox.Group`, type the ref as `CheckboxGroupExpose` and call `ref.value?.focus()` — that focuses the selected item, or the first if none is selected. Pass DOM `FocusOptions` (`preventScroll`, `focusVisible`); `focusVisible` is pass-through only, not emulated. Renderless roots expose `element: null` — there is no host to focus.
+
+```vue
+<script setup lang="ts">
+  import { Checkbox } from '@vuetify/v0'
+  import type { AtomExpose, CheckboxGroupExpose } from '@vuetify/v0'
+  import { useTemplateRef } from 'vue'
+
+  const root = useTemplateRef<AtomExpose>('root')
+  const group = useTemplateRef<CheckboxGroupExpose>('group')
+</script>
+
+<template>
+  <Checkbox.Root ref="root" />
+  <Checkbox.Group ref="group">
+    <Checkbox.Root value="a" />
+  </Checkbox.Group>
+</template>
+```
+
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/components/forms/radio.md
+++ b/apps/docs/src/pages/components/forms/radio.md
@@ -166,6 +166,27 @@ Clicking an already-selected radio does not deselect it because `Radio.Root` exp
 
 Yes. Initialize the `v-model` on `Radio.Group` with the desired `value` — whichever `Radio.Root` has a matching `value` prop will render as checked on mount. You can also use `mandatory="force"` to auto-select the first non-disabled option when no initial value is provided.
 
+??? How do I focus this control programmatically?
+
+Hold a template ref on `Radio.Root` typed as `AtomExpose` — `ref.value?.element` is the host; call `.focus()` on it. On `Radio.Group`, type the ref as `RadioGroupExpose` and call `ref.value?.focus()` — that focuses the selected item, or the first if none is selected. Pass DOM `FocusOptions` (`preventScroll`, `focusVisible`); `focusVisible` is pass-through only, not emulated. Renderless roots expose `element: null` — there is no host to focus.
+
+```vue
+<script setup lang="ts">
+  import { Radio } from '@vuetify/v0'
+  import type { AtomExpose, RadioGroupExpose } from '@vuetify/v0'
+  import { useTemplateRef } from 'vue'
+
+  const root = useTemplateRef<AtomExpose>('root')
+  const group = useTemplateRef<RadioGroupExpose>('group')
+</script>
+
+<template>
+  <Radio.Group ref="group">
+    <Radio.Root ref="root" value="a" />
+  </Radio.Group>
+</template>
+```
+
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/components/forms/switch.md
+++ b/apps/docs/src/pages/components/forms/switch.md
@@ -164,6 +164,28 @@ Drive it off the `data-state` attribute — no JavaScript event handling needed.
 
 Yes. `Switch.Track` and `Switch.Thumb` are purely cosmetic — they read switch state from context to render the rail and knob. You can omit them entirely and render your own visual using the `attrs` slot prop on `Switch.Root`, or use `renderless` mode for full control over the rendered element.
 
+??? How do I focus this control programmatically?
+
+Hold a template ref on `Switch.Root` typed as `AtomExpose` — `ref.value?.element` is the host; call `.focus()` on it. On `Switch.Group`, type the ref as `SwitchGroupExpose` and call `ref.value?.focus()` — that focuses the selected item, or the first if none is selected. Pass DOM `FocusOptions` (`preventScroll`, `focusVisible`); `focusVisible` is pass-through only, not emulated. Renderless roots expose `element: null` — there is no host to focus.
+
+```vue
+<script setup lang="ts">
+  import { Switch } from '@vuetify/v0'
+  import type { AtomExpose, SwitchGroupExpose } from '@vuetify/v0'
+  import { useTemplateRef } from 'vue'
+
+  const root = useTemplateRef<AtomExpose>('root')
+  const group = useTemplateRef<SwitchGroupExpose>('group')
+</script>
+
+<template>
+  <Switch.Root ref="root" />
+  <Switch.Group ref="group">
+    <Switch.Root value="a" />
+  </Switch.Group>
+</template>
+```
+
 :::
 
 <DocsApi />

--- a/packages/0/src/components/Button/ButtonGroup.vue
+++ b/packages/0/src/components/Button/ButtonGroup.vue
@@ -17,12 +17,29 @@
   import { createSelection } from '#v0/composables/createSelection'
   import { useProxyModel } from '#v0/composables/useProxyModel'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Utilities
+  import { isUndefined } from '#v0/utilities'
   import { toRef, toValue } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { SelectionContext, SelectionTicket } from '#v0/composables/createSelection'
+  import type { MaybeRefOrGetter } from 'vue'
+
+  /** Ticket for button items with element reference for focus management */
+  export interface ButtonTicket extends SelectionTicket {
+    /** Element reference for group focus management */
+    el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Imperative handle exposed by Button.Group. */
+  export interface ButtonGroupExpose {
+    /** Focus the selected button, or the first if none is selected. */
+    focus: (options?: FocusOptions) => void
+  }
 
   export interface ButtonGroupProps extends AtomProps {
     /** Namespace for dependency injection */
@@ -58,7 +75,7 @@
     }
   }
 
-  export const [useButtonGroup, provideButtonGroup] = createContext<SelectionContext<SelectionTicket>>()
+  export const [useButtonGroup, provideButtonGroup] = createContext<SelectionContext<ButtonTicket>>()
 </script>
 
 <script lang="ts" setup generic="T = unknown">
@@ -86,7 +103,7 @@
 
   const model = defineModel<T | T[]>()
 
-  const selection = createSelection({
+  const selection = createSelection<ButtonTicket>({
     disabled: toRef(() => disabled),
     multiple: toRef(() => multiple),
     mandatory: toRef(() => mandatory),
@@ -96,6 +113,14 @@
   useProxyModel(selection, model, { multiple: toRef(() => multiple) })
 
   provideButtonGroup(namespace, selection)
+
+  function focus (options?: FocusOptions) {
+    const id = [...selection.selectedIds][0]
+    const ticket = isUndefined(id) ? selection.seek('first') : selection.get(id)
+    ;(toElement(toValue(ticket?.el)) as HTMLElement | undefined)?.focus(options)
+  }
+
+  defineExpose<ButtonGroupExpose>({ focus })
 
   const slotProps = toRef((): ButtonGroupSlotProps => ({
     isDisabled: toValue(selection.disabled),

--- a/packages/0/src/components/Button/ButtonRoot.vue
+++ b/packages/0/src/components/Button/ButtonRoot.vue
@@ -25,13 +25,17 @@
   import { useLocale } from '#v0/composables/useLocale'
   import { useTimer } from '#v0/composables/useTimer'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Utilities
-  import { mergeProps, onBeforeUnmount, shallowRef, toRef, toValue, useAttrs, watch } from 'vue'
+  import { mergeProps, onBeforeUnmount, shallowRef, toRef, toValue, useAttrs, useTemplateRef, watch } from 'vue'
 
   // Types
-  import type { AtomProps } from '#v0/components/Atom'
-  import type { SelectionContext, SelectionTicket } from '#v0/composables/createSelection'
+  import type { AtomExpose, AtomProps } from '#v0/components/Atom'
+  import type { SelectionContext } from '#v0/composables/createSelection'
   import type { SingleContext } from '#v0/composables/createSingle'
+  import type { ButtonTicket } from './ButtonGroup.vue'
   import type { Ref } from 'vue'
 
   export interface ButtonRootContext {
@@ -142,12 +146,15 @@
     groupNamespace = 'v0:button:group',
   } = defineProps<ButtonRootProps<V>>()
 
-  let group: SelectionContext<SelectionTicket> | null = null
+  let group: SelectionContext<ButtonTicket> | null = null
   try {
     group = useButtonGroup(groupNamespace)
   } catch {}
 
-  const ticket = group?.register({ value, disabled: () => toValue(disabled) ?? false })
+  const atomRef = useTemplateRef<AtomExpose>('atom')
+  const el = toRef(() => toElement(atomRef.value?.element) ?? undefined)
+
+  const ticket = group?.register({ value, disabled: () => toValue(disabled) ?? false, el })
 
   const isDisabled = toRef(() => group && ticket
     ? toValue(ticket.disabled) || toValue(group.disabled)
@@ -242,10 +249,17 @@
     isSelected: isSelected.value,
     attrs: elementAttrs.value,
   }))
+
+  defineExpose<AtomExpose>({
+    get element () {
+      return (atomRef.value?.element ?? null) as AtomExpose['element']
+    },
+  })
 </script>
 
 <template>
   <Atom
+    ref="atom"
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless

--- a/packages/0/src/components/Button/index.browser.test.ts
+++ b/packages/0/src/components/Button/index.browser.test.ts
@@ -796,4 +796,93 @@ describe('button', () => {
       expect(spy).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('expose', () => {
+    describe('root', () => {
+      it('should expose the rendered host as element', async () => {
+        const wrapper = mount(Button.Root, {
+          slots: { default: () => h('span', 'Click me') },
+        })
+        await nextTick()
+
+        expect((wrapper.vm as any).element).toBe(wrapper.find('button').element)
+      })
+
+      it('should focus the host via the exposed element', async () => {
+        const wrapper = mount(Button.Root, {
+          slots: { default: () => h('span', 'Click me') },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        const el = (wrapper.vm as any).element as HTMLElement
+        el.focus()
+        expect(document.activeElement).toBe(el)
+        wrapper.unmount()
+      })
+
+      it('should expose null element when renderless', async () => {
+        const wrapper = mount(Button.Root, {
+          props: { renderless: true },
+          slots: {
+            default: (props: any) => h('div', { class: 'custom', ...props.attrs }, 'Custom'),
+          },
+        })
+        await nextTick()
+
+        expect((wrapper.vm as any).element).toBeNull()
+      })
+    })
+
+    describe('group', () => {
+      it('should focus the selected item', async () => {
+        const wrapper = mount(Button.Group, {
+          props: { modelValue: 'italic' },
+          slots: {
+            default: () => [
+              h(Button.Root as any, { value: 'bold' }, () => h('span', 'bold')),
+              h(Button.Root as any, { value: 'italic' }, () => h('span', 'italic')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the first item when none is selected', async () => {
+        const wrapper = mount(Button.Group, {
+          slots: {
+            default: () => [
+              h(Button.Root as any, { value: 'bold' }, () => h('span', 'bold')),
+              h(Button.Root as any, { value: 'italic' }, () => h('span', 'italic')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[0]!.element)
+        wrapper.unmount()
+      })
+
+      it('should not throw when the group is empty', async () => {
+        const { wrapper, wait } = mountGroup({ items: [] })
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus()).not.toThrow()
+      })
+
+      it('should accept preventScroll in FocusOptions', async () => {
+        const { wrapper, wait } = mountGroup()
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus({ preventScroll: true })).not.toThrow()
+      })
+    })
+  })
 })

--- a/packages/0/src/components/Button/index.ts
+++ b/packages/0/src/components/Button/index.ts
@@ -13,7 +13,7 @@ export { default as ButtonRoot } from './ButtonRoot.vue'
 export { provideButtonRoot, useButtonRoot } from './ButtonRoot.vue'
 
 export type { ButtonContentProps, ButtonContentSlotProps } from './ButtonContent.vue'
-export type { ButtonGroupProps, ButtonGroupSlotProps } from './ButtonGroup.vue'
+export type { ButtonGroupExpose, ButtonGroupProps, ButtonGroupSlotProps, ButtonTicket } from './ButtonGroup.vue'
 export type { ButtonHiddenInputProps } from './ButtonHiddenInput.vue'
 export type { ButtonIconProps, ButtonIconSlotProps } from './ButtonIcon.vue'
 export type { ButtonLoadingProps, ButtonLoadingSlotProps } from './ButtonLoading.vue'

--- a/packages/0/src/components/Checkbox/CheckboxGroup.vue
+++ b/packages/0/src/components/Checkbox/CheckboxGroup.vue
@@ -16,10 +16,29 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
+  // Utilities
+  import { isUndefined } from '#v0/utilities'
+
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
   import type { ID } from '#v0/types'
+  import type { MaybeRefOrGetter } from 'vue'
+
+  /** Ticket for checkbox items with element reference for focus management */
+  export interface CheckboxTicket extends GroupTicket {
+    /** Element reference for group focus management */
+    el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Imperative handle exposed by Checkbox.Group. */
+  export interface CheckboxGroupExpose {
+    /** Focus the selected checkbox, or the first if none is selected. */
+    focus: (options?: FocusOptions) => void
+  }
 
   export interface CheckboxGroupProps extends AtomProps {
     /** Namespace for dependency injection */
@@ -73,7 +92,7 @@
     }
   }
 
-  export const [useCheckboxGroup, provideCheckboxGroup] = createContext<GroupContext<GroupTicket>>()
+  export const [useCheckboxGroup, provideCheckboxGroup] = createContext<GroupContext<CheckboxTicket>>()
 </script>
 
 <script setup lang="ts" generic="T = unknown">
@@ -108,7 +127,7 @@
 
   const model = defineModel<T | T[]>()
 
-  const group = createGroup({
+  const group = createGroup<CheckboxTicket>({
     disabled: toRef(() => disabled),
     enroll: toRef(() => enroll),
     mandatory: toRef(() => mandatory),
@@ -118,6 +137,14 @@
   useProxyModel(group, model, { multiple: true })
 
   provideCheckboxGroup(namespace, group)
+
+  function focus (options?: FocusOptions) {
+    const id = [...group.selectedIds][0]
+    const ticket = isUndefined(id) ? group.seek('first') : group.get(id)
+    ;(toElement(toValue(ticket?.el)) as HTMLElement | undefined)?.focus(options)
+  }
+
+  defineExpose<CheckboxGroupExpose>({ focus })
 
   const slotProps = toRef((): CheckboxGroupSlotProps => ({
     isDisabled: toValue(group.disabled),

--- a/packages/0/src/components/Checkbox/CheckboxRoot.vue
+++ b/packages/0/src/components/Checkbox/CheckboxRoot.vue
@@ -19,9 +19,13 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Types
-  import type { AtomProps } from '#v0/components/Atom'
+  import type { AtomExpose, AtomProps } from '#v0/components/Atom'
   import type { ID } from '#v0/types'
+  import type { CheckboxTicket } from './CheckboxGroup.vue'
   import type { MaybeRefOrGetter, Ref } from 'vue'
 
   /** Visual state of the checkbox for styling purposes */
@@ -134,10 +138,10 @@
 
   // Utilities
   import { useId } from '#v0/utilities'
-  import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs } from 'vue'
+  import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs, useTemplateRef } from 'vue'
 
   // Types
-  import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
+  import type { GroupContext } from '#v0/composables/createGroup'
 
   defineOptions({ name: 'CheckboxRoot', inheritAttrs: false })
 
@@ -169,7 +173,7 @@
   } = defineProps<CheckboxRootProps<V>>()
 
   // Dual-mode: try to inject group context, null if standalone
-  let group: GroupContext<GroupTicket> | null = null
+  let group: GroupContext<CheckboxTicket> | null = null
   try {
     group = useCheckboxGroup(groupNamespace)
   } catch {
@@ -178,8 +182,11 @@
 
   const model = defineModel<boolean>()
 
+  const atomRef = useTemplateRef<AtomExpose>('atom')
+  const el = toRef(() => toElement(atomRef.value?.element) ?? undefined)
+
   // Dual mode: register with parent
-  const ticket = group?.register({ id, value, disabled: () => toValue(disabled) ?? false, indeterminate: () => toValue(indeterminate) ?? false })
+  const ticket = group?.register({ id, value, disabled: () => toValue(disabled) ?? false, indeterminate: () => toValue(indeterminate) ?? false, el })
 
   const isChecked = toRef(() => ticket
     ? toValue(ticket.isSelected)
@@ -304,10 +311,17 @@
       'onKeydown': onKeydown,
     },
   }))
+
+  defineExpose<AtomExpose>({
+    get element () {
+      return (atomRef.value?.element ?? null) as AtomExpose['element']
+    },
+  })
 </script>
 
 <template>
   <Atom
+    ref="atom"
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless

--- a/packages/0/src/components/Checkbox/index.browser.test.ts
+++ b/packages/0/src/components/Checkbox/index.browser.test.ts
@@ -1387,4 +1387,109 @@ describe('checkbox', () => {
       })
     })
   })
+
+  describe('expose', () => {
+    describe('root', () => {
+      it('should expose the rendered host as element', async () => {
+        const { wrapper, wait } = mountCheckbox()
+        await wait()
+
+        expect((wrapper.vm as any).element).toBe(wrapper.find('button').element)
+      })
+
+      it('should focus the host via the exposed element', async () => {
+        const wrapper = mount(Checkbox.Root, {
+          slots: { default: () => h(Checkbox.Indicator as any, {}, () => 'X') },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        const el = (wrapper.vm as any).element as HTMLElement
+        el.focus()
+        expect(document.activeElement).toBe(el)
+        wrapper.unmount()
+      })
+
+      it('should expose null element when renderless', async () => {
+        const wrapper = mount(Checkbox.Root, {
+          props: { renderless: true },
+          slots: {
+            default: (props: any) => h('div', { class: 'custom', ...props.attrs }, 'Custom'),
+          },
+        })
+        await nextTick()
+
+        expect((wrapper.vm as any).element).toBeNull()
+      })
+    })
+
+    describe('group', () => {
+      it('should focus the selected item', async () => {
+        const wrapper = mount(Checkbox.Group, {
+          props: { modelValue: ['item-2'] },
+          slots: {
+            default: () => [
+              h(Checkbox.Root as any, { value: 'item-1' }, () => h(Checkbox.Indicator as any, {}, () => '1')),
+              h(Checkbox.Root as any, { value: 'item-2' }, () => h(Checkbox.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the selected item when its id is 0', async () => {
+        const wrapper = mount(Checkbox.Group, {
+          props: { modelValue: ['item-2'] },
+          slots: {
+            default: () => [
+              h(Checkbox.Root as any, { id: 1, value: 'item-1' }, () => h(Checkbox.Indicator as any, {}, () => '1')),
+              h(Checkbox.Root as any, { id: 0, value: 'item-2' }, () => h(Checkbox.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the first item when none is selected', async () => {
+        const wrapper = mount(Checkbox.Group, {
+          slots: {
+            default: () => [
+              h(Checkbox.Root as any, { value: 'item-1' }, () => h(Checkbox.Indicator as any, {}, () => '1')),
+              h(Checkbox.Root as any, { value: 'item-2' }, () => h(Checkbox.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[0]!.element)
+        wrapper.unmount()
+      })
+
+      it('should not throw when the group is empty', async () => {
+        const { wrapper, wait } = mountGroup({ items: [] })
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus()).not.toThrow()
+      })
+
+      it('should accept preventScroll in FocusOptions', async () => {
+        const { wrapper, wait } = mountGroup()
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus({ preventScroll: true })).not.toThrow()
+      })
+    })
+  })
 })

--- a/packages/0/src/components/Checkbox/index.ts
+++ b/packages/0/src/components/Checkbox/index.ts
@@ -10,7 +10,7 @@ export { default as CheckboxRoot } from './CheckboxRoot.vue'
 export { default as CheckboxSelectAll } from './CheckboxSelectAll.vue'
 export { provideCheckboxRoot, useCheckboxRoot } from './CheckboxRoot.vue'
 
-export type { CheckboxGroupProps, CheckboxGroupSlotProps } from './CheckboxGroup.vue'
+export type { CheckboxGroupExpose, CheckboxGroupProps, CheckboxGroupSlotProps, CheckboxTicket } from './CheckboxGroup.vue'
 export type { CheckboxHiddenInputProps } from './CheckboxHiddenInput.vue'
 export type { CheckboxIndicatorProps, CheckboxIndicatorSlotProps } from './CheckboxIndicator.vue'
 export type { CheckboxRootContext, CheckboxRootProps, CheckboxRootSlotProps, CheckboxState } from './CheckboxRoot.vue'

--- a/packages/0/src/components/Radio/RadioGroup.vue
+++ b/packages/0/src/components/Radio/RadioGroup.vue
@@ -16,6 +16,12 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
+  // Utilities
+  import { isUndefined } from '#v0/utilities'
+
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { SingleContext, SingleTicket } from '#v0/composables/createSingle'
@@ -26,6 +32,12 @@
   export interface RadioTicket extends SingleTicket {
     /** Element reference for roving tabindex focus management */
     el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Imperative handle exposed by Radio.Group. */
+  export interface RadioGroupExpose {
+    /** Focus the selected radio, or the first if none is selected. */
+    focus: (options?: FocusOptions) => void
   }
 
   /** Activation mode alias for Radio component API */
@@ -203,6 +215,14 @@
   useProxyModel(single, model, { multiple: false })
 
   provideRadioGroup(namespace, { ...single, name, activation: toRef(() => activation) })
+
+  function focus (options?: FocusOptions) {
+    const id = [...single.selectedIds][0]
+    const ticket = isUndefined(id) ? single.seek('first') : single.get(id)
+    ;(toElement(toValue(ticket?.el)) as HTMLElement | undefined)?.focus(options)
+  }
+
+  defineExpose<RadioGroupExpose>({ focus })
 
   const slotProps = toRef((): RadioGroupSlotProps => ({
     isDisabled: toValue(single.disabled),

--- a/packages/0/src/components/Radio/RadioRoot.vue
+++ b/packages/0/src/components/Radio/RadioRoot.vue
@@ -308,6 +308,12 @@
       'onKeydown': onKeydown,
     },
   }))
+
+  defineExpose<AtomExpose>({
+    get element () {
+      return (rootRef.value?.element ?? null) as AtomExpose['element']
+    },
+  })
 </script>
 
 <template>

--- a/packages/0/src/components/Radio/index.browser.test.ts
+++ b/packages/0/src/components/Radio/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Radio } from './index'
@@ -1128,6 +1128,131 @@ describe('radio', () => {
 
         expect(formData.get('choice')).toBe(expected)
         wrapper.unmount()
+      })
+    })
+  })
+
+  describe('expose', () => {
+    describe('root', () => {
+      function mountRoot (renderless = false) {
+        using _warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        return mount({
+          components: {
+            RadioGroup: Radio.Group,
+            RadioRoot: Radio.Root,
+            RadioIndicator: Radio.Indicator,
+          },
+          template: renderless
+            ? `
+              <RadioGroup>
+                <RadioRoot ref="root" value="a" renderless v-slot="{ attrs }">
+                  <div class="custom" v-bind="attrs">Custom</div>
+                </RadioRoot>
+              </RadioGroup>
+            `
+            : `
+              <RadioGroup>
+                <RadioRoot ref="root" value="a">
+                  <RadioIndicator>●</RadioIndicator>
+                </RadioRoot>
+              </RadioGroup>
+            `,
+        }, { attachTo: document.body })
+      }
+
+      it('should expose the rendered host as element', async () => {
+        const wrapper = mountRoot()
+        await nextTick()
+
+        expect((wrapper.vm.$refs.root as any).element).toBe(wrapper.find('button').element)
+        wrapper.unmount()
+      })
+
+      it('should focus the host via the exposed element', async () => {
+        const wrapper = mountRoot()
+        await nextTick()
+
+        const el = (wrapper.vm.$refs.root as any).element as HTMLElement
+        el.focus()
+        expect(document.activeElement).toBe(el)
+        wrapper.unmount()
+      })
+
+      it('should expose null element when renderless', async () => {
+        const wrapper = mountRoot(true)
+        await nextTick()
+
+        expect((wrapper.vm.$refs.root as any).element).toBeNull()
+        wrapper.unmount()
+      })
+    })
+
+    describe('group', () => {
+      it('should focus the selected item', async () => {
+        const wrapper = mount(Radio.Group, {
+          props: { modelValue: 'item-2' },
+          slots: {
+            default: () => [
+              h(Radio.Root as any, { value: 'item-1' }, () => h(Radio.Indicator as any, {}, () => '1')),
+              h(Radio.Root as any, { value: 'item-2' }, () => h(Radio.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the selected item when its id is 0', async () => {
+        const wrapper = mount(Radio.Group, {
+          props: { modelValue: 'item-2' },
+          slots: {
+            default: () => [
+              h(Radio.Root as any, { id: 1, value: 'item-1' }, () => h(Radio.Indicator as any, {}, () => '1')),
+              h(Radio.Root as any, { id: 0, value: 'item-2' }, () => h(Radio.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the first item when none is selected', async () => {
+        const wrapper = mount(Radio.Group, {
+          slots: {
+            default: () => [
+              h(Radio.Root as any, { value: 'item-1' }, () => h(Radio.Indicator as any, {}, () => '1')),
+              h(Radio.Root as any, { value: 'item-2' }, () => h(Radio.Indicator as any, {}, () => '2')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[0]!.element)
+        wrapper.unmount()
+      })
+
+      it('should not throw when the group is empty', async () => {
+        const { wrapper, wait } = mountGroup({ items: [] })
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus()).not.toThrow()
+      })
+
+      it('should accept preventScroll in FocusOptions', async () => {
+        const { wrapper, wait } = mountGroup()
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus({ preventScroll: true })).not.toThrow()
       })
     })
   })

--- a/packages/0/src/components/Radio/index.ts
+++ b/packages/0/src/components/Radio/index.ts
@@ -8,7 +8,7 @@ export { default as RadioIndicator } from './RadioIndicator.vue'
 export { default as RadioRoot } from './RadioRoot.vue'
 export { provideRadioRoot, useRadioRoot } from './RadioRoot.vue'
 
-export type { RadioActivation, RadioGroupContext, RadioGroupProps, RadioGroupSlotProps, RadioTicket } from './RadioGroup.vue'
+export type { RadioActivation, RadioGroupContext, RadioGroupExpose, RadioGroupProps, RadioGroupSlotProps, RadioTicket } from './RadioGroup.vue'
 export type { RadioHiddenInputProps } from './RadioHiddenInput.vue'
 export type { RadioIndicatorProps, RadioIndicatorSlotProps } from './RadioIndicator.vue'
 export type { RadioRootContext, RadioRootProps, RadioRootSlotProps, RadioState } from './RadioRoot.vue'

--- a/packages/0/src/components/Switch/SwitchGroup.vue
+++ b/packages/0/src/components/Switch/SwitchGroup.vue
@@ -18,13 +18,30 @@
   import { createGroup } from '#v0/composables/createGroup'
   import { useProxyModel } from '#v0/composables/useProxyModel'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Utilities
+  import { isUndefined } from '#v0/utilities'
   import { toRef, toValue } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
   import type { ID } from '#v0/types'
+  import type { MaybeRefOrGetter } from 'vue'
+
+  /** Ticket for switch items with element reference for focus management */
+  export interface SwitchTicket extends GroupTicket {
+    /** Element reference for group focus management */
+    el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Imperative handle exposed by Switch.Group. */
+  export interface SwitchGroupExpose {
+    /** Focus the selected switch, or the first if none is selected. */
+    focus: (options?: FocusOptions) => void
+  }
 
   export interface SwitchGroupProps extends AtomProps {
     /** Namespace for context provision to children */
@@ -73,7 +90,7 @@
     }
   }
 
-  export const [useSwitchGroup, provideSwitchGroup] = createContext<GroupContext<GroupTicket>>()
+  export const [useSwitchGroup, provideSwitchGroup] = createContext<GroupContext<SwitchTicket>>()
 </script>
 
 <script setup lang="ts" generic="T = unknown">
@@ -101,7 +118,7 @@
 
   const model = defineModel<T | T[]>()
 
-  const group = createGroup({
+  const group = createGroup<SwitchTicket>({
     disabled: toRef(() => disabled),
     enroll: toRef(() => enroll),
     mandatory: toRef(() => mandatory),
@@ -111,6 +128,14 @@
   useProxyModel(group, model, { multiple: true })
 
   provideSwitchGroup(namespace, group)
+
+  function focus (options?: FocusOptions) {
+    const id = [...group.selectedIds][0]
+    const ticket = isUndefined(id) ? group.seek('first') : group.get(id)
+    ;(toElement(toValue(ticket?.el)) as HTMLElement | undefined)?.focus(options)
+  }
+
+  defineExpose<SwitchGroupExpose>({ focus })
 
   const slotProps = toRef((): SwitchGroupSlotProps => ({
     isDisabled: toValue(group.disabled),

--- a/packages/0/src/components/Switch/SwitchRoot.vue
+++ b/packages/0/src/components/Switch/SwitchRoot.vue
@@ -23,14 +23,18 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Utilities
   import { useId } from '#v0/utilities'
-  import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs } from 'vue'
+  import { mergeProps, onBeforeUnmount, toRef, toValue, useAttrs, useTemplateRef } from 'vue'
 
   // Types
-  import type { AtomProps } from '#v0/components/Atom'
-  import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
+  import type { AtomExpose, AtomProps } from '#v0/components/Atom'
+  import type { GroupContext } from '#v0/composables/createGroup'
   import type { ID } from '#v0/types'
+  import type { SwitchTicket } from './SwitchGroup.vue'
   import type { MaybeRefOrGetter, Ref } from 'vue'
 
   /** Visual state of the switch for styling purposes */
@@ -166,7 +170,7 @@
     groupNamespace = 'v0:switch:group',
   } = defineProps<SwitchRootProps<V>>()
 
-  let group: GroupContext<GroupTicket> | null = null
+  let group: GroupContext<SwitchTicket> | null = null
   try {
     group = useSwitchGroup(groupNamespace)
   } catch {
@@ -175,7 +179,10 @@
 
   const model = defineModel<boolean>()
 
-  const ticket = group?.register({ id, value, disabled: () => toValue(disabled) ?? false, indeterminate: () => toValue(indeterminate) ?? false })
+  const atomRef = useTemplateRef<AtomExpose>('atom')
+  const el = toRef(() => toElement(atomRef.value?.element) ?? undefined)
+
+  const ticket = group?.register({ id, value, disabled: () => toValue(disabled) ?? false, indeterminate: () => toValue(indeterminate) ?? false, el })
 
   const isChecked = toRef(() => ticket
     ? toValue(ticket.isSelected)
@@ -295,10 +302,17 @@
       'onKeydown': onKeydown,
     },
   }))
+
+  defineExpose<AtomExpose>({
+    get element () {
+      return (atomRef.value?.element ?? null) as AtomExpose['element']
+    },
+  })
 </script>
 
 <template>
   <Atom
+    ref="atom"
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless

--- a/packages/0/src/components/Switch/index.browser.test.ts
+++ b/packages/0/src/components/Switch/index.browser.test.ts
@@ -1416,4 +1416,123 @@ describe('switch', () => {
       })
     })
   })
+
+  describe('expose', () => {
+    describe('root', () => {
+      it('should expose the rendered host as element', async () => {
+        const { wrapper, wait } = mountSwitch()
+        await wait()
+
+        expect((wrapper.vm as any).element).toBe(wrapper.find('button').element)
+      })
+
+      it('should focus the host via the exposed element', async () => {
+        const wrapper = mount(Switch.Root, {
+          slots: {
+            default: () => h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        const el = (wrapper.vm as any).element as HTMLElement
+        el.focus()
+        expect(document.activeElement).toBe(el)
+        wrapper.unmount()
+      })
+
+      it('should expose null element when renderless', async () => {
+        const wrapper = mount(Switch.Root, {
+          props: { renderless: true },
+          slots: {
+            default: (props: any) => h('div', { class: 'custom', ...props.attrs }, 'Custom'),
+          },
+        })
+        await nextTick()
+
+        expect((wrapper.vm as any).element).toBeNull()
+      })
+    })
+
+    describe('group', () => {
+      it('should focus the selected item', async () => {
+        const wrapper = mount(Switch.Group, {
+          props: { modelValue: ['item-2'] },
+          slots: {
+            default: () => [
+              h(Switch.Root as any, { value: 'item-1' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+              h(Switch.Root as any, { value: 'item-2' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the selected item when its id is 0', async () => {
+        const wrapper = mount(Switch.Group, {
+          props: { modelValue: ['item-2'] },
+          slots: {
+            default: () => [
+              h(Switch.Root as any, { id: 1, value: 'item-1' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+              h(Switch.Root as any, { id: 0, value: 'item-2' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the first item when none is selected', async () => {
+        const wrapper = mount(Switch.Group, {
+          slots: {
+            default: () => [
+              h(Switch.Root as any, { value: 'item-1' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+              h(Switch.Root as any, { value: 'item-2' }, () =>
+                h(Switch.Track as any, {}, () => h(Switch.Thumb as any)),
+              ),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[0]!.element)
+        wrapper.unmount()
+      })
+
+      it('should not throw when the group is empty', async () => {
+        const { wrapper, wait } = mountGroup({ items: [] })
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus()).not.toThrow()
+      })
+
+      it('should accept preventScroll in FocusOptions', async () => {
+        const { wrapper, wait } = mountGroup()
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus({ preventScroll: true })).not.toThrow()
+      })
+    })
+  })
 })

--- a/packages/0/src/components/Switch/index.ts
+++ b/packages/0/src/components/Switch/index.ts
@@ -11,7 +11,7 @@ export { provideSwitchGroup, useSwitchGroup } from './SwitchGroup.vue'
 export { provideSwitchRoot, useSwitchRoot } from './SwitchRoot.vue'
 
 // Types
-export type { SwitchGroupProps, SwitchGroupSlotProps } from './SwitchGroup.vue'
+export type { SwitchGroupExpose, SwitchGroupProps, SwitchGroupSlotProps, SwitchTicket } from './SwitchGroup.vue'
 export type { SwitchHiddenInputProps } from './SwitchHiddenInput.vue'
 export type { SwitchRootContext, SwitchRootProps, SwitchRootSlotProps, SwitchState } from './SwitchRoot.vue'
 export type { SwitchSelectAllProps, SwitchSelectAllSlotProps } from './SwitchSelectAll.vue'

--- a/packages/0/src/components/Toggle/ToggleGroup.vue
+++ b/packages/0/src/components/Toggle/ToggleGroup.vue
@@ -16,16 +16,40 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
+  // Utilities
+  import { isUndefined } from '#v0/utilities'
+
   // Types
   import type { AtomProps } from '#v0/components/Atom'
   import type { GroupContext, GroupTicket } from '#v0/composables/createGroup'
   import type { SingleContext, SingleTicket } from '#v0/composables/createSingle'
-  import type { Ref } from 'vue'
+  import type { MaybeRefOrGetter, Ref } from 'vue'
 
   export type ToggleOrientation = 'horizontal' | 'vertical'
 
+  /** Ticket for single-select toggle items with element reference for focus management */
+  export interface ToggleTicket extends SingleTicket {
+    /** Element reference for group focus management */
+    el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Ticket for multi-select toggle items with element reference for focus management */
+  export interface ToggleGroupTicket extends GroupTicket {
+    /** Element reference for group focus management */
+    el?: MaybeRefOrGetter<Element | null | undefined>
+  }
+
+  /** Imperative handle exposed by Toggle.Group. */
+  export interface ToggleGroupExpose {
+    /** Focus the selected toggle, or the first if none is selected. */
+    focus: (options?: FocusOptions) => void
+  }
+
   export interface ToggleGroupContext<
-    S extends SingleContext<SingleTicket> | GroupContext<GroupTicket> = SingleContext<SingleTicket> | GroupContext<GroupTicket>,
+    S extends SingleContext<ToggleTicket> | GroupContext<ToggleGroupTicket> = SingleContext<ToggleTicket> | GroupContext<ToggleGroupTicket>,
   > {
     disabled: Ref<boolean>
     orientation: Ref<ToggleOrientation>
@@ -105,12 +129,12 @@
   const model = defineModel<T | T[]>()
 
   const selection = multiple
-    ? createGroup({
+    ? createGroup<ToggleGroupTicket>({
       disabled: toRef(() => disabled),
       mandatory: toRef(() => mandatory),
       events: true,
     })
-    : createSingle({
+    : createSingle<ToggleTicket>({
       disabled: toRef(() => disabled),
       mandatory: toRef(() => mandatory),
       events: true,
@@ -123,6 +147,14 @@
     orientation: toRef(() => orientation),
     selection,
   })
+
+  function focus (options?: FocusOptions) {
+    const id = [...selection.selectedIds][0]
+    const ticket = isUndefined(id) ? selection.seek('first') : selection.get(id)
+    ;(toElement(toValue(ticket?.el)) as HTMLElement | undefined)?.focus(options)
+  }
+
+  defineExpose<ToggleGroupExpose>({ focus })
 
   const slotProps = toRef((): ToggleGroupSlotProps => ({
     isDisabled: toValue(disabled),

--- a/packages/0/src/components/Toggle/ToggleRoot.vue
+++ b/packages/0/src/components/Toggle/ToggleRoot.vue
@@ -17,8 +17,11 @@
   // Composables
   import { createContext } from '#v0/composables/createContext'
 
+  // Transformers
+  import { toElement } from '#v0/composables/toElement'
+
   // Types
-  import type { AtomProps } from '#v0/components/Atom'
+  import type { AtomExpose, AtomProps } from '#v0/components/Atom'
   import type { ID } from '#v0/types'
   import type { Ref } from 'vue'
 
@@ -74,7 +77,7 @@
 
   // Utilities
   import { useId } from '#v0/utilities'
-  import { mergeProps, onBeforeUnmount, shallowRef, toRef, toValue, useAttrs, watch } from 'vue'
+  import { mergeProps, onBeforeUnmount, shallowRef, toRef, toValue, useAttrs, useTemplateRef, watch } from 'vue'
 
   // Types
   import type { ToggleGroupContext } from './ToggleGroup.vue'
@@ -119,8 +122,11 @@
     pressed.value = v ?? false
   })
 
+  const atomRef = useTemplateRef<AtomExpose>('atom')
+  const el = toRef(() => toElement(atomRef.value?.element) ?? undefined)
+
   // Dual mode: register with group's selection composable
-  const ticket = group?.selection.register({ id, value, disabled: () => toValue(disabled) ?? false })
+  const ticket = group?.selection.register({ id, value, disabled: () => toValue(disabled) ?? false, el })
 
   const isPressed = toRef(() => ticket
     ? toValue(ticket.isSelected)
@@ -182,10 +188,17 @@
       'onKeydown': as === 'button' ? undefined : onKeydown,
     },
   }))
+
+  defineExpose<AtomExpose>({
+    get element () {
+      return (atomRef.value?.element ?? null) as AtomExpose['element']
+    },
+  })
 </script>
 
 <template>
   <Atom
+    ref="atom"
     v-bind="mergeProps(attrs, slotProps.attrs)"
     :as
     :renderless

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -571,4 +571,109 @@ describe('toggle', () => {
       expect(html).toContain('data-state="off"')
     })
   })
+
+  describe('expose', () => {
+    describe('root', () => {
+      it('should expose the rendered host as element', async () => {
+        const { wrapper, wait } = mountToggle()
+        await wait()
+
+        expect((wrapper.vm as any).element).toBe(wrapper.find('button').element)
+      })
+
+      it('should focus the host via the exposed element', async () => {
+        const wrapper = mount(Toggle.Root, {
+          slots: { default: () => h('span', 'Toggle') },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        const el = (wrapper.vm as any).element as HTMLElement
+        el.focus()
+        expect(document.activeElement).toBe(el)
+        wrapper.unmount()
+      })
+
+      it('should expose null element when renderless', async () => {
+        const wrapper = mount(Toggle.Root, {
+          props: { renderless: true },
+          slots: {
+            default: (props: any) => h('div', { class: 'custom', ...props.attrs }, 'Custom'),
+          },
+        })
+        await nextTick()
+
+        expect((wrapper.vm as any).element).toBeNull()
+      })
+    })
+
+    describe('group', () => {
+      it('should focus the selected item', async () => {
+        const wrapper = mount(Toggle.Group, {
+          props: { modelValue: 'b' },
+          slots: {
+            default: () => [
+              h(Toggle.Root as any, { value: 'a' }, () => h('span', 'a')),
+              h(Toggle.Root as any, { value: 'b' }, () => h('span', 'b')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the selected item when its id is 0', async () => {
+        const wrapper = mount(Toggle.Group, {
+          props: { modelValue: 'b' },
+          slots: {
+            default: () => [
+              h(Toggle.Root as any, { id: 1, value: 'a' }, () => h('span', 'a')),
+              h(Toggle.Root as any, { id: 0, value: 'b' }, () => h('span', 'b')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[1]!.element)
+        wrapper.unmount()
+      })
+
+      it('should focus the first item when none is selected', async () => {
+        const wrapper = mount(Toggle.Group, {
+          slots: {
+            default: () => [
+              h(Toggle.Root as any, { value: 'a' }, () => h('span', 'a')),
+              h(Toggle.Root as any, { value: 'b' }, () => h('span', 'b')),
+            ],
+          },
+          attachTo: document.body,
+        })
+        await nextTick()
+
+        ;(wrapper.vm as any).focus()
+        expect(document.activeElement).toBe(wrapper.findAll('button')[0]!.element)
+        wrapper.unmount()
+      })
+
+      it('should not throw when the group is empty', async () => {
+        const { wrapper, wait } = mountGroup({ items: [] })
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus()).not.toThrow()
+      })
+
+      it('should accept preventScroll in FocusOptions', async () => {
+        const { wrapper, wait } = mountGroup()
+        await wait()
+
+        expect(() => (wrapper.vm as any).focus({ preventScroll: true })).not.toThrow()
+      })
+    })
+  })
 })

--- a/packages/0/src/components/Toggle/index.ts
+++ b/packages/0/src/components/Toggle/index.ts
@@ -6,7 +6,7 @@ export { default as ToggleIndicator } from './ToggleIndicator.vue'
 export { default as ToggleRoot } from './ToggleRoot.vue'
 export { provideToggleRoot, useToggleRoot } from './ToggleRoot.vue'
 
-export type { ToggleGroupContext, ToggleGroupProps, ToggleGroupSlotProps, ToggleOrientation } from './ToggleGroup.vue'
+export type { ToggleGroupContext, ToggleGroupExpose, ToggleGroupProps, ToggleGroupSlotProps, ToggleGroupTicket, ToggleOrientation, ToggleTicket } from './ToggleGroup.vue'
 export type { ToggleIndicatorProps, ToggleIndicatorSlotProps } from './ToggleIndicator.vue'
 export type { ToggleRootContext, ToggleRootProps, ToggleRootSlotProps } from './ToggleRoot.vue'
 


### PR DESCRIPTION
Form and action control roots exposed nothing, so a template ref could not focus the host. Groups rendered a non-focusable `div`, so even AtomExpose on the group would be the wrong tab stop.

`Checkbox.Root`, `Radio.Root`, `Switch.Root`, `Toggle.Root`, and `Button.Root` now forward `AtomExpose.element`. Matching `.Group` components expose `focus(options?: FocusOptions)`, which focuses the selected item (or the first if none is selected) via registered ticket `el` — no DOM query.

Closes #923