### PR TITLE
fix(EmCalendar): fill parent width instead of shrinking to the header

### DIFF
--- a/.changeset/emerald-calendar-full-width.md
+++ b/.changeset/emerald-calendar-full-width.md
@@ -1,0 +1,7 @@
+---
+"@paper/emerald": patch
+---
+
+fix(EmCalendar): fill the parent width instead of shrinking to the header
+
+A calendar in a full-width column used to size itself to the month label, so the grid sat as a skinny card on mobile. The root is now `width: 100%`.

--- a/apps/docs/src/examples/systems/emerald/calendar/basic.vue
+++ b/apps/docs/src/examples/systems/emerald/calendar/basic.vue
@@ -7,7 +7,7 @@
 </script>
 
 <template>
-  <div class="emerald-docs-stack">
+  <div class="emerald-docs-calendar">
     <EmCalendar v-model="day">
       <EmCalendar.Header>
         <EmCalendar.Prev />
@@ -27,10 +27,11 @@
 </template>
 
 <style>
-  .emerald-docs-stack {
+  .emerald-docs-calendar {
     display: flex;
     flex-direction: column;
     gap: var(--emerald-spacing-m, 16px);
+    width: 100%;
   }
 
   .emerald-docs-note {

--- a/apps/docs/src/examples/systems/emerald/calendar/events.vue
+++ b/apps/docs/src/examples/systems/emerald/calendar/events.vue
@@ -31,7 +31,7 @@
 </script>
 
 <template>
-  <div class="emerald-docs-stack">
+  <div class="emerald-docs-calendar">
     <EmCalendar v-model="day" :events>
       <EmCalendarHeader>
         <EmCalendarPrev />
@@ -47,10 +47,10 @@
 </template>
 
 <style>
-  .emerald-docs-stack {
+  .emerald-docs-calendar {
     display: flex;
     flex-direction: column;
     gap: var(--emerald-spacing-m, 16px);
-    max-width: 460px;
+    width: 100%;
   }
 </style>

--- a/apps/docs/src/examples/systems/emerald/calendar/mini.vue
+++ b/apps/docs/src/examples/systems/emerald/calendar/mini.vue
@@ -28,7 +28,7 @@
 </script>
 
 <template>
-  <div class="emerald-docs-stack">
+  <div class="emerald-docs-calendar emerald-docs-calendar-mini">
     <EmCalendar v-model="day" :events>
       <EmCalendarHeader>
         <EmCalendarPrev />
@@ -44,10 +44,20 @@
 </template>
 
 <style>
-  .emerald-docs-stack {
+  .emerald-docs-calendar {
     display: flex;
     flex-direction: column;
     gap: var(--emerald-spacing-m, 16px);
+    width: 100%;
+  }
+
+  .emerald-docs-calendar-mini {
     max-width: 260px;
+  }
+
+  @media (max-width: 640px) {
+    .emerald-docs-calendar-mini {
+      max-width: none;
+    }
   }
 </style>

--- a/apps/docs/src/examples/systems/emerald/calendar/month.vue
+++ b/apps/docs/src/examples/systems/emerald/calendar/month.vue
@@ -21,7 +21,7 @@
 </script>
 
 <template>
-  <div class="emerald-docs-stack">
+  <div class="emerald-docs-calendar">
     <EmCalendar v-model="day" v-model:month="month">
       <EmCalendarHeader>
         <EmCalendarPrev />
@@ -43,10 +43,11 @@
 </template>
 
 <style>
-  .emerald-docs-stack {
+  .emerald-docs-calendar {
     display: flex;
     flex-direction: column;
     gap: var(--emerald-spacing-m, 16px);
+    width: 100%;
   }
 
   .emerald-docs-row {

--- a/packages/emerald/src/components/EmCalendar/EmCalendar.vue
+++ b/packages/emerald/src/components/EmCalendar/EmCalendar.vue
@@ -182,6 +182,8 @@
   .emerald-calendar {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
     overflow: hidden;
     background: var(--emerald-background, #fefefe);
     border: var(--emerald-stroke-s, 1px) solid var(--emerald-neutral-300, #ccd6e7);


### PR DESCRIPTION
EmCalendar sized itself to the month label, so the Emerald calendar examples (and any flex column with `align-items: start`) rendered a skinny card on mobile.

The root is now `width: 100%`. Docs examples use a dedicated wrapper so they are not affected by the shared `.emerald-docs-stack` styles from other Emerald examples. Mini stays 260px on desktop and goes full-width under 640px.