### PR TITLE
docs(nav): collapse Emerald and Bulma by default

### DIFF
--- a/apps/docs/build/generate-nav.ts
+++ b/apps/docs/build/generate-nav.ts
@@ -27,11 +27,13 @@ export interface NavItemLink {
   emphasized?: EmphasisLevel
   devmode?: boolean
   children?: NavItem[]
+  collapsible?: boolean
 }
 
 export interface NavItemCategory {
   name: string
   children: NavItem[]
+  collapsible?: boolean
 }
 
 export interface NavItemDivider {
@@ -66,12 +68,13 @@ function getEmphasisLevel (iso: string | undefined | null): EmphasisLevel {
 
 // Section configuration - defines structure and ordering
 // rootPath: string = custom link, undefined = default to /${section}, null = no link
-const SECTIONS: Record<string, { order: number, hasSubcategories: boolean, rootPath?: string | null, name?: string }> = {
+// collapsibleSubcategories: nested groups start collapsed (top-level sections already do)
+const SECTIONS: Record<string, { order: number, hasSubcategories: boolean, rootPath?: string | null, name?: string, collapsibleSubcategories?: boolean }> = {
   introduction: { order: 0, hasSubcategories: false, rootPath: null },
   guide: { order: 2, hasSubcategories: true },
   components: { order: 4, hasSubcategories: true },
   composables: { order: 6, hasSubcategories: true },
-  systems: { order: 7, hasSubcategories: true, rootPath: null, name: 'Design Systems' },
+  systems: { order: 7, hasSubcategories: true, rootPath: null, name: 'Design Systems', collapsibleSubcategories: true },
 }
 
 // Subcategory ordering within sections
@@ -233,27 +236,34 @@ function buildSubcategories (section: string, pages: PageInfo[]): NavItem[] {
   }
 
   const order = SUBCATEGORY_ORDER[section] ?? []
+  const collapsible = SECTIONS[section]?.collapsibleSubcategories === true
 
   return [
     ...roots.toSorted(comparePages).map(toNavLink),
     ...Array.from(subcategories.entries())
       .toSorted(createSubcategoryComparator(order))
-      .map(([subcategory, subPages]) => toSubcategory(titleCase(subcategory), subPages)),
+      .map(([subcategory, subPages]) => toSubcategory(titleCase(subcategory), subPages, collapsible)),
   ]
 }
 
 // A subcategory that owns an index page becomes a link that still expands —
 // the same shape a top-level section gets — rather than a dead label with the
 // index page listed under it as a separate child.
-function toSubcategory (name: string, pages: PageInfo[]): NavItem {
+function toSubcategory (name: string, pages: PageInfo[], collapsible = false): NavItem {
   const index = pages.find(p => p.path.endsWith('index.md'))
   const children = pages.filter(p => p !== index).toSorted(comparePages).map(toNavLink)
 
-  if (!index) return { name, children }
+  if (!index) {
+    const item: NavItemCategory = { name, children }
+    if (collapsible) item.collapsible = true
+    return item
+  }
 
-  return children.length > 0
-    ? { name, to: index.urlPath, children }
-    : { name, to: index.urlPath }
+  if (children.length === 0) return { name, to: index.urlPath }
+
+  const item: NavItemLink = { name, to: index.urlPath, children }
+  if (collapsible) item.collapsible = true
+  return item
 }
 
 async function generateNav (): Promise<NavItem[]> {

--- a/apps/docs/build/generate-test-count.test.ts
+++ b/apps/docs/build/generate-test-count.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { countTests } from './generate-test-count'
+
+describe('countTests', () => {
+  it('should skip Playwright screenshot directories named after the test file', async () => {
+    await expect(countTests()).resolves.toEqual({
+      files: expect.any(Number),
+      tests: expect.any(Number),
+    })
+  })
+})

--- a/apps/docs/build/generate-test-count.ts
+++ b/apps/docs/build/generate-test-count.ts
@@ -1,4 +1,4 @@
-import { readFile, glob } from 'node:fs/promises'
+import { glob, readFile, stat } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -18,7 +18,7 @@ export interface TestCount {
 
 const TEST_CALL_RE = /(?<![\w.])(?:it|test)\s*(?:\.(each|skip|todo|fails|concurrent|sequential|only))?\s*\(/g
 
-const EXCLUDE_RE = /\/(?:node_modules|dist|coverage|\.cache|\.claude|\.output)\//
+const EXCLUDE_RE = /\/(?:node_modules|dist|coverage|\.cache|\.claude|\.output|__screenshots__)\//
 
 function stripCommentsAndStrings (source: string): string {
   let out = ''
@@ -101,7 +101,7 @@ function countEachRows (source: string, openIndex: number): number {
   return 1
 }
 
-async function countTests (): Promise<TestCount> {
+export async function countTests (): Promise<TestCount> {
   let files = 0
   let tests = 0
   for await (const file of glob([
@@ -110,6 +110,9 @@ async function countTests (): Promise<TestCount> {
     `${ROOT_DIR}/apps/**/*.test.ts`,
     `${ROOT_DIR}/apps/**/*.spec.ts`,
   ], { exclude: path => EXCLUDE_RE.test(path) })) {
+    // Playwright names screenshot dirs after the test file (`foo.browser.test.ts/`),
+    // which matches `**/*.test.ts`. Skip anything that isn't a regular file.
+    if (!(await stat(file)).isFile()) continue
     const raw = await readFile(file, 'utf8')
     const source = stripCommentsAndStrings(raw)
     files++

--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -64,10 +64,18 @@
   const childIds = toRef(() => navNested.nested.children.get(id) ?? [])
   const hasChildren = toRef(() => childIds.value.length > 0)
 
-  // Only top-level items can be collapsed (disabled in flat mode)
+  // Top-level groups always collapse; nested groups only when the nav item opts in.
   const isTopLevel = toRef(() => depth === 0)
-  const isCollapsible = toRef(() => !navConfig.flatMode.value && isTopLevel.value && hasChildren.value)
+  const navItem = toRef(() => navNested.nested.get(id)?.value)
+  const isCollapsible = toRef(() => !navConfig.flatMode.value && hasChildren.value && (isTopLevel.value || !!navItem.value?.collapsible))
   const isOpen = toRef(() => isCollapsible.value ? navNested.nested.opened(id) : true)
+  // Persistent groups keep the section indent. Nested collapsible groups
+  // already have a chevron; use a smaller offset so children still line up.
+  const childrenIndent = toRef(() => {
+    if (navItem.value?.collapsible) return 'ml-2'
+    if (isTopLevel.value && !navConfig.flatMode.value) return 'ml-6'
+    return undefined
+  })
 
   // Check if this node is an ancestor of the current route (for highlighting category headers)
   const containsActivePage = toRef(() => {
@@ -128,8 +136,11 @@
 
 <template>
   <li ref="item" class="px-3 scroll-my-[100px]">
-    <div class="flex items-center gap-1" :class="isTopLevel && navConfig.flatMode.value && 'pl-1'">
-      <!-- Expand/collapse toggle button (only for top-level) -->
+    <div
+      class="flex items-center gap-1"
+      :class="[isTopLevel && navConfig.flatMode.value && 'pl-1', !isTopLevel && isCollapsible && '-ml-2']"
+    >
+      <!-- Expand/collapse toggle button -->
       <button
         v-if="isCollapsible"
         :aria-controls="`nav-section-${id}`"
@@ -207,9 +218,9 @@
       </span>
     </div>
 
-    <!-- Children (always visible for nested items, conditional for top-level) -->
+    <!-- Children (conditional when collapsible, always visible otherwise) -->
     <Transition :name="expandTransition" @after-enter="onAfterExpand">
-      <div v-if="hasChildren && isOpen" class="grid mt-2" :class="isTopLevel && !navConfig.flatMode.value && 'ml-6'">
+      <div v-if="hasChildren && isOpen" class="grid mt-2" :class="childrenIndent">
         <ul
           :id="`nav-section-${id}`"
           class="flex flex-col gap-2 overflow-hidden"


### PR DESCRIPTION
Design-system subcategories in the docs nav are now collapsible and start closed, so opening Design Systems no longer dumps every Emerald and Bulma page. Guide/Components/Composables groups stay always-open. Nested chevron rows offset so labels still line up with persistent items.

Also skips Playwright screenshot directories when counting tests — those folders are named `*.test.ts` and were tripping `readFile` with EISDIR.