### PR TITLE
docs: match small-screen gutters with app bar and increase code-fence action inset

### DIFF
--- a/apps/docs/src/components/app/AppMainDocs.vue
+++ b/apps/docs/src/components/app/AppMainDocs.vue
@@ -119,7 +119,7 @@
     id="main-content"
     ref="main"
     :class="[
-      'pa-6 ms-0 md:ms-[230px] relative z-0',
+      'py-6 px-3 md:px-6 ms-0 md:ms-[230px] relative z-0',
       isSettled.value && !settings.prefersReducedMotion.value && 'transition-[padding] duration-200',
       'data-[has-toc]:xl:pe-[232px]',
       'data-[ask-open]:xl:pe-[calc(clamp(280px,calc(100vw-230px-730px-64px),500px)+32px)]',

--- a/apps/docs/src/components/docs/DocsApiCard.vue
+++ b/apps/docs/src/components/docs/DocsApiCard.vue
@@ -144,7 +144,7 @@
         <DocsCodeActions
           v-model:wrap="lineWrap"
           bin
-          class="absolute top-1 right-1 z-10 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+          class="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
           :code="api.highlighted[key]?.code ?? ''"
           language="typescript"
           show-copy

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -271,8 +271,8 @@
 
   .docs-genesis-example-pane__actions {
     position: absolute;
-    top: 0.25rem;
-    inset-inline-end: 0.25rem;
+    top: 0.5rem;
+    inset-inline-end: 0.5rem;
     z-index: 10;
     display: flex;
     gap: 0.25rem;

--- a/apps/docs/src/components/docs/DocsMarkup.vue
+++ b/apps/docs/src/components/docs/DocsMarkup.vue
@@ -60,7 +60,7 @@
         {{ hideFilename ? language : title ?? language }}
       </span>
 
-      <div class="absolute top-1 end-1 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100">
+      <div class="absolute top-2 end-2 z-10 flex gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity max-md:opacity-100">
         <DocsCodeActions
           v-model:size="size"
           v-model:wrap="lineWrap"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two docs layout tweaks:

### 1. Main content x-padding on small screens
On small screens, the docs main content had `pa-6` (24px) horizontal padding while the app bar had `px-3` (12px). This caused a visual misalignment where the main content gutters did not line up with the top bar's padding.

Changes `AppMainDocs` from `pa-6` to `py-6 px-3 md:px-6`:
- **Small screens (< md)**: `px-3` (12px) matches the AppBar's `px-3`
- **Medium+ screens (≥ 768px)**: `px-6` (24px) retains the existing desktop behavior
- Vertical padding (`py-6`) stays consistent at 24px on all breakpoints

### 2. Code-fence action button inset
The 4px inset shipped in #949 was too tight. Bumps all action button positioning from spacing-1 (0.25rem / 4px) to spacing-2 (0.5rem / 8px):

- `DocsMarkup.vue`: `top-1 end-1` → `top-2 end-2`
- `DocsApiCard.vue`: `top-1 right-1` → `top-2 right-2`
- `DocsGenesisExample.vue`: `0.25rem` → `0.5rem` for `top` / `inset-inline-end`

## Test plan

**Small-screen gutters:**
1. Load the docs site on a mobile viewport (< 768px wide)
2. Verify the main content left/right gutters now align with the app bar padding
3. Load the docs site on a desktop viewport (≥ 768px wide)
4. Verify the padding behavior is unchanged on larger screens

**Code-fence action buttons:**
1. Navigate to any docs page with code fences (e.g., a component API page or guide with examples)
2. Hover over a code block to reveal the action buttons (copy, wrap, etc.)
3. Verify the buttons now have 8px inset from the top-right corner instead of 4px
4. Check DocsMarkup, DocsApiCard examples, and DocsGenesisExample code panes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a69c32e1-a48b-4e59-9de4-091fe4f840ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a69c32e1-a48b-4e59-9de4-091fe4f840ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

