### PR TITLE
fix(usePopover): name the plugin namespace v0:popover

### DIFF
--- a/.changeset/popover-plugin-namespace.md
+++ b/.changeset/popover-plugin-namespace.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(usePopover): name the plugin namespace `v0:popover`
+
+`createPopoverPlugin` now provides at `v0:popover`, matching every other plugin. Compound `Popover.Root` context moved to `v0:popover:root` so the two keys do not collide. If you passed `namespace: 'v0:popover-plugin'` explicitly, drop it or switch to `v0:popover`.

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -982,7 +982,7 @@ Every key passed to `createContext(key)` or `createXContext({ namespace })` must
 
 **Static-key vs dynamic-key modes.** `createContext` operates in two modes:
 
-- **Static-key mode** — the call site passes a single string (`createContext('v0:popover')`). The namespace is fixed at module load; the `[useX, provideX]` pair injects against that one key. Used by the few Roots whose namespace never needs to vary per subtree — in component source today, only `Popover` (`'v0:popover'`) and `Splitter` (`'v0:splitter'`).
+- **Static-key mode** — the call site passes a single string (`createContext('v0:popover:root')`). The namespace is fixed at module load; the `[useX, provideX]` pair injects against that one key. Used by the few Roots whose namespace never needs to vary per subtree — in component source today, only `Popover` (`'v0:popover:root'`) and `Splitter` (`'v0:splitter'`).
 - **Dynamic-key mode** — the call site passes an options object or omits the positional key (`createContext({ suffix: 'item' })` or `createContext()`), which makes the returned `useX` / `provideX` accept a runtime namespace argument supplied at provide time; `suffix` is an optional string appended to that runtime key (`key:suffix`). This is the default for compound Roots — `Tabs`, `Dialog`, `Combobox`, `Select`, and the rest omit the positional key and pass the namespace to `provideXRoot(namespace, context)` (see §6.5). It is also what lets a single composable service multiple disjoint subtrees within the same app (e.g., nested `Selection` providers). The `[v0:context]` colon warning is static-key-mode only (gated on `isString(keyOrOptions)`); the dynamic branch performs no colon check on the runtime key.
 
 ### 9.4 SSR gating

--- a/packages/0/src/components/Popover/PopoverRoot.vue
+++ b/packages/0/src/components/Popover/PopoverRoot.vue
@@ -39,7 +39,7 @@
     toggle: () => void
   }
 
-  export const [usePopoverContext, providePopoverContext] = createContext<PopoverContext>('v0:popover')
+  export const [usePopoverContext, providePopoverContext] = createContext<PopoverContext>('v0:popover:root')
 </script>
 
 <script setup lang="ts">

--- a/packages/0/src/composables/usePopover/index.test.ts
+++ b/packages/0/src/composables/usePopover/index.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Components
+import { providePopoverContext } from '#v0/components/Popover'
+
 // Composables
 import { createTooltipPlugin } from '#v0/composables/useTooltip'
 
@@ -713,6 +716,32 @@ describe('usePopover', () => {
         'position-try-fallbacks': 'most-width bottom',
       })
       probe.unmount()
+    })
+
+    it('should keep the plugin adapter under a Popover.Root instance context', () => {
+      let styles: Record<string, string> | undefined
+
+      const Child = defineComponent({
+        setup () {
+          styles = usePopover({ id: 'child' }).contentStyles.value
+          return () => h('div')
+        },
+      })
+
+      const Root = defineComponent({
+        setup () {
+          providePopoverContext(usePopover({ id: 'root' }))
+          return () => h(Child)
+        },
+      })
+
+      const app = createApp(Root)
+      app.use(createPopoverPlugin({ adapter: new MarkerAdapter('plugin') }))
+      const el = document.createElement('div')
+      app.mount(el)
+
+      expect(styles).toEqual({ '--engine': 'plugin' })
+      app.unmount()
     })
   })
 })

--- a/packages/0/src/composables/usePopover/index.ts
+++ b/packages/0/src/composables/usePopover/index.ts
@@ -186,17 +186,18 @@ export function createPopoverFallback (): PopoverPluginContext {
  * import { FloatingUIPopoverAdapter } from '@vuetify/v0/popover/adapters/floating-ui'
  *
  * export const [useAppPopover, provideAppPopover, appPopover] = createPopoverContext({
- *   namespace: 'app:popover-plugin',
+ *   namespace: 'app:popover',
  *   adapter: new FloatingUIPopoverAdapter(),
  * })
  * ```
  *
  * Plugin trinity for an app-wide popover positioning adapter.
  *
- * Namespace is `v0:popover-plugin` — not `v0:popover`, which `Popover.Root`
- * already owns for compound context. The generated consumer is module-private;
- * `usePopover()` consults it internally. Fallback is `{ adapter: undefined }`,
- * so zero-config matches today's `V0PopoverAdapter` default.
+ * Namespace is `v0:popover`. Compound `Popover.Root` context lives at
+ * `v0:popover:root` so the two do not collide. The generated consumer is
+ * module-private; `usePopover()` consults it internally. Fallback is
+ * `{ adapter: undefined }`, so zero-config matches today's `V0PopoverAdapter`
+ * default.
  *
  * @example
  * ```ts
@@ -208,7 +209,7 @@ export function createPopoverFallback (): PopoverPluginContext {
  */
 const [createPopoverContext, createPopoverPlugin, usePopoverPlugin] =
   createPluginContext<PopoverPluginOptions, PopoverPluginContext>(
-    'v0:popover-plugin',
+    'v0:popover',
     createPopover,
     {
       fallback: () => createPopoverFallback(),

--- a/packages/bulma/harness/V0-CHEATSHEET.md
+++ b/packages/bulma/harness/V0-CHEATSHEET.md
@@ -68,7 +68,7 @@ Parts: `Popover.Root`, `.Activator`, `.Content`.
 
 | Part | `as` default | Key props | Slot props |
 |---|---|---|---|
-| Root | renderless (`as = null`) | `id` (auto) — **no `namespace` prop**; context is `createContext<PopoverContext>('v0:popover')` fixed | `{ id, isSelected, toggle }` |
+| Root | renderless (`as = null`) | `id` (auto) — **no `namespace` prop**; context is `createContext<PopoverContext>('v0:popover:root')` fixed | `{ id, isSelected, toggle }` |
 | Activator | `button` | `target` (override popover id) | `{ isOpen, attrs }` — attrs: **`popovertarget`** (native invoker), `type/role` polyfill, `tabindex:0`, `aria-expanded`, `aria-controls`, `data-open`, `style` (anchor-name), `onKeydown` (non-button only; toggle via context) |
 | Content | Atom default `div` | `id`, `positionArea`, `positionTry` | `{ isOpen, attrs }` — attrs: `id`, **`popover: ''`**, `style` (CSS anchor positioning: `position: fixed`, `position-area`, `position-anchor`, `position-try-fallbacks`), `onBeforetoggle` |
 


### PR DESCRIPTION
`createPopoverPlugin` was providing at `v0:popover-plugin`, a one-off name. It now uses `v0:popover`, matching every other plugin.

`Popover.Root` compound context moved to `v0:popover:root` so the plugin and instance keys do not collide. Nested `usePopover()` calls (Select, Combobox, Tooltip inside a popover) keep the app-wide adapter.

If you passed `namespace: 'v0:popover-plugin'` explicitly, drop it or switch to `v0:popover`.