### PR TITLE
docs(useDragDrop): fix page gaps that read as a 3/4

### DIFF
--- a/apps/docs/build/markdown.test.ts
+++ b/apps/docs/build/markdown.test.ts
@@ -15,4 +15,22 @@ Answer with \`baz\`.
     expect(html).toMatch(/<template #question>[\s\S]*<code[^>]*>foo<\/code>[\s\S]*<code[^>]*>bar<\/code>/)
     expect(html).not.toMatch(/<template #question>[^<]*`foo`/)
   })
+
+  it('should not dump page footnotes into FAQ question titles', async () => {
+    const md = await createMarkdownIt()
+    const html = md.render(`See the cancel chain[^drag-cancel].
+
+[^drag-cancel]: onLeave then onCancel.
+
+::: faq
+??? Why not use HTML5 drag-and-drop?
+
+Native HTML5 DnD has terrible mobile support.
+:::
+`)
+
+    expect(html).toMatch(/<template #question>Why not use HTML5 drag-and-drop\?<\/template>/)
+    expect(html).not.toMatch(/<template #question>[\s\S]*footnotes[\s\S]*<\/template>/)
+    expect(html).toContain('class="footnotes"')
+  })
 })

--- a/apps/docs/build/markdown.ts
+++ b/apps/docs/build/markdown.ts
@@ -288,7 +288,9 @@ export function applyMarkdownPlugins (md: MarkdownIt, highlighter: DocsHighlight
       inlineToken.children = []
       // `question` stays plain text for search/filter; the slot is the same
       // inline pipeline as body markdown (`code`, API hover, links).
-      const title = md.renderInline(question, env)
+      // Do not pass the page `env` — markdown-it-footnote flushes collected
+      // footnotes into renderInline and they land in every question title.
+      const title = md.renderInline(question)
       return `${closeTag}<DocsFaqItem question="${md.utils.escapeHtml(question)}">\n<template #question>${title}</template>\n`
     }
     return defaultParagraphOpen

--- a/apps/docs/src/examples/composables/use-drag-drop/DropList.vue
+++ b/apps/docs/src/examples/composables/use-drag-drop/DropList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-  import { onBeforeUnmount, useTemplateRef } from 'vue'
-  import type { DragDropContext } from '@vuetify/v0'
+  import { onBeforeUnmount, toRef, useTemplateRef } from 'vue'
+  import { isNull, type DragDropContext } from '@vuetify/v0'
 
   import DragItem from './DragItem.vue'
 
@@ -19,6 +19,7 @@
   }>()
 
   const el = useTemplateRef<HTMLElement>('el')
+  const wrap = useTemplateRef<HTMLElement>('wrap')
 
   const zone = dnd.zones.register({
     el,
@@ -29,18 +30,42 @@
     },
   })
 
+  const indicatorStyle = toRef(() => {
+    const ind = zone.indicator.value
+    const wrapEl = wrap.value
+    if (isNull(ind) || isNull(wrapEl)) return undefined
+
+    const wrapRect = wrapEl.getBoundingClientRect()
+    const y = ind.edge === 'before' ? ind.rect.top : ind.rect.bottom
+
+    return {
+      top: `${y - wrapRect.top}px`,
+      left: `${ind.rect.left - wrapRect.left}px`,
+      width: `${ind.rect.width}px`,
+    }
+  })
+
   onBeforeUnmount(() => zone.unregister())
 </script>
 
 <template>
-  <div
-    ref="el"
-    class="basis-48 grow min-h-32 p-2 border rounded flex flex-col gap-2 transition-colors border-divider bg-surface data-[accepts]:border-primary data-[accepts]:bg-primary/10 data-[accepts]:ring-2 data-[accepts]:ring-primary/40"
-    :data-accepts="(zone.isOver.value && zone.willAccept.value) || undefined"
-    data-dropzone
-    :data-over="zone.isOver.value || undefined"
-    role="list"
-  >
-    <DragItem v-for="item in items" :key="item.id" :dnd :item />
+  <div ref="wrap" class="relative basis-48 grow">
+    <div
+      ref="el"
+      class="min-h-32 p-2 border rounded flex flex-col gap-2 transition-colors border-divider bg-surface data-[accepts]:border-primary data-[accepts]:bg-primary/10 data-[accepts]:ring-2 data-[accepts]:ring-primary/40"
+      :data-accepts="(zone.isOver.value && zone.willAccept.value) || undefined"
+      data-dropzone
+      :data-over="zone.isOver.value || undefined"
+      role="list"
+    >
+      <DragItem v-for="item in items" :key="item.id" :dnd :item />
+    </div>
+
+    <div
+      v-if="zone.indicator.value"
+      aria-hidden="true"
+      class="pointer-events-none absolute z-10 h-0.5 rounded-full bg-primary -translate-y-1/2"
+      :style="indicatorStyle"
+    />
   </div>
 </template>

--- a/apps/docs/src/examples/composables/use-drag-drop/basic.vue
+++ b/apps/docs/src/examples/composables/use-drag-drop/basic.vue
@@ -21,9 +21,12 @@
   function onMove (item: Item, toSide: Side, toIndex: number) {
     const fromList = left.value.some(i => i.id === item.id) ? left : right
     const toList = toSide === 'left' ? left : right
+    const fromIndex = fromList.value.findIndex(i => i.id === item.id)
     fromList.value = fromList.value.filter(i => i.id !== item.id)
-    toList.value.splice(toIndex, 0, item)
-    announcement.value = `${item.label} moved to ${toSide}, position ${toIndex + 1}`
+    // position.index is pre-move. Same-list downward: subtract 1 after removing.
+    const index = fromList === toList && toIndex > fromIndex ? toIndex - 1 : toIndex
+    toList.value.splice(index, 0, item)
+    announcement.value = `${item.label} moved to ${toSide}, position ${index + 1}`
   }
 </script>
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -255,9 +255,7 @@ Every consumer-facing state field is a reactive ref <AppSuccessIcon />. Reads in
 | `delta` | `{ x, y }` | `current - origin` |
 | `over` | `ID \| null` | Zone id under the point, or `null` |
 | `willAccept` | `boolean` | Whether that zone's `accept` matches this drag |
-| `via` | `DragVia` | `'pointer'`, `'keyboard'`, or an adapter-declared extension[^drag-via-usage] |
-
-[^drag-via-usage]: Read this to branch keyboard-only behaviors like focus restoration.
+| `via` | `DragVia` | `'pointer'`, `'keyboard'`, or an adapter-declared extension. Read this to branch keyboard-only behaviors like focus restoration. |
 
 Indicator rects are cached per zone; `getBoundingClientRect` runs only when the zone resizes or its children mount/unmount, not on each pointer move. The index is measured against **every element child** of the zone `el` (`zoneEl.children`) — headers, spacers, and an in-zone indicator all count as slots. Keep the indicator as a sibling of the zone, not a child.
 
@@ -268,9 +266,7 @@ Indicator rects are cached per zone; `getBoundingClientRect` runs only when the 
 | `dnd.draggables.register(input)` | Register a draggable. Requires `el`, `type`, and `value`. Returns a ticket with `isDragging` and `unregister()`. |
 | `dnd.zones.register(input)` | Register a drop zone. Requires `el`. Returns a ticket with `isOver`, `willAccept`, `indicator`, and `unregister()`. |
 | `ticket.unregister()` | Drop a ticket from its registry. Child components that register must unregister on unmount — the factory only disposes remaining tickets when its own scope tears down. Unregistering the active draggable cancels the drag. |
-| `dnd.cancel()` | Programmatically cancel the active drag. Fires the cancel chain[^drag-cancel-chain] with `reason: 'cancel'`. No-op when no drag is active. |
-
-[^drag-cancel-chain]: `onLeave` on the over-zone → per-draggable `onCancel` → global `onCancel`.
+| `dnd.cancel()` | Programmatically cancel the active drag. Fires `onLeave` on the over-zone, then per-draggable `onCancel`, then global `onCancel`, with `reason: 'cancel'`. No-op when no drag is active. |
 
 ### DOM attributes
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -11,58 +11,76 @@ features:
   github: /composables/useDragDrop/
   level: 2
 related:
+  - /composables/data/create-sortable
+  - /composables/data/create-kanban
   - /composables/registration/create-registry
-  - /composables/foundation/create-context
   - /composables/system/use-roving-focus
 ---
 
 # useDragDrop
 
-Headless drag-and-drop primitive. Owns two registries — draggables and zones — plus the active-drag state.
-
 <DocsPageFeatures :frontmatter />
+
+Headless drag-and-drop primitive. Owns two registries — draggables and zones — plus the active-drag state.
 
 ## Usage
 
-Call `useDragDrop` once per scope and pass the returned context to children that register draggables or zones.
+Call `useDragDrop` once per scope and pass the returned context to children that register draggables or zones. Adapters locate by registered `el`, not `data-draggable`. Keyboard pickup needs the ticket focused — `tabindex="0"`, or [useRovingFocus](/composables/system/use-roving-focus).
+
+Drop the card onto the zone. Pointer, touch, or keyboard (`Tab`, then `Space` / `Enter` to pick up, arrows to nudge, `Space` / `Enter` to drop).
 
 ```vue playground collapse no-filename useDragDrop
 <script setup lang="ts">
   import { useDragDrop } from '@vuetify/v0'
-  import { useTemplateRef } from 'vue'
+  import { ref, useTemplateRef } from 'vue'
 
   const dnd = useDragDrop<{ type: 'card', value: string }>()
+  const held = ref(['Card'])
+  const dropped = ref<string[]>([])
 
   const draggable = useTemplateRef<HTMLElement>('draggable')
   const dropzone = useTemplateRef<HTMLElement>('dropzone')
 
-  dnd.draggables.register({
+  const ticket = dnd.draggables.register({
     el: draggable,
     type: 'card',
-    value: 'card-1',
+    value: 'Card',
   })
 
-  dnd.zones.register({
+  const zone = dnd.zones.register({
     el: dropzone,
     accept: ['card'],
     orientation: 'vertical',
     onDrop: (drag, position) => {
-      console.log(drag.value, position.index) // 'card-1', 0
+      held.value = held.value.filter(v => v !== drag.value)
+      dropped.value.splice(position.index ?? 0, 0, drag.value)
     },
   })
 </script>
 
 <template>
-  <div
-    ref="draggable"
-    data-draggable
-    aria-roledescription="draggable"
-  >
-    Card
-  </div>
+  <div class="flex flex-wrap gap-4">
+    <div
+      v-if="held.length"
+      ref="draggable"
+      aria-roledescription="draggable"
+      class="touch-none cursor-grab select-none px-3 py-2 rounded bg-primary text-on-primary data-[dragging]:cursor-grabbing data-[dragging]:opacity-50"
+      data-draggable
+      :data-dragging="ticket.isDragging.value || undefined"
+      tabindex="0"
+    >
+      Card
+    </div>
 
-  <div ref="dropzone" data-dropzone>
-    Drop zone
+    <div
+      ref="dropzone"
+      class="min-h-12 min-w-32 px-3 py-2 rounded border border-divider data-[accepts]:border-primary data-[accepts]:bg-primary/10"
+      :data-accepts="(zone.isOver.value && zone.willAccept.value) || undefined"
+      data-dropzone
+      :data-over="zone.isOver.value || undefined"
+    >
+      {{ dropped[0] ?? 'Drop zone' }}
+    </div>
   </div>
 </template>
 ```
@@ -77,9 +95,11 @@ Adapters are pluggable input layers: an adapter observes the DOM (or any other i
 | `KeyboardAdapter` | `@vuetify/v0` | Keyboard activation (default) |
 | `DragDropAdapter` | `@vuetify/v0` | Abstract base class for custom adapters — see [Custom adapters](#custom-adapters) |
 
+`locate()` walks ancestors of the event target until it finds a ticket whose `el` matches. It does not read `data-draggable`.
+
 ### PointerAdapter
 
-Pointer Events for mouse, touch, and pen. Installed by default.
+Pointer Events for mouse, touch, and pen. Installed by default. You do not need a separate touch adapter.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
@@ -121,10 +141,10 @@ To extend instead of replace, list the defaults alongside your custom adapter:
 
 ```ts
 import { useDragDrop, PointerAdapter, KeyboardAdapter } from '@vuetify/v0'
-import { TouchAdapter } from './touch-adapter'
+import { GamepadAdapter } from './gamepad-adapter'
 
 useDragDrop({
-  adapters: [new PointerAdapter(), new KeyboardAdapter(), new TouchAdapter()],
+  adapters: [new PointerAdapter(), new KeyboardAdapter(), new GamepadAdapter()],
 })
 ```
 
@@ -138,10 +158,10 @@ Extend the abstract `DragDropAdapter` base for shared `cleanup` + `dispose()` li
 import { DragDropAdapter } from '@vuetify/v0'
 import type { DragDropAdapterContext, DragType } from '@vuetify/v0'
 
-class TouchAdapter<Z extends DragType = DragType> extends DragDropAdapter<Z> {
+class GamepadAdapter<Z extends DragType = DragType> extends DragDropAdapter<Z> {
   setup (context: DragDropAdapterContext<Z>): void {
     // observe input, then call:
-    //   context.emit.start(source, origin, 'touch')
+    //   context.emit.start(source, origin, 'gamepad')
     //   context.emit.move(point)
     //   context.emit.drop()
     //   context.emit.cancel()
@@ -150,7 +170,7 @@ class TouchAdapter<Z extends DragType = DragType> extends DragDropAdapter<Z> {
 }
 ```
 
-`context.emit` exposes `start(source, origin, via)`, `move(point)`, `drop()`, and `cancel()` — call these as input arrives. Adapters declare their own `via` value (typed as `DragVia`) so consumers reading `active.value.via` can distinguish the input source. `DragVia` is `Extensible<'pointer' | 'keyboard'>` — additional modalities (e.g. `'touch'`, `'gamepad'`) flow through without type-level coordination.
+`context.emit` exposes `start(source, origin, via)`, `move(point)`, `drop()`, and `cancel()` — call these as input arrives. Adapters declare their own `via` value (typed as `DragVia`) so consumers reading `active.value.via` can distinguish the input source. `DragVia` is `Extensible<'pointer' | 'keyboard'>` — additional modalities (e.g. `'gamepad'`) flow through without type-level coordination.
 
 ## Architecture
 
@@ -191,6 +211,20 @@ flowchart TD
   active -->|reactive| child2
 ```
 
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `adapters` | `DragDropAdapter<Z>[]` | `[PointerAdapter, KeyboardAdapter]` | Replaces the default adapter array when provided. `[]` disables both. |
+| `plugins` | `DragDropPlugin<Z>[]` | `[]` | Install-time observers. Each plugin receives the public context and may return a disposer. No plugins ship in v1 — you write them. |
+| `onBeforeStart` | `(drag) => boolean \| void` | — | Return `false` to veto the start. Runs while `active` is still `null`; read the `drag` argument. |
+| `onMove` | `(drag) => void` | — | Fires on every move **while `active` is set**. |
+| `onBeforeDrop` | `(drag, position) => boolean \| void` | — | Return `false` to veto the drop (`reason: 'reject'`). Runs while `active` is still set. |
+| `onDrop` | `(drag, position) => void` | — | Fires **after** `active` is cleared to `null`. Read the `drag` argument, not the ref. |
+| `onCancel` | `(drag, reason) => void` | — | `reason` is `'cancel'` (Escape, `dnd.cancel()`) or `'reject'` (drop veto). Fires after `active` is cleared. |
+
+Per-ticket hooks (`onBeforeStart`, `onMove`, `onCancel` on a draggable; `onEnter`, `onLeave`, `onBeforeDrop`, `onDrop` on a zone) have the same signatures and the same `active` timing as the matching global option. `disabled?: MaybeRefOrGetter<boolean>` on either registration skips pointer/keyboard start (draggable) or hit-testing (zone).
+
 ## Reactivity
 
 ### Reactive fields
@@ -200,7 +234,6 @@ Every consumer-facing state field is a reactive ref <AppSuccessIcon />. Reads in
 | Field | Shape | Updates when |
 |---|---|---|
 | `dnd.active` | `Readonly<ShallowRef<ActiveDrag<Z> \| null>>` | A drag starts, moves, drops, or cancels |
-| `dnd.active.value.via` | `DragVia` | Source modality (`'pointer'`, `'keyboard'`, or any extension)[^drag-via-usage] |
 | `dnd.isDragging` | `Readonly<Ref<boolean>>` | `active` becomes non-null / null |
 | `ticket.isDragging` | `Readonly<Ref<boolean>>` | This specific ticket is the active drag |
 | `ticket.el` | `Readonly<Ref<HTMLElement \| null>>` | Mounts / unmounts (registry element-ref pattern) |
@@ -209,26 +242,45 @@ Every consumer-facing state field is a reactive ref <AppSuccessIcon />. Reads in
 | `zone.indicator` | `Readonly<Ref<DropIndicator \| null>>` | While over an oriented zone, computes the index/edge/rect of the resolved drop slot. `null` over an unoriented or empty zone — and over the two slots flanking the dragged element's own position in its home zone, which are stays, not moves |
 | `zone.el` | `Readonly<Ref<HTMLElement \| null>>` | Mounts / unmounts (registry element-ref pattern) |
 
+### Active drag
+
+`dnd.active.value` is `null` when idle. While set, the object is:
+
+| Field | Shape | Notes |
+|---|---|---|
+| `id` | `ID` | Registry ticket id. Auto-generated unless you pass `id` to `register`. Not your payload id. |
+| `type` / `value` | `Z['type']` / `Z['value']` | Discriminated payload. Narrow on `type` to narrow `value`. |
+| `origin` | `{ x, y }` | Pointer (or keyboard start point) at pickup |
+| `current` | `{ x, y }` | Latest point |
+| `delta` | `{ x, y }` | `current - origin` |
+| `over` | `ID \| null` | Zone id under the point, or `null` |
+| `willAccept` | `boolean` | Whether that zone's `accept` matches this drag |
+| `via` | `DragVia` | `'pointer'`, `'keyboard'`, or an adapter-declared extension[^drag-via-usage] |
+
 [^drag-via-usage]: Read this to branch keyboard-only behaviors like focus restoration.
 
-Indicator rects are cached per zone; `getBoundingClientRect` runs only when the zone resizes or its children mount/unmount, not on each pointer move.
+Indicator rects are cached per zone; `getBoundingClientRect` runs only when the zone resizes or its children mount/unmount, not on each pointer move. The index is measured against **every element child** of the zone `el` (`zoneEl.children`) — headers, spacers, and an in-zone indicator all count as slots. Keep the indicator as a sibling of the zone, not a child.
 
 ### Methods
 
 | Method | Purpose |
 |---|---|
+| `dnd.draggables.register(input)` | Register a draggable. Requires `el`, `type`, and `value`. Returns a ticket with `isDragging` and `unregister()`. |
+| `dnd.zones.register(input)` | Register a drop zone. Requires `el`. Returns a ticket with `isOver`, `willAccept`, `indicator`, and `unregister()`. |
+| `ticket.unregister()` | Drop a ticket from its registry. Child components that register must unregister on unmount — the factory only disposes remaining tickets when its own scope tears down. Unregistering the active draggable cancels the drag. |
 | `dnd.cancel()` | Programmatically cancel the active drag. Fires the cancel chain[^drag-cancel-chain] with `reason: 'cancel'`. No-op when no drag is active. |
 
 [^drag-cancel-chain]: `onLeave` on the over-zone → per-draggable `onCancel` → global `onCancel`.
 
 ### DOM attributes
 
-The composable does not produce attribute objects — consumers wire data attributes themselves so the design-system layer can choose its own keys. The canonical wiring is:
+The composable does not produce attribute objects — consumers wire data attributes themselves so the design-system layer can choose its own keys. Adapters never read these; they locate by registered `el`. The canonical wiring is:
 
 **Draggable element:**
 - `data-draggable` (always)
 - `aria-roledescription="draggable"` (always)
 - `data-dragging` toggled while `ticket.isDragging.value` is true
+- `tabindex="0"` (or a roving tabindex) so `KeyboardAdapter` can find the focused ticket
 - `touch-action: none` (CSS or `style="touch-action: none"`) so the browser doesn't pan/zoom on pointer drag
 
 **Drop zone element:**
@@ -245,19 +297,19 @@ The composable does not produce attribute objects — consumers wire data attrib
 
 ### Basic two-list drag
 
-Pick up an item with the pointer or keyboard (`Space` / `Enter`) and drop it in the other list. The example splits the surface across three files to mirror how a real consumer would compose the primitive: a `DragItem` that registers itself as a draggable, a `DropList` that registers itself as a zone and renders draggables, and a `basic` entry that wires the lists together and owns the data.
+Pick up an item with the pointer or keyboard (`Space` / `Enter`) and drop it in either list. The example splits the surface across three files to mirror how a real consumer would compose the primitive: a `DragItem` that registers itself as a draggable, a `DropList` that registers itself as a zone, paints `zone.indicator` as a sibling bar, and renders draggables, and a `basic` entry that wires the lists together and owns the data.
 
-The zones declare `orientation: 'vertical'` to opt into list-style index resolution — the `onDrop` callback receives `position.index` indicating where in the destination list the drop landed. While a drag is active the wrapper toggles `cursor-grabbing` so the cursor stays consistent across both lists, and each zone shows a primary-tinted ring + background when it would accept the active drag.
+The zones declare `orientation: 'vertical'` to opt into list-style index resolution — the `onDrop` callback receives `position.index` against the **pre-move** child list. Same-list downward moves subtract 1 after removing the source so the splice lands in the intended slot; cross-list drops use the index as-is. While a drag is active the wrapper toggles `cursor-grabbing`, each zone shows a primary-tinted ring when it would accept the drag, and a 2px bar marks the resolved slot. The bar lives *outside* the zone `el` so it is not counted as a child slot.
 
-Reach for this shape when you want a sortable list with cross-container moves and headless control over visual affordances. For a single-list reorder, drop the second `DropList`. For more drag types in the same scope (e.g. items *and* their containers), widen the discriminated union — the type narrowing on `drag.type` carries the corresponding `drag.value` through.
+Reach for this shape when you want a sortable list with cross-container moves and headless control over visual affordances. For a single-list reorder driven by [createSortable](/composables/data/create-sortable) instead of a plain array, see that page's drag-and-drop example. For a two-level board, compose with [createKanban](/composables/data/create-kanban). For more drag types in the same scope (e.g. items *and* their containers), widen the discriminated union — the type narrowing on `drag.type` carries the corresponding `drag.value` through.
 
-Need to share the context across deeply nested components without prop-threading? Wrap the parent's `useDragDrop()` call with your own `provide`/`inject` pair (Vue's standard DI pattern) and call `inject` from descendants. A first-class `createDragDropContext()` trinity factory may ship later — see the [createSelectionContext](/composables/selection/create-selection) precedent for the shape it would take.
+This example uses `tabindex="0"` on every item so keyboard pickup works without extra wiring. Production lists usually add [useRovingFocus](/composables/system/use-roving-focus) so each zone is one tab stop — see [Accessibility](#accessibility). Share the `dnd` context with Vue `provide` / `inject` when prop-threading gets noisy; there is no first-class drag-drop trinity.
 
 | File | Role |
 |------|------|
 | `DragItem.vue` | Receives the shared `dnd` context as a prop and registers itself as a draggable via `dnd.draggables.register({ el, type, value })` |
-| `DropList.vue` | Receives the shared `dnd` context as a prop, registers itself as a zone via `dnd.zones.register({ el, accept, orientation, onDrop })`, and emits `move` events upward |
-| `basic.vue` | Owns the lists, calls `useDragDrop()` to create the context, threads it to children, and handles cross-list moves |
+| `DropList.vue` | Receives the shared `dnd` context as a prop, registers itself as a zone, renders `zone.indicator` as a sibling, and emits `move` events upward |
+| `basic.vue` | Owns the lists, calls `useDragDrop()` to create the context, threads it to children, and applies the pre-move index adjustment on same-list reorder |
 :::
 
 ## Recipes
@@ -289,7 +341,7 @@ dnd.zones.register({ el, accept: ['column'], orientation: 'horizontal' })
 Either layer can veto. Per-zone vetoes route the drag through the cancel chain (`onLeave` on the active zone → `onCancel` on the source draggable → global `onCancel`) so consumers can roll back optimistic UI without subscribing to a separate "drop failed" event. Both `onCancel` callbacks (per-draggable and global) receive a second argument `reason: 'cancel' | 'reject'` — `'reject'` when the cancel was triggered by a drop veto, `'cancel'` for user-initiated aborts (Escape, programmatic `dnd.cancel()`).
 
 > [!TIP]
-> All hooks fire AFTER `dnd.active.value` is cleared to `null` — read the `drag` argument inside `onDrop`, `onCancel`, and `onLeave`-during-cancel rather than re-reading the reactive ref. The cleared-before-notify ordering prevents re-entrance loops when a hook calls `dnd.cancel()` or unregisters a ticket.
+> `onDrop`, `onCancel`, and `onLeave`-during-cancel fire AFTER `dnd.active.value` is cleared to `null` — read the `drag` argument, not the reactive ref. `onMove`, `onEnter`, `onLeave` during a drag, `onBeforeStart`, and `onBeforeDrop` run while `active` still holds the draft (or, for `onBeforeStart`, before it is written). The cleared-before-notify ordering on drop/cancel prevents re-entrance loops when a hook calls `dnd.cancel()` or unregisters a ticket.
 
 `accept` (function form) must return synchronously — predicates that return a Promise / thenable are rejected with a console warning. Wrap async work in `onBeforeDrop` instead, returning `false` to veto.
 
@@ -317,10 +369,15 @@ WAI-ARIA does not standardize a kanban or "drag list" pattern. The primitive fol
 
 - Draggable tickets carry `aria-roledescription="draggable"` only — no `aria-grabbed` or `aria-dropeffect`, both deprecated in ARIA 1.1.
 - Wrap each drop zone in a container with `role="list"` and the draggable list items with `role="listitem"`.
-- Each zone should wire a roving tabindex via [useRovingFocus](/composables/system/use-roving-focus) — one focus stop per zone, arrow keys move between items in the same zone, Tab moves to the next zone.
+- Each zone should wire a roving tabindex via [useRovingFocus](/composables/system/use-roving-focus) — one focus stop per zone, arrow keys move between items in the same zone **while idle**, Tab moves to the next zone. The two-list example uses `tabindex="0"` on every item instead, so every card is a tab stop.
 - Provide a single live region per scope (`<div role="status" aria-live="polite">`) and watch `active` to announce moves ("Card moved to Done, position 2 of 5"). The live region is the consumer's responsibility — the headless contract excludes user-facing strings (PHILOSOPHY §5.5).
 
-The default `KeyboardAdapter` honours the standard contract: `Space` / `Enter` to pick up and drop, arrow keys to nudge the drag point by `step` px (default 16), `Escape` to cancel.
+Keyboard maps split on whether a drag is active:
+
+| State | `Space` / `Enter` | Arrow keys | `Escape` |
+|---|---|---|---|
+| Idle | Pick up the focused ticket | Roving focus between items (your `useRovingFocus`, not the adapter) | — |
+| Dragging | Drop | Nudge the drag point by `step` px (default 16). `KeyboardAdapter` calls `preventDefault`, so roving does not see these keys. | Cancel |
 
 ### Post-drop focus
 
@@ -334,13 +391,24 @@ After a successful keyboard drop, the moved element is typically replaced by the
 
 Native HTML5 DnD has terrible mobile support, an ugly default ghost element you can't customize cross-browser, no programmatic activation distance, and inconsistent event semantics across input devices. `PointerAdapter` uses Pointer Events instead — uniform mouse, touch, and pen handling, no default ghost (you render whatever you want), and full control over activation thresholds. Plug HTML5 in as a custom adapter if you need cross-window drops or OS file-drag integration; the headless contract doesn't lock it out.
 
-??? When does `position.index` get set?
+??? When does position.index get set?
 
-Only when the over-zone declares `orientation`. Without orientation, the zone is opaque — drops fire with `position.pointer` only. With orientation, the composable measures child rects and resolves an index. Empty oriented zones default `index` to `0` (the only sensible drop position when there's nothing to splice between). The indicator is also `null` over the two slots flanking the dragged element's own position in its home zone — dropping there changes nothing, so no slot is proposed and the drop resolves `index` to the element's current position.
+Only when the over-zone declares `orientation`. Without orientation, the zone is opaque — drops fire with `position.pointer` only. With orientation, the composable measures **every element child** of the zone `el` (`zoneEl.children`) and resolves an index against that list, not against registered draggables. Empty oriented zones default `index` to `0`. The indicator is `null` over the two slots flanking the dragged element's own position in its home zone — dropping there changes nothing, so no slot is proposed and the drop resolves `index` to the element's current position.
 
-??? How do I pick the right `Z` parameter?
+`position.index` is computed against the **pre-move** child list. If your `onDrop` removes the source first and then splices at that index, same-list downward moves overshoot by one:
 
-`Z` is a discriminated union of every drag type the scope handles. For a single type, write `useDragDrop<{ type: 'card', value: Card }>()`. For multiple, union them: `{ type: 'card', value: Card } | { type: 'column', value: Column }`. The types are distributive — narrowing on `drag.type` narrows `drag.value` to the matching variant.
+```ts
+const from = items.findIndex(i => i.id === drag.value.id)
+const to = position.index ?? 0
+items.splice(from, 1)
+items.splice(to > from ? to - 1 : to, 0, drag.value)
+```
+
+Cross-list drops do not need the `-1` — the destination's children never included the source. [createSortable](/composables/data/create-sortable) documents the same contract next to `sortable.move`.
+
+??? How do I pick the right Z parameter?
+
+`Z` is a discriminated union of every drag type the scope handles. For a single type, write `useDragDrop<{ type: 'card', value: Card }>()`. For multiple, union them: `{ type: 'card', value: Card } | { type: 'column', value: Column }`. The types are distributive — narrowing on `drag.type` narrows `drag.value` to the matching variant. `ActiveDrag.id` is the registry ticket id (pass `id` to `register` if you need it stable); your payload lives on `value`.
 
 ??? Can the same DOM element be both a draggable and a zone?
 
@@ -348,7 +416,22 @@ Yes. Two registrations on the same element work because they live in different r
 
 ??? What if I need autoscroll, FLIP animations, or multi-select drag?
 
-These don't ship in v1 to keep the surface small. The plugin slot is the extension point — `useDragDrop({ plugins: [scroll(), flip()] })` — and lifecycle hooks let you observe everything from outside the composable. Multi-select drag is best composed with [createSelection](/composables/selection/create-selection) so the selected set is its own first-class concept.
+These don't ship in v1 to keep the surface small. The plugin slot is the extension point — a plugin is `(context) => disposer`, installed via `useDragDrop({ plugins: [logDrops] })`. Write autoscroll or FLIP as plugins that subscribe to `active` / registry events; nothing named `scroll()` or `flip()` is exported. Multi-select drag is best composed with [createSelection](/composables/selection/create-selection) so the selected set is its own first-class concept.
+
+```ts
+import { useDragDrop } from '@vuetify/v0'
+import type { DragDropPlugin } from '@vuetify/v0'
+
+const logDrops: DragDropPlugin = context => {
+  function onRegister (ticket: { id: string }) {
+    console.log('zone', ticket.id)
+  }
+  context.zones.on('register:ticket', onRegister)
+  return () => context.zones.off('register:ticket', onRegister)
+}
+
+const dnd = useDragDrop({ plugins: [logDrops] })
+```
 
 :::
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -363,6 +363,25 @@ dnd.draggables.register({
 })
 ```
 
+### Installing a plugin
+
+A plugin is `(context) => disposer`. Nothing named `scroll()` or `flip()` is exported — write autoscroll or FLIP yourself against `active` and the registry event bus.
+
+```ts
+import { useDragDrop } from '@vuetify/v0'
+import type { DragDropPlugin } from '@vuetify/v0'
+
+const logDrops: DragDropPlugin = context => {
+  function onRegister (ticket: { id: string }) {
+    console.log('zone', ticket.id)
+  }
+  context.zones.on('register:ticket', onRegister)
+  return () => context.zones.off('register:ticket', onRegister)
+}
+
+const dnd = useDragDrop({ plugins: [logDrops] })
+```
+
 ## Accessibility
 
 WAI-ARIA does not standardize a kanban or "drag list" pattern. The primitive follows the **list-of-lists** convention used by Pragmatic DnD, dnd-kit, and headless-ui:
@@ -391,22 +410,13 @@ After a successful keyboard drop, the moved element is typically replaced by the
 
 Native HTML5 DnD has terrible mobile support, an ugly default ghost element you can't customize cross-browser, no programmatic activation distance, and inconsistent event semantics across input devices. `PointerAdapter` uses Pointer Events instead — uniform mouse, touch, and pen handling, no default ghost (you render whatever you want), and full control over activation thresholds. Plug HTML5 in as a custom adapter if you need cross-window drops or OS file-drag integration; the headless contract doesn't lock it out.
 
-??? When does position.index get set?
+??? When does `position.index` get set?
 
 Only when the over-zone declares `orientation`. Without orientation, the zone is opaque — drops fire with `position.pointer` only. With orientation, the composable measures **every element child** of the zone `el` (`zoneEl.children`) and resolves an index against that list, not against registered draggables. Empty oriented zones default `index` to `0`. The indicator is `null` over the two slots flanking the dragged element's own position in its home zone — dropping there changes nothing, so no slot is proposed and the drop resolves `index` to the element's current position.
 
-`position.index` is computed against the **pre-move** child list. If your `onDrop` removes the source first and then splices at that index, same-list downward moves overshoot by one:
+`position.index` is computed against the **pre-move** child list. If your `onDrop` removes the source first and then splices at that index, same-list downward moves overshoot by one — use `to > from ? to - 1 : to`. Cross-list drops do not need the `-1`; the destination's children never included the source. The two-list example and [createSortable](/composables/data/create-sortable)'s DnD demo both apply that adjustment.
 
-```ts
-const from = items.findIndex(i => i.id === drag.value.id)
-const to = position.index ?? 0
-items.splice(from, 1)
-items.splice(to > from ? to - 1 : to, 0, drag.value)
-```
-
-Cross-list drops do not need the `-1` — the destination's children never included the source. [createSortable](/composables/data/create-sortable) documents the same contract next to `sortable.move`.
-
-??? How do I pick the right Z parameter?
+??? How do I pick the right `Z` parameter?
 
 `Z` is a discriminated union of every drag type the scope handles. For a single type, write `useDragDrop<{ type: 'card', value: Card }>()`. For multiple, union them: `{ type: 'card', value: Card } | { type: 'column', value: Column }`. The types are distributive — narrowing on `drag.type` narrows `drag.value` to the matching variant. `ActiveDrag.id` is the registry ticket id (pass `id` to `register` if you need it stable); your payload lives on `value`.
 
@@ -416,22 +426,7 @@ Yes. Two registrations on the same element work because they live in different r
 
 ??? What if I need autoscroll, FLIP animations, or multi-select drag?
 
-These don't ship in v1 to keep the surface small. The plugin slot is the extension point — a plugin is `(context) => disposer`, installed via `useDragDrop({ plugins: [logDrops] })`. Write autoscroll or FLIP as plugins that subscribe to `active` / registry events; nothing named `scroll()` or `flip()` is exported. Multi-select drag is best composed with [createSelection](/composables/selection/create-selection) so the selected set is its own first-class concept.
-
-```ts
-import { useDragDrop } from '@vuetify/v0'
-import type { DragDropPlugin } from '@vuetify/v0'
-
-const logDrops: DragDropPlugin = context => {
-  function onRegister (ticket: { id: string }) {
-    console.log('zone', ticket.id)
-  }
-  context.zones.on('register:ticket', onRegister)
-  return () => context.zones.off('register:ticket', onRegister)
-}
-
-const dnd = useDragDrop({ plugins: [logDrops] })
-```
+These don't ship in v1 to keep the surface small. The plugin slot is the extension point — a plugin is `(context) => disposer`. Write autoscroll or FLIP against `active` and the registry event bus; nothing named `scroll()` or `flip()` is exported. See [Installing a plugin](#installing-a-plugin). Multi-select drag is best composed with [createSelection](/composables/selection/create-selection) so the selected set is its own first-class concept.
 
 :::
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -414,7 +414,27 @@ Only when the over-zone declares `orientation`. Without orientation, the zone is
 
 ??? How do I pick the right `Z` parameter?
 
-`Z` is a discriminated union of every drag type the scope handles. For a single type, write `useDragDrop<{ type: 'card', value: Card }>()`. For multiple, union them: `{ type: 'card', value: Card } | { type: 'column', value: Column }`. The types are distributive — narrowing on `drag.type` narrows `drag.value` to the matching variant. `ActiveDrag.id` is the registry ticket id (pass `id` to `register` if you need it stable); your payload lives on `value`.
+`Z` is a discriminated union of every drag type the scope handles. Default to one variant. Widen only when two types actually interact in the same scope — otherwise a second `useDragDrop()` is cleaner. The types are distributive: narrowing `drag.type` narrows `drag.value`. `ActiveDrag.id` is the registry ticket id (pass `id` to `register` if you need it stable); your payload lives on `value`.
+
+```ts
+// One type — every callback already knows the shape
+const cards = useDragDrop<{ type: 'card', value: Card }>()
+
+// Two types that meet — narrow on drag.type
+type Kanban =
+  | { type: 'card', value: Card }
+  | { type: 'column', value: Column }
+
+const dnd = useDragDrop<Kanban>()
+
+dnd.zones.register({
+  el,
+  accept: ['card'],
+  onDrop: drag => {
+    drag.value // Card
+  },
+})
+```
 
 ??? Can the same DOM element be both a draggable and a zone?
 

--- a/apps/docs/src/pages/composables/system/use-drag-drop.md
+++ b/apps/docs/src/pages/composables/system/use-drag-drop.md
@@ -417,6 +417,8 @@ Only when the over-zone declares `orientation`. Without orientation, the zone is
 `Z` is a discriminated union of every drag type the scope handles. Default to one variant. Widen only when two types actually interact in the same scope — otherwise a second `useDragDrop()` is cleaner. The types are distributive: narrowing `drag.type` narrows `drag.value`. `ActiveDrag.id` is the registry ticket id (pass `id` to `register` if you need it stable); your payload lives on `value`.
 
 ```ts
+import { useDragDrop } from '@vuetify/v0'
+
 // One type — every callback already knows the shape
 const cards = useDragDrop<{ type: 'card', value: Card }>()
 


### PR DESCRIPTION
The useDragDrop page was usable but the first demo lied: Usage logged instead of dropping, the two-list example spliced same-list downward one slot too far, and `zone.indicator` was never painted.

- Usage playground actually moves the card (keyboard + pointer attrs included)
- Same-list reorder uses the pre-move index contract (`to > from ? to - 1 : to`); FAQ documents it
- Drop indicator renders as a sibling of the zone `el`, so it is not counted as a child slot
- Options table, register/unregister, ActiveDrag fields; hooks TIP no longer claims every hook sees `active === null`
- Drop invented `scroll()` / `flip()` plugins; keyboard idle vs dragging is split