### PR TITLE
fix(Input): required fields fail Form submit under novalidate

### DIFF
--- a/.changeset/form-required.md
+++ b/.changeset/form-required.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Input): required fields fail Form submit under novalidate
+
+`required` on Input and NumberField now registers a presence rule, so empty required fields fail `submit()` even though Form defaults to `novalidate`.

--- a/apps/docs/src/pages/components/forms/form.md
+++ b/apps/docs/src/pages/components/forms/form.md
@@ -181,6 +181,10 @@ Call `submit()` from slot props when you need to trigger validation without a su
 
 ::: faq
 
+??? Why does required still fail submit when Form is novalidate?
+
+Form defaults to `novalidate`, so the browser never runs native constraint validation. `required` on [Input](/components/forms/input) and [NumberField](/components/forms/number-field) still registers a presence rule with the Form, so empty required fields make `submit()` return `false`.
+
 ??? Why does my `@submit` handler run even when the form is invalid?
 
 `@submit` is pass-through — it fires on every native submit regardless of validity. Guard inside the handler: read the `valid` flag from the payload and `return` early when it's `false`.

--- a/apps/docs/src/pages/components/forms/input.md
+++ b/apps/docs/src/pages/components/forms/input.md
@@ -191,7 +191,7 @@ Input.Control renders as a native `<input>` and manages all ARIA attributes auto
 | `aria-describedby` | Description ID | Only present when `Input.Description` is mounted |
 | `aria-errormessage` | Error ID | Only present when `Input.Error` is mounted and errors exist |
 | `aria-required` | `true` | From Root's `required` prop |
-| `required` | `true` | Native attribute, from Root's `required` prop |
+| `required` | `true` | Native attribute, from Root's `required` prop. Also registers a presence rule so Form submit fails on empty values even with `novalidate`. |
 | `disabled` | `true` | Native attribute, from Root's `disabled` prop |
 | `readonly` | `true` | Native attribute, from Root's `readonly` prop |
 

--- a/apps/docs/src/pages/composables/forms/create-input.md
+++ b/apps/docs/src/pages/composables/forms/create-input.md
@@ -152,6 +152,10 @@ Composables never bind DOM events — that's a component responsibility. createI
 
 createValidation handles rule evaluation only. createInput wraps it and adds field state (dirty, pristine, focused, touched), ARIA IDs, error merging with manual messages, and the `error` prop override. Think of createInput as the full "form field" while createValidation is just the "rule runner."
 
+??? Does required participate in Form submit?
+
+Yes. Form defaults to `novalidate`, so the native `required` attribute never blocks submit. Pass `required: true` to `createInput` and a presence rule is registered — empty values fail `validate()` / Form `submit()`. Presence uses the same `dirty` predicate as `isDirty`.
+
 ??? Why is there no validateOn option?
 
 `validateOn` is event policy — "validate on blur vs input vs submit." That decision belongs in the component, not the composable. The component calls `input.validate()` whenever it decides to.

--- a/packages/0/src/components/Form/index.browser.test.ts
+++ b/packages/0/src/components/Form/index.browser.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+// Components
+import { Input } from '#v0/components/Input'
+
 // Composables
 import { useForm } from '#v0/composables/createForm'
 import { createValidation } from '#v0/composables/createValidation'
@@ -139,6 +142,36 @@ describe('form', () => {
     it('should emit submit with valid:true when no fields registered', async () => {
       const wrapper = mount(Form)
       await wrapper.trigger('submit')
+      const emitted = wrapper.emitted('submit')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([{ valid: true }])
+    })
+
+    it('should fail submit when a required Input is empty', async () => {
+      const wrapper = mount(Form, {
+        slots: {
+          default: () => h(Input.Root, { required: true }, {
+            default: () => h(Input.Control as any),
+          }),
+        },
+      })
+      await wrapper.trigger('submit')
+      await flushPromises()
+      const emitted = wrapper.emitted('submit')
+      expect(emitted).toHaveLength(1)
+      expect(emitted![0]).toEqual([{ valid: false }])
+    })
+
+    it('should submit empty Input without required as valid', async () => {
+      const wrapper = mount(Form, {
+        slots: {
+          default: () => h(Input.Root, {}, {
+            default: () => h(Input.Control as any),
+          }),
+        },
+      })
+      await wrapper.trigger('submit')
+      await flushPromises()
       const emitted = wrapper.emitted('submit')
       expect(emitted).toHaveLength(1)
       expect(emitted![0]).toEqual([{ valid: true }])

--- a/packages/0/src/components/NumberField/NumberFieldRoot.vue
+++ b/packages/0/src/components/NumberField/NumberFieldRoot.vue
@@ -243,6 +243,7 @@
     label,
     name,
     formNamespace,
+    required,
     locale,
     format: formatOptions,
     clamp: shouldClamp,

--- a/packages/0/src/composables/createInput/index.test.ts
+++ b/packages/0/src/composables/createInput/index.test.ts
@@ -156,6 +156,41 @@ describe('createInput', () => {
       })
       expect(input.isValid.value).toBe(false)
     })
+
+    it('should fail validation when required and empty', async () => {
+      const input = createInput({
+        value: ref(''),
+        required: true,
+      })
+      const result = await input.validate()
+      expect(result).toBe(false)
+      expect(input.errors.value).toEqual(['Required'])
+      expect(input.isValid.value).toBe(false)
+    })
+
+    it('should pass validation when required and filled', async () => {
+      const input = createInput({
+        value: ref('hello'),
+        required: true,
+      })
+      const result = await input.validate()
+      expect(result).toBe(true)
+      expect(input.errors.value).toEqual([])
+    })
+
+    it('should use the dirty predicate for required presence', async () => {
+      const value = ref<number | null>(null)
+      const input = createInput({
+        value,
+        required: true,
+        dirty: v => v !== null,
+      })
+
+      expect(await input.validate()).toBe(false)
+
+      value.value = 0
+      expect(await input.validate()).toBe(true)
+    })
   })
 
   describe('reset', () => {

--- a/packages/0/src/composables/createInput/index.test.ts
+++ b/packages/0/src/composables/createInput/index.test.ts
@@ -191,6 +191,36 @@ describe('createInput', () => {
       value.value = 0
       expect(await input.validate()).toBe(true)
     })
+
+    it('should treat non-string null as empty when required', async () => {
+      const input = createInput<number | null>({
+        value: ref<number | null>(null),
+        required: true,
+      })
+
+      expect(await input.validate()).toBe(false)
+      expect(input.errors.value).toEqual(['Required'])
+    })
+
+    it('should treat non-string 0 as filled when required', async () => {
+      const input = createInput<number | null>({
+        value: ref<number | null>(0),
+        required: true,
+      })
+
+      expect(await input.validate()).toBe(true)
+    })
+
+    it('should run required before additional rules', async () => {
+      const input = createInput({
+        value: ref(''),
+        required: true,
+        rules: [v => (v as string).length >= 3 || 'Too short'],
+      })
+
+      await input.validate()
+      expect(input.errors.value).toEqual(['Required', 'Too short'])
+    })
   })
 
   describe('reset', () => {

--- a/packages/0/src/composables/createInput/index.ts
+++ b/packages/0/src/composables/createInput/index.ts
@@ -16,7 +16,7 @@
  * import { createInput } from '@vuetify/v0'
  *
  * const value = shallowRef('')
- * const input = createInput({ value, label: 'Name', rules: ['required'] })
+ * const input = createInput({ value, label: 'Name', required: true })
  * await input.validate()
  * ```
  */
@@ -24,6 +24,7 @@
 // Composables
 import { createRegistry } from '#v0/composables/createRegistry'
 import { createValidation } from '#v0/composables/createValidation'
+import { useLocale } from '#v0/composables/useLocale'
 
 // Transformers
 import { toArray } from '#v0/composables/toArray'
@@ -59,7 +60,10 @@ export interface InputOptions<T = string> {
    * @default 'v0:form'
    */
   formNamespace?: string
-  /** Whether required. */
+  /**
+   * Whether required. When true, a presence rule is registered so Form
+   * submit fails on empty values even with `novalidate`.
+   */
   required?: boolean
   /** Disabled state. */
   disabled?: MaybeRefOrGetter<boolean>
@@ -132,7 +136,22 @@ export function createInput<T = string> (options: InputOptions<T>): InputContext
     equals = (a: T, b: T) => a === b,
   } = options
 
-  const validation = createValidation({ rules, value, formNamespace })
+  function filled (val: T): boolean {
+    if (dirtyFn) return dirtyFn(val)
+    return isString(val) ? val.length > 0 : !isNullOrUndefined(val)
+  }
+
+  const locale = useLocale()
+
+  function requiredRule (v: unknown) {
+    return filled(v as T) || (locale.ti('Input.required') ?? 'Required')
+  }
+
+  const validation = createValidation({
+    rules: required ? [requiredRule, ...rules] : rules,
+    value,
+    formNamespace,
+  })
 
   const initialValue = value.value
   const isFocused = shallowRef(false)
@@ -147,10 +166,7 @@ export function createInput<T = string> (options: InputOptions<T>): InputContext
   const descriptionId = `${id}-description`
   const errorId = `${id}-error`
 
-  const isDirty = toRef(() => {
-    if (dirtyFn) return dirtyFn(value.value)
-    return isString(value.value) ? value.value.length > 0 : !isNullOrUndefined(value.value)
-  })
+  const isDirty = toRef(() => filled(value.value))
 
   const isPristine = shallowRef(true)
 

--- a/packages/0/src/composables/createNumberField/index.test.ts
+++ b/packages/0/src/composables/createNumberField/index.test.ts
@@ -406,5 +406,16 @@ describe('createNumberField', () => {
       value.value = null
       expect(field.input.isPristine.value).toBe(true)
     })
+
+    it('should fail validate when required and empty', async () => {
+      const field = setup({ required: true })
+      expect(await field.input.validate()).toBe(false)
+      expect(field.input.errors.value).toEqual(['Required'])
+    })
+
+    it('should pass validate when required and 0', async () => {
+      const field = setup({ value: ref(0), required: true })
+      expect(await field.input.validate()).toBe(true)
+    })
   })
 })

--- a/packages/0/src/composables/createNumberField/index.ts
+++ b/packages/0/src/composables/createNumberField/index.ts
@@ -72,6 +72,11 @@ export interface NumberFieldOptions extends NumericOptions {
    * @default 'v0:form'
    */
   formNamespace?: string
+  /**
+   * Whether required. When true, a presence rule is registered so Form
+   * submit fails on empty values even with `novalidate`.
+   */
+  required?: boolean
   /** Validation rules. */
   rules?: InputOptions<number | null>['rules']
   /** Manual error state override — forces invalid. */
@@ -142,6 +147,7 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
     label,
     name,
     formNamespace,
+    required,
     rules,
     error,
     errorMessages,
@@ -155,6 +161,7 @@ export function createNumberField (options: NumberFieldOptions = {}): NumberFiel
     label,
     name,
     formNamespace,
+    required,
     disabled,
     readonly: _readonly,
     rules,

--- a/packages/0/src/locale/messages/en/index.test.ts
+++ b/packages/0/src/locale/messages/en/index.test.ts
@@ -68,7 +68,7 @@ describe('locale/messages/en', () => {
   it('should export an English aria-string catalog for every v0 component namespace', () => {
     expect(en).toBeTypeOf('object')
 
-    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'DataGrid', 'Dialog', 'NumberField', 'Pagination', 'Rating', 'Slider', 'Snackbar', 'Splitter']) {
+    for (const key of ['AlertDialog', 'Avatar', 'Breadcrumbs', 'Button', 'Carousel', 'Combobox', 'DataGrid', 'Dialog', 'Input', 'NumberField', 'Pagination', 'Rating', 'Slider', 'Snackbar', 'Splitter']) {
       expect(en).toHaveProperty(key)
     }
   })

--- a/packages/0/src/locale/messages/en/index.ts
+++ b/packages/0/src/locale/messages/en/index.ts
@@ -52,6 +52,9 @@ export default {
   Dialog: {
     close: 'Close',
   },
+  Input: {
+    required: 'Required',
+  },
   NumberField: {
     decrement: 'Decrement',
     increment: 'Increment',


### PR DESCRIPTION
Form defaults to `novalidate`, so the native `required` attribute never blocked submit. `createInput({ required: true })` now registers a presence rule (same predicate as `isDirty`); NumberField forwards the option.

Empty required Input/NumberField fields fail `submit()`. Locale key `Input.required`, fallback `Required`.