### PR TITLE
feat(bulma): reach a compound's parts from the parent import

### DIFF
--- a/.changeset/bu-compound-parent-exports.md
+++ b/.changeset/bu-compound-parent-exports.md
@@ -1,0 +1,25 @@
+---
+"@paper/bulma": minor
+---
+
+feat(bulma): reach a compound's parts from the parent import
+
+Importing `BuModal` now brings its whole tree with it — `<BuModal.Head />`, `<BuModal.Title />`, and the rest — so a compound costs one import instead of eight. The sub-key drops the parent prefix (`BuModalHead` is `BuModal.Head`, `BuNumberFieldInput` is `BuNumberField.Input`).
+
+```vue
+<script setup lang="ts">
+  import { BuModal } from '@paper/bulma'
+</script>
+
+<template>
+  <BuModal>
+    <BuModal.Card>
+      <BuModal.Head>
+        <BuModal.Title />
+      </BuModal.Head>
+    </BuModal.Card>
+  </BuModal>
+</template>
+```
+
+Nothing is removed: every flat name (`BuModalHead`, `BuDropdownMenu`, …) is still exported and resolves to the same component, so existing imports keep working and the two styles can be mixed.

--- a/DESIGN_SYSTEMS.md
+++ b/DESIGN_SYSTEMS.md
@@ -67,10 +67,11 @@ file per component:
 **Additional rulings, compat only:**
 
 - **No named slots.** Every region is an express part component named after the
-  upstream part class (`BuModalHead`, `BuDropdownMenu`). List-shaped families
-  (breadcrumb, pagination, menu, file) are parts too, not `items` props. Parts
-  read parent state through optional context and warn in dev when it is missing;
-  parts backed by a v0 context throw instead.
+  upstream part class (`BuModalHead`, `BuDropdownMenu`). Those parts also attach
+  to the parent export (`BuModal.Head`, `BuDropdown.Menu`); the flat names remain
+  valid. List-shaped families (breadcrumb, pagination, menu, file) are parts too,
+  not `items` props. Parts read parent state through optional context and warn in
+  dev when it is missing; parts backed by a v0 context throw instead.
 - **Optional peer** for the upstream CSS package. Zero-config consumers load it
   off-CDN. The package never imports it.
 - **Conformance harness** is the factory asset: fixtures captured from upstream

--- a/apps/docs/src/examples/systems/bulma/breadcrumb/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/breadcrumb/basic.vue
@@ -1,26 +1,26 @@
 <script setup lang="ts">
-  import { BuBreadcrumb, BuBreadcrumbItem } from '@paper/bulma'
+  import { BuBreadcrumb } from '@paper/bulma'
 </script>
 
 <template>
   <BuBreadcrumb>
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Bulma
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Documentation
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Components
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem
+    <BuBreadcrumb.Item
       current
       href="#"
     >
       Breadcrumb
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
   </BuBreadcrumb>
 </template>

--- a/apps/docs/src/examples/systems/bulma/breadcrumb/icons.vue
+++ b/apps/docs/src/examples/systems/bulma/breadcrumb/icons.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-  import { BuBreadcrumb, BuBreadcrumbItem } from '@paper/bulma'
+  import { BuBreadcrumb } from '@paper/bulma'
 </script>
 
 <template>
   <BuBreadcrumb>
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       <span class="icon is-small">
         <i
           aria-hidden="true"
@@ -13,9 +13,9 @@
       </span>
 
       <span>Bulma</span>
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       <span class="icon is-small">
         <i
           aria-hidden="true"
@@ -24,9 +24,9 @@
       </span>
 
       <span>Documentation</span>
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem
+    <BuBreadcrumb.Item
       current
       href="#"
     >
@@ -38,6 +38,6 @@
       </span>
 
       <span>Breadcrumb</span>
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
   </BuBreadcrumb>
 </template>

--- a/apps/docs/src/examples/systems/bulma/breadcrumb/separators.vue
+++ b/apps/docs/src/examples/systems/bulma/breadcrumb/separators.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuBreadcrumb, BuBreadcrumbItem } from '@paper/bulma'
+  import { BuBreadcrumb } from '@paper/bulma'
 </script>
 
 <template>
@@ -9,46 +9,46 @@
     class="mb-5"
     separator="arrow"
   >
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Bulma
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Documentation
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Components
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem
+    <BuBreadcrumb.Item
       current
       href="#"
     >
       Breadcrumb
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
   </BuBreadcrumb>
 
   <p class="is-size-7 has-text-grey mb-2">bullet</p>
 
   <BuBreadcrumb separator="bullet">
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Bulma
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Documentation
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Components
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem
+    <BuBreadcrumb.Item
       current
       href="#"
     >
       Breadcrumb
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
   </BuBreadcrumb>
 </template>

--- a/apps/docs/src/examples/systems/bulma/dropdown/alignment.vue
+++ b/apps/docs/src/examples/systems/bulma/dropdown/alignment.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -15,7 +15,7 @@
 
   <div class="is-flex is-justify-content-space-between">
     <BuDropdown v-model="up" up>
-      <BuDropdownTrigger v-slot="{ attrs }">
+      <BuDropdown.Trigger v-slot="{ attrs }">
         <button class="button" type="button" v-bind="attrs">
           <span>Opens up</span>
 
@@ -23,17 +23,17 @@
             <i aria-hidden="true" class="fas fa-angle-up" />
           </span>
         </button>
-      </BuDropdownTrigger>
+      </BuDropdown.Trigger>
 
-      <BuDropdownMenu v-slot="{ close }">
+      <BuDropdown.Menu v-slot="{ close }">
         <a class="dropdown-item" @click="close">Overview</a>
 
         <a class="dropdown-item" @click="close">Modifiers</a>
-      </BuDropdownMenu>
+      </BuDropdown.Menu>
     </BuDropdown>
 
     <BuDropdown v-model="right" right>
-      <BuDropdownTrigger v-slot="{ attrs }">
+      <BuDropdown.Trigger v-slot="{ attrs }">
         <button class="button" type="button" v-bind="attrs">
           <span>Aligns right</span>
 
@@ -41,13 +41,13 @@
             <i aria-hidden="true" class="fas fa-angle-down" />
           </span>
         </button>
-      </BuDropdownTrigger>
+      </BuDropdown.Trigger>
 
-      <BuDropdownMenu v-slot="{ close }">
+      <BuDropdown.Menu v-slot="{ close }">
         <a class="dropdown-item" @click="close">Overview</a>
 
         <a class="dropdown-item" @click="close">Modifiers</a>
-      </BuDropdownMenu>
+      </BuDropdown.Menu>
     </BuDropdown>
   </div>
 </template>

--- a/apps/docs/src/examples/systems/bulma/dropdown/arbitrary.vue
+++ b/apps/docs/src/examples/systems/bulma/dropdown/arbitrary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,7 +8,7 @@
 
 <template>
   <BuDropdown v-model="open">
-    <BuDropdownTrigger v-slot="{ attrs }">
+    <BuDropdown.Trigger v-slot="{ attrs }">
       <button class="button" type="button" v-bind="attrs">
         <span>Content</span>
 
@@ -16,9 +16,9 @@
           <i aria-hidden="true" class="fas fa-angle-down" />
         </span>
       </button>
-    </BuDropdownTrigger>
+    </BuDropdown.Trigger>
 
-    <BuDropdownMenu v-slot="{ close }">
+    <BuDropdown.Menu v-slot="{ close }">
       <div class="dropdown-item">
         <p>
           You can insert <strong>any type of content</strong> within the dropdown
@@ -33,6 +33,6 @@
           Got it
         </button>
       </div>
-    </BuDropdownMenu>
+    </BuDropdown.Menu>
   </BuDropdown>
 </template>

--- a/apps/docs/src/examples/systems/bulma/dropdown/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/dropdown/basic.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 </script>
 
 <template>
   <BuDropdown menu>
-    <BuDropdownTrigger v-slot="{ isOpen, attrs }">
+    <BuDropdown.Trigger v-slot="{ isOpen, attrs }">
       <button class="button" type="button" v-bind="attrs">
         <span>Dropdown button</span>
 
@@ -12,9 +12,9 @@
           <i aria-hidden="true" class="fas" :class="isOpen ? 'fa-angle-up' : 'fa-angle-down'" />
         </span>
       </button>
-    </BuDropdownTrigger>
+    </BuDropdown.Trigger>
 
-    <BuDropdownMenu v-slot="{ close, item }">
+    <BuDropdown.Menu v-slot="{ close, item }">
       <a class="dropdown-item" v-bind="item" @click="close">Dropdown item</a>
 
       <a class="dropdown-item" v-bind="item" @click="close">Other dropdown item</a>
@@ -24,6 +24,6 @@
       <hr class="dropdown-divider">
 
       <a class="dropdown-item" v-bind="item" @click="close">With a divider</a>
-    </BuDropdownMenu>
+    </BuDropdown.Menu>
   </BuDropdown>
 </template>

--- a/apps/docs/src/examples/systems/bulma/dropdown/hoverable.vue
+++ b/apps/docs/src/examples/systems/bulma/dropdown/hoverable.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 </script>
 
 <template>
   <BuDropdown hoverable>
-    <BuDropdownTrigger v-slot="{ attrs }">
+    <BuDropdown.Trigger v-slot="{ attrs }">
       <button class="button" type="button" v-bind="attrs">
         <span>Hover me</span>
 
@@ -12,12 +12,12 @@
           <i aria-hidden="true" class="fas fa-angle-down" />
         </span>
       </button>
-    </BuDropdownTrigger>
+    </BuDropdown.Trigger>
 
-    <BuDropdownMenu>
+    <BuDropdown.Menu>
       <a class="dropdown-item">Overview</a>
 
       <a class="dropdown-item">Modifiers</a>
-    </BuDropdownMenu>
+    </BuDropdown.Menu>
   </BuDropdown>
 </template>

--- a/apps/docs/src/examples/systems/bulma/dropdown/items.vue
+++ b/apps/docs/src/examples/systems/bulma/dropdown/items.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -15,7 +15,7 @@
 
 <template>
   <BuDropdown v-model="open" menu>
-    <BuDropdownTrigger v-slot="{ isOpen, attrs }">
+    <BuDropdown.Trigger v-slot="{ isOpen, attrs }">
       <button class="button" type="button" v-bind="attrs">
         <span>Documentation</span>
 
@@ -23,9 +23,9 @@
           <i aria-hidden="true" class="fas" :class="isOpen ? 'fa-angle-up' : 'fa-angle-down'" />
         </span>
       </button>
-    </BuDropdownTrigger>
+    </BuDropdown.Trigger>
 
-    <BuDropdownMenu v-slot="{ close, item }">
+    <BuDropdown.Menu v-slot="{ close, item }">
       <a
         v-for="entry in sections"
         :key="entry.value"
@@ -40,6 +40,6 @@
       <hr class="dropdown-divider">
 
       <a class="dropdown-item" v-bind="item" @click="close">Report an issue</a>
-    </BuDropdownMenu>
+    </BuDropdown.Menu>
   </BuDropdown>
 </template>

--- a/apps/docs/src/examples/systems/bulma/field/horizontal.vue
+++ b/apps/docs/src/examples/systems/bulma/field/horizontal.vue
@@ -2,8 +2,6 @@
   import {
     BuControl,
     BuField,
-    BuFieldBody,
-    BuFieldLabel,
     BuHelp,
     BuInput,
     BuLabel,
@@ -16,11 +14,11 @@
 
 <template>
   <BuField horizontal>
-    <BuFieldLabel size="normal">
+    <BuField.Label size="normal">
       <BuLabel>Subject</BuLabel>
-    </BuFieldLabel>
+    </BuField.Label>
 
-    <BuFieldBody>
+    <BuField.Body>
       <BuField>
         <BuControl>
           <BuInput
@@ -31,6 +29,6 @@
 
         <BuHelp color="danger">This field is required</BuHelp>
       </BuField>
-    </BuFieldBody>
+    </BuField.Body>
   </BuField>
 </template>

--- a/apps/docs/src/examples/systems/bulma/file/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/file/basic.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
-  import { BuFile, BuFileCta, BuFileIcon } from '@paper/bulma'
+  import { BuFile } from '@paper/bulma'
 </script>
 
 <template>
   <BuFile name="resume">
-    <BuFileCta>
-      <BuFileIcon>
+    <BuFile.Cta>
+      <BuFile.Icon>
         <i class="fas fa-upload" />
-      </BuFileIcon>
+      </BuFile.Icon>
 
       <span class="file-label">Choose a file…</span>
-    </BuFileCta>
+    </BuFile.Cta>
   </BuFile>
 </template>

--- a/apps/docs/src/examples/systems/bulma/file/filename.vue
+++ b/apps/docs/src/examples/systems/bulma/file/filename.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-  import { BuFile, BuFileCta, BuFileIcon, BuFileName } from '@paper/bulma'
+  import { BuFile } from '@paper/bulma'
 </script>
 
 <template>
   <BuFile filename name="resume">
-    <BuFileCta>
-      <BuFileIcon>
+    <BuFile.Cta>
+      <BuFile.Icon>
         <i class="fas fa-upload" />
-      </BuFileIcon>
+      </BuFile.Icon>
 
       <span class="file-label">Choose a file…</span>
-    </BuFileCta>
+    </BuFile.Cta>
 
-    <BuFileName />
+    <BuFile.Name />
   </BuFile>
 </template>

--- a/apps/docs/src/examples/systems/bulma/menu/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/menu/basic.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-  import {
-    BuMenu,
-    BuMenuItem,
-    BuMenuLabel,
-    BuMenuLink,
-    BuMenuList,
-  } from '@paper/bulma'
+  import { BuMenu } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -14,32 +8,32 @@
 
 <template>
   <BuMenu v-model="active">
-    <BuMenuLabel>General</BuMenuLabel>
+    <BuMenu.Label>General</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Dashboard">Dashboard</BuMenuLink>
-      </BuMenuItem>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Dashboard">Dashboard</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Customers">Customers</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Customers">Customers</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
 
-    <BuMenuLabel>Transactions</BuMenuLabel>
+    <BuMenu.Label>Transactions</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Payments">Payments</BuMenuLink>
-      </BuMenuItem>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Payments">Payments</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Transfers">Transfers</BuMenuLink>
-      </BuMenuItem>
+      <BuMenu.Item>
+        <BuMenu.Link value="Transfers">Transfers</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Balance">Balance</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Balance">Balance</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
   </BuMenu>
 </template>

--- a/apps/docs/src/examples/systems/bulma/menu/nested.vue
+++ b/apps/docs/src/examples/systems/bulma/menu/nested.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-  import {
-    BuMenu,
-    BuMenuItem,
-    BuMenuLabel,
-    BuMenuLink,
-    BuMenuList,
-  } from '@paper/bulma'
+  import { BuMenu } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -14,51 +8,51 @@
 
 <template>
   <BuMenu v-model="active">
-    <BuMenuLabel>Administration</BuMenuLabel>
+    <BuMenu.Label>Administration</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Team Settings">
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Team Settings">
           <span class="icon is-small">
             <i aria-hidden="true" class="fas fa-cog" />
           </span>
 
           <span>Team Settings</span>
-        </BuMenuLink>
-      </BuMenuItem>
+        </BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Manage Your Team">
+      <BuMenu.Item>
+        <BuMenu.Link value="Manage Your Team">
           <span class="icon is-small">
             <i aria-hidden="true" class="fas fa-users" />
           </span>
 
           <span>Manage Your Team</span>
           <span class="tag is-info is-light ml-2">3</span>
-        </BuMenuLink>
+        </BuMenu.Link>
 
-        <BuMenuList nested>
-          <BuMenuItem>
-            <BuMenuLink value="Members">Members</BuMenuLink>
-          </BuMenuItem>
+        <BuMenu.List nested>
+          <BuMenu.Item>
+            <BuMenu.Link value="Members">Members</BuMenu.Link>
+          </BuMenu.Item>
 
-          <BuMenuItem>
-            <BuMenuLink value="Plugins">Plugins</BuMenuLink>
-          </BuMenuItem>
+          <BuMenu.Item>
+            <BuMenu.Link value="Plugins">Plugins</BuMenu.Link>
+          </BuMenu.Item>
 
-          <BuMenuItem>
-            <BuMenuLink value="Add a member">Add a member</BuMenuLink>
-          </BuMenuItem>
-        </BuMenuList>
-      </BuMenuItem>
+          <BuMenu.Item>
+            <BuMenu.Link value="Add a member">Add a member</BuMenu.Link>
+          </BuMenu.Item>
+        </BuMenu.List>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Invitations">Invitations</BuMenuLink>
-      </BuMenuItem>
+      <BuMenu.Item>
+        <BuMenu.Link value="Invitations">Invitations</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Authentication">Authentication</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Authentication">Authentication</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
   </BuMenu>
 </template>

--- a/apps/docs/src/examples/systems/bulma/message/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/message/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuMessage, BuMessageBody, BuMessageDelete, BuMessageHeader } from '@paper/bulma'
+  import { BuMessage } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -17,16 +17,16 @@
   </button>
 
   <BuMessage v-model="open">
-    <BuMessageHeader>
+    <BuMessage.Header>
       <p>Hello World</p>
-      <BuMessageDelete />
-    </BuMessageHeader>
+      <BuMessage.Delete />
+    </BuMessage.Header>
 
-    <BuMessageBody>
+    <BuMessage.Body>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec
       nulla. Vestibulum rhoncus ac ex sit amet fringilla. Nullam gravida purus
       diam, et dictum <a>felis venenatis</a> efficitur.
-    </BuMessageBody>
+    </BuMessage.Body>
   </BuMessage>
 </template>

--- a/apps/docs/src/examples/systems/bulma/message/body-only.vue
+++ b/apps/docs/src/examples/systems/bulma/message/body-only.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-  import { BuMessage, BuMessageBody } from '@paper/bulma'
+  import { BuMessage } from '@paper/bulma'
 </script>
 
 <template>
   <BuMessage>
-    <BuMessageBody>
+    <BuMessage.Body>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec
       nulla. Vestibulum rhoncus ac ex sit amet fringilla. Nullam gravida purus
       diam, et dictum <a>felis venenatis</a> efficitur.
-    </BuMessageBody>
+    </BuMessage.Body>
   </BuMessage>
 </template>

--- a/apps/docs/src/examples/systems/bulma/modal/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/modal/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuModal, BuModalClose, BuModalContent } from '@paper/bulma'
+  import { BuModal } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -12,7 +12,7 @@
   </button>
 
   <BuModal v-model="open">
-    <BuModalContent>
+    <BuModal.Content>
       <div class="box">
         <h3 class="title is-5">Bring your own JS</h3>
 
@@ -21,8 +21,8 @@
           return and the backdrop click come from Vuetify0.
         </p>
       </div>
-    </BuModalContent>
+    </BuModal.Content>
 
-    <BuModalClose />
+    <BuModal.Close />
   </BuModal>
 </template>

--- a/apps/docs/src/examples/systems/bulma/modal/card.vue
+++ b/apps/docs/src/examples/systems/bulma/modal/card.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuModal, BuModalBody, BuModalCard, BuModalDelete, BuModalFoot, BuModalHead, BuModalTitle } from '@paper/bulma'
+  import { BuModal } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -12,21 +12,21 @@
   </button>
 
   <BuModal v-model="open">
-    <BuModalCard>
-      <BuModalHead>
-        <BuModalTitle>Modal title</BuModalTitle>
-        <BuModalDelete />
-      </BuModalHead>
+    <BuModal.Card>
+      <BuModal.Head>
+        <BuModal.Title>Modal title</BuModal.Title>
+        <BuModal.Delete />
+      </BuModal.Head>
 
-      <BuModalBody>
+      <BuModal.Body>
         <p>
-          Composing <code>BuModalCard</code> renders the <code>.modal-card</code>
-          variant: head, body and foot regions. Compose <code>BuModalDelete</code>
+          Composing <code>BuModal.Card</code> renders the <code>.modal-card</code>
+          variant: head, body and foot regions. Compose <code>BuModal.Delete</code>
           in the head for the card-head X.
         </p>
-      </BuModalBody>
+      </BuModal.Body>
 
-      <BuModalFoot>
+      <BuModal.Foot>
         <div class="buttons">
           <button class="button is-success" type="button" @click="open = false">
             Save changes
@@ -36,7 +36,7 @@
             Cancel
           </button>
         </div>
-      </BuModalFoot>
-    </BuModalCard>
+      </BuModal.Foot>
+    </BuModal.Card>
   </BuModal>
 </template>

--- a/apps/docs/src/examples/systems/bulma/navbar/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/navbar/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuNavbar, BuNavbarBrand, BuNavbarMenu } from '@paper/bulma'
+  import { BuNavbar } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,13 +8,13 @@
 
 <template>
   <BuNavbar v-model="open">
-    <BuNavbarBrand>
+    <BuNavbar.Brand>
       <a class="navbar-item" href="https://bulma.io">
         <strong>Bulma</strong>
       </a>
-    </BuNavbarBrand>
+    </BuNavbar.Brand>
 
-    <BuNavbarMenu>
+    <BuNavbar.Menu>
       <div class="navbar-start">
         <a class="navbar-item">Home</a>
 
@@ -44,6 +44,6 @@
           </div>
         </div>
       </div>
-    </BuNavbarMenu>
+    </BuNavbar.Menu>
   </BuNavbar>
 </template>

--- a/apps/docs/src/examples/systems/bulma/navbar/color.vue
+++ b/apps/docs/src/examples/systems/bulma/navbar/color.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuNavbar, BuNavbarBrand, BuNavbarMenu } from '@paper/bulma'
+  import { BuNavbar } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,13 +8,13 @@
 
 <template>
   <BuNavbar v-model="open" color="primary">
-    <BuNavbarBrand>
+    <BuNavbar.Brand>
       <a class="navbar-item" href="https://bulma.io">
         <strong>Bulma</strong>
       </a>
-    </BuNavbarBrand>
+    </BuNavbar.Brand>
 
-    <BuNavbarMenu>
+    <BuNavbar.Menu>
       <div class="navbar-start">
         <a class="navbar-item">Home</a>
         <a class="navbar-item">Documentation</a>
@@ -31,6 +31,6 @@
           </div>
         </div>
       </div>
-    </BuNavbarMenu>
+    </BuNavbar.Menu>
   </BuNavbar>
 </template>

--- a/apps/docs/src/examples/systems/bulma/notification/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/notification/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuNotification, BuNotificationDelete } from '@paper/bulma'
+  import { BuNotification } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -17,7 +17,7 @@
   </button>
 
   <BuNotification v-model="open">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Lorem ipsum dolor sit amet, consectetur adipiscing elit lorem ipsum dolor.
     <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec
     nulla. Vestibulum rhoncus ac ex sit amet fringilla. Nullam gravida purus diam,

--- a/apps/docs/src/examples/systems/bulma/notification/color.vue
+++ b/apps/docs/src/examples/systems/bulma/notification/color.vue
@@ -1,30 +1,30 @@
 <script setup lang="ts">
-  import { BuNotification, BuNotificationDelete } from '@paper/bulma'
+  import { BuNotification } from '@paper/bulma'
 </script>
 
 <template>
   <BuNotification class="mb-4" color="primary">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Primary — the brand color, for context with no action attached.
   </BuNotification>
 
   <BuNotification class="mb-4" color="info">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Info — supporting context. Put the meaning in the words, not the tint.
   </BuNotification>
 
   <BuNotification class="mb-4" color="success">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Success — a completed action. Dismisses the same way as the others.
   </BuNotification>
 
   <BuNotification class="mb-4" color="warning">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Warning — something will go wrong if ignored.
   </BuNotification>
 
   <BuNotification color="danger">
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Danger — something failed and needs action.
   </BuNotification>
 </template>

--- a/apps/docs/src/examples/systems/bulma/number-field/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/number-field/basic.vue
@@ -4,9 +4,6 @@
     BuHelp,
     BuLabel,
     BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
   } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
@@ -25,9 +22,9 @@
       :min="0"
       :step="1"
     >
-      <BuNumberFieldDecrement />
-      <BuNumberFieldInput expanded />
-      <BuNumberFieldIncrement />
+      <BuNumberField.Decrement />
+      <BuNumberField.Input expanded />
+      <BuNumberField.Increment />
     </BuNumberField>
 
     <BuHelp>Value: {{ quantity }} — the steppers go inert at 0 and 10.</BuHelp>

--- a/apps/docs/src/examples/systems/bulma/number-field/formatted.vue
+++ b/apps/docs/src/examples/systems/bulma/number-field/formatted.vue
@@ -4,9 +4,6 @@
     BuHelp,
     BuLabel,
     BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
   } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
@@ -27,9 +24,9 @@
       :min="0"
       :step="0.5"
     >
-      <BuNumberFieldDecrement />
-      <BuNumberFieldInput expanded />
-      <BuNumberFieldIncrement />
+      <BuNumberField.Decrement />
+      <BuNumberField.Input expanded />
+      <BuNumberField.Increment />
     </BuNumberField>
 
     <BuHelp>Focus the input to edit the raw number; blur it to see the currency.</BuHelp>

--- a/apps/docs/src/examples/systems/bulma/number-field/readonly.vue
+++ b/apps/docs/src/examples/systems/bulma/number-field/readonly.vue
@@ -4,9 +4,6 @@
     BuHelp,
     BuLabel,
     BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
   } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
@@ -19,9 +16,9 @@
     <BuLabel for="allocated">Allocated seats</BuLabel>
 
     <BuNumberField id="allocated" v-model="allocated" readonly>
-      <BuNumberFieldDecrement />
-      <BuNumberFieldInput expanded />
-      <BuNumberFieldIncrement />
+      <BuNumberField.Decrement />
+      <BuNumberField.Input expanded />
+      <BuNumberField.Increment />
     </BuNumberField>
 
     <BuHelp>The value is selectable and the field still takes focus; the steppers do not.</BuHelp>

--- a/apps/docs/src/examples/systems/bulma/number-field/validated.vue
+++ b/apps/docs/src/examples/systems/bulma/number-field/validated.vue
@@ -4,9 +4,6 @@
     BuHelp,
     BuLabel,
     BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
   } from '@paper/bulma'
 
   import { isNumber, NumberFieldRoot } from '@vuetify/v0'
@@ -30,9 +27,9 @@
       <BuLabel namespace="v0:number-field:root">Seats</BuLabel>
 
       <BuNumberField>
-        <BuNumberFieldDecrement />
-        <BuNumberFieldInput expanded />
-        <BuNumberFieldIncrement />
+        <BuNumberField.Decrement />
+        <BuNumberField.Input expanded />
+        <BuNumberField.Increment />
       </BuNumberField>
 
       <BuHelp namespace="v0:number-field:root" validation />

--- a/apps/docs/src/examples/systems/bulma/overview.vue
+++ b/apps/docs/src/examples/systems/bulma/overview.vue
@@ -1,50 +1,20 @@
 <script setup lang="ts">
   import {
     BuBreadcrumb,
-    BuBreadcrumbItem,
     BuCheckbox,
     BuControl,
     BuDropdown,
-    BuDropdownMenu,
-    BuDropdownTrigger,
     BuField,
     BuInput,
     BuLabel,
     BuMenu,
-    BuMenuItem,
-    BuMenuLabel,
-    BuMenuLink,
-    BuMenuList,
     BuModal,
-    BuModalBody,
-    BuModalCard,
-    BuModalDelete,
-    BuModalFoot,
-    BuModalHead,
-    BuModalTitle,
     BuNavbar,
-    BuNavbarBrand,
-    BuNavbarMenu,
     BuNotification,
-    BuNotificationDelete,
     BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
     BuPagination,
-    BuPaginationEllipsis,
-    BuPaginationItem,
-    BuPaginationList,
-    BuPaginationNext,
-    BuPaginationPrev,
     BuPanel,
-    BuPanelBlock,
-    BuPanelHeading,
-    BuPanelIcon,
     BuSelect,
-    BuTab,
-    BuTabList,
-    BuTabPanel,
     BuTabs,
   } from '@paper/bulma'
 
@@ -65,13 +35,13 @@
 
 <template>
   <BuNavbar v-model="nav">
-    <BuNavbarBrand :burger="false">
+    <BuNavbar.Brand :burger="false">
       <a class="navbar-item" href="#">
         <strong>Paper / Bulma</strong>
       </a>
-    </BuNavbarBrand>
+    </BuNavbar.Brand>
 
-    <BuNavbarMenu>
+    <BuNavbar.Menu>
       <div class="navbar-start">
         <a class="navbar-item">Dashboard</a>
         <a class="navbar-item">Documentation</a>
@@ -86,76 +56,76 @@
           </div>
         </div>
       </div>
-    </BuNavbarMenu>
+    </BuNavbar.Menu>
   </BuNavbar>
 
   <section class="section">
     <BuBreadcrumb>
-      <BuBreadcrumbItem href="#">
+      <BuBreadcrumb.Item href="#">
         Paper
-      </BuBreadcrumbItem>
+      </BuBreadcrumb.Item>
 
-      <BuBreadcrumbItem href="#">
+      <BuBreadcrumb.Item href="#">
         Bulma
-      </BuBreadcrumbItem>
+      </BuBreadcrumb.Item>
 
-      <BuBreadcrumbItem current>
+      <BuBreadcrumb.Item current>
         Dashboard
-      </BuBreadcrumbItem>
+      </BuBreadcrumb.Item>
     </BuBreadcrumb>
 
     <div class="columns">
       <div class="column is-one-quarter">
         <BuMenu v-model="section">
-          <BuMenuLabel>General</BuMenuLabel>
+          <BuMenu.Label>General</BuMenu.Label>
 
-          <BuMenuList>
-            <BuMenuItem>
-              <BuMenuLink value="Dashboard">Dashboard</BuMenuLink>
-            </BuMenuItem>
+          <BuMenu.List>
+            <BuMenu.Item>
+              <BuMenu.Link value="Dashboard">Dashboard</BuMenu.Link>
+            </BuMenu.Item>
 
-            <BuMenuItem>
-              <BuMenuLink value="Customers">Customers</BuMenuLink>
-            </BuMenuItem>
-          </BuMenuList>
+            <BuMenu.Item>
+              <BuMenu.Link value="Customers">Customers</BuMenu.Link>
+            </BuMenu.Item>
+          </BuMenu.List>
 
-          <BuMenuLabel>Transactions</BuMenuLabel>
+          <BuMenu.Label>Transactions</BuMenu.Label>
 
-          <BuMenuList>
-            <BuMenuItem>
-              <BuMenuLink value="Payments">Payments</BuMenuLink>
-            </BuMenuItem>
+          <BuMenu.List>
+            <BuMenu.Item>
+              <BuMenu.Link value="Payments">Payments</BuMenu.Link>
+            </BuMenu.Item>
 
-            <BuMenuItem>
-              <BuMenuLink value="Transfers">Transfers</BuMenuLink>
-            </BuMenuItem>
+            <BuMenu.Item>
+              <BuMenu.Link value="Transfers">Transfers</BuMenu.Link>
+            </BuMenu.Item>
 
-            <BuMenuItem>
-              <BuMenuLink value="Balance">Balance</BuMenuLink>
-            </BuMenuItem>
-          </BuMenuList>
+            <BuMenu.Item>
+              <BuMenu.Link value="Balance">Balance</BuMenu.Link>
+            </BuMenu.Item>
+          </BuMenu.List>
         </BuMenu>
       </div>
 
       <div class="column">
         <BuNotification v-model="notice" color="info">
-          <BuNotificationDelete />
+          <BuNotification.Delete />
           Bulma ships the classes. Escape, focus return, and the burger toggle
           come from Vuetify0.
         </BuNotification>
 
         <BuTabs v-model="tab">
-          <BuTabList>
-            <BuTab value="repos">Repositories</BuTab>
-            <BuTab value="settings">Settings</BuTab>
-          </BuTabList>
+          <BuTabs.List>
+            <BuTabs.Tab value="repos">Repositories</BuTabs.Tab>
+            <BuTabs.Tab value="settings">Settings</BuTabs.Tab>
+          </BuTabs.List>
 
-          <BuTabPanel value="repos">
+          <BuTabs.Panel value="repos">
             <div class="is-flex is-justify-content-space-between is-align-items-center mb-3 mt-4">
               <p class="title is-5 mb-0">{{ section }}</p>
 
               <BuDropdown menu right>
-                <BuDropdownTrigger v-slot="{ attrs }">
+                <BuDropdown.Trigger v-slot="{ attrs }">
                   <button class="button is-small" type="button" v-bind="attrs">
                     <span>Actions</span>
 
@@ -163,52 +133,52 @@
                       <i aria-hidden="true" class="fas fa-angle-down" />
                     </span>
                   </button>
-                </BuDropdownTrigger>
+                </BuDropdown.Trigger>
 
-                <BuDropdownMenu v-slot="{ close, item }">
+                <BuDropdown.Menu v-slot="{ close, item }">
                   <a class="dropdown-item" v-bind="item" @click="close(); modal = true">New repository</a>
                   <a class="dropdown-item" v-bind="item" @click="close">Clone</a>
                   <hr class="dropdown-divider">
                   <a class="dropdown-item" v-bind="item" @click="close">Settings</a>
-                </BuDropdownMenu>
+                </BuDropdown.Menu>
               </BuDropdown>
             </div>
 
             <BuPanel v-model="repo">
-              <BuPanelHeading>Repositories</BuPanelHeading>
+              <BuPanel.Heading>Repositories</BuPanel.Heading>
 
-              <BuPanelBlock value="bulma">
-                <BuPanelIcon icon="fas fa-book" />
+              <BuPanel.Block value="bulma">
+                <BuPanel.Icon icon="fas fa-book" />
                 bulma
-              </BuPanelBlock>
+              </BuPanel.Block>
 
-              <BuPanelBlock value="paper">
-                <BuPanelIcon icon="fas fa-book" />
+              <BuPanel.Block value="paper">
+                <BuPanel.Icon icon="fas fa-book" />
                 paper
-              </BuPanelBlock>
+              </BuPanel.Block>
 
-              <BuPanelBlock value="v0">
-                <BuPanelIcon icon="fas fa-code-branch" />
+              <BuPanel.Block value="v0">
+                <BuPanel.Icon icon="fas fa-code-branch" />
                 vuetify0
-              </BuPanelBlock>
+              </BuPanel.Block>
             </BuPanel>
 
             <BuPagination v-slot="{ items }" v-model="page" class="mt-4" :pages="4">
-              <BuPaginationPrev />
+              <BuPagination.Prev />
 
-              <BuPaginationNext />
+              <BuPagination.Next />
 
-              <BuPaginationList>
+              <BuPagination.List>
                 <template v-for="(item, index) in items" :key="index">
-                  <BuPaginationItem v-if="item.type === 'page'" :value="item.value" />
+                  <BuPagination.Item v-if="item.type === 'page'" :value="item.value" />
 
-                  <BuPaginationEllipsis v-else />
+                  <BuPagination.Ellipsis v-else />
                 </template>
-              </BuPaginationList>
+              </BuPagination.List>
             </BuPagination>
-          </BuTabPanel>
+          </BuTabs.Panel>
 
-          <BuTabPanel value="settings">
+          <BuTabs.Panel value="settings">
             <div class="mt-4">
               <BuField>
                 <BuLabel>Repository name</BuLabel>
@@ -234,9 +204,9 @@
                 <BuLabel>Watchers</BuLabel>
 
                 <BuNumberField v-model="watchers" :max="99" :min="0">
-                  <BuNumberFieldDecrement />
-                  <BuNumberFieldInput expanded />
-                  <BuNumberFieldIncrement />
+                  <BuNumberField.Decrement />
+                  <BuNumberField.Input expanded />
+                  <BuNumberField.Increment />
                 </BuNumberField>
               </BuField>
 
@@ -246,20 +216,20 @@
                 </BuControl>
               </BuField>
             </div>
-          </BuTabPanel>
+          </BuTabs.Panel>
         </BuTabs>
       </div>
     </div>
   </section>
 
   <BuModal v-model="modal">
-    <BuModalCard>
-      <BuModalHead>
-        <BuModalTitle>New repository</BuModalTitle>
-        <BuModalDelete />
-      </BuModalHead>
+    <BuModal.Card>
+      <BuModal.Head>
+        <BuModal.Title>New repository</BuModal.Title>
+        <BuModal.Delete />
+      </BuModal.Head>
 
-      <BuModalBody>
+      <BuModal.Body>
         <BuField>
           <BuLabel>Name</BuLabel>
 
@@ -278,9 +248,9 @@
             </BuSelect>
           </BuControl>
         </BuField>
-      </BuModalBody>
+      </BuModal.Body>
 
-      <BuModalFoot>
+      <BuModal.Foot>
         <div class="buttons">
           <button class="button is-success" type="button" @click="modal = false">
             Create
@@ -290,8 +260,8 @@
             Cancel
           </button>
         </div>
-      </BuModalFoot>
-    </BuModalCard>
+      </BuModal.Foot>
+    </BuModal.Card>
   </BuModal>
 </template>
 

--- a/apps/docs/src/examples/systems/bulma/pagination/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/pagination/basic.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-  import {
-    BuPagination,
-    BuPaginationEllipsis,
-    BuPaginationItem,
-    BuPaginationList,
-    BuPaginationNext,
-    BuPaginationPrev,
-  } from '@paper/bulma'
+  import { BuPagination } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -17,16 +10,16 @@
   <p class="is-size-7 has-text-grey mb-3">Page {{ page }} of 5</p>
 
   <BuPagination v-slot="{ items }" v-model="page" :pages="5">
-    <BuPaginationPrev>Previous</BuPaginationPrev>
+    <BuPagination.Prev>Previous</BuPagination.Prev>
 
-    <BuPaginationNext>Next page</BuPaginationNext>
+    <BuPagination.Next>Next page</BuPagination.Next>
 
-    <BuPaginationList>
+    <BuPagination.List>
       <template v-for="(item, index) in items" :key="index">
-        <BuPaginationItem v-if="item.type === 'page'" :value="item.value" />
+        <BuPagination.Item v-if="item.type === 'page'" :value="item.value" />
 
-        <BuPaginationEllipsis v-else />
+        <BuPagination.Ellipsis v-else />
       </template>
-    </BuPaginationList>
+    </BuPagination.List>
   </BuPagination>
 </template>

--- a/apps/docs/src/examples/systems/bulma/pagination/window.vue
+++ b/apps/docs/src/examples/systems/bulma/pagination/window.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-  import {
-    BuPagination,
-    BuPaginationEllipsis,
-    BuPaginationItem,
-    BuPaginationList,
-    BuPaginationNext,
-    BuPaginationPrev,
-  } from '@paper/bulma'
+  import { BuPagination } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -17,16 +10,16 @@
   <p class="is-size-7 has-text-grey mb-3">Page {{ page }} of 86 — five links visible</p>
 
   <BuPagination v-slot="{ items }" v-model="page" :pages="86" :visible="5">
-    <BuPaginationPrev>Previous</BuPaginationPrev>
+    <BuPagination.Prev>Previous</BuPagination.Prev>
 
-    <BuPaginationNext>Next page</BuPaginationNext>
+    <BuPagination.Next>Next page</BuPagination.Next>
 
-    <BuPaginationList>
+    <BuPagination.List>
       <template v-for="(item, index) in items" :key="index">
-        <BuPaginationItem v-if="item.type === 'page'" :value="item.value" />
+        <BuPagination.Item v-if="item.type === 'page'" :value="item.value" />
 
-        <BuPaginationEllipsis v-else />
+        <BuPagination.Ellipsis v-else />
       </template>
-    </BuPaginationList>
+    </BuPagination.List>
   </BuPagination>
 </template>

--- a/apps/docs/src/examples/systems/bulma/panel/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/panel/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuPanel, BuPanelBlock, BuPanelHeading, BuPanelIcon } from '@paper/bulma'
+  import { BuPanel } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,26 +8,26 @@
 
 <template>
   <BuPanel v-model="selected">
-    <BuPanelHeading>Repositories</BuPanelHeading>
+    <BuPanel.Heading>Repositories</BuPanel.Heading>
 
-    <BuPanelBlock value="bulma">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="bulma">
+      <BuPanel.Icon icon="fas fa-book" />
       bulma
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="marksheet">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="marksheet">
+      <BuPanel.Icon icon="fas fa-book" />
       marksheet
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="minireset.css">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="minireset.css">
+      <BuPanel.Icon icon="fas fa-book" />
       minireset.css
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="mojs">
-      <BuPanelIcon icon="fas fa-code-branch" />
+    <BuPanel.Block value="mojs">
+      <BuPanel.Icon icon="fas fa-code-branch" />
       mojs
-    </BuPanelBlock>
+    </BuPanel.Block>
   </BuPanel>
 </template>

--- a/apps/docs/src/examples/systems/bulma/panel/tabs.vue
+++ b/apps/docs/src/examples/systems/bulma/panel/tabs.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-  import {
-    BuPanel,
-    BuPanelBlock,
-    BuPanelHeading,
-    BuPanelIcon,
-    BuPanelTab,
-    BuPanelTabs,
-  } from '@paper/bulma'
+  import { BuPanel } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -16,7 +9,7 @@
 
 <template>
   <BuPanel v-model="selected">
-    <BuPanelHeading>Repositories</BuPanelHeading>
+    <BuPanel.Heading>Repositories</BuPanel.Heading>
 
     <div class="panel-block">
       <p class="control has-icons-left">
@@ -28,43 +21,43 @@
       </p>
     </div>
 
-    <BuPanelTabs v-model="tab">
-      <BuPanelTab value="All">All</BuPanelTab>
-      <BuPanelTab value="Public">Public</BuPanelTab>
-      <BuPanelTab value="Private">Private</BuPanelTab>
-      <BuPanelTab value="Sources">Sources</BuPanelTab>
-      <BuPanelTab value="Forks">Forks</BuPanelTab>
-    </BuPanelTabs>
+    <BuPanel.Tabs v-model="tab">
+      <BuPanel.Tab value="All">All</BuPanel.Tab>
+      <BuPanel.Tab value="Public">Public</BuPanel.Tab>
+      <BuPanel.Tab value="Private">Private</BuPanel.Tab>
+      <BuPanel.Tab value="Sources">Sources</BuPanel.Tab>
+      <BuPanel.Tab value="Forks">Forks</BuPanel.Tab>
+    </BuPanel.Tabs>
 
-    <BuPanelBlock value="bulma">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="bulma">
+      <BuPanel.Icon icon="fas fa-book" />
       bulma
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="marksheet">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="marksheet">
+      <BuPanel.Icon icon="fas fa-book" />
       marksheet
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="minireset.css">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="minireset.css">
+      <BuPanel.Icon icon="fas fa-book" />
       minireset.css
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="jgthms.github.io">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="jgthms.github.io">
+      <BuPanel.Icon icon="fas fa-book" />
       jgthms.github.io
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="daniellowtw/infboard">
-      <BuPanelIcon icon="fas fa-code-branch" />
+    <BuPanel.Block value="daniellowtw/infboard">
+      <BuPanel.Icon icon="fas fa-code-branch" />
       daniellowtw/infboard
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="mojs">
-      <BuPanelIcon icon="fas fa-code-branch" />
+    <BuPanel.Block value="mojs">
+      <BuPanel.Icon icon="fas fa-code-branch" />
       mojs
-    </BuPanelBlock>
+    </BuPanel.Block>
 
     <label class="panel-block">
       <input type="checkbox">

--- a/apps/docs/src/examples/systems/bulma/tabs/basic.vue
+++ b/apps/docs/src/examples/systems/bulma/tabs/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuTab, BuTabList, BuTabPanel, BuTabs } from '@paper/bulma'
+  import { BuTabs } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,22 +8,22 @@
 
 <template>
   <BuTabs v-model="tab">
-    <BuTabList>
-      <BuTab value="pictures">Pictures</BuTab>
+    <BuTabs.List>
+      <BuTabs.Tab value="pictures">Pictures</BuTabs.Tab>
 
-      <BuTab value="music">Music</BuTab>
-    </BuTabList>
+      <BuTabs.Tab value="music">Music</BuTabs.Tab>
+    </BuTabs.List>
 
-    <BuTabPanel value="pictures">
+    <BuTabs.Panel value="pictures">
       <div class="content mt-4">
         <p>Pictures panel.</p>
       </div>
-    </BuTabPanel>
+    </BuTabs.Panel>
 
-    <BuTabPanel value="music">
+    <BuTabs.Panel value="music">
       <div class="content mt-4">
         <p>Music panel.</p>
       </div>
-    </BuTabPanel>
+    </BuTabs.Panel>
   </BuTabs>
 </template>

--- a/apps/docs/src/examples/systems/bulma/tabs/boxed.vue
+++ b/apps/docs/src/examples/systems/bulma/tabs/boxed.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BuTab, BuTabList, BuTabPanel, BuTabs } from '@paper/bulma'
+  import { BuTabs } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -8,39 +8,39 @@
 
 <template>
   <BuTabs v-model="tab">
-    <BuTabList boxed>
-      <BuTab value="pictures">
+    <BuTabs.List boxed>
+      <BuTabs.Tab value="pictures">
         <span class="icon is-small"><i aria-hidden="true" class="fas fa-image" /></span>
         <span>Pictures</span>
-      </BuTab>
+      </BuTabs.Tab>
 
-      <BuTab value="music">
+      <BuTabs.Tab value="music">
         <span class="icon is-small"><i aria-hidden="true" class="fas fa-music" /></span>
         <span>Music</span>
-      </BuTab>
+      </BuTabs.Tab>
 
-      <BuTab value="videos">
+      <BuTabs.Tab value="videos">
         <span class="icon is-small"><i aria-hidden="true" class="fas fa-film" /></span>
         <span>Videos</span>
-      </BuTab>
-    </BuTabList>
+      </BuTabs.Tab>
+    </BuTabs.List>
 
-    <BuTabPanel value="pictures">
+    <BuTabs.Panel value="pictures">
       <div class="content mt-4">
         <p>Pictures panel.</p>
       </div>
-    </BuTabPanel>
+    </BuTabs.Panel>
 
-    <BuTabPanel value="music">
+    <BuTabs.Panel value="music">
       <div class="content mt-4">
         <p>Music panel.</p>
       </div>
-    </BuTabPanel>
+    </BuTabs.Panel>
 
-    <BuTabPanel value="videos">
+    <BuTabs.Panel value="videos">
       <div class="content mt-4">
         <p>Videos panel.</p>
       </div>
-    </BuTabPanel>
+    </BuTabs.Panel>
   </BuTabs>
 </template>

--- a/apps/docs/src/pages/systems/bulma/breadcrumb.md
+++ b/apps/docs/src/pages/systems/bulma/breadcrumb.md
@@ -38,12 +38,12 @@ Bulma's `.breadcrumb` — compose crumb items, mark the current page with `curre
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuBreadcrumb, BuBreadcrumbItem } from '@paper/bulma'
+  import { BuBreadcrumb } from '@paper/bulma'
 </script>
 
 <template>
   <BuBreadcrumb>
-    <BuBreadcrumbItem />
+    <BuBreadcrumb.Item />
   </BuBreadcrumb>
 </template>
 ```
@@ -78,24 +78,24 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuBreadcrumb>
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Bulma
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Documentation
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem href="#">
+    <BuBreadcrumb.Item href="#">
       Components
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
 
-    <BuBreadcrumbItem
+    <BuBreadcrumb.Item
       current
       href="#"
     >
       Breadcrumb
-    </BuBreadcrumbItem>
+    </BuBreadcrumb.Item>
   </BuBreadcrumb>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/dropdown.md
+++ b/apps/docs/src/pages/systems/bulma/dropdown.md
@@ -40,14 +40,14 @@ Positioning stays Bulma's. The menu is placed by CSS against the trigger, so the
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuDropdown, BuDropdownMenu, BuDropdownTrigger } from '@paper/bulma'
+  import { BuDropdown } from '@paper/bulma'
 </script>
 
 <template>
   <BuDropdown>
-    <BuDropdownTrigger />
+    <BuDropdown.Trigger />
 
-    <BuDropdownMenu />
+    <BuDropdown.Menu />
   </BuDropdown>
 </template>
 ```
@@ -90,21 +90,21 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue collapse
 <template>
   <BuDropdown menu>
-    <BuDropdownTrigger v-slot="{ attrs }">
+    <BuDropdown.Trigger v-slot="{ attrs }">
       <button class="button" type="button" v-bind="attrs">
         <span>Dropdown button</span>
         <span class="icon is-small">
           <i class="fas fa-angle-down" aria-hidden="true" />
         </span>
       </button>
-    </BuDropdownTrigger>
+    </BuDropdown.Trigger>
 
-    <BuDropdownMenu v-slot="{ close, item }">
+    <BuDropdown.Menu v-slot="{ close, item }">
       <a class="dropdown-item" v-bind="item" @click="close">Dropdown item</a>
       <a class="dropdown-item is-active" v-bind="item" @click="close">Active dropdown item</a>
       <hr class="dropdown-divider">
       <a class="dropdown-item" v-bind="item" @click="close">With a divider</a>
-    </BuDropdownMenu>
+    </BuDropdown.Menu>
   </BuDropdown>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/field.md
+++ b/apps/docs/src/pages/systems/bulma/field.md
@@ -45,8 +45,6 @@ The first tree is a stacked field. The second is the horizontal layout — a fie
   import {
     BuControl,
     BuField,
-    BuFieldBody,
-    BuFieldLabel,
     BuHelp,
     BuLabel,
   } from '@paper/bulma'
@@ -62,15 +60,15 @@ The first tree is a stacked field. The second is the horizontal layout — a fie
   </BuField>
 
   <BuField>
-    <BuFieldLabel>
+    <BuField.Label>
       <BuLabel />
-    </BuFieldLabel>
+    </BuField.Label>
 
-    <BuFieldBody>
+    <BuField.Body>
       <BuField>
         <BuControl />
       </BuField>
-    </BuFieldBody>
+    </BuField.Body>
   </BuField>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/file.md
+++ b/apps/docs/src/pages/systems/bulma/file.md
@@ -42,16 +42,16 @@ Boxed, centered, right, fullwidth, color and size all land on the root `.file`. 
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuFile, BuFileCta, BuFileIcon, BuFileName } from '@paper/bulma'
+  import { BuFile } from '@paper/bulma'
 </script>
 
 <template>
   <BuFile>
-    <BuFileCta>
-      <BuFileIcon />
-    </BuFileCta>
+    <BuFile.Cta>
+      <BuFile.Icon />
+    </BuFile.Cta>
 
-    <BuFileName />
+    <BuFile.Name />
   </BuFile>
 </template>
 ```
@@ -87,12 +87,12 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuFile name="resume">
-    <BuFileCta>
-      <BuFileIcon>
+    <BuFile.Cta>
+      <BuFile.Icon>
         <i class="fas fa-upload" />
-      </BuFileIcon>
+      </BuFile.Icon>
       <span class="file-label">Choose a file…</span>
-    </BuFileCta>
+    </BuFile.Cta>
   </BuFile>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/index.md
+++ b/apps/docs/src/pages/systems/bulma/index.md
@@ -69,7 +69,7 @@ There is no plugin to install and no provider to mount. Import a component and u
 
 ```vue collapse
 <script setup lang="ts">
-  import { BuModal, BuModalClose, BuModalContent } from '@paper/bulma'
+  import { BuModal } from '@paper/bulma'
 
   import { shallowRef } from 'vue'
 
@@ -82,16 +82,16 @@ There is no plugin to install and no provider to mount. Import a component and u
   </button>
 
   <BuModal v-model="open">
-    <BuModalContent>
+    <BuModal.Content>
       <div class="box">Your content</div>
-    </BuModalContent>
+    </BuModal.Content>
 
-    <BuModalClose />
+    <BuModal.Close />
   </BuModal>
 </template>
 ```
 
-Every region Bulma documents is an express part component — `BuModalContent`, `BuModalHead`, `BuDropdownMenu` — never a named slot. You compose the markup you already know.
+Every region Bulma documents is an express part component — `BuModal.Content`, `BuModal.Head`, `BuDropdown.Menu` — never a named slot. Import the parent; the parts hang off it. The flat names (`BuModalContent`) remain exported and valid.
 
 > [!NOTE]
 > Bulma **1.0+** only. The 0.9.x line predates Bulma's CSS variables and is explicitly unsupported. Latest verified: 1.0.4.

--- a/apps/docs/src/pages/systems/bulma/menu.md
+++ b/apps/docs/src/pages/systems/bulma/menu.md
@@ -38,24 +38,18 @@ Compose `BuMenuLabel`, `BuMenuList`, `BuMenuItem`, and `BuMenuLink`. `v-model` i
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import {
-    BuMenu,
-    BuMenuItem,
-    BuMenuLabel,
-    BuMenuLink,
-    BuMenuList,
-  } from '@paper/bulma'
+  import { BuMenu } from '@paper/bulma'
 </script>
 
 <template>
   <BuMenu>
-    <BuMenuLabel />
+    <BuMenu.Label />
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink />
-      </BuMenuItem>
-    </BuMenuList>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link />
+      </BuMenu.Item>
+    </BuMenu.List>
   </BuMenu>
 </template>
 ```
@@ -108,73 +102,73 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuMenu v-model="active">
-    <BuMenuLabel>General</BuMenuLabel>
+    <BuMenu.Label>General</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Dashboard">Dashboard</BuMenuLink>
-      </BuMenuItem>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Dashboard">Dashboard</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Customers">Customers</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Customers">Customers</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
 
-    <BuMenuLabel>Administration</BuMenuLabel>
+    <BuMenu.Label>Administration</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Team Settings">Team Settings</BuMenuLink>
-      </BuMenuItem>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Team Settings">Team Settings</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Manage Your Team">Manage Your Team</BuMenuLink>
+      <BuMenu.Item>
+        <BuMenu.Link value="Manage Your Team">Manage Your Team</BuMenu.Link>
 
-        <BuMenuList nested>
-          <BuMenuItem>
-            <BuMenuLink value="Members">Members</BuMenuLink>
-          </BuMenuItem>
+        <BuMenu.List nested>
+          <BuMenu.Item>
+            <BuMenu.Link value="Members">Members</BuMenu.Link>
+          </BuMenu.Item>
 
-          <BuMenuItem>
-            <BuMenuLink value="Plugins">Plugins</BuMenuLink>
-          </BuMenuItem>
+          <BuMenu.Item>
+            <BuMenu.Link value="Plugins">Plugins</BuMenu.Link>
+          </BuMenu.Item>
 
-          <BuMenuItem>
-            <BuMenuLink value="Add a member">Add a member</BuMenuLink>
-          </BuMenuItem>
-        </BuMenuList>
-      </BuMenuItem>
+          <BuMenu.Item>
+            <BuMenu.Link value="Add a member">Add a member</BuMenu.Link>
+          </BuMenu.Item>
+        </BuMenu.List>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Invitations">Invitations</BuMenuLink>
-      </BuMenuItem>
+      <BuMenu.Item>
+        <BuMenu.Link value="Invitations">Invitations</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Cloud Storage Environment Settings">
+      <BuMenu.Item>
+        <BuMenu.Link value="Cloud Storage Environment Settings">
           Cloud Storage Environment Settings
-        </BuMenuLink>
-      </BuMenuItem>
+        </BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Authentication">Authentication</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Authentication">Authentication</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
 
-    <BuMenuLabel>Transactions</BuMenuLabel>
+    <BuMenu.Label>Transactions</BuMenu.Label>
 
-    <BuMenuList>
-      <BuMenuItem>
-        <BuMenuLink value="Payments">Payments</BuMenuLink>
-      </BuMenuItem>
+    <BuMenu.List>
+      <BuMenu.Item>
+        <BuMenu.Link value="Payments">Payments</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Transfers">Transfers</BuMenuLink>
-      </BuMenuItem>
+      <BuMenu.Item>
+        <BuMenu.Link value="Transfers">Transfers</BuMenu.Link>
+      </BuMenu.Item>
 
-      <BuMenuItem>
-        <BuMenuLink value="Balance">Balance</BuMenuLink>
-      </BuMenuItem>
-    </BuMenuList>
+      <BuMenu.Item>
+        <BuMenu.Link value="Balance">Balance</BuMenu.Link>
+      </BuMenu.Item>
+    </BuMenu.List>
   </BuMenu>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/message.md
+++ b/apps/docs/src/pages/systems/bulma/message.md
@@ -38,16 +38,16 @@ Bulma's `.message` with a dismissible header and a headerless body-only variant.
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuMessage, BuMessageBody, BuMessageDelete, BuMessageHeader } from '@paper/bulma'
+  import { BuMessage } from '@paper/bulma'
 </script>
 
 <template>
   <BuMessage>
-    <BuMessageHeader>
-      <BuMessageDelete />
-    </BuMessageHeader>
+    <BuMessage.Header>
+      <BuMessage.Delete />
+    </BuMessage.Header>
 
-    <BuMessageBody />
+    <BuMessage.Body />
   </BuMessage>
 </template>
 ```
@@ -86,17 +86,17 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuMessage>
-    <BuMessageHeader>
+    <BuMessage.Header>
       <p>Hello World</p>
-      <BuMessageDelete />
-    </BuMessageHeader>
+      <BuMessage.Delete />
+    </BuMessage.Header>
 
-    <BuMessageBody>
+    <BuMessage.Body>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec
       nulla. Vestibulum rhoncus ac ex sit amet fringilla. Nullam gravida purus
       diam, et dictum <a>felis venenatis</a> efficitur.
-    </BuMessageBody>
+    </BuMessage.Body>
   </BuMessage>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/modal.md
+++ b/apps/docs/src/pages/systems/bulma/modal.md
@@ -40,36 +40,26 @@ Both panels are shown here for completeness — a modal composes one or the othe
 
 ```vue Anatomy no-filename collapse
 <script setup lang="ts">
-  import {
-    BuModal,
-    BuModalBody,
-    BuModalCard,
-    BuModalClose,
-    BuModalContent,
-    BuModalDelete,
-    BuModalFoot,
-    BuModalHead,
-    BuModalTitle,
-  } from '@paper/bulma'
+  import { BuModal } from '@paper/bulma'
 </script>
 
 <template>
   <BuModal>
-    <BuModalContent />
+    <BuModal.Content />
 
-    <BuModalClose />
+    <BuModal.Close />
 
-    <BuModalCard>
-      <BuModalHead>
-        <BuModalTitle />
+    <BuModal.Card>
+      <BuModal.Head>
+        <BuModal.Title />
 
-        <BuModalDelete />
-      </BuModalHead>
+        <BuModal.Delete />
+      </BuModal.Head>
 
-      <BuModalBody />
+      <BuModal.Body />
 
-      <BuModalFoot />
-    </BuModalCard>
+      <BuModal.Foot />
+    </BuModal.Card>
   </BuModal>
 </template>
 ```
@@ -114,23 +104,23 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue collapse
 <template>
   <BuModal v-model="open">
-    <BuModalCard>
-      <BuModalHead>
-        <BuModalTitle>Modal title</BuModalTitle>
-        <BuModalDelete />
-      </BuModalHead>
+    <BuModal.Card>
+      <BuModal.Head>
+        <BuModal.Title>Modal title</BuModal.Title>
+        <BuModal.Delete />
+      </BuModal.Head>
 
-      <BuModalBody>
+      <BuModal.Body>
         Content ...
-      </BuModalBody>
+      </BuModal.Body>
 
-      <BuModalFoot>
+      <BuModal.Foot>
         <div class="buttons">
           <button class="button is-success">Save changes</button>
           <button class="button">Cancel</button>
         </div>
-      </BuModalFoot>
-    </BuModalCard>
+      </BuModal.Foot>
+    </BuModal.Card>
   </BuModal>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/navbar.md
+++ b/apps/docs/src/pages/systems/bulma/navbar.md
@@ -40,14 +40,14 @@ Compose three parts: `BuNavbar` renders `nav.navbar` and owns the open state, `B
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuNavbar, BuNavbarBrand, BuNavbarMenu } from '@paper/bulma'
+  import { BuNavbar } from '@paper/bulma'
 </script>
 
 <template>
   <BuNavbar>
-    <BuNavbarBrand />
+    <BuNavbar.Brand />
 
-    <BuNavbarMenu />
+    <BuNavbar.Menu />
   </BuNavbar>
 </template>
 ```
@@ -135,13 +135,13 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue collapse
 <template>
   <BuNavbar id="navbarBasicExample" v-model="open">
-    <BuNavbarBrand>
+    <BuNavbar.Brand>
       <a class="navbar-item" href="https://bulma.io">
         <img src="logo.png" alt="Logo">
       </a>
-    </BuNavbarBrand>
+    </BuNavbar.Brand>
 
-    <BuNavbarMenu>
+    <BuNavbar.Menu>
       <div class="navbar-start">
         <a class="navbar-item">Home</a>
         <a class="navbar-item">Documentation</a>
@@ -166,7 +166,7 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
           </div>
         </div>
       </div>
-    </BuNavbarMenu>
+    </BuNavbar.Menu>
   </BuNavbar>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/notification.md
+++ b/apps/docs/src/pages/systems/bulma/notification.md
@@ -38,12 +38,12 @@ Bulma's `.notification` with a dismiss that unmounts the block.
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuNotification, BuNotificationDelete } from '@paper/bulma'
+  import { BuNotification } from '@paper/bulma'
 </script>
 
 <template>
   <BuNotification>
-    <BuNotificationDelete />
+    <BuNotification.Delete />
   </BuNotification>
 </template>
 ```
@@ -75,7 +75,7 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuNotification>
-    <BuNotificationDelete />
+    <BuNotification.Delete />
     Lorem ipsum dolor sit amet, consectetur adipiscing elit lorem ipsum dolor.
     <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec
     nulla. Vestibulum rhoncus ac ex sit amet fringilla. Nullam gravida purus diam,

--- a/apps/docs/src/pages/systems/bulma/number-field.md
+++ b/apps/docs/src/pages/systems/bulma/number-field.md
@@ -40,21 +40,16 @@ Give the input the leftover width with `expanded`. Without it the input sizes to
 
 ```vue Anatomy no-filename collapse
 <script setup lang="ts">
-  import {
-    BuNumberField,
-    BuNumberFieldDecrement,
-    BuNumberFieldIncrement,
-    BuNumberFieldInput,
-  } from '@paper/bulma'
+  import { BuNumberField } from '@paper/bulma'
 </script>
 
 <template>
   <BuNumberField>
-    <BuNumberFieldDecrement />
+    <BuNumberField.Decrement />
 
-    <BuNumberFieldInput />
+    <BuNumberField.Input />
 
-    <BuNumberFieldIncrement />
+    <BuNumberField.Increment />
   </BuNumberField>
 </template>
 ```
@@ -92,11 +87,11 @@ That changes what conformance can promise here, and the change is declared rathe
 ```vue Vue
 <template>
   <BuNumberField v-model="quantity" :max="10" :min="0">
-    <BuNumberFieldDecrement />
+    <BuNumberField.Decrement />
 
-    <BuNumberFieldInput expanded />
+    <BuNumberField.Input expanded />
 
-    <BuNumberFieldIncrement />
+    <BuNumberField.Increment />
   </BuNumberField>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/pagination.md
+++ b/apps/docs/src/pages/systems/bulma/pagination.md
@@ -38,27 +38,20 @@ Bulma's `.pagination` with the JavaScript it never shipped: current page, ellips
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import {
-    BuPagination,
-    BuPaginationEllipsis,
-    BuPaginationItem,
-    BuPaginationList,
-    BuPaginationNext,
-    BuPaginationPrev,
-  } from '@paper/bulma'
+  import { BuPagination } from '@paper/bulma'
 </script>
 
 <template>
   <BuPagination>
-    <BuPaginationPrev />
+    <BuPagination.Prev />
 
-    <BuPaginationNext />
+    <BuPagination.Next />
 
-    <BuPaginationList>
-      <BuPaginationItem />
+    <BuPagination.List>
+      <BuPagination.Item />
 
-      <BuPaginationEllipsis />
-    </BuPaginationList>
+      <BuPagination.Ellipsis />
+    </BuPagination.List>
   </BuPagination>
 </template>
 ```
@@ -112,17 +105,17 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuPagination v-slot="{ items }" v-model="page" :pages="86" :visible="7">
-    <BuPaginationPrev>Previous</BuPaginationPrev>
+    <BuPagination.Prev>Previous</BuPagination.Prev>
 
-    <BuPaginationNext>Next page</BuPaginationNext>
+    <BuPagination.Next>Next page</BuPagination.Next>
 
-    <BuPaginationList>
+    <BuPagination.List>
       <template v-for="(item, index) in items" :key="index">
-        <BuPaginationItem v-if="item.type === 'page'" :value="item.value" />
+        <BuPagination.Item v-if="item.type === 'page'" :value="item.value" />
 
-        <BuPaginationEllipsis v-else />
+        <BuPagination.Ellipsis v-else />
       </template>
-    </BuPaginationList>
+    </BuPagination.List>
   </BuPagination>
 </template>
 ```

--- a/apps/docs/src/pages/systems/bulma/panel.md
+++ b/apps/docs/src/pages/systems/bulma/panel.md
@@ -40,27 +40,20 @@ Tabs have a second `v-model` of their own. The two selections never share.
 
 ```vue Anatomy no-filename collapse
 <script setup lang="ts">
-  import {
-    BuPanel,
-    BuPanelBlock,
-    BuPanelHeading,
-    BuPanelIcon,
-    BuPanelTab,
-    BuPanelTabs,
-  } from '@paper/bulma'
+  import { BuPanel } from '@paper/bulma'
 </script>
 
 <template>
   <BuPanel>
-    <BuPanelHeading />
+    <BuPanel.Heading />
 
-    <BuPanelTabs>
-      <BuPanelTab />
-    </BuPanelTabs>
+    <BuPanel.Tabs>
+      <BuPanel.Tab />
+    </BuPanel.Tabs>
 
-    <BuPanelBlock>
-      <BuPanelIcon />
-    </BuPanelBlock>
+    <BuPanel.Block>
+      <BuPanel.Icon />
+    </BuPanel.Block>
   </BuPanel>
 </template>
 ```
@@ -148,7 +141,7 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue collapse
 <template>
   <BuPanel v-model="selected">
-    <BuPanelHeading>Repositories</BuPanelHeading>
+    <BuPanel.Heading>Repositories</BuPanel.Heading>
 
     <div class="panel-block">
       <p class="control has-icons-left">
@@ -159,43 +152,43 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
       </p>
     </div>
 
-    <BuPanelTabs v-model="tab">
-      <BuPanelTab value="All">All</BuPanelTab>
-      <BuPanelTab value="Public">Public</BuPanelTab>
-      <BuPanelTab value="Private">Private</BuPanelTab>
-      <BuPanelTab value="Sources">Sources</BuPanelTab>
-      <BuPanelTab value="Forks">Forks</BuPanelTab>
-    </BuPanelTabs>
+    <BuPanel.Tabs v-model="tab">
+      <BuPanel.Tab value="All">All</BuPanel.Tab>
+      <BuPanel.Tab value="Public">Public</BuPanel.Tab>
+      <BuPanel.Tab value="Private">Private</BuPanel.Tab>
+      <BuPanel.Tab value="Sources">Sources</BuPanel.Tab>
+      <BuPanel.Tab value="Forks">Forks</BuPanel.Tab>
+    </BuPanel.Tabs>
 
-    <BuPanelBlock value="bulma">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="bulma">
+      <BuPanel.Icon icon="fas fa-book" />
       bulma
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="marksheet">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="marksheet">
+      <BuPanel.Icon icon="fas fa-book" />
       marksheet
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="minireset.css">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="minireset.css">
+      <BuPanel.Icon icon="fas fa-book" />
       minireset.css
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="jgthms.github.io">
-      <BuPanelIcon icon="fas fa-book" />
+    <BuPanel.Block value="jgthms.github.io">
+      <BuPanel.Icon icon="fas fa-book" />
       jgthms.github.io
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="daniellowtw/infboard">
-      <BuPanelIcon icon="fas fa-code-branch" />
+    <BuPanel.Block value="daniellowtw/infboard">
+      <BuPanel.Icon icon="fas fa-code-branch" />
       daniellowtw/infboard
-    </BuPanelBlock>
+    </BuPanel.Block>
 
-    <BuPanelBlock value="mojs">
-      <BuPanelIcon icon="fas fa-code-branch" />
+    <BuPanel.Block value="mojs">
+      <BuPanel.Icon icon="fas fa-code-branch" />
       mojs
-    </BuPanelBlock>
+    </BuPanel.Block>
 
     <label class="panel-block">
       <input type="checkbox">

--- a/apps/docs/src/pages/systems/bulma/tabs.md
+++ b/apps/docs/src/pages/systems/bulma/tabs.md
@@ -38,16 +38,16 @@ Bulma's `.tabs` with selection and panels — the JavaScript and the tabpanels t
 
 ```vue Anatomy no-filename
 <script setup lang="ts">
-  import { BuTab, BuTabList, BuTabPanel, BuTabs } from '@paper/bulma'
+  import { BuTabs } from '@paper/bulma'
 </script>
 
 <template>
   <BuTabs>
-    <BuTabList>
-      <BuTab />
-    </BuTabList>
+    <BuTabs.List>
+      <BuTabs.Tab />
+    </BuTabs.List>
 
-    <BuTabPanel />
+    <BuTabs.Panel />
   </BuTabs>
 </template>
 ```
@@ -84,12 +84,12 @@ The Bulma tab is the markup [published on bulma.io](https://bulma.io/documentati
 ```vue Vue
 <template>
   <BuTabs>
-    <BuTabList>
-      <BuTab value="pictures">Pictures</BuTab>
-      <BuTab value="music">Music</BuTab>
-      <BuTab value="videos">Videos</BuTab>
-      <BuTab value="documents">Documents</BuTab>
-    </BuTabList>
+    <BuTabs.List>
+      <BuTabs.Tab value="pictures">Pictures</BuTabs.Tab>
+      <BuTabs.Tab value="music">Music</BuTabs.Tab>
+      <BuTabs.Tab value="videos">Videos</BuTabs.Tab>
+      <BuTabs.Tab value="documents">Documents</BuTabs.Tab>
+    </BuTabs.List>
   </BuTabs>
 </template>
 ```

--- a/packages/bulma/SPEC.md
+++ b/packages/bulma/SPEC.md
@@ -123,6 +123,9 @@ markup against bulma.io's documented fixtures.
   shows `is-danger` — deceptively half-wired). Compose validation fields as
   `<InputRoot renderless v-model :rules>` wrapping the whole field; BuHelp warns in
   dev when `validation` is set with no ambient root.
+- **Part components attach to the parent export:** `import { BuModal } from '@paper/bulma'`
+  reaches the whole family (`<BuModal.Head />`, `<BuModal.Title />`). Flat names
+  (`BuModalHead`) remain exported and resolve to the same component.
 - **Part components are composed, not enforced:** region parts (BuMessageDelete,
   BuNotificationDelete, BuDropdownMenu, BuNavbarBrand, …) read their parent's state through an optional context
   and warn in dev when it is missing, so a part rendered outside its parent still emits

--- a/packages/bulma/harness/CANON.md
+++ b/packages/bulma/harness/CANON.md
@@ -6,7 +6,7 @@
 - Import ONLY from `@vuetify/v0` — never `#v0/*` (that alias in tsconfig/tsdown exists for tooling parity with genesis; the cheatsheet forbids its use in package source).
 - Layout: `src/components/BuThing/BuThing.vue` + `src/components/BuThing/index.ts` (`export type { BuThingProps } from './BuThing.vue'` + `export { default as BuThing } from './BuThing.vue'`). Append ONE alphabetically-placed line per component to `src/components/index.ts`; touch no other shared file. Never edit root tsconfig.json, vitest.config.ts, pnpm-workspace.yaml, or packages/0.
 - Dual-script SFC, `defineOptions({ name: 'BuThing' })`, destructured props (no `withDefaults`), `defineModel` + explicit kebab `defineEmits`, `toRef` slotProps object, no `<style>` block at all in Tier 1, no `<style scoped>` ever.
-- Family shape is FLAT components (BuField > BuControl > BuInput composed in userland exactly as Bulma nests classes) — no compound `BuX.Y` namespaces in Tier 1. Region parts are flat components too (`BuModalHead`, not `BuModal.Head`); see "Slots" below.
+- Family shape is nested classes composed in userland exactly as Bulma nests them (BuField > BuControl > BuInput). Region parts attach to the parent export (`BuModal.Head`) the same way Emerald does; the flat names (`BuModalHead`) remain exported and valid. See "Slots" below.
 
 ## Prop → modifier class mapping (identical across all groups)
 | Prop | Type | Class |

--- a/packages/bulma/harness/V0-CHEATSHEET.md
+++ b/packages/bulma/harness/V0-CHEATSHEET.md
@@ -257,7 +257,7 @@ Parts: `Radio.Group` (`div`, `role='radiogroup'`), `Radio.Root` (`button`, `role
 - No type-guard raw comparisons: `isNull/isUndefined/isNullOrUndefined/isString/...` from `@vuetify/v0` (`#v0/utilities` re-exports through the main barrel).
 
 **Package/barrel (genesis precedent, `packages/genesis/src/components/*/index.ts`)**
-- Per-component dir `BuThing/BuThing.vue` + `index.ts`: `export type { BuThingProps } from './BuThing.vue'` + `export { default as BuThing } from './BuThing.vue'`. Never `export *` from a `.vue`. Compound Bu components follow the v0 compound barrel (`components/Dialog/index.ts`): named default re-exports, one `export type` block, then a plain object literal compound with JSDoc per member — never `Object.assign`.
+- Per-component dir `BuThing/BuThing.vue` + `index.ts`: `export type { BuThingProps } from './BuThing.vue'` + `export { default as BuThing } from './BuThing.vue'`. Never `export *` from a `.vue`. Compound families follow Emerald: keep the part's own folder and flat export, then `Object.assign` the parts onto the parent (`BuModal.Head` is `BuModalHead`). The parent *is* the root — not `BuModal.Root`.
 - Package deps: `@vuetify/v0` as `workspace:^` dependency, `vue >=3.5.0` peer (see `packages/genesis/package.json`); `bulma@^1.0` is a peer, never a dependency.
 
 ---

--- a/packages/bulma/src/components/BuBreadcrumb/index.ts
+++ b/packages/bulma/src/components/BuBreadcrumb/index.ts
@@ -1,2 +1,30 @@
 export type { BuBreadcrumbProps } from './BuBreadcrumb.vue'
-export { default as BuBreadcrumb } from './BuBreadcrumb.vue'
+
+// Context
+import Root from './BuBreadcrumb.vue'
+
+import Item from '../BuBreadcrumbItem/BuBreadcrumbItem.vue'
+
+/**
+ * Breadcrumb trail. Renders `nav.breadcrumb > ul`; crumbs are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuBreadcrumbItem`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuBreadcrumb } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuBreadcrumb>
+ *     <BuBreadcrumb.Item />
+ *   </BuBreadcrumb>
+ * </template>
+ * ```
+ */
+export const BuBreadcrumb = Object.assign(Root, {
+  /** A single crumb (`li > a`). Last crumb uses `current`. */
+  Item,
+})

--- a/packages/bulma/src/components/BuDropdown/index.ts
+++ b/packages/bulma/src/components/BuDropdown/index.ts
@@ -1,3 +1,35 @@
 export type { BuDropdownContext, BuDropdownProps } from './BuDropdown.vue'
 
-export { default as BuDropdown } from './BuDropdown.vue'
+// Context
+import Root from './BuDropdown.vue'
+
+import Menu from '../BuDropdownMenu/BuDropdownMenu.vue'
+import Trigger from '../BuDropdownTrigger/BuDropdownTrigger.vue'
+
+/**
+ * Dropdown. Owns the open state; trigger and menu are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuDropdownMenu`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuDropdown } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuDropdown>
+ *     <BuDropdown.Trigger />
+ *
+ *     <BuDropdown.Menu />
+ *   </BuDropdown>
+ * </template>
+ * ```
+ */
+export const BuDropdown = Object.assign(Root, {
+  /** Button that opens the menu. */
+  Trigger,
+  /** The `.dropdown-menu` panel. */
+  Menu,
+})

--- a/packages/bulma/src/components/BuField/index.ts
+++ b/packages/bulma/src/components/BuField/index.ts
@@ -1,3 +1,35 @@
-export { default as BuField } from './BuField.vue'
-
 export type { BuFieldProps } from './BuField.vue'
+
+// Context
+import Root from './BuField.vue'
+
+import Body from '../BuFieldBody/BuFieldBody.vue'
+import Label from '../BuFieldLabel/BuFieldLabel.vue'
+
+/**
+ * Form field. Renders `.field`; horizontal columns are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuFieldLabel`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuField } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuField horizontal>
+ *     <BuField.Label />
+ *
+ *     <BuField.Body />
+ *   </BuField>
+ * </template>
+ * ```
+ */
+export const BuField = Object.assign(Root, {
+  /** `.field-label` column when the field is horizontal. */
+  Label,
+  /** `.field-body` column when the field is horizontal. */
+  Body,
+})

--- a/packages/bulma/src/components/BuFile/index.ts
+++ b/packages/bulma/src/components/BuFile/index.ts
@@ -1,2 +1,40 @@
 export type { BuFileColor, BuFileContext, BuFileExpose, BuFileProps, BuFileSize, BuFileSlotProps } from './BuFile.vue'
-export { default as BuFile } from './BuFile.vue'
+
+// Context
+import Root from './BuFile.vue'
+
+import Cta from '../BuFileCta/BuFileCta.vue'
+import Icon from '../BuFileIcon/BuFileIcon.vue'
+import Name from '../BuFileName/BuFileName.vue'
+
+/**
+ * File input. Renders `.file`; CTA, icon, and name are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuFileCta`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuFile } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuFile>
+ *     <BuFile.Cta>
+ *       <BuFile.Icon />
+ *     </BuFile.Cta>
+ *
+ *     <BuFile.Name />
+ *   </BuFile>
+ * </template>
+ * ```
+ */
+export const BuFile = Object.assign(Root, {
+  /** `.file-cta` choose-file control. */
+  Cta,
+  /** `.file-icon` inside the CTA. */
+  Icon,
+  /** `.file-name` selected-file label. */
+  Name,
+})

--- a/packages/bulma/src/components/BuMenu/index.ts
+++ b/packages/bulma/src/components/BuMenu/index.ts
@@ -1,1 +1,43 @@
-export { default as BuMenu } from './BuMenu.vue'
+// Context
+import Root from './BuMenu.vue'
+
+import Item from '../BuMenuItem/BuMenuItem.vue'
+import Label from '../BuMenuLabel/BuMenuLabel.vue'
+import Link from '../BuMenuLink/BuMenuLink.vue'
+import List from '../BuMenuList/BuMenuList.vue'
+
+/**
+ * Side menu. Renders `aside.menu`; labels, lists, and links are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuMenuItem`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuMenu } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuMenu>
+ *     <BuMenu.Label />
+ *
+ *     <BuMenu.List>
+ *       <BuMenu.Item>
+ *         <BuMenu.Link />
+ *       </BuMenu.Item>
+ *     </BuMenu.List>
+ *   </BuMenu>
+ * </template>
+ * ```
+ */
+export const BuMenu = Object.assign(Root, {
+  /** `p.menu-label` section heading. */
+  Label,
+  /** `ul.menu-list`; `nested` omits the class. */
+  List,
+  /** `li` row. */
+  Item,
+  /** Renderless selectable link inside an item. */
+  Link,
+})

--- a/packages/bulma/src/components/BuMessage/index.ts
+++ b/packages/bulma/src/components/BuMessage/index.ts
@@ -1,3 +1,40 @@
 export type { BuMessageContext, BuMessageProps } from './BuMessage.vue'
 
-export { default as BuMessage } from './BuMessage.vue'
+// Context
+import Root from './BuMessage.vue'
+
+import Body from '../BuMessageBody/BuMessageBody.vue'
+import Delete from '../BuMessageDelete/BuMessageDelete.vue'
+import Header from '../BuMessageHeader/BuMessageHeader.vue'
+
+/**
+ * Message box. Owns the open state; header, delete, and body are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuMessageHeader`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuMessage } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuMessage>
+ *     <BuMessage.Header>
+ *       <BuMessage.Delete />
+ *     </BuMessage.Header>
+ *
+ *     <BuMessage.Body />
+ *   </BuMessage>
+ * </template>
+ * ```
+ */
+export const BuMessage = Object.assign(Root, {
+  /** `.message-header` title row. */
+  Header,
+  /** Header dismiss button. */
+  Delete,
+  /** `.message-body` content. */
+  Body,
+})

--- a/packages/bulma/src/components/BuModal/index.ts
+++ b/packages/bulma/src/components/BuModal/index.ts
@@ -1,3 +1,65 @@
 export type { BuModalContext, BuModalProps } from './BuModal.vue'
 
-export { default as BuModal } from './BuModal.vue'
+// Context
+import Root from './BuModal.vue'
+
+import Body from '../BuModalBody/BuModalBody.vue'
+import Card from '../BuModalCard/BuModalCard.vue'
+import Close from '../BuModalClose/BuModalClose.vue'
+import Content from '../BuModalContent/BuModalContent.vue'
+import Delete from '../BuModalDelete/BuModalDelete.vue'
+import Foot from '../BuModalFoot/BuModalFoot.vue'
+import Head from '../BuModalHead/BuModalHead.vue'
+import Title from '../BuModalTitle/BuModalTitle.vue'
+
+/**
+ * Modal. Owns the open state, backdrop, and focus trap; the panel is composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuModalContent`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuModal } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuModal>
+ *     <BuModal.Content />
+ *
+ *     <BuModal.Close />
+ *
+ *     <BuModal.Card>
+ *       <BuModal.Head>
+ *         <BuModal.Title />
+ *
+ *         <BuModal.Delete />
+ *       </BuModal.Head>
+ *
+ *       <BuModal.Body />
+ *
+ *       <BuModal.Foot />
+ *     </BuModal.Card>
+ *   </BuModal>
+ * </template>
+ * ```
+ */
+export const BuModal = Object.assign(Root, {
+  /** Plain `.modal-content` panel. */
+  Content,
+  /** Large `.modal-close` beside the content panel. */
+  Close,
+  /** `.modal-card` panel. */
+  Card,
+  /** `header.modal-card-head`. */
+  Head,
+  /** `p.modal-card-title`. */
+  Title,
+  /** Card-head `.delete`. */
+  Delete,
+  /** `section.modal-card-body`. */
+  Body,
+  /** `footer.modal-card-foot`. */
+  Foot,
+})

--- a/packages/bulma/src/components/BuNavbar/index.ts
+++ b/packages/bulma/src/components/BuNavbar/index.ts
@@ -1,2 +1,35 @@
 export type { BuNavbarContext, BuNavbarProps, BuNavbarSlotProps } from './BuNavbar.vue'
-export { default as BuNavbar } from './BuNavbar.vue'
+
+// Context
+import Root from './BuNavbar.vue'
+
+import Brand from '../BuNavbarBrand/BuNavbarBrand.vue'
+import Menu from '../BuNavbarMenu/BuNavbarMenu.vue'
+
+/**
+ * Navbar. Owns the burger/menu open state; brand and menu are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuNavbarBrand`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuNavbar } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuNavbar>
+ *     <BuNavbar.Brand />
+ *
+ *     <BuNavbar.Menu />
+ *   </BuNavbar>
+ * </template>
+ * ```
+ */
+export const BuNavbar = Object.assign(Root, {
+  /** `.navbar-brand`, including the burger. */
+  Brand,
+  /** `.navbar-menu` collapsible region. */
+  Menu,
+})

--- a/packages/bulma/src/components/BuNotification/index.ts
+++ b/packages/bulma/src/components/BuNotification/index.ts
@@ -1,3 +1,30 @@
 export type { BuNotificationContext, BuNotificationProps } from './BuNotification.vue'
 
-export { default as BuNotification } from './BuNotification.vue'
+// Context
+import Root from './BuNotification.vue'
+
+import Delete from '../BuNotificationDelete/BuNotificationDelete.vue'
+
+/**
+ * Notification box. Owns the open state; the dismiss button is a composed part.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuNotificationDelete`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuNotification } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuNotification>
+ *     <BuNotification.Delete />
+ *   </BuNotification>
+ * </template>
+ * ```
+ */
+export const BuNotification = Object.assign(Root, {
+  /** `.delete` dismiss button. */
+  Delete,
+})

--- a/packages/bulma/src/components/BuNumberField/index.ts
+++ b/packages/bulma/src/components/BuNumberField/index.ts
@@ -1,3 +1,40 @@
 export type { BuNumberFieldColor, BuNumberFieldContext, BuNumberFieldProps, BuNumberFieldSize } from './BuNumberField.vue'
 
-export { default as BuNumberField } from './BuNumberField.vue'
+// Context
+import Root from './BuNumberField.vue'
+
+import Decrement from '../BuNumberFieldDecrement/BuNumberFieldDecrement.vue'
+import Increment from '../BuNumberFieldIncrement/BuNumberFieldIncrement.vue'
+import Input from '../BuNumberFieldInput/BuNumberFieldInput.vue'
+
+/**
+ * Numeric stepper. Owns the value; decrement, input, and increment are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuNumberFieldInput`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuNumberField } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuNumberField>
+ *     <BuNumberField.Decrement />
+ *
+ *     <BuNumberField.Input />
+ *
+ *     <BuNumberField.Increment />
+ *   </BuNumberField>
+ * </template>
+ * ```
+ */
+export const BuNumberField = Object.assign(Root, {
+  /** Decrement stepper. */
+  Decrement,
+  /** The numeric input. */
+  Input,
+  /** Increment stepper. */
+  Increment,
+})

--- a/packages/bulma/src/components/BuPagination/index.ts
+++ b/packages/bulma/src/components/BuPagination/index.ts
@@ -1,2 +1,50 @@
 export type { BuPaginationProps } from './BuPagination.vue'
-export { default as BuPagination } from './BuPagination.vue'
+
+// Context
+import Root from './BuPagination.vue'
+
+import Ellipsis from '../BuPaginationEllipsis/BuPaginationEllipsis.vue'
+import Item from '../BuPaginationItem/BuPaginationItem.vue'
+import List from '../BuPaginationList/BuPaginationList.vue'
+import Next from '../BuPaginationNext/BuPaginationNext.vue'
+import Prev from '../BuPaginationPrev/BuPaginationPrev.vue'
+
+/**
+ * Pager. Owns the current page; prev, next, list, items, and ellipsis are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuPaginationPrev`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuPagination } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuPagination>
+ *     <BuPagination.Prev />
+ *
+ *     <BuPagination.Next />
+ *
+ *     <BuPagination.List>
+ *       <BuPagination.Item />
+ *
+ *       <BuPagination.Ellipsis />
+ *     </BuPagination.List>
+ *   </BuPagination>
+ * </template>
+ * ```
+ */
+export const BuPagination = Object.assign(Root, {
+  /** Previous-page control. */
+  Prev,
+  /** Next-page control. */
+  Next,
+  /** `ul.pagination-list`. */
+  List,
+  /** A page number. */
+  Item,
+  /** Gap marker between page windows. */
+  Ellipsis,
+})

--- a/packages/bulma/src/components/BuPanel/index.ts
+++ b/packages/bulma/src/components/BuPanel/index.ts
@@ -1,3 +1,50 @@
 export type { BuPanelProps } from './BuPanel.vue'
 
-export { default as BuPanel } from './BuPanel.vue'
+// Context
+import Root from './BuPanel.vue'
+
+import Block from '../BuPanelBlock/BuPanelBlock.vue'
+import Heading from '../BuPanelHeading/BuPanelHeading.vue'
+import Icon from '../BuPanelIcon/BuPanelIcon.vue'
+import Tab from '../BuPanelTab/BuPanelTab.vue'
+import Tabs from '../BuPanelTabs/BuPanelTabs.vue'
+
+/**
+ * Panel. Owns block selection; heading, tabs, and blocks are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuPanelBlock`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuPanel } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuPanel>
+ *     <BuPanel.Heading />
+ *
+ *     <BuPanel.Tabs>
+ *       <BuPanel.Tab />
+ *     </BuPanel.Tabs>
+ *
+ *     <BuPanel.Block>
+ *       <BuPanel.Icon />
+ *     </BuPanel.Block>
+ *   </BuPanel>
+ * </template>
+ * ```
+ */
+export const BuPanel = Object.assign(Root, {
+  /** `p.panel-heading`. */
+  Heading,
+  /** `.panel-tabs` selection scope. */
+  Tabs,
+  /** A tab inside `.panel-tabs`. */
+  Tab,
+  /** `.panel-block` row. */
+  Block,
+  /** `.panel-icon` inside a block. */
+  Icon,
+})

--- a/packages/bulma/src/components/BuTabs/index.ts
+++ b/packages/bulma/src/components/BuTabs/index.ts
@@ -1,1 +1,38 @@
-export { default as BuTabs } from './BuTabs.vue'
+// Context
+import Root from './BuTabs.vue'
+
+import Tab from '../BuTab/BuTab.vue'
+import List from '../BuTabList/BuTabList.vue'
+import Panel from '../BuTabPanel/BuTabPanel.vue'
+
+/**
+ * Tabs. Owns the selected tab; the tablist, tabs, and panels are composed as parts.
+ *
+ * Sub-components are attached to the root, so one import reaches the whole
+ * compound. The flat names (`BuTabList`) remain exported and valid.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts" setup>
+ *   import { BuTabs } from '@paper/bulma'
+ * </script>
+ *
+ * <template>
+ *   <BuTabs>
+ *     <BuTabs.List>
+ *       <BuTabs.Tab />
+ *     </BuTabs.List>
+ *
+ *     <BuTabs.Panel />
+ *   </BuTabs>
+ * </template>
+ * ```
+ */
+export const BuTabs = Object.assign(Root, {
+  /** `.tabs > ul` tablist. Modifier props live here. */
+  List,
+  /** A single tab. */
+  Tab,
+  /** Content shown for the matching tab. */
+  Panel,
+})

--- a/packages/bulma/src/components/compound.browser.test.ts
+++ b/packages/bulma/src/components/compound.browser.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import { BuBreadcrumb } from './BuBreadcrumb'
+import { BuBreadcrumbItem } from './BuBreadcrumbItem'
+import { BuDropdown } from './BuDropdown'
+import { BuDropdownMenu } from './BuDropdownMenu'
+import { BuDropdownTrigger } from './BuDropdownTrigger'
+import { BuField } from './BuField'
+import { BuFieldBody } from './BuFieldBody'
+import { BuFieldLabel } from './BuFieldLabel'
+import { BuFile } from './BuFile'
+import { BuFileCta } from './BuFileCta'
+import { BuFileIcon } from './BuFileIcon'
+import { BuFileName } from './BuFileName'
+import { BuMenu } from './BuMenu'
+import { BuMenuItem } from './BuMenuItem'
+import { BuMenuLabel } from './BuMenuLabel'
+import { BuMenuLink } from './BuMenuLink'
+import { BuMenuList } from './BuMenuList'
+import { BuMessage } from './BuMessage'
+import { BuMessageBody } from './BuMessageBody'
+import { BuMessageDelete } from './BuMessageDelete'
+import { BuMessageHeader } from './BuMessageHeader'
+import { BuModal } from './BuModal'
+import { BuModalBody } from './BuModalBody'
+import { BuModalCard } from './BuModalCard'
+import { BuModalClose } from './BuModalClose'
+import { BuModalContent } from './BuModalContent'
+import { BuModalDelete } from './BuModalDelete'
+import { BuModalFoot } from './BuModalFoot'
+import { BuModalHead } from './BuModalHead'
+import { BuModalTitle } from './BuModalTitle'
+import { BuNavbar } from './BuNavbar'
+import { BuNavbarBrand } from './BuNavbarBrand'
+import { BuNavbarMenu } from './BuNavbarMenu'
+import { BuNotification } from './BuNotification'
+import { BuNotificationDelete } from './BuNotificationDelete'
+import { BuNumberField } from './BuNumberField'
+import { BuNumberFieldDecrement } from './BuNumberFieldDecrement'
+import { BuNumberFieldIncrement } from './BuNumberFieldIncrement'
+import { BuNumberFieldInput } from './BuNumberFieldInput'
+import { BuPagination } from './BuPagination'
+import { BuPaginationEllipsis } from './BuPaginationEllipsis'
+import { BuPaginationItem } from './BuPaginationItem'
+import { BuPaginationList } from './BuPaginationList'
+import { BuPaginationNext } from './BuPaginationNext'
+import { BuPaginationPrev } from './BuPaginationPrev'
+import { BuPanel } from './BuPanel'
+import { BuPanelBlock } from './BuPanelBlock'
+import { BuPanelHeading } from './BuPanelHeading'
+import { BuPanelIcon } from './BuPanelIcon'
+import { BuPanelTab } from './BuPanelTab'
+import { BuPanelTabs } from './BuPanelTabs'
+import { BuTab } from './BuTab'
+import { BuTabList } from './BuTabList'
+import { BuTabPanel } from './BuTabPanel'
+import { BuTabs } from './BuTabs'
+
+describe('compound parent exports', () => {
+  it('attaches each part to the parent as the same component as the flat name', () => {
+    expect(BuBreadcrumb.Item).toBe(BuBreadcrumbItem)
+
+    expect(BuDropdown.Trigger).toBe(BuDropdownTrigger)
+    expect(BuDropdown.Menu).toBe(BuDropdownMenu)
+
+    expect(BuField.Label).toBe(BuFieldLabel)
+    expect(BuField.Body).toBe(BuFieldBody)
+
+    expect(BuFile.Cta).toBe(BuFileCta)
+    expect(BuFile.Icon).toBe(BuFileIcon)
+    expect(BuFile.Name).toBe(BuFileName)
+
+    expect(BuMenu.Label).toBe(BuMenuLabel)
+    expect(BuMenu.List).toBe(BuMenuList)
+    expect(BuMenu.Item).toBe(BuMenuItem)
+    expect(BuMenu.Link).toBe(BuMenuLink)
+
+    expect(BuMessage.Header).toBe(BuMessageHeader)
+    expect(BuMessage.Delete).toBe(BuMessageDelete)
+    expect(BuMessage.Body).toBe(BuMessageBody)
+
+    expect(BuModal.Content).toBe(BuModalContent)
+    expect(BuModal.Close).toBe(BuModalClose)
+    expect(BuModal.Card).toBe(BuModalCard)
+    expect(BuModal.Head).toBe(BuModalHead)
+    expect(BuModal.Title).toBe(BuModalTitle)
+    expect(BuModal.Delete).toBe(BuModalDelete)
+    expect(BuModal.Body).toBe(BuModalBody)
+    expect(BuModal.Foot).toBe(BuModalFoot)
+
+    expect(BuNavbar.Brand).toBe(BuNavbarBrand)
+    expect(BuNavbar.Menu).toBe(BuNavbarMenu)
+
+    expect(BuNotification.Delete).toBe(BuNotificationDelete)
+
+    expect(BuNumberField.Decrement).toBe(BuNumberFieldDecrement)
+    expect(BuNumberField.Input).toBe(BuNumberFieldInput)
+    expect(BuNumberField.Increment).toBe(BuNumberFieldIncrement)
+
+    expect(BuPagination.Prev).toBe(BuPaginationPrev)
+    expect(BuPagination.Next).toBe(BuPaginationNext)
+    expect(BuPagination.List).toBe(BuPaginationList)
+    expect(BuPagination.Item).toBe(BuPaginationItem)
+    expect(BuPagination.Ellipsis).toBe(BuPaginationEllipsis)
+
+    expect(BuPanel.Heading).toBe(BuPanelHeading)
+    expect(BuPanel.Tabs).toBe(BuPanelTabs)
+    expect(BuPanel.Tab).toBe(BuPanelTab)
+    expect(BuPanel.Block).toBe(BuPanelBlock)
+    expect(BuPanel.Icon).toBe(BuPanelIcon)
+
+    expect(BuTabs.List).toBe(BuTabList)
+    expect(BuTabs.Tab).toBe(BuTab)
+    expect(BuTabs.Panel).toBe(BuTabPanel)
+  })
+})


### PR DESCRIPTION
Importing a Bu family now reaches its parts the same way Emerald does — `import { BuModal }` is enough to use `<BuModal.Head />`. The sub-key drops the parent prefix (`BuModalHead` → `BuModal.Head`).

Flat names stay exported and resolve to the same component, so existing imports keep working. Docs examples and anatomy blocks use the parent import.