### PR TITLE
docs: reduce code-fence action button spacing by 8px

### DIFF
--- a/apps/docs/src/components/docs/DocsApiCard.vue
+++ b/apps/docs/src/components/docs/DocsApiCard.vue
@@ -144,7 +144,7 @@
         <DocsCodeActions
           v-model:wrap="lineWrap"
           bin
-          class="absolute top-3 right-3 z-10 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+          class="absolute top-1 right-1 z-10 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
           :code="api.highlighted[key]?.code ?? ''"
           language="typescript"
           show-copy

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -271,8 +271,8 @@
 
   .docs-genesis-example-pane__actions {
     position: absolute;
-    top: 0.75rem;
-    inset-inline-end: 0.75rem;
+    top: 0.25rem;
+    inset-inline-end: 0.25rem;
     z-index: 10;
     display: flex;
     gap: 0.25rem;

--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -60,7 +60,7 @@
         {{ hideFilename ? language : title ?? language }}
       </span>
 
-      <div class="absolute top-3 end-3 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100">
+      <div class="absolute top-1 end-1 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100">
         <DocsCodeActions
           v-model:size="size"
           v-model:wrap="lineWrap"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces the top and right (inset-inline-end) spacing of code-fence action buttons from 12px to 4px (an 8px reduction) to tighten the visual gap between the action cluster and the code block edges.

Changes made:
- `DocsMarkup.vue`: `top-3 end-3` → `top-1 end-1`
- `DocsGenesisExample.vue`: `0.75rem` → `0.25rem` (CSS)
- `DocsApiCard.vue`: `top-3 right-3` → `top-1 right-1`

## Test plan

1. Run the docs dev server (`pnpm dev` in `apps/docs`)
2. Navigate to any page with code blocks (e.g., component/composable documentation)
3. Verify the action buttons (copy, playground, wrap, etc.) sit closer to the top-right corner of code fences
4. Confirm the buttons remain fully visible and clickable on both desktop and mobile viewports
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1d50427-854b-4255-9053-c6a7a75fad2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1d50427-854b-4255-9053-c6a7a75fad2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

