### PR TITLE
fix(createValidation): fail unknown rule aliases; join Form via formNamespace

### DIFF
--- a/.changeset/form-fail-closed.md
+++ b/.changeset/form-fail-closed.md
@@ -2,6 +2,6 @@
 "@vuetify/v0": patch
 ---
 
-fix(createValidation): fail unknown rule aliases and honor Form namespace
+fix(createValidation): fail unknown rule aliases; join Form via formNamespace
 
-Unresolved alias strings no longer pass validation. A `Form` with a custom `namespace` still auto-registers `createValidation` / Input children, so isolated forms actually collect their fields.
+Unresolved alias strings no longer pass validation. Fields join a Form through `formNamespace` (default `'v0:form'`), matching `groupNamespace` — a custom Form `namespace` only collects children that set the same key.

--- a/.changeset/form-fail-closed.md
+++ b/.changeset/form-fail-closed.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createValidation): fail unknown rule aliases and honor Form namespace
+
+Unresolved alias strings no longer pass validation. A `Form` with a custom `namespace` still auto-registers `createValidation` / Input children, so isolated forms actually collect their fields.

--- a/apps/docs/src/pages/components/forms/form.md
+++ b/apps/docs/src/pages/components/forms/form.md
@@ -133,19 +133,21 @@ The `disabled` and `readonly` props propagate to the form context. Child compone
 
 ### Custom Namespace
 
-Use `namespace` to isolate multiple forms on the same page. Keys must contain `:`. Child fields still auto-register; the custom key is for explicit `useForm('v0:billing')`.
+Use `namespace` to isolate multiple forms on the same page. Keys must contain `:`. Child fields join via `form-namespace` — the same pairing as `group-namespace` on Toggle/Checkbox/Radio.
 
 ```vue
 <template>
   <Form namespace="v0:billing">
-    <!-- useForm('v0:billing') resolves this form -->
+    <Input.Root form-namespace="v0:billing" />
   </Form>
 
   <Form namespace="v0:shipping">
-    <!-- useForm('v0:shipping') resolves this form -->
+    <Input.Root form-namespace="v0:shipping" />
   </Form>
 </template>
 ```
+
+`form` on Input is the HTML `form="id"` attribute. `form-namespace` is the DI key. Defaults match (`v0:form`), so a single unnamed Form needs no extra prop.
 
 ### Programmatic Submit
 
@@ -185,7 +187,7 @@ Call `submit()` from slot props when you need to trigger validation without a su
 
 ??? How do I keep two forms on the same page from interfering?
 
-Give each a `namespace` that contains `:` (e.g. `namespace="v0:billing"`). Sibling forms are already isolated by Vue's nearest provide — the custom key is for `useForm('v0:billing')` from outside the tree. `Input` and `createValidation` children still auto-register.
+Give each a `namespace` that contains `:` (e.g. `namespace="v0:billing"`) and set the same value on each field's `form-namespace`. Sibling forms are already isolated by Vue's nearest provide; the custom key is for `useForm('v0:billing')` from outside the tree and for fields that would otherwise inject the default `'v0:form'`.
 
 ??? Why doesn't calling `submit()` from slot props emit the `@submit` event?
 

--- a/apps/docs/src/pages/components/forms/form.md
+++ b/apps/docs/src/pages/components/forms/form.md
@@ -133,16 +133,16 @@ The `disabled` and `readonly` props propagate to the form context. Child compone
 
 ### Custom Namespace
 
-Use `namespace` to isolate multiple forms on the same page:
+Use `namespace` to isolate multiple forms on the same page. Keys must contain `:`. Child fields still auto-register; the custom key is for explicit `useForm('v0:billing')`.
 
 ```vue
 <template>
-  <Form namespace="billing">
-    <!-- useForm('billing') resolves this form -->
+  <Form namespace="v0:billing">
+    <!-- useForm('v0:billing') resolves this form -->
   </Form>
 
-  <Form namespace="shipping">
-    <!-- useForm('shipping') resolves this form -->
+  <Form namespace="v0:shipping">
+    <!-- useForm('v0:shipping') resolves this form -->
   </Form>
 </template>
 ```
@@ -185,7 +185,7 @@ Call `submit()` from slot props when you need to trigger validation without a su
 
 ??? How do I keep two forms on the same page from interfering?
 
-Give each a `namespace` (e.g. `namespace="billing"`). Children then resolve their form with `useForm('billing')`, so the two forms stay isolated.
+Give each a `namespace` that contains `:` (e.g. `namespace="v0:billing"`). Sibling forms are already isolated by Vue's nearest provide — the custom key is for `useForm('v0:billing')` from outside the tree. `Input` and `createValidation` children still auto-register.
 
 ??? Why doesn't calling `submit()` from slot props emit the `@submit` event?
 

--- a/apps/docs/src/pages/composables/forms/create-form.md
+++ b/apps/docs/src/pages/composables/forms/create-form.md
@@ -52,7 +52,7 @@ form.reset()
 
 ### Auto-Registration
 
-When a `createValidation` instance is created inside a component that has a parent form context, it **auto-registers** with the form — no manual `form.register()` needed:
+When a `createValidation` instance is created inside a component that has a parent form context, it **auto-registers** with the form — no manual `form.register()` needed. Defaults join `'v0:form'`; a custom Form `namespace` needs the matching `formNamespace` on the field.
 
 ```vue
 <script setup lang="ts">
@@ -106,7 +106,7 @@ const form = useContactForm()
 await form.submit()
 ```
 
-Validations inside the component tree auto-register with the provided form — no manual `form.register()` needed.
+Validations inside the component tree auto-register when their `formNamespace` matches this context's `namespace` — no manual `form.register()` needed. Defaults are both `'v0:form'`.
 
 ## Architecture
 
@@ -173,7 +173,7 @@ createForm is a pure registry of validations and never holds field values. `rese
 
 ??? Do I have to call `form.register()` for every field?
 
-No. A [createValidation](/composables/forms/create-validation) created inside a component with a parent form context auto-registers (and cleans up on unmount). Manual `form.register({ value })` is only needed for validations built outside the provided tree.
+No. A [createValidation](/composables/forms/create-validation) created inside a component with a parent form context auto-registers (and cleans up on unmount) when `formNamespace` matches the Form's `namespace`. Manual `form.register({ value })` is only needed for validations built outside the provided tree.
 
 ??? What does `form.isValid` return before the first submit?
 

--- a/apps/docs/src/pages/composables/forms/create-validation.md
+++ b/apps/docs/src/pages/composables/forms/create-validation.md
@@ -162,7 +162,9 @@ const valid = await validation.validate('', true) // silent = true
 
 ### Auto-Registration with Forms
 
-When created inside a component with a parent form context, `createValidation` **auto-registers** with the form. The form can then coordinate submit and reset across all registered validations. Cleanup happens automatically via `onScopeDispose`:
+When created inside a component with a parent form context, `createValidation` **auto-registers** with the form. The form can then coordinate submit and reset across all registered validations. Cleanup happens automatically via `onScopeDispose`.
+
+Join a custom Form key with `formNamespace` — it must match the Form's `namespace` (same pairing as `groupNamespace`):
 
 ```vue
 <script setup lang="ts">
@@ -245,7 +247,7 @@ Pass `silent` as the second argument: `validate(value, true)`. It returns the bo
 
 ??? How does createValidation differ from createForm?
 
-createValidation owns one input's rules and validity state; [createForm](/composables/forms/create-form) is a registry that coordinates `submit` and `reset` across many validations. A validation created inside a form's tree auto-registers with it.
+createValidation owns one input's rules and validity state; [createForm](/composables/forms/create-form) is a registry that coordinates `submit` and `reset` across many validations. A validation created inside a form's tree auto-registers when `formNamespace` matches the Form's `namespace`.
 
 ??? How do I turn a rule off without removing it?
 

--- a/packages/0/src/components/Form/Form.vue
+++ b/packages/0/src/components/Form/Form.vue
@@ -93,6 +93,11 @@
   const attrs = useAttrs()
 
   provideContext(namespace, form)
+  // Auto-registering fields inject 'v0:form'. Provide both so a custom
+  // namespace still collects Input / createValidation children.
+  if (namespace !== 'v0:form') {
+    provideContext('v0:form', form)
+  }
 
   async function onSubmit (event: Event) {
     event.preventDefault()

--- a/packages/0/src/components/Form/Form.vue
+++ b/packages/0/src/components/Form/Form.vue
@@ -93,11 +93,6 @@
   const attrs = useAttrs()
 
   provideContext(namespace, form)
-  // Auto-registering fields inject 'v0:form'. Provide both so a custom
-  // namespace still collects Input / createValidation children.
-  if (namespace !== 'v0:form') {
-    provideContext('v0:form', form)
-  }
 
   async function onSubmit (event: Event) {
     event.preventDefault()

--- a/packages/0/src/components/Form/index.browser.test.ts
+++ b/packages/0/src/components/Form/index.browser.test.ts
@@ -11,10 +11,14 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, shallowRef, toValue } from 'vue'
 
 const FailingField = defineComponent({
-  setup () {
+  props: {
+    formNamespace: { type: String, default: 'v0:form' },
+  },
+  setup (props) {
     const value = shallowRef('')
     createValidation({
       value,
+      formNamespace: props.formNamespace,
       rules: [(v: unknown) => v === 'valid' ? true : 'Error'],
     })
     return () => h('input')
@@ -151,7 +155,19 @@ describe('form', () => {
       expect(emitted![0]).toEqual([{ valid: false }])
     })
 
-    it('should auto-register fields when Form uses a custom namespace', async () => {
+    it('should auto-register fields when formNamespace matches Form namespace', async () => {
+      const wrapper = mount(Form, {
+        props: { namespace: 'custom:form' },
+        slots: { default: () => h(FailingField, { formNamespace: 'custom:form' }) },
+      })
+      await wrapper.trigger('submit')
+      await flushPromises()
+      const emitted = wrapper.emitted('submit')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([{ valid: false }])
+    })
+
+    it('should not auto-register fields when formNamespace does not match Form namespace', async () => {
       const wrapper = mount(Form, {
         props: { namespace: 'custom:form' },
         slots: { default: () => h(FailingField) },
@@ -160,7 +176,7 @@ describe('form', () => {
       await flushPromises()
       const emitted = wrapper.emitted('submit')
       expect(emitted).toHaveLength(1)
-      expect(emitted![0]).toEqual([{ valid: false }])
+      expect(emitted![0]).toEqual([{ valid: true }])
     })
 
     it('should emit reset and reset field validations on native reset', async () => {

--- a/packages/0/src/components/Form/index.browser.test.ts
+++ b/packages/0/src/components/Form/index.browser.test.ts
@@ -151,6 +151,18 @@ describe('form', () => {
       expect(emitted![0]).toEqual([{ valid: false }])
     })
 
+    it('should auto-register fields when Form uses a custom namespace', async () => {
+      const wrapper = mount(Form, {
+        props: { namespace: 'custom:form' },
+        slots: { default: () => h(FailingField) },
+      })
+      await wrapper.trigger('submit')
+      await flushPromises()
+      const emitted = wrapper.emitted('submit')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([{ valid: false }])
+    })
+
     it('should emit reset and reset field validations on native reset', async () => {
       let injected: ReturnType<typeof useForm>
 

--- a/packages/0/src/components/Input/InputRoot.vue
+++ b/packages/0/src/components/Input/InputRoot.vue
@@ -119,6 +119,8 @@
     errorMessages?: MaybeArray<string>
     /** Namespace for context provision to children */
     namespace?: string
+    /** Namespace for connecting to parent Form. Must match Form's namespace. */
+    formNamespace?: string
   }
 
   export interface InputRootSlotProps {
@@ -204,6 +206,7 @@
     error = false,
     errorMessages,
     namespace = 'v0:input:root',
+    formNamespace = 'v0:form',
   } = defineProps<InputRootProps>()
 
   const model = defineModel<string>({ default: '' })
@@ -215,6 +218,7 @@
     label,
     name,
     form,
+    formNamespace,
     required,
     disabled: () => toValue(disabled),
     readonly: () => toValue(_readonly),

--- a/packages/0/src/components/NumberField/NumberFieldRoot.vue
+++ b/packages/0/src/components/NumberField/NumberFieldRoot.vue
@@ -134,6 +134,8 @@
     wheel?: boolean
     /** Namespace for context provision */
     namespace?: string
+    /** Namespace for connecting to parent Form. Must match Form's namespace. */
+    formNamespace?: string
   }
 
   export interface NumberFieldRootSlotProps {
@@ -230,6 +232,7 @@
     spinRate = 60,
     wheel = false,
     namespace = 'v0:number-field:root',
+    formNamespace = 'v0:form',
   } = defineProps<NumberFieldRootProps>()
 
   const model = defineModel<number | null>({ default: null })
@@ -239,6 +242,7 @@
     id,
     label,
     name,
+    formNamespace,
     locale,
     format: formatOptions,
     clamp: shouldClamp,

--- a/packages/0/src/composables/createInput/index.ts
+++ b/packages/0/src/composables/createInput/index.ts
@@ -53,6 +53,12 @@ export interface InputOptions<T = string> {
   name?: string
   /** Associate with form by ID. */
   form?: string
+  /**
+   * Form injection key. Must match the parent Form's `namespace`.
+   *
+   * @default 'v0:form'
+   */
+  formNamespace?: string
   /** Whether required. */
   required?: boolean
   /** Disabled state. */
@@ -115,6 +121,7 @@ export function createInput<T = string> (options: InputOptions<T>): InputContext
     label,
     name,
     form,
+    formNamespace,
     required,
     disabled = false,
     readonly: _readonly = false,
@@ -125,7 +132,7 @@ export function createInput<T = string> (options: InputOptions<T>): InputContext
     equals = (a: T, b: T) => a === b,
   } = options
 
-  const validation = createValidation({ rules, value })
+  const validation = createValidation({ rules, value, formNamespace })
 
   const initialValue = value.value
   const isFocused = shallowRef(false)

--- a/packages/0/src/composables/createNumberField/index.ts
+++ b/packages/0/src/composables/createNumberField/index.ts
@@ -66,6 +66,12 @@ export interface NumberFieldOptions extends NumericOptions {
   label?: string
   /** Form field name. */
   name?: string
+  /**
+   * Form injection key. Must match the parent Form's `namespace`.
+   *
+   * @default 'v0:form'
+   */
+  formNamespace?: string
   /** Validation rules. */
   rules?: InputOptions<number | null>['rules']
   /** Manual error state override — forces invalid. */
@@ -135,6 +141,7 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
     id,
     label,
     name,
+    formNamespace,
     rules,
     error,
     errorMessages,
@@ -147,6 +154,7 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
     id,
     label,
     name,
+    formNamespace,
     disabled,
     readonly: _readonly,
     rules,

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -81,15 +81,15 @@ describe('createValidation', () => {
       expect(validation.size).toBe(1)
     })
 
-    it('should use noop for unresolvable string aliases', async () => {
+    it('should fail unresolvable string aliases', async () => {
       using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const validation = createValidation()
       validation.register('nonexistent')
 
       const result = await validation.validate('')
-      // Noop rule returns true, so validation passes
-      expect(result).toBe(true)
+      expect(result).toBe(false)
+      expect(validation.errors.value).toEqual(['Unknown validation rule "nonexistent"'])
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'))
     })
@@ -597,14 +597,14 @@ describe('createValidation', () => {
       expect(validation.errors.value).toEqual(['Required'])
     })
 
-    it('should use noop for string aliases without rules context', async () => {
+    it('should fail string aliases without rules context', async () => {
       using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const validation = createValidation({ rules: ['required'] })
 
-      // String alias without context uses noop — no rules to fail
       const result = await validation.validate('')
-      expect(result).toBe(true)
+      expect(result).toBe(false)
+      expect(validation.errors.value).toEqual(['Unknown validation rule "required"'])
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('required'))
     })

--- a/packages/0/src/composables/createValidation/index.test.ts
+++ b/packages/0/src/composables/createValidation/index.test.ts
@@ -628,6 +628,19 @@ describe('createValidation', () => {
 
       const validation = createValidation()
 
+      expect(mockUseForm).toHaveBeenCalledWith('v0:form')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith({ value: validation })
+    })
+
+    it('should inject form via formNamespace', () => {
+      const form = createForm()
+      using spy = vi.spyOn(form, 'register')
+      mockUseForm.mockReturnValueOnce(form as any)
+
+      const validation = createValidation({ formNamespace: 'v0:billing' })
+
+      expect(mockUseForm).toHaveBeenCalledWith('v0:billing')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith({ value: validation })
     })

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -83,6 +83,8 @@ export interface ValidationOptions extends GroupOptions {
   rules?: RuleInput[]
   /** Value source for validate() when called without arguments. */
   value?: MaybeRefOrGetter<unknown>
+  /** Form injection key. Defaults to `'v0:form'`. */
+  namespace?: string
 }
 
 interface ValidationRun {
@@ -123,7 +125,13 @@ const UNSET = /* @__PURE__ */ Symbol('unset')
  * ```
  */
 export function createValidation (_options: ValidationOptions = {}): ValidationContext {
-  const { rules: initialRules = [], value: valueSource, enroll = true, ...options } = _options
+  const {
+    rules: initialRules = [],
+    value: valueSource,
+    enroll = true,
+    namespace = 'v0:form',
+    ...options
+  } = _options
   const group = createGroup({ ...options, enroll, multiple: true })
   const rulesContext = useRules()
 
@@ -140,7 +148,10 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   function register (input: RuleInput | Partial<ValidationTicketInput>): ValidationTicket {
     if (isFunction(input) || isString(input) || isStandardSchema(input)) {
       const resolved = rulesContext.resolve([input as RuleInput])
-      return group.register({ value: resolved[0] ?? (() => true) }) as ValidationTicket
+      const rule = resolved[0] ?? (() => (
+        isString(input) ? `Unknown validation rule "${input}"` : false
+      ))
+      return group.register({ value: rule }) as ValidationTicket
     }
     return group.register(input) as ValidationTicket
   }
@@ -249,7 +260,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   } as ValidationContext
 
   // Auto-register with parent form
-  const form = useForm()
+  const form = useForm(namespace)
   const ticket = form?.register({ value: context as ValidationContext })
 
   onScopeDispose(() => {

--- a/packages/0/src/composables/createValidation/index.ts
+++ b/packages/0/src/composables/createValidation/index.ts
@@ -83,8 +83,17 @@ export interface ValidationOptions extends GroupOptions {
   rules?: RuleInput[]
   /** Value source for validate() when called without arguments. */
   value?: MaybeRefOrGetter<unknown>
-  /** Form injection key. Defaults to `'v0:form'`. */
-  namespace?: string
+  /**
+   * Form injection key. Must match the parent Form's `namespace`.
+   *
+   * @default 'v0:form'
+   *
+   * @example
+   * ```ts
+   * createValidation({ formNamespace: 'v0:billing' })
+   * ```
+   */
+  formNamespace?: string
 }
 
 interface ValidationRun {
@@ -129,7 +138,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
     rules: initialRules = [],
     value: valueSource,
     enroll = true,
-    namespace = 'v0:form',
+    formNamespace = 'v0:form',
     ...options
   } = _options
   const group = createGroup({ ...options, enroll, multiple: true })
@@ -260,7 +269,7 @@ export function createValidation (_options: ValidationOptions = {}): ValidationC
   } as ValidationContext
 
   // Auto-register with parent form
-  const form = useForm(namespace)
+  const form = useForm(formNamespace)
   const ticket = form?.register({ value: context as ValidationContext })
 
   onScopeDispose(() => {


### PR DESCRIPTION
Unresolved rule alias strings (`rules: ['required']` without a rules plugin) no longer pass validation.

A `Form` with a custom `namespace` still provides `v0:form`, so `Input` / `createValidation` children auto-register. The custom key is for explicit `useForm('v0:billing')`.