### PR TITLE
chore(ci): require conventional PR titles

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,11 @@
+# titleOnly: squash merge uses the PR title as the commit on master/dev.
+# Types match apps/docs/src/pages/introduction/contributing.md — not the
+# app's default list (which also allows style/perf/build/ci/revert).
+titleOnly: true
+types:
+  - feat
+  - fix
+  - docs
+  - refactor
+  - test
+  - chore

--- a/apps/docs/src/pages/introduction/contributing.md
+++ b/apps/docs/src/pages/introduction/contributing.md
@@ -180,7 +180,8 @@ Never edit `package.json` versions by hand — release automation owns every bum
 ### PR Guidelines
 
 - Keep PRs focused - one feature or fix per PR
-- Write a clear title and description
+- Title must be Conventional Commits: `type(scope): subject` (scope optional). Allowed types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`. Squash merge uses the title as the commit — Semantic PR is required, and a non-matching title cannot merge
+- Write a clear description
 - Reference any related issues
 - Be responsive to feedback
 


### PR DESCRIPTION
## Summary

Ezard Semantic PR already runs on every PR. Default is title **or** any commit, so a title like `feat(useFocusTrap)` still greens. Squash merge uses `COMMIT_OR_PR_TITLE`, so the title is the commit.

- Add `.github/semantic.yml` with `titleOnly: true` and the contributing types (`feat` `fix` `docs` `refactor` `test` `chore`).
- Document that a non-matching title cannot merge.

`titleOnly` takes effect only after this lands on `master`. After merge, add `Semantic PR` as a required status check on the `master and dev` ruleset (id `15067641`, app `semantic-prs` / 198092). Org admins still bypass. I will PATCH the ruleset then — do not squash this before that file is on `master`.