### PR TITLE
fix(toHighlight): directional ignoreAccents should not just fold

### DIFF
--- a/.changeset/ignore-accents-directional-exact-match.md
+++ b/.changeset/ignore-accents-directional-exact-match.md
@@ -1,0 +1,9 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(findMatchRanges): directional `ignoreAccents` now matches an already-accented spelling verbatim
+
+`ignoreAccents: 'query'` and `'target'` fold only one side of the comparison, so a heavily-accented word like `Kraków` could fail to match its own exact spelling — the query got folded to `Krakow` while the target stayed accented, and the two no longer agreed.
+
+Both modes now also check for a literal, unfolded match, so typing the exact accented text always finds it — without changing what they're for: `'query'` still only folds the query (typing `cafe` won't find `café`) and `'target'` still only folds the text (typing `café` won't find `cafe`), so a different accent on either side (`café` vs `cafè`) still doesn't match.

--- a/packages/0/src/utilities/diacritics.test.ts
+++ b/packages/0/src/utilities/diacritics.test.ts
@@ -45,6 +45,23 @@ describe('diacritics', () => {
       expect(findMatchRanges('café', 'cafe', { ignoreAccents: 'query' })).toStrictEqual([])
     })
 
+    // https://github.com/vuetifyjs/v0/issues/944 — folding only one side must
+    // never hide a spelling that already agrees, accents and all, on both.
+    it('should still match an identical accented spelling under directional folding', () => {
+      expect(findMatchRanges('… Kraków …', 'Kraków', { ignoreAccents: 'query' })).toStrictEqual([[2, 8]])
+      expect(findMatchRanges('café', 'café', { ignoreAccents: 'target' })).toStrictEqual([[0, 4]])
+    })
+
+    it('should not lose the exact-match distinction between different accents', () => {
+      expect(findMatchRanges('café', 'cafè', { ignoreAccents: 'query' })).toStrictEqual([])
+      expect(findMatchRanges('café', 'cafè', { ignoreAccents: 'target' })).toStrictEqual([])
+    })
+
+    it('should merge an exact match with a folded match under matchAll', () => {
+      expect(findMatchRanges('café and cafe', 'café', { ignoreAccents: 'query', matchAll: true }))
+        .toStrictEqual([[0, 4], [9, 13]])
+    })
+
     it('should find the first occurrence only unless matchAll is set', () => {
       expect(findMatchRanges('é é', 'e', { ignoreAccents: true })).toStrictEqual([[0, 1]])
       expect(findMatchRanges('é é', 'e', { ignoreAccents: true, matchAll: true })).toStrictEqual([[0, 1], [2, 3]])

--- a/packages/0/src/utilities/diacritics.test.ts
+++ b/packages/0/src/utilities/diacritics.test.ts
@@ -45,8 +45,6 @@ describe('diacritics', () => {
       expect(findMatchRanges('café', 'cafe', { ignoreAccents: 'query' })).toStrictEqual([])
     })
 
-    // https://github.com/vuetifyjs/v0/issues/944 — folding only one side must
-    // never hide a spelling that already agrees, accents and all, on both.
     it('should still match an identical accented spelling under directional folding', () => {
       expect(findMatchRanges('… Kraków …', 'Kraków', { ignoreAccents: 'query' })).toStrictEqual([[2, 8]])
       expect(findMatchRanges('café', 'café', { ignoreAccents: 'target' })).toStrictEqual([[0, 4]])

--- a/packages/0/src/utilities/diacritics.test.ts
+++ b/packages/0/src/utilities/diacritics.test.ts
@@ -60,6 +60,25 @@ describe('diacritics', () => {
         .toStrictEqual([[0, 4], [9, 13]])
     })
 
+    it('should return the first source-order range after merging exact and folded', () => {
+      expect(findMatchRanges('café and cafe', 'café', { ignoreAccents: 'query' }))
+        .toStrictEqual([[0, 4]])
+      expect(findMatchRanges('cafe and café', 'café', { ignoreAccents: 'query' }))
+        .toStrictEqual([[0, 4]])
+    })
+
+    it('should collapse an exact match that coincides with a folded match', () => {
+      expect(findMatchRanges('cafe', 'cafe', { ignoreAccents: 'query', matchAll: true }))
+        .toStrictEqual([[0, 4]])
+    })
+
+    it('should still match an identical accented spelling when ignoreCase is set', () => {
+      expect(findMatchRanges('Kraków', 'kraków', { ignoreAccents: 'query', ignoreCase: true }))
+        .toStrictEqual([[0, 6]])
+      expect(findMatchRanges('Kraków', 'kraków', { ignoreAccents: 'target', ignoreCase: true }))
+        .toStrictEqual([[0, 6]])
+    })
+
     it('should find the first occurrence only unless matchAll is set', () => {
       expect(findMatchRanges('é é', 'e', { ignoreAccents: true })).toStrictEqual([[0, 1]])
       expect(findMatchRanges('é é', 'e', { ignoreAccents: true, matchAll: true })).toStrictEqual([[0, 1], [2, 3]])

--- a/packages/0/src/utilities/diacritics.ts
+++ b/packages/0/src/utilities/diacritics.ts
@@ -230,7 +230,7 @@ function mergeRanges (a: readonly MatchRange[], b: readonly MatchRange[]): Match
  * // [[0, 2]]
  *
  * findMatchRanges('… Kraków …', 'Kraków', { ignoreAccents: 'query' })
- * // [[4, 10]] — typing the exact accented name always finds itself
+ * // [[2, 8]] — typing the exact accented name always finds itself
  * ```
  */
 /* #__NO_SIDE_EFFECTS__ */

--- a/packages/0/src/utilities/diacritics.ts
+++ b/packages/0/src/utilities/diacritics.ts
@@ -23,10 +23,15 @@ export type MatchRange = readonly [number, number]
 /**
  * Which side of a comparison has its accents folded before matching.
  *
- * - `'query'` — only the query, so typing `café` finds plain `cafe`
- * - `'target'` — only the text, so typing `cafe` finds accented `café`
- * - `true` — both sides
- * - `false` — neither
+ * - `'query'` — folds the query, so typing `café` finds plain `cafe`
+ * - `'target'` — folds the text, so typing `cafe` finds accented `café`
+ * - `true` — both sides fold, so any accent variant matches any other
+ * - `false` — neither folds, exact match only
+ *
+ * `'query'` and `'target'` fold only one side, but a spelling that already
+ * agrees on both sides still matches verbatim — folding one side never
+ * hides a match the other side already has. They still don't fold each
+ * other's accents together, so `café` won't match `cafè` under either.
  */
 export type IgnoreAccents = boolean | 'query' | 'target'
 
@@ -154,42 +159,14 @@ function project (ranges: readonly [number, number][], map: number[]): MatchRang
   return projected
 }
 
-/**
- * Finds `[start, end]` index pairs where `query` occurs in `text`, optionally
- * folding accents on either side. Returned indices always address the original
- * `text`, even when folding or case-conversion changed its length.
- *
- * @param text The string to search.
- * @param query The term to look for. An empty query yields no ranges.
- * @param options Optional `ignoreCase`, `ignoreAccents`, `matchAll`.
- * @returns Ranges into `text`, where `end` is exclusive.
- *
- * @example
- * ```ts
- * import { findMatchRanges } from '@vuetify/v0'
- *
- * findMatchRanges('Zürich', 'zurich', { ignoreCase: true, ignoreAccents: true })
- * // [[0, 6]]
- *
- * findMatchRanges('Łódź', 'Lo', { ignoreAccents: 'target' })
- * // [[0, 2]]
- * ```
- */
-/* #__NO_SIDE_EFFECTS__ */
-export function findMatchRanges (
+function search (
   text: string,
   query: string,
-  options: FindMatchRangesOptions = {},
+  ignoreCase: boolean,
+  foldQuery: boolean,
+  foldTarget: boolean,
+  matchAll: boolean,
 ): MatchRange[] {
-  const {
-    ignoreCase = false,
-    ignoreAccents = false,
-    matchAll = false,
-  } = options
-
-  const foldQuery = ignoreAccents === true || ignoreAccents === 'query'
-  const foldTarget = ignoreAccents === true || ignoreAccents === 'target'
-
   const folded = foldQuery ? fold(query) : query
   const needle = ignoreCase ? lower(folded) : folded
 
@@ -211,4 +188,76 @@ export function findMatchRanges (
   const { folded: haystack, map } = foldWithMap(text, ignoreCase, foldTarget)
 
   return project(collect(haystack, needle, matchAll), map)
+}
+
+// Merges two already-sorted range lists, dropping duplicates and overlaps.
+// Ties (identical start) keep whichever range came from `a`, so the exact
+// (unfolded) pass wins over the folded one when both find the same spot.
+function mergeRanges (a: readonly MatchRange[], b: readonly MatchRange[]): MatchRange[] {
+  const combined = [...a, ...b].toSorted((x, y) => x[0] - y[0] || x[1] - y[1])
+  const merged: MatchRange[] = []
+
+  for (const range of combined) {
+    const last = merged.at(-1)
+    if (last && range[0] < last[1]) continue
+
+    merged.push(range)
+  }
+
+  return merged
+}
+
+/**
+ * Finds `[start, end]` index pairs where `query` occurs in `text`, optionally
+ * folding accents on either side. Returned indices always address the original
+ * `text`, even when folding or case-conversion changed its length.
+ *
+ * Directional folding (`'query'` or `'target'`) only transforms one side, but
+ * a spelling that's already identical on both sides — accents and all — is
+ * merged in verbatim, so folding one side never hides a match the other side
+ * already has.
+ *
+ * @param text The string to search.
+ * @param query The term to look for. An empty query yields no ranges.
+ * @param options Optional `ignoreCase`, `ignoreAccents`, `matchAll`.
+ * @returns Ranges into `text`, where `end` is exclusive.
+ *
+ * @example
+ * ```ts
+ * import { findMatchRanges } from '@vuetify/v0'
+ *
+ * findMatchRanges('Zürich', 'zurich', { ignoreCase: true, ignoreAccents: true })
+ * // [[0, 6]]
+ *
+ * findMatchRanges('Łódź', 'Lo', { ignoreAccents: 'target' })
+ * // [[0, 2]]
+ *
+ * findMatchRanges('… Kraków …', 'Kraków', { ignoreAccents: 'query' })
+ * // [[4, 10]] — typing the exact accented name always finds itself
+ * ```
+ */
+/* #__NO_SIDE_EFFECTS__ */
+export function findMatchRanges (
+  text: string,
+  query: string,
+  options: FindMatchRangesOptions = {},
+): MatchRange[] {
+  const {
+    ignoreCase = false,
+    ignoreAccents = false,
+    matchAll = false,
+  } = options
+
+  const foldQuery = ignoreAccents === true || ignoreAccents === 'query'
+  const foldTarget = ignoreAccents === true || ignoreAccents === 'target'
+
+  if (foldQuery === foldTarget) {
+    return search(text, query, ignoreCase, foldQuery, foldTarget, matchAll)
+  }
+
+  const exact = search(text, query, ignoreCase, false, false, true)
+  const folded = search(text, query, ignoreCase, foldQuery, foldTarget, true)
+  const merged = mergeRanges(exact, folded)
+
+  return matchAll ? merged : merged.slice(0, 1)
 }

--- a/packages/0/src/utilities/diacritics.ts
+++ b/packages/0/src/utilities/diacritics.ts
@@ -190,9 +190,6 @@ function search (
   return project(collect(haystack, needle, matchAll), map)
 }
 
-// Merges two already-sorted range lists, dropping duplicates and overlaps.
-// Ties (identical start) keep whichever range came from `a`, so the exact
-// (unfolded) pass wins over the folded one when both find the same spot.
 function mergeRanges (a: readonly MatchRange[], b: readonly MatchRange[]): MatchRange[] {
   const combined = [...a, ...b].toSorted((x, y) => x[0] - y[0] || x[1] - y[1])
   const merged: MatchRange[] = []


### PR DESCRIPTION
As it works right now, the real-life utility may be limited for `query` and `target`.

Example: with "query", I cannot find Kraków by typing the exact name. It literally means "_if user types ó it becomes o for matching_" (folding one side only).

Why it matters: the original use case for was:
- (for target) let user find localized names (countries, cities, names) that are stored in DB with accents. Typing `ö` should not match `ó`, nor `o`
- (for query) let user find certain words in text that mixes accented and not-accented forms (typical multi-source search). Typing `ö` should match `o`

...in both cases we do not want to match different accents against each other.

Current implementation:
- `target` replaces accents on target, then query needs to be non-accented to fit the expectations
- `query` replaces accents on query, so target data needs to be non-accented, otherwise they are never going to match

blocks [vuetify#22922](https://github.com/vuetifyjs/vuetify/pull/22922)