### PR TITLE
docs: square example theme-toggle top-right

### DIFF
--- a/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
+++ b/apps/docs/src/components/docs/DocsExampleThemeMenu.vue
@@ -28,7 +28,7 @@
   const uid = useId()
   const open = shallowRef(false)
 
-  const chip = 'bg-surface-tint text-on-surface-tint hover:bg-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] rounded-tr-[0.375rem] cursor-pointer'
+  const chip = 'bg-surface-tint text-on-surface-tint hover:bg-surface-tint pa-1 inline-flex rounded-none rounded-bl-[0.375rem] cursor-pointer'
 
   function onFlip () {
     toggle.setMode(toggle.isDark.value ? 'light' : 'dark')

--- a/apps/docs/src/components/docs/DocsSystemExample.vue
+++ b/apps/docs/src/components/docs/DocsSystemExample.vue
@@ -370,14 +370,14 @@
   >
     <div
       :aria-busy="pending || undefined"
-      class="relative w-full overflow-hidden rounded-2xl"
+      class="relative w-full overflow-hidden rounded-2xl rounded-tr-none"
       :style="[surface, { height: `${height}px` }]"
     >
       <iframe
         ref="frame"
         :class="overlay
           ? 'fixed inset-0 z-[9999] h-full w-full border-0'
-          : 'absolute inset-0 h-full w-full rounded-2xl border-0'"
+          : 'absolute inset-0 h-full w-full rounded-2xl rounded-tr-none border-0'"
         loading="lazy"
         :src
         :style="[surface, overlay && clip ? { clipPath: `path('${clip}')` } : undefined]"


### PR DESCRIPTION
The example theme chip had a matching 6px top-right radius, so it read as a bubble instead of a tab against the preview. Drop it; keep the bottom-left bite.

The Bulma sandbox iframe that light/dark paints still used `rounded-2xl` on every corner. Square its top-right to match.