### PR TITLE
fix(InputControl): keep wrapper attrs when Root leaves them unset

### DIFF
--- a/.changeset/input-control-omit-undefined.md
+++ b/.changeset/input-control-omit-undefined.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(InputControl): keep wrapper attrs when Root leaves them unset
+
+Wrappers can set a control attr the ambient Input.Root left unset (`readonly`, `disabled`, `required`, `name`, `form`). Root-set values still win.

--- a/packages/0/src/components/Input/InputControl.vue
+++ b/packages/0/src/components/Input/InputControl.vue
@@ -16,10 +16,21 @@
   import { useInputRoot } from './InputRoot.vue'
 
   // Utilities
+  import { isUndefined } from '#v0/utilities'
   import { mergeProps, toRef, useAttrs } from 'vue'
 
   // Types
   import type { AtomProps } from '#v0/components/Atom'
+
+  function defined (attrs: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {}
+
+    for (const key of Object.keys(attrs)) {
+      if (!isUndefined(attrs[key])) result[key] = attrs[key]
+    }
+
+    return result
+  }
 
   export interface InputControlProps extends AtomProps {
     namespace?: string
@@ -79,7 +90,7 @@
     const readonly = root.isReadonly.value
     const isFocused = root.isFocused.value
 
-    return {
+    return defined({
       'id': root.id,
       'type': root.type.value,
       'name': root.name,
@@ -100,7 +111,7 @@
       'onInput': onInput,
       'onFocus': onFocus,
       'onBlur': onBlur,
-    }
+    })
   })
 
   const slotProps = toRef((): InputControlSlotProps => ({

--- a/packages/0/src/components/Input/index.browser.test.ts
+++ b/packages/0/src/components/Input/index.browser.test.ts
@@ -8,7 +8,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { createSSRApp, defineComponent, h, nextTick, ref } from 'vue'
 
 // Types
-import type { InputRootSlotProps } from './index'
+import type { InputControlSlotProps, InputRootSlotProps } from './index'
 import type { VueWrapper } from '@vue/test-utils'
 
 interface MountResult {
@@ -22,6 +22,7 @@ function mountInput (options: {
   model?: ReturnType<typeof ref<string>>
   withDescription?: boolean
   withError?: boolean
+  controlAttrs?: Record<string, unknown>
 } = {}): MountResult {
   let capturedProps: any
 
@@ -39,7 +40,7 @@ function mountInput (options: {
       default: (props: any) => {
         capturedProps = props
         const children = [
-          h(Input.Control as any),
+          h(Input.Control as any, options.controlAttrs),
         ]
         if (options.withDescription !== false) {
           children.push(h(Input.Description as any, {}, () => 'Help text'))
@@ -791,6 +792,92 @@ describe('input', () => {
       await wait()
 
       expect(props().isValid).toBeNull()
+    })
+  })
+
+  describe('control fallthrough attrs', () => {
+    it('should apply Control readonly when Root leaves it unset', () => {
+      const { wrapper } = mountInput({ controlAttrs: { readonly: true } })
+
+      expect(wrapper.find('input').attributes('readonly')).toBeDefined()
+    })
+
+    it('should apply Control disabled when Root leaves it unset', () => {
+      const { wrapper } = mountInput({ controlAttrs: { disabled: true } })
+
+      expect(wrapper.find('input').attributes('disabled')).toBeDefined()
+    })
+
+    it('should apply Control required when Root leaves it unset', () => {
+      const { wrapper } = mountInput({ controlAttrs: { required: true } })
+
+      expect(wrapper.find('input').attributes('required')).toBeDefined()
+    })
+
+    it('should apply Control name when Root leaves it unset', () => {
+      const { wrapper } = mountInput({ controlAttrs: { name: 'email' } })
+
+      expect(wrapper.find('input').attributes('name')).toBe('email')
+    })
+
+    it('should apply Control form when Root leaves it unset', () => {
+      const { wrapper } = mountInput({ controlAttrs: { form: 'signup' } })
+
+      expect(wrapper.find('input').attributes('form')).toBe('signup')
+    })
+
+    it('should keep Root readonly when Control also sets readonly', () => {
+      const { wrapper } = mountInput({
+        props: { readonly: true },
+        controlAttrs: { readonly: true },
+      })
+
+      expect(wrapper.find('input').attributes('readonly')).toBeDefined()
+    })
+
+    it('should keep Root readonly when Control omits readonly', () => {
+      const { wrapper } = mountInput({ props: { readonly: true } })
+
+      expect(wrapper.find('input').attributes('readonly')).toBeDefined()
+    })
+
+    it('should not set readonly when Root and Control leave it unset', () => {
+      const { wrapper } = mountInput()
+
+      expect(wrapper.find('input').attributes('readonly')).toBeUndefined()
+    })
+
+    it('should keep empty value on the native input', () => {
+      const { wrapper } = mountInput()
+      const input = wrapper.find('input').element as HTMLInputElement
+
+      expect(input.value).toBe('')
+    })
+
+    it('should keep empty value in control attrs', () => {
+      let captured: InputControlSlotProps | undefined
+
+      mount(Input.Root, {
+        slots: {
+          default: () => h(Input.Control as any, { renderless: true }, {
+            default: (p: InputControlSlotProps) => {
+              captured = p
+            },
+          }),
+        },
+      })
+
+      expect(captured?.attrs.value).toBe('')
+      expect(Object.hasOwn(captured!.attrs, 'value')).toBe(true)
+    })
+
+    it('should keep Root type when Control sets a different type', () => {
+      const { wrapper } = mountInput({
+        props: { type: 'password' },
+        controlAttrs: { type: 'email' },
+      })
+
+      expect(wrapper.find('input').attributes('type')).toBe('password')
     })
   })
 


### PR DESCRIPTION
Vue's `mergeProps` assigns `undefined` keys, so `InputControl`'s later `controlAttrs` object wiped wrapper fallthrough whenever the ambient `Input.Root` left a field unset.

`controlAttrs` now drops `undefined` keys before the merge. A wrapper can set `readonly`, `disabled`, `required`, `name`, and `form` when Root did not. Root-set values still win. `type`, `id`, and `v-model` stay Root-owned because those keys are always defined.

Closes #913
https://github.com/vuetifyjs/0/issues/913