### PR TITLE
docs: split hosted MCP into public /mcp and OAuth /one

### DIFF
--- a/apps/docs/src/pages/guide/tooling/agents.md
+++ b/apps/docs/src/pages/guide/tooling/agents.md
@@ -31,7 +31,7 @@ Paste a prompt into [Grok Bot](https://x.ai/bot). It walks GitHub, dry-runs one 
 Use this when you don't know yet whether the bot is for an app or the monorepo — it will ask. Connect GitHub when it asks. It fetches [SKILL.md](/SKILL.md) and the matching page on [0.vuetifyjs.com](https://0.vuetifyjs.com) itself.
 
 ```text
-Set up a new bot for me dedicated to Vuetify0 work, in its own dedicated chat. Walk me through connecting GitHub, then configure it: default to @vuetify/v0 headless primitives — never Vuetify 3/4 (VBtn, vuetify/components) unless I ask. Before inventing an API, fetch https://0.vuetifyjs.com/SKILL.md and the matching page on https://0.vuetifyjs.com; use Vuetify MCP at https://mcp.vuetifyjs.com/mcp (docs, no login) when it's available. For bins/playgrounds add https://mcp.vuetifyjs.com/one (Vuetify One OAuth). If a named primitive covers the need, use it. Ask me whether this bot is for a consumer app (import from @vuetify/v0) or the vuetifyjs/0 monorepo (use the #v0/ alias and follow AGENTS.md), which repositories it may touch, and whether it may open pull requests or must hand me a diff. Do a supervised dry run on a small real task I name, cite the v0 primitive it chose, then save it as "Vuetify0 Engineer".
+Set up a new bot for me dedicated to Vuetify0 work, in its own dedicated chat. Walk me through connecting GitHub, then configure it: default to @vuetify/v0 headless primitives — never Vuetify 3/4 (VBtn, vuetify/components) unless I ask. Before inventing an API, fetch https://0.vuetifyjs.com/SKILL.md and the matching page on https://0.vuetifyjs.com; use Vuetify MCP at https://mcp.vuetifyjs.com/mcp (docs, no login) when it's available. To authenticate with Vuetify One and reach ecosystem sites, add https://mcp.vuetifyjs.com/one. If a named primitive covers the need, use it. Ask me whether this bot is for a consumer app (import from @vuetify/v0) or the vuetifyjs/0 monorepo (use the #v0/ alias and follow AGENTS.md), which repositories it may touch, and whether it may open pull requests or must hand me a diff. Do a supervised dry run on a small real task I name, cite the v0 primitive it chose, then save it as "Vuetify0 Engineer".
 ```
 
 After the dry run, paste the matching identity below onto the saved bot so later sessions keep the same rules.
@@ -82,7 +82,7 @@ grok mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
 
 :::
 
-Docs-only. For bins add `https://mcp.vuetifyjs.com/one` — see [Vuetify MCP](/guide/tooling/vuetify-mcp).
+Docs-only. Add `https://mcp.vuetifyjs.com/one` to authenticate with Vuetify One — see [Vuetify MCP](/guide/tooling/vuetify-mcp).
 
 Paste the identity **Description** into the agent's persona / system prompt. For harness tips (surface map in always-loaded context, reminder hooks, typecheck gate), see [Making Agents Actually Use v0](/guide/tooling/ai-tools#making-agents-actually-use-v0). Add [Vuetify MCP](/guide/tooling/vuetify-mcp) so the agent can call `get_vuetify0_*` tools.
 

--- a/apps/docs/src/pages/guide/tooling/agents.md
+++ b/apps/docs/src/pages/guide/tooling/agents.md
@@ -31,7 +31,7 @@ Paste a prompt into [Grok Bot](https://x.ai/bot). It walks GitHub, dry-runs one 
 Use this when you don't know yet whether the bot is for an app or the monorepo — it will ask. Connect GitHub when it asks. It fetches [SKILL.md](/SKILL.md) and the matching page on [0.vuetifyjs.com](https://0.vuetifyjs.com) itself.
 
 ```text
-Set up a new bot for me dedicated to Vuetify0 work, in its own dedicated chat. Walk me through connecting GitHub, then configure it: default to @vuetify/v0 headless primitives — never Vuetify 3/4 (VBtn, vuetify/components) unless I ask. Before inventing an API, fetch https://0.vuetifyjs.com/SKILL.md and the matching page on https://0.vuetifyjs.com; use Vuetify MCP at https://mcp.vuetifyjs.com/mcp when it's available. If a named primitive covers the need, use it. Ask me whether this bot is for a consumer app (import from @vuetify/v0) or the vuetifyjs/0 monorepo (use the #v0/ alias and follow AGENTS.md), which repositories it may touch, and whether it may open pull requests or must hand me a diff. Do a supervised dry run on a small real task I name, cite the v0 primitive it chose, then save it as "Vuetify0 Engineer".
+Set up a new bot for me dedicated to Vuetify0 work, in its own dedicated chat. Walk me through connecting GitHub, then configure it: default to @vuetify/v0 headless primitives — never Vuetify 3/4 (VBtn, vuetify/components) unless I ask. Before inventing an API, fetch https://0.vuetifyjs.com/SKILL.md and the matching page on https://0.vuetifyjs.com; use Vuetify MCP at https://mcp.vuetifyjs.com/mcp (docs, no login) when it's available. For bins/playgrounds add https://mcp.vuetifyjs.com/one (Vuetify One OAuth). If a named primitive covers the need, use it. Ask me whether this bot is for a consumer app (import from @vuetify/v0) or the vuetifyjs/0 monorepo (use the #v0/ alias and follow AGENTS.md), which repositories it may touch, and whether it may open pull requests or must hand me a diff. Do a supervised dry run on a small real task I name, cite the v0 primitive it chose, then save it as "Vuetify0 Engineer".
 ```
 
 After the dry run, paste the matching identity below onto the saved bot so later sessions keep the same rules.
@@ -81,6 +81,8 @@ grok mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
 ```
 
 :::
+
+Docs-only. For bins add `https://mcp.vuetifyjs.com/one` — see [Vuetify MCP](/guide/tooling/vuetify-mcp).
 
 Paste the identity **Description** into the agent's persona / system prompt. For harness tips (surface map in always-loaded context, reminder hooks, typecheck gate), see [Making Agents Actually Use v0](/guide/tooling/ai-tools#making-agents-actually-use-v0). Add [Vuetify MCP](/guide/tooling/vuetify-mcp) so the agent can call `get_vuetify0_*` tools.
 

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -61,7 +61,7 @@ npx skills add vuetifyjs/0
 
 ### Editors and CLIs
 
-**Claude Code / Grok Build** — add Vuetify MCP for structured API access (`/mcp` is public docs; bins are a second URL — see [Vuetify MCP](/guide/tooling/vuetify-mcp)):
+**Claude Code / Grok Build** — add Vuetify MCP for structured API access (`/mcp` is public docs; `/one` authenticates with Vuetify One — see [Vuetify MCP](/guide/tooling/vuetify-mcp)):
 
 ::: code-group no-filename
 

--- a/apps/docs/src/pages/guide/tooling/ai-tools.md
+++ b/apps/docs/src/pages/guide/tooling/ai-tools.md
@@ -61,7 +61,7 @@ npx skills add vuetifyjs/0
 
 ### Editors and CLIs
 
-**Claude Code / Grok Build** — add Vuetify MCP for structured API access:
+**Claude Code / Grok Build** — add Vuetify MCP for structured API access (`/mcp` is public docs; bins are a second URL — see [Vuetify MCP](/guide/tooling/vuetify-mcp)):
 
 ::: code-group no-filename
 

--- a/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
@@ -20,7 +20,14 @@ logo: vmcp
 
 Vuetify MCP is a [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants structured access to Vuetify 3/4 and v0 APIs, install/upgrade/breaking-change docs, and — with [Vuetify One](https://one.vuetifyjs.com) — bins, playgrounds, and links. Unlike [llms.txt](/guide/tooling/ai-tools), MCP is real-time and queryable.
 
-The hosted server is [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) (streamable HTTP). Documentation and API tools need no account; bins, playgrounds, and links prompt Vuetify One OAuth.
+Two hosted URLs (streamable HTTP). Clients that treat OAuth as connect-time (Grok Bot, Cursor Agents) must not share them:
+
+| URL | Auth | Tools |
+| - | - | - |
+| [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) | none | docs, APIs, install/upgrade guides |
+| [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one) | [Vuetify One](https://one.vuetifyjs.com) OAuth | docs plus bins, playgrounds, and [vtfy.link](https://vtfy.link) |
+
+Most editors should add `/mcp`. Add `/one` only if you have a One subscription and want bins. Do not paste an API key.
 
 <DocsPageFeatures :frontmatter />
 
@@ -80,9 +87,9 @@ claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
 
 1. Go to [https://grok.com/connectors](https://grok.com/connectors)
 2. Click **New Connector**, then select **Custom**
-3. Enter the MCP server URL `https://mcp.vuetifyjs.com/mcp` (streamable HTTP) and complete any required authentication
+3. Enter `https://mcp.vuetifyjs.com/mcp` for docs (no login). For bins, add a second connector at `https://mcp.vuetifyjs.com/one` and complete Vuetify One OAuth.
 
-Documentation and API tools are public; bins, playgrounds, and links prompt Vuetify One OAuth on demand. Do not paste an API key.
+Do not paste an API key.
 
 Grok Build / CLI:
 
@@ -97,6 +104,15 @@ Or edit `~/.grok/config.toml` (user) or `.grok/config.toml` (project):
 url = "https://mcp.vuetifyjs.com/mcp"
 ```
 
+```toml
+[mcp_servers.vuetify-one]
+url = "https://mcp.vuetifyjs.com/one"
+```
+
+### Grok Bot
+
+[Grok Bot](/guide/tooling/agents) (Cursor Agents) treats OAuth as connect-time for the whole URL. Add `https://mcp.vuetifyjs.com/mcp` for docs (no Authorize). Add `https://mcp.vuetifyjs.com/one` only for bins and complete Vuetify One OAuth on that connector.
+
 ### Codex
 
 [OpenAI Codex](https://developers.openai.com/codex/mcp) CLI, ChatGPT desktop, and the IDE extension share `~/.codex/config.toml` (project: `.codex/config.toml`, trusted projects only):
@@ -108,7 +124,7 @@ url = "https://mcp.vuetifyjs.com/mcp"
 
 Or in ChatGPT / the IDE: **Settings → MCP servers → Add server → Streamable HTTP** and the URL above.
 
-Documentation and API tools need no login. When One tools are used, Codex can prompt `codex mcp login vuetify-mcp`.
+Documentation and API tools on `/mcp` need no login. For bins, add `https://mcp.vuetifyjs.com/one` and run `codex mcp login vuetify-one`.
 
 ### Kimi CLI
 
@@ -124,7 +140,7 @@ Documentation and API tools need no login. When One tools are used, Codex can pr
 }
 ```
 
-Or run `/mcp-config` in the Kimi TUI to add the server interactively. `/mcp-config login vuetify-mcp` if One OAuth is needed.
+Or run `/mcp-config` in the Kimi TUI to add `/mcp` interactively. Add `https://mcp.vuetifyjs.com/one` and `/mcp-config login vuetify-one` only for bins.
 
 ### Claude Desktop
 
@@ -262,11 +278,11 @@ Manual configuration for each IDE. Use the interactive setup above for automatic
 
 ## Available Tools
 
-31 tools on the hosted server. Documentation and API tools are public. Bins, playgrounds, and links prompt Vuetify One OAuth.
+Public `/mcp` has the documentation and API tools. `/one` adds the Vuetify One tools and requires OAuth.
 
 ### Documentation and API
 
-No account required.
+No account. Served on both `/mcp` and `/one`.
 
 | Tool | Purpose |
 | - | - |
@@ -294,7 +310,7 @@ No account required.
 
 ### Vuetify One
 
-These prompt [Vuetify One](https://one.vuetifyjs.com) OAuth when the assistant needs them. They are not configured with a pasted API key.
+Only on [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Connect that URL and complete [Vuetify One](https://one.vuetifyjs.com) OAuth. They are not on `/mcp` and are not configured with a pasted API key.
 
 | Tool | Purpose |
 | - | - |
@@ -330,10 +346,10 @@ For Vuetify 3/4 work, start with `get_installation_guide`, `get_component_api_by
 
 ## Authentication
 
-Connect at [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) (streamable HTTP).
+- **Public** — [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp). Documentation and API tools, no login.
+- **Vuetify One OAuth** — [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Bins, playgrounds, and links. Do not paste an API key.
 
-- **Public** — documentation and API tools need no login.
-- **Vuetify One OAuth** — bins, playgrounds, and links prompt a Vuetify One sign-in when used. Do not paste an API key to use them on the hosted server.
+Grok Bot and Cursor Agents treat OAuth as connect-time for the whole URL. That is why One is a second endpoint.
 
 ### Advanced: API key
 

--- a/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
+++ b/apps/docs/src/pages/guide/tooling/vuetify-mcp.md
@@ -6,9 +6,9 @@ features:
   level: 1
 meta:
   - name: description
-    content: Connect Claude, Cursor, and other AI assistants to Vuetify 3/4 and v0 APIs, install and upgrade docs, plus Vuetify One bins, playgrounds, and links.
+    content: Connect Claude, Cursor, and other AI assistants to Vuetify 3/4 and v0 APIs, install and upgrade docs, and authenticate with Vuetify One for ecosystem sites.
   - name: keywords
-    content: MCP, Model Context Protocol, Claude, Cursor, Grok, Codex, Kimi, AI assistant, Vuetify API, Vuetify One, OAuth, bins, playgrounds, developer tools
+    content: MCP, Model Context Protocol, Claude, Cursor, Grok, Codex, Kimi, AI assistant, Vuetify API, Vuetify One, OAuth, developer tools
 related:
   - /guide/tooling/ai-tools
   - /guide/tooling/vuetify-cli
@@ -18,16 +18,16 @@ logo: vmcp
 
 # Vuetify MCP
 
-Vuetify MCP is a [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants structured access to Vuetify 3/4 and v0 APIs, install/upgrade/breaking-change docs, and — with [Vuetify One](https://one.vuetifyjs.com) — bins, playgrounds, and links. Unlike [llms.txt](/guide/tooling/ai-tools), MCP is real-time and queryable.
+Vuetify MCP is a [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants structured access to Vuetify 3/4 and v0 APIs and install/upgrade/breaking-change docs. Authenticate with [Vuetify One](https://one.vuetifyjs.com) to reach ecosystem sites. Unlike [llms.txt](/guide/tooling/ai-tools), MCP is real-time and queryable.
 
 Two hosted URLs (streamable HTTP). Clients that treat OAuth as connect-time (Grok Bot, Cursor Agents) must not share them:
 
 | URL | Auth | Tools |
 | - | - | - |
 | [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp) | none | docs, APIs, install/upgrade guides |
-| [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one) | [Vuetify One](https://one.vuetifyjs.com) OAuth | docs plus bins, playgrounds, and [vtfy.link](https://vtfy.link) |
+| [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one) | [Vuetify One](https://one.vuetifyjs.com) OAuth | docs plus ecosystem sites |
 
-Most editors should add `/mcp`. Add `/one` only if you have a One subscription and want bins. Do not paste an API key.
+Most editors should add `/mcp`. Add `/one` to authenticate with Vuetify One; subscribers can then access anything from the ecosystem sites. Do not paste an API key.
 
 <DocsPageFeatures :frontmatter />
 
@@ -87,7 +87,7 @@ claude mcp add --transport http vuetify-mcp https://mcp.vuetifyjs.com/mcp
 
 1. Go to [https://grok.com/connectors](https://grok.com/connectors)
 2. Click **New Connector**, then select **Custom**
-3. Enter `https://mcp.vuetifyjs.com/mcp` for docs (no login). For bins, add a second connector at `https://mcp.vuetifyjs.com/one` and complete Vuetify One OAuth.
+3. Enter `https://mcp.vuetifyjs.com/mcp` for docs (no login). To authenticate with Vuetify One, add a second connector at `https://mcp.vuetifyjs.com/one`.
 
 Do not paste an API key.
 
@@ -111,7 +111,7 @@ url = "https://mcp.vuetifyjs.com/one"
 
 ### Grok Bot
 
-[Grok Bot](/guide/tooling/agents) (Cursor Agents) treats OAuth as connect-time for the whole URL. Add `https://mcp.vuetifyjs.com/mcp` for docs (no Authorize). Add `https://mcp.vuetifyjs.com/one` only for bins and complete Vuetify One OAuth on that connector.
+[Grok Bot](/guide/tooling/agents) (Cursor Agents) treats OAuth as connect-time for the whole URL. Add `https://mcp.vuetifyjs.com/mcp` for docs (no Authorize). Add `https://mcp.vuetifyjs.com/one` to authenticate with Vuetify One on that connector.
 
 ### Codex
 
@@ -124,7 +124,7 @@ url = "https://mcp.vuetifyjs.com/mcp"
 
 Or in ChatGPT / the IDE: **Settings → MCP servers → Add server → Streamable HTTP** and the URL above.
 
-Documentation and API tools on `/mcp` need no login. For bins, add `https://mcp.vuetifyjs.com/one` and run `codex mcp login vuetify-one`.
+Documentation and API tools on `/mcp` need no login. To authenticate with Vuetify One, add `https://mcp.vuetifyjs.com/one` and run `codex mcp login vuetify-one`.
 
 ### Kimi CLI
 
@@ -140,7 +140,7 @@ Documentation and API tools on `/mcp` need no login. For bins, add `https://mcp.
 }
 ```
 
-Or run `/mcp-config` in the Kimi TUI to add `/mcp` interactively. Add `https://mcp.vuetifyjs.com/one` and `/mcp-config login vuetify-one` only for bins.
+Or run `/mcp-config` in the Kimi TUI to add `/mcp` interactively. Add `https://mcp.vuetifyjs.com/one` and `/mcp-config login vuetify-one` to authenticate with Vuetify One.
 
 ### Claude Desktop
 
@@ -278,7 +278,7 @@ Manual configuration for each IDE. Use the interactive setup above for automatic
 
 ## Available Tools
 
-Public `/mcp` has the documentation and API tools. `/one` adds the Vuetify One tools and requires OAuth.
+Public `/mcp` has the documentation and API tools. `/one` authenticates with Vuetify One so subscribers can access ecosystem sites.
 
 ### Documentation and API
 
@@ -310,7 +310,7 @@ No account. Served on both `/mcp` and `/one`.
 
 ### Vuetify One
 
-Only on [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Connect that URL and complete [Vuetify One](https://one.vuetifyjs.com) OAuth. They are not on `/mcp` and are not configured with a pasted API key.
+Only on [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Connect that URL to authenticate with [Vuetify One](https://one.vuetifyjs.com). Subscribers can then access ecosystem sites. These tools are not on `/mcp` and are not configured with a pasted API key.
 
 | Tool | Purpose |
 | - | - |
@@ -347,7 +347,7 @@ For Vuetify 3/4 work, start with `get_installation_guide`, `get_component_api_by
 ## Authentication
 
 - **Public** — [https://mcp.vuetifyjs.com/mcp](https://mcp.vuetifyjs.com/mcp). Documentation and API tools, no login.
-- **Vuetify One OAuth** — [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Bins, playgrounds, and links. Do not paste an API key.
+- **Vuetify One OAuth** — [https://mcp.vuetifyjs.com/one](https://mcp.vuetifyjs.com/one). Authenticate with Vuetify One; subscribers can access anything from the ecosystem sites. Do not paste an API key.
 
 Grok Bot and Cursor Agents treat OAuth as connect-time for the whole URL. That is why One is a second endpoint.
 


### PR DESCRIPTION
## Summary

Hosted Vuetify MCP is two URLs: \`https://mcp.vuetifyjs.com/mcp\` (docs, no login) and \`https://mcp.vuetifyjs.com/one\` (Vuetify One OAuth). Grok Bot / Cursor Agents treat OAuth as connect-time, so they cannot share one URL.

Updates \`vuetify-mcp.md\`, \`ai-tools.md\`, and the Grok Bot identity prompt in \`agents.md\`.

## Test plan

- [ ] Vuetify MCP guide table matches live /mcp 200 vs /one 401
- [ ] Grok Bot section: docs on /mcp, bins on /one
- [ ] Historical blog posts left alone