### PR TITLE
fix(selection): make ticket.unregister() clear selection and tree state

### DIFF
--- a/.changeset/selection-layer-cleanup.md
+++ b/.changeset/selection-layer-cleanup.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(selection): make ticket.unregister() clear selection and tree state
+
+`ticket.unregister()` now drops the id from selection, mixed, and nested maps — the same cleanup `unregister(id)` already did. `clear()` / `dispose()` on a group or tree wipe mixed and open state too. Stepping after an earlier item unmounts, Progress percent after a segment unmounts, and mandatory `unselectAll` on a tree no longer leave ghost ids or re-select a disabled node.

--- a/packages/0/src/composables/createGroup/index.test.ts
+++ b/packages/0/src/composables/createGroup/index.test.ts
@@ -654,6 +654,45 @@ describe('createGroup', () => {
       expect(group.mixedIds.size).toBe(0)
     })
 
+    it('should clear mixedIds on dispose', () => {
+      const group = createGroup()
+
+      group.onboard([
+        { id: 'item-1', value: 'value-1' },
+      ])
+      group.mix('item-1')
+
+      group.dispose()
+
+      expect(group.size).toBe(0)
+      expect(group.mixedIds.size).toBe(0)
+    })
+
+    it('should clear mixedIds on clear', () => {
+      const group = createGroup()
+
+      group.onboard([
+        { id: 'item-1', value: 'value-1' },
+      ])
+      group.mix('item-1')
+
+      group.clear()
+
+      expect(group.size).toBe(0)
+      expect(group.mixedIds.size).toBe(0)
+    })
+
+    it('should drop mixedIds via ticket.unregister', () => {
+      const group = createGroup()
+      const ticket = group.register({ id: 'item-1', value: 'value-1' })
+      group.mix('item-1')
+
+      ticket.unregister()
+
+      expect(group.size).toBe(0)
+      expect(group.mixedIds.has('item-1')).toBe(false)
+    })
+
     it('should remove from mixedIds on unregister', () => {
       const group = createGroup()
 

--- a/packages/0/src/composables/createGroup/index.ts
+++ b/packages/0/src/composables/createGroup/index.ts
@@ -263,6 +263,7 @@ export function createGroup<
       toggle: () => toggle(id),
       mix: () => mix(id),
       unmix: () => unmix(id),
+      unregister: () => unregister(id),
     }
 
     // Type assertion needed because item has more properties than Partial<Z>
@@ -295,6 +296,16 @@ export function createGroup<
   function reset () {
     mixedIds.clear()
     selection.reset()
+  }
+
+  function clear () {
+    mixedIds.clear()
+    selection.clear()
+  }
+
+  function dispose () {
+    mixedIds.clear()
+    selection.dispose()
   }
 
   const selectableItems = computed(() => {
@@ -348,6 +359,8 @@ export function createGroup<
     offboard,
     onboard,
     reset,
+    clear,
+    dispose,
     selectAll,
     unselectAll,
     toggleAll,

--- a/packages/0/src/composables/createModel/index.test.ts
+++ b/packages/0/src/composables/createModel/index.test.ts
@@ -69,6 +69,17 @@ describe('createModel', () => {
 
       expect(model.selectedIds.has('item-1')).toBe(false)
     })
+
+    it('should drop selectedIds via ticket.unregister', () => {
+      const model = createModel()
+      const ticket = model.register({ id: 'item-1', value: 'val-1' })
+      model.select('item-1')
+
+      ticket.unregister()
+
+      expect(model.size).toBe(0)
+      expect(model.selectedIds.has('item-1')).toBe(false)
+    })
   })
 
   describe('offboard', () => {

--- a/packages/0/src/composables/createModel/index.ts
+++ b/packages/0/src/composables/createModel/index.ts
@@ -445,6 +445,7 @@ export function createModel<
     const id = registration.id ?? useId()
     const item: Partial<E> = {
       disabled: false,
+      unregister: () => unregister(id),
       ...registration,
       isSelected: toRef(() => selected(id)),
       id,

--- a/packages/0/src/composables/createNested/index.test.ts
+++ b/packages/0/src/composables/createNested/index.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { createNested } from './index'
 
+// Utilities
+import { ref } from 'vue'
+
 // Types
 import type { NestedRegistration } from './types'
 
@@ -1059,6 +1062,34 @@ describe('createNested', () => {
     })
   })
 
+  describe('dispose', () => {
+    it('should wipe topology on dispose', () => {
+      const nested = createNested()
+
+      nested.register({ id: 'a', value: 'A' })
+      nested.open('a')
+      nested.dispose()
+
+      expect(nested.size).toBe(0)
+      expect(nested.openedIds.size).toBe(0)
+    })
+  })
+
+  describe('ticket.unregister', () => {
+    it('should drop topology via ticket.unregister', () => {
+      const nested = createNested()
+
+      nested.register({ id: 'root', value: 'Root' })
+      const child = nested.register({ id: 'child', value: 'Child', parentId: 'root' })
+
+      child.unregister()
+
+      expect(nested.has('child')).toBe(false)
+      expect(nested.parents.has('child')).toBe(false)
+      expect(nested.children.get('root') ?? []).not.toContain('child')
+    })
+  })
+
   describe('inherited group behavior', () => {
     it('should support selection independent of open state', () => {
       const nested = createNested()
@@ -1883,8 +1914,27 @@ describe('disabled state blocking', () => {
 
     nested.unselectAll()
 
-    // Mandatory keeps the first selected item; the rest is cleared
+    // Mandatory keeps the first enabled ticket in registry order
     expect(nested.selectedIds.size).toBe(1)
+    expect(nested.selectedIds.has('a')).toBe(true)
+  })
+
+  it('should not re-select a disabled id on unselectAll', () => {
+    const disabled = ref(false)
+    const nested = createNested({ mandatory: true })
+
+    nested.onboard([
+      { id: 'a', value: 'A', disabled },
+      { id: 'b', value: 'B' },
+    ])
+    nested.select('a')
+    nested.select('b')
+    disabled.value = true
+
+    nested.unselectAll()
+
+    expect(nested.selectedIds.has('a')).toBe(false)
+    expect(nested.selectedIds.has('b')).toBe(true)
   })
 })
 

--- a/packages/0/src/composables/createNested/index.ts
+++ b/packages/0/src/composables/createNested/index.ts
@@ -624,12 +624,13 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
 
   function unselectAll (): void {
     if (toValue(group.disabled)) return
-    const first = group.selectedIds.values().next().value
     group.selectedIds.clear()
     group.mixedIds.clear()
-    if (toValue(mandatoryOption) && first) {
-      group.selectedIds.add(first)
-      updateAncestors(first)
+    if (!toValue(mandatoryOption)) return
+    const ticket = group.seek('first')
+    if (ticket) {
+      group.selectedIds.add(ticket.id)
+      updateAncestors(ticket.id)
     }
   }
 
@@ -720,10 +721,11 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
 
     const ticket = group.register(item as Partial<GroupTicketInput>) as NestedTicket
 
-    // Override group-level selection methods with cascade-aware versions
+    // Override group-level methods with cascade-aware versions
     ticket.select = () => select(id)
     ticket.unselect = () => unselect(id)
     ticket.toggle = () => toggle(id)
+    ticket.unregister = () => unregister(id)
 
     if (registration.active) {
       activate(id)
@@ -846,6 +848,15 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     group.reset()
   }
 
+  function dispose (): void {
+    children.clear()
+    parents.clear()
+    openedIds.clear()
+    activeIds.clear()
+    rootIds.clear()
+    group.dispose()
+  }
+
   const context = {
     ...group,
     children: children as ReadonlyMap<ID, readonly ID[]>,
@@ -894,6 +905,7 @@ export function createNested (_options: NestedOptions = {}): NestedContext {
     onboard,
     clear,
     reset,
+    dispose,
     get size () {
       return group.size
     },

--- a/packages/0/src/composables/createProgress/index.test.ts
+++ b/packages/0/src/composables/createProgress/index.test.ts
@@ -82,6 +82,26 @@ describe('createProgress', () => {
       progress.register()
       expect(progress.size).toBe(3)
     })
+
+    it('should drop selectedIds via ticket.unregister', () => {
+      const progress = setup()
+      const ticket = progress.register({ value: shallowRef(50) })
+
+      expect(progress.percent.value).toBe(50)
+
+      ticket.unregister()
+
+      expect(progress.selectedIds.has(ticket.id)).toBe(false)
+      expect(progress.percent.value).toBe(0)
+    })
+
+    it('should apply pending values through onboard', () => {
+      const progress = setup({ max: 100 })
+      progress.apply([50, 25])
+      progress.onboard([{}, {}])
+
+      expect(progress.percent.value).toBe(75)
+    })
   })
 
   describe('total', () => {

--- a/packages/0/src/composables/createProgress/index.ts
+++ b/packages/0/src/composables/createProgress/index.ts
@@ -150,6 +150,10 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
     return ticket
   }
 
+  function onboard (registrations: Partial<ProgressTicketInput>[]): ProgressTicket[] {
+    return model.batch(() => registrations.map(registration => register(registration)))
+  }
+
   function apply (incoming: unknown[], _options?: { multiple?: boolean }): void {
     const clamped = incoming.map(v => clamp(Number(v), min, max))
 
@@ -175,6 +179,7 @@ export function createProgress (options: ProgressOptions = {}): ProgressContext 
     isIndeterminate,
     fromValue,
     register,
+    onboard,
     apply,
     min,
     max,

--- a/packages/0/src/composables/createRegistry/index.ts
+++ b/packages/0/src/composables/createRegistry/index.ts
@@ -73,7 +73,13 @@ export interface RegistryTicket<V = unknown> {
    * @remarks Set to true when no explicit value is provided during registration. It's not recommended to manually set this.
    */
   valueIsIndex: boolean
-  /** Remove this ticket from the registry. Semantic sugar for `registry.unregister(ticket.id)`. */
+  /**
+   * Remove this ticket from the collection that registered it.
+   *
+   * @remarks Equivalent to calling `unregister(ticket.id)` on that collection.
+   * Wrapping registries (model, group, nested) rebind this so sugar hits their
+   * cleanup, not only the base Map delete.
+   */
   unregister: () => void
 }
 
@@ -1085,12 +1091,12 @@ export function createRegistry<
     }
 
     const input = {
+      unregister: () => unregister(id),
       ...registration,
       id,
       index,
       value,
       valueIsIndex,
-      unregister: () => unregister(id),
     } as E
 
     const ticket = reactive ? shallowReactive(input) : input

--- a/packages/0/src/composables/createStep/index.test.ts
+++ b/packages/0/src/composables/createStep/index.test.ts
@@ -180,6 +180,21 @@ describe('createStep', () => {
         expect(stepper.selectedId.value).toBe('step-3')
       })
 
+      it('should next after removing an earlier explicit-value ticket', () => {
+        const stepper = createStep()
+
+        stepper.onboard([
+          { id: 'a', value: 'A' },
+          { id: 'b', value: 'B' },
+          { id: 'c', value: 'C' },
+        ])
+        stepper.select('b')
+        stepper.unregister('a')
+        stepper.next()
+
+        expect(stepper.selectedId.value).toBe('c')
+      })
+
       it('should not wrap around at end when circular is false (default)', () => {
         const stepper = createStep()
 

--- a/packages/0/src/composables/createStep/index.ts
+++ b/packages/0/src/composables/createStep/index.ts
@@ -198,6 +198,10 @@ export function createStep<
     const length = registry.size
     if (!length) return
 
+    // Drain deferred reindex before reading selectedIndex (ticket.index can
+    // lag after unregister of an explicit-value sibling).
+    void registry.lookup(0)
+
     const currentIndex = registry.selectedIndex.value
     const direction = Math.sign(count || 1)
     let hops = 0


### PR DESCRIPTION
`ticket.unregister()` skipped layer cleanup and left ghost ids in `selectedIds`, `mixedIds`, and nested maps. It now matches `unregister(id)`.

Group/tree `clear()` and `dispose()` wipe mixed and open state. `step()` drains reindex before reading `selectedIndex`, so removing an earlier item no longer stalls next/prev. Progress `onboard` consumes pending `apply()` values. Mandatory tree `unselectAll` skips disabled tickets.