### PR TITLE
fix(Popover): restore CSS anchoring when Content sets a custom id

### DIFF
--- a/.changeset/popover-content-id-anchor.md
+++ b/.changeset/popover-content-id-anchor.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Popover): restore CSS anchoring when Content sets a custom id
+
+A custom Content `id` paired with a matching Activator `target` is the native popover pairing. Positioning now follows that id again instead of the Root-generated one.

--- a/packages/0/src/components/Popover/PopoverContent.vue
+++ b/packages/0/src/components/Popover/PopoverContent.vue
@@ -79,7 +79,15 @@
   }, { immediate: true })
 
   const id = toRef(() => _id ?? context.id)
-  const style = toRef(() => context.contentStyles.value)
+  const style = toRef(() => {
+    const styles = context.contentStyles.value
+    if (isUndefined(_id)) return styles
+    // Custom id pairs with Activator `target`; position-anchor must match that id, not Root's.
+    return {
+      ...styles,
+      'position-anchor': `--${String(_id).replace(/[^a-zA-Z0-9_-]/g, '')}`,
+    }
+  })
 
   context.attach(() => ref.value?.element)
 

--- a/packages/0/src/components/Popover/index.browser.test.ts
+++ b/packages/0/src/components/Popover/index.browser.test.ts
@@ -440,6 +440,37 @@ describe('popover', () => {
 
         expect(contentProps.attrs.id).toBe('custom-id')
       })
+
+      it('should CSS-anchor a custom Content id to a matching Activator target', async () => {
+        let activatorProps: any
+        let contentProps: any
+
+        mount(Popover.Root, {
+          slots: {
+            default: () => [
+              h(Popover.Activator, { target: 'custom-id' }, {
+                default: (props: any) => {
+                  activatorProps = props
+                  return h('button', 'Toggle')
+                },
+              }),
+              h(Popover.Content, { id: 'custom-id', positionArea: 'bottom span-right' }, {
+                default: (props: any) => {
+                  contentProps = props
+                  return h('div', 'Content')
+                },
+              }),
+            ],
+          },
+        })
+
+        await nextTick()
+
+        expect(activatorProps.attrs.style.anchorName).toBe('--custom-id')
+        expect(contentProps.attrs.style['position-anchor']).toBe('--custom-id')
+        expect(contentProps.attrs.style['position-area']).toBe('bottom span-right')
+        expect(contentProps.attrs.style['inset-area']).toBe('bottom span-right')
+      })
     })
 
     describe('open state', () => {


### PR DESCRIPTION
Closes #937.

Regression from #917: `Popover.Content`'s custom `id` is the DOM id `popovertarget` points at, but `position-anchor` started following Root's generated id (`--v-0`). Native open still worked; CSS anchoring did not.

Playground hamburger (`PlaygroundMenuBar`: Activator `target` + Content `id`, no Root `id`) opened at the viewport origin. Confirmed in Chromium: master `position-anchor: --v-0` at `(0,0)`; this branch `--playground-menu` under the activator.

When Content sets `id`, override only `position-anchor` on top of adapter styles so the native pairing holds. Browser test covers Activator `target` + Content `id` sharing `--custom-id`.