### PR TITLE
chore(playground): map @paper/bulma and @paper/emerald on the sandbox import map

### DIFF
--- a/apps/docs/src/composables/usePlayground.test.ts
+++ b/apps/docs/src/composables/usePlayground.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
 // Composables
-import { playgroundRegistryUrl } from './usePlayground'
+import { paperImportsFromCode, playgroundRegistryUrl } from './usePlayground'
 
 describe('playgroundRegistryUrl', () => {
   it('should append a theme query param when provided', () => {
     const url = playgroundRegistryUrl({ item: 'dialog', example: 'basic', theme: 'dark' })
     expect(url).toContain('example=dialog%2Fbasic')
     expect(url).toContain('theme=dark')
+  })
+})
+
+describe('paperImportsFromCode', () => {
+  it('should map paper specifiers to jsDelivr ESM entries', () => {
+    expect(paperImportsFromCode([
+      { code: 'import { BuModal } from \'@paper/bulma\'\n' },
+      { code: 'import { EmButton } from \'@paper/emerald\'\n' },
+    ])).toEqual({
+      '@paper/bulma': 'https://cdn.jsdelivr.net/npm/@paper/bulma@latest/dist/index.mjs',
+      '@paper/emerald': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/index.mjs',
+      '@paper/emerald/style.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/style.css',
+      '@paper/emerald/theme.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/theme.css',
+    })
+  })
+
+  it('should return an empty map when no paper specifiers are present', () => {
+    expect(paperImportsFromCode([
+      { code: 'import { createSingle } from \'@vuetify/v0\'\n' },
+    ])).toEqual({})
   })
 })

--- a/apps/docs/src/composables/usePlayground.ts
+++ b/apps/docs/src/composables/usePlayground.ts
@@ -32,6 +32,34 @@ function playgroundBase () {
   return import.meta.env.VITE_PLAYGROUND_URL ?? 'https://v0play.vuetifyjs.com'
 }
 
+const PAPER_CDN = {
+  '@paper/bulma': 'https://cdn.jsdelivr.net/npm/@paper/bulma@latest/dist/index.mjs',
+  '@paper/emerald': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/index.mjs',
+  '@paper/emerald/style.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/style.css',
+  '@paper/emerald/theme.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/theme.css',
+} as const
+
+/**
+ * Map `@paper/emerald` / `@paper/bulma` specifiers in example source to jsDelivr
+ * ESM URLs. The playground also has these on its builtin import map; embedding
+ * them in the hash keeps older v0play builds and shared links self-contained.
+ *
+ * jsDelivr, not esm.sh — these packages import `vue` / `@vuetify/v0` as bare
+ * specifiers and must share the REPL's copies.
+ */
+export function paperImportsFromCode (files: Iterable<{ code: string }>): Record<string, string> {
+  const imports: Record<string, string> = {}
+  for (const file of files) {
+    if (file.code.includes('@paper/emerald')) {
+      imports['@paper/emerald'] = PAPER_CDN['@paper/emerald']
+      imports['@paper/emerald/style.css'] = PAPER_CDN['@paper/emerald/style.css']
+      imports['@paper/emerald/theme.css'] = PAPER_CDN['@paper/emerald/theme.css']
+    }
+    if (file.code.includes('@paper/bulma')) imports['@paper/bulma'] = PAPER_CDN['@paper/bulma']
+  }
+  return imports
+}
+
 /**
  * Build a v0play URL for the given files.
  *
@@ -65,7 +93,11 @@ export async function usePlayground (
 
   const files = buildPlaygroundFiles(inputFiles, options.dir)
   const data: PlaygroundHashData = { files }
-  if (options.imports && Object.keys(options.imports).length > 0) data.imports = options.imports
+  const resolved = {
+    ...paperImportsFromCode(inputFiles),
+    ...options.imports,
+  }
+  if (Object.keys(resolved).length > 0) data.imports = resolved
   if (options.settings && Object.keys(options.settings).length > 0) data.settings = options.settings
   if (options.theme) data.theme = options.theme
   if (options.themes && Object.keys(options.themes).length > 0) data.themes = options.themes

--- a/apps/playground/src/composables/usePlayground.ts
+++ b/apps/playground/src/composables/usePlayground.ts
@@ -118,6 +118,7 @@ export function parseVuetifyPlayTuple (parsed: unknown[]): { files: Record<strin
     ...Object.keys(imports),
     'vue', 'vue/server-renderer', '@vue/devtools-api',
     '@vuetify/v0', 'vuetify',
+    '@paper/emerald', '@paper/bulma',
   ])
   const bareImportRe = /\bfrom\s+['"]([^./][^'"]*)['"]/g
   for (const code of Object.values(files)) {

--- a/apps/playground/src/composables/usePlaygroundFiles.ts
+++ b/apps/playground/src/composables/usePlaygroundFiles.ts
@@ -9,7 +9,7 @@ import { decodePlaygroundHash, encodePlaygroundHash, isFileRecord, parseVuetifyP
 import { usePlaygroundSettings } from '@/composables/usePlaygroundSettings'
 
 // Data
-import { createMainTs, createVuetifyTs, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS, vuetifyEsmUrl } from '@/data/playground-defaults'
+import { createMainTs, createVuetifyTs, detectPaperUsage, paperCdnImports, REPL_BUILTIN_FILES, REPL_TSCONFIG, REPL_TYPESCRIPT_VERSION, UNO_CONFIG_TS, v0CdnImports, vuetifyEsmUrl } from '@/data/playground-defaults'
 import { ADDONS, DEFAULT_APP, PRESETS } from '@/data/presets'
 import { parseRegistryQuery, resolveRegistryExample } from '@/data/registry'
 import { parseVuetifyExampleQuery, resolveVuetifyExample } from '@/data/vuetify-examples'
@@ -51,7 +51,8 @@ export function usePlaygroundFiles () {
   const builtinImportMap = computed(() => ({
     imports: {
       ...importMap.value?.imports,
-      '@vuetify/v0': `https://cdn.jsdelivr.net/npm/@vuetify/v0@${v0Version.value}/dist/index.mjs`,
+      ...v0CdnImports(v0Version.value),
+      ...paperCdnImports(),
       // Always available — pinia/vue-router prod builds import this at runtime to detect devtools
       '@vue/devtools-api': 'https://esm.sh/@vue/devtools-api@6',
     },
@@ -123,9 +124,24 @@ export function usePlaygroundFiles () {
     theme.select(dark ? 'dark' : 'light')
   }
 
-  function mainTs (defaultTheme?: string) {
+  function scanFiles (scan?: Record<string, string>): Record<string, string> {
+    if (scan) return scan
+    const files: Record<string, string> = {}
+    for (const [path, file] of Object.entries(store.files)) {
+      files[path] = file.code
+    }
+    return files
+  }
+
+  function mainTs (defaultTheme?: string, scan?: Record<string, string>) {
     const id = defaultTheme ?? sandboxThemeId(theme.isDark.value)
-    return createMainTs(id, mergedMainOptions(), vuetifyVersion.value, vuetifyNightly.value, extraThemes.value)
+    return createMainTs(
+      id,
+      { ...mergedMainOptions(), ...detectPaperUsage(scanFiles(scan)) },
+      vuetifyVersion.value,
+      vuetifyNightly.value,
+      extraThemes.value,
+    )
   }
 
   function rebuildMain () {
@@ -319,7 +335,7 @@ export function usePlaygroundFiles () {
     rebuildImportMap()
     await store.setFiles(
       {
-        'src/main.ts': mainTs(theme_),
+        'src/main.ts': mainTs(theme_, files),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'tsconfig.json': REPL_TSCONFIG,
         ...(options.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme.isDark.value ? 'dark' : 'light') } : {}),
@@ -432,6 +448,15 @@ export function usePlaygroundFiles () {
     rebuildImportMap()
   })
 
+  // Inject Paper CSS / icon plugin when the user starts (or stops) importing a DS.
+  watch(() => {
+    const usage = detectPaperUsage(scanFiles())
+    return `${usage.emerald}:${usage.bulma}`
+  }, (next, prev) => {
+    if (!isReady.value || next === prev) return
+    rebuildMain()
+  })
+
   watch(() => store.activeFile?.code, code => {
     if (code === undefined) return
     const flatPath = aliasMap.value.get(store.activeFile.filename)
@@ -460,7 +485,7 @@ export function usePlaygroundFiles () {
     const options = preset.mainOptions
     await store.setFiles(
       {
-        'src/main.ts': createMainTs(theme_, options, vuetifyVersion.value, vuetifyNightly.value),
+        'src/main.ts': createMainTs(theme_, { ...options, ...detectPaperUsage(preset.files) }, vuetifyVersion.value, vuetifyNightly.value),
         'src/uno.config.ts': UNO_CONFIG_TS,
         'tsconfig.json': REPL_TSCONFIG,
         ...(options?.vuetify ? { 'src/vuetify.ts': createVuetifyTs(theme_) } : {}),

--- a/apps/playground/src/data/playground-defaults.test.ts
+++ b/apps/playground/src/data/playground-defaults.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 // Data
-import { createMainTs } from './playground-defaults'
+import { createMainTs, detectPaperUsage, paperCdnImports, paperEsmUrl, v0CdnImports } from './playground-defaults'
 
 describe('createMainTs', () => {
   it('should keep default light and dark themes', () => {
@@ -9,6 +9,8 @@ describe('createMainTs', () => {
     expect(source).toContain('default: \'light\'')
     expect(source).toContain('#3b82f6')
     expect(source).toContain('#c4b5fd')
+    expect(source).not.toContain('@paper/emerald')
+    expect(source).not.toContain('@paper/bulma')
   })
 
   it('should merge extra palettes and overwrite matching ids', () => {
@@ -54,6 +56,22 @@ describe('createMainTs', () => {
     expect(source).not.toContain('alert(1)')
   })
 
+  it('should inject emerald CSS and the icon plugin when emerald is set', () => {
+    const source = createMainTs('light', { emerald: true })
+    expect(source).toContain('import { createEmeraldIconsPlugin } from \'@paper/emerald\'')
+    expect(source).toContain('https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/theme.css')
+    expect(source).toContain('https://cdn.jsdelivr.net/npm/@paper/emerald@latest/dist/style.css')
+    expect(source).toContain('app.use(createEmeraldIconsPlugin())')
+    expect(source).toContain('link.dataset.presetCss = \'emerald\'')
+  })
+
+  it('should inject bulma.css when bulma is set', () => {
+    const source = createMainTs('light', { bulma: true })
+    expect(source).toContain('https://cdn.jsdelivr.net/npm/bulma@latest/css/bulma.min.css')
+    expect(source).toContain('link.dataset.presetCss = \'bulma\'')
+    expect(source).not.toContain('@paper/emerald')
+  })
+
   it('should drop constructor keys, url() values, and css comments', () => {
     const source = createMainTs('ok-theme', undefined, 'latest', false, {
       'constructor': { dark: true, colors: { primary: '#111111' } },
@@ -71,5 +89,44 @@ describe('createMainTs', () => {
     expect(source).not.toContain('javascript:alert')
     expect(source).not.toContain('red /*')
     expect(source).toContain('#00ff00')
+  })
+})
+
+describe('v0CdnImports', () => {
+  it('should map the package root and the utilities subpath Paper DS builds import', () => {
+    expect(v0CdnImports('1.2.0')).toEqual({
+      '@vuetify/v0': 'https://cdn.jsdelivr.net/npm/@vuetify/v0@1.2.0/dist/index.mjs',
+      '@vuetify/v0/utilities': 'https://cdn.jsdelivr.net/npm/@vuetify/v0@1.2.0/dist/utilities/index.mjs',
+    })
+  })
+})
+
+describe('paperCdnImports', () => {
+  it('should map both design systems to jsDelivr ESM entries', () => {
+    expect(paperEsmUrl('bulma')).toBe('https://cdn.jsdelivr.net/npm/@paper/bulma@latest/dist/index.mjs')
+    expect(paperCdnImports('0.1.0')).toEqual({
+      '@paper/bulma': 'https://cdn.jsdelivr.net/npm/@paper/bulma@0.1.0/dist/index.mjs',
+      '@paper/emerald': 'https://cdn.jsdelivr.net/npm/@paper/emerald@0.1.0/dist/index.mjs',
+      '@paper/emerald/style.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@0.1.0/dist/style.css',
+      '@paper/emerald/theme.css': 'https://cdn.jsdelivr.net/npm/@paper/emerald@0.1.0/dist/theme.css',
+    })
+  })
+})
+
+describe('detectPaperUsage', () => {
+  it('should detect paper specifiers in user files', () => {
+    expect(detectPaperUsage({
+      'src/App.vue': 'import { BuModal } from \'@paper/bulma\'\n',
+    })).toEqual({ emerald: false, bulma: true })
+    expect(detectPaperUsage({
+      'src/App.vue': 'import { EmButton } from \'@paper/emerald\'\n',
+    })).toEqual({ emerald: true, bulma: false })
+  })
+
+  it('should ignore generated main.ts so injected plugin imports cannot latch', () => {
+    expect(detectPaperUsage({
+      'src/main.ts': 'import { createEmeraldIconsPlugin } from \'@paper/emerald\'\n',
+      'src/App.vue': 'export default {}\n',
+    })).toEqual({ emerald: false, bulma: false })
   })
 })

--- a/apps/playground/src/data/playground-defaults.ts
+++ b/apps/playground/src/data/playground-defaults.ts
@@ -61,6 +61,10 @@ export interface MainOptions {
   vuetify?: boolean
   /** Set to false to omit @vuetify/v0 theme plugin and UnoCSS (e.g. for Vuetify 4 preset) */
   v0?: boolean
+  /** Load @paper/emerald CSS + icon plugin when user files import it */
+  emerald?: boolean
+  /** Load bulma.css when user files import @paper/bulma */
+  bulma?: boolean
 }
 
 /**
@@ -101,6 +105,83 @@ export function vuetifyEsmUrl (version = 'latest', nightly = false): string {
 function vuetifyCssUrl (version = 'latest', nightly = false): string {
   const pkg = nightly ? '@vuetify/nightly' : 'vuetify'
   return `https://cdn.jsdelivr.net/npm/${pkg}@${version}/dist/vuetify-labs.css`
+}
+
+/** Sandbox import-map entries for `@vuetify/v0`, including subpaths Paper DS builds import. */
+export function v0CdnImports (version = 'latest'): Record<string, string> {
+  const base = `https://cdn.jsdelivr.net/npm/@vuetify/v0@${version}/dist`
+  return {
+    '@vuetify/v0': `${base}/index.mjs`,
+    '@vuetify/v0/utilities': `${base}/utilities/index.mjs`,
+  }
+}
+
+/**
+ * jsDelivr ESM entry for a published `@paper/*` design system.
+ *
+ * Always jsDelivr, never esm.sh — these packages import `vue` / `@vuetify/v0`
+ * as bare specifiers and must share the REPL's copies. esm.sh without
+ * `?external=` would dual-bundle Vue.
+ */
+export function paperEsmUrl (pkg: 'emerald' | 'bulma', version = 'latest'): string {
+  return `https://cdn.jsdelivr.net/npm/@paper/${pkg}@${version}/dist/index.mjs`
+}
+
+/** Sandbox import-map entries for Paper design systems, including CSS subpaths. */
+export function paperCdnImports (version = 'latest'): Record<string, string> {
+  return {
+    '@paper/bulma': paperEsmUrl('bulma', version),
+    '@paper/emerald': paperEsmUrl('emerald', version),
+    '@paper/emerald/style.css': `https://cdn.jsdelivr.net/npm/@paper/emerald@${version}/dist/style.css`,
+    '@paper/emerald/theme.css': `https://cdn.jsdelivr.net/npm/@paper/emerald@${version}/dist/theme.css`,
+  }
+}
+
+const PAPER_SCAN_SKIP = new Set([
+  'src/main.ts',
+  'src/uno.config.ts',
+  'src/vuetify.ts',
+  'import-map.json',
+  'tsconfig.json',
+])
+
+/**
+ * Detect `@paper/*` specifiers in user files. Skips generated infrastructure
+ * so injecting CSS/plugin imports into `main.ts` cannot latch the flag.
+ */
+export function detectPaperUsage (files: Record<string, string>): { emerald: boolean, bulma: boolean } {
+  let emerald = false
+  let bulma = false
+  for (const [path, code] of Object.entries(files)) {
+    if (PAPER_SCAN_SKIP.has(path)) continue
+    if (!emerald && code.includes('@paper/emerald')) emerald = true
+    if (!bulma && code.includes('@paper/bulma')) bulma = true
+    if (emerald && bulma) break
+  }
+  return { emerald, bulma }
+}
+
+function paperCssUrls (system: 'emerald' | 'bulma', version = 'latest'): string[] {
+  if (system === 'emerald') {
+    return [
+      `https://cdn.jsdelivr.net/npm/@paper/emerald@${version}/dist/theme.css`,
+      `https://cdn.jsdelivr.net/npm/@paper/emerald@${version}/dist/style.css`,
+    ]
+  }
+  return ['https://cdn.jsdelivr.net/npm/bulma@latest/css/bulma.min.css']
+}
+
+function stylesheetSetup (preset: string, hrefs: string[]): string[] {
+  if (hrefs.length === 0) return []
+  return [
+    `for (const href of [`,
+    ...hrefs.map(href => `  '${href}',`),
+    `]) {`,
+    `  const link = Object.assign(document.createElement('link'), { rel: 'stylesheet', href })`,
+    `  link.dataset.presetCss = '${preset}'`,
+    `  document.head.appendChild(link)`,
+    `}`,
+  ]
 }
 
 const DEFAULT_SANDBOX_THEMES: { light: PlaygroundThemeDefinition, dark: PlaygroundThemeDefinition } = {
@@ -212,6 +293,14 @@ export function createMainTs (defaultTheme = 'light', options?: MainOptions, vue
       `}`,
     )
     extraPlugins.push(`app.use(vuetify)`)
+  }
+  if (options?.emerald) {
+    extraImports.push(`import { createEmeraldIconsPlugin } from '@paper/emerald'`)
+    extraSetup.push(...stylesheetSetup('emerald', paperCssUrls('emerald')))
+    extraPlugins.push(`app.use(createEmeraldIconsPlugin())`)
+  }
+  if (options?.bulma) {
+    extraSetup.push(...stylesheetSetup('bulma', paperCssUrls('bulma')))
   }
 
   const importBlock = extraImports.length > 0 ? '\n' + extraImports.join('\n') : ''

--- a/apps/playground/src/data/registry.ts
+++ b/apps/playground/src/data/registry.ts
@@ -160,7 +160,12 @@ function exampleToPlayground (example: RegistryExample): {
   const imports: Record<string, string> = {}
 
   for (const dep of example.dependencies) {
-    if (dep === 'vue' || dep.startsWith('vue/') || dep === '@vuetify/v0') continue
+    if (
+      dep === 'vue'
+      || dep.startsWith('vue/')
+      || dep === '@vuetify/v0'
+      || dep.startsWith('@paper/')
+    ) continue
     imports[dep] = `https://esm.sh/${dep}`
   }
 


### PR DESCRIPTION
v0play only mapped `@vuetify/v0`, so `import { … } from '@paper/bulma'` (and emerald) threw `Failed to resolve module specifier`.

Puts both packages on the sandbox import map via jsDelivr (sharing the REPL's Vue / `@vuetify/v0` copies, including the `/utilities` subpath Emerald's published build imports), injects their CSS when user files import them, and embeds the same URLs in docs playground hashes so older v0play builds still resolve.