### PR TITLE
fix(TabsItem): let renderless items supply a focus target

### DIFF
--- a/.changeset/butab-keyboard-focus.md
+++ b/.changeset/butab-keyboard-focus.md
@@ -1,0 +1,5 @@
+---
+"@paper/bulma": patch
+---
+
+fix(BuTab): follow keyboard focus onto the tab anchor

--- a/.changeset/tabsitem-focus-target.md
+++ b/.changeset/tabsitem-focus-target.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(TabsItem): let renderless items supply a focus target
+
+Pass `el` to `Tabs.Item` when `as` is `null` so arrow keys move focus to the real control.

--- a/apps/docs/src/pages/components/disclosure/tabs.md
+++ b/apps/docs/src/pages/components/disclosure/tabs.md
@@ -139,6 +139,10 @@ Add `enroll` to `Tabs.Root`. The first tab to register becomes the active one, w
 
 Set `orientation="vertical"` on `Tabs.Root`. Keyboard navigation then uses Arrow Up/Down instead of Arrow Left/Right.
 
+??? How do I keep arrow-key focus when a tab is renderless?
+
+Pass `el` on `Tabs.Item` when `as` is `null`, pointing at the real control the slot renders. Arrow, Home, and End then move focus to that node. Without `el`, selection still updates but DOM focus stays put.
+
 :::
 
 <DocsApi />

--- a/apps/docs/src/pages/systems/bulma/tabs.md
+++ b/apps/docs/src/pages/systems/bulma/tabs.md
@@ -58,9 +58,7 @@ Bulma's `.tabs` with selection and panels — the JavaScript and the tabpanels t
 
 `BuTabs` is `Tabs.Root` with no element of its own. Bulma's `.tabs` block is the list, and the panels are siblings of that block, so the selection context has to wrap both. Every `.tabs` modifier — `centered`, `boxed`, `toggle`, `size` — therefore lives on `BuTabList`, which is the `div.tabs` plus the `ul` (`Tabs.List as="ul"`). Putting those classes on the root would paint a wrapper Bulma does not document.
 
-`BuTab` is `Tabs.Item` with `as` set to `null`, not the `renderless` prop. `as` feeds the item's button polyfill, so `renderless` alone would leak `type="button"` and `disabled` onto the anchor. The item renders `li.is-active > a` itself, which is what the fixture demands: `is-active` on the `li`, no `href` on the `a`.
-
-That renderless item registers no element. v0's `focusSelectedTab` / `focusAdjacent` then become no-ops — Arrow keys still move selection, panels and `aria-selected`, but DOM focus stays on the previously selected anchor. That is a documented APG deviation, not an oversight; the v0-core follow-up is to let `TabsItem` accept an element via registration so a renderless consumer can supply the focus target.
+`BuTab` is `Tabs.Item` with `as` set to `null`, not the `renderless` prop. `as` feeds the item's button polyfill, so `renderless` alone would leak `type="button"` and `disabled` onto the anchor. The item renders `li.is-active > a` itself, which is what the fixture demands: `is-active` on the `li`, no `href` on the `a`. The `<a>` is passed as `el` so arrow-key focus follows the real control.
 
 `BuTabPanel` is `Tabs.Panel` as-is. The `hidden` attribute is fine here: Bulma defines no panel CSS, so there is no class for the wrapper to fight.
 
@@ -137,8 +135,5 @@ Size still belongs on the list. `small` / `medium` / `large` scale the tabs with
 | Key | Behavior |
 |-----|----------|
 | Click | Selects that tab |
-| Arrow Left / Right | Moves **selection**, not focus |
-| Home / End | Selects first / last |
-
-> [!WARNING]
-> Arrow keys update selection, panels and `aria-selected`, but the focus ring and the screen-reader cursor stay on the tab that was focused. `BuTab` is renderless, so v0 has no element to move focus to. This is an APG tabs deviation the axe sweep cannot catch. Click still focuses the tab you clicked; keyboard users who start on a tab and arrow away will hear the old tab while a new panel is showing.
+| Arrow Left / Right | Moves focus **and** activates the tab |
+| Home / End | Focuses **and** activates first / last |

--- a/packages/0/src/components/Tabs/TabsItem.vue
+++ b/packages/0/src/components/Tabs/TabsItem.vue
@@ -53,6 +53,8 @@
     ariaLabelledby?: string
     /** ID of element that describes this tab */
     ariaDescribedby?: string
+    /** Focus target when renderless / `:as="null"`. Defaults to the Atom host. */
+    el?: MaybeRefOrGetter<Element | null | undefined>
   }
 
   export interface TabsItemSlotProps {
@@ -106,11 +108,12 @@
     ariaLabel,
     ariaLabelledby,
     ariaDescribedby,
+    el: _el,
   } = defineProps<TabsItemProps<V>>()
 
   const tabs = useTabsRoot(namespace)
 
-  const el = toRef(() => toElement(rootRef.value?.element) ?? undefined)
+  const el = toRef(() => toElement(_el) ?? toElement(rootRef.value?.element) ?? undefined)
   const ticket = tabs.register({ id, value, disabled: () => toValue(disabled) ?? false, el })
 
   const isDisabled = toRef(() => toValue(ticket.disabled) || toValue(tabs.disabled))
@@ -126,7 +129,7 @@
     nextTick(() => {
       const selected = tabs.selectedItem.value
       if (selected) {
-        (toValue(selected.el) as HTMLElement | undefined)?.focus()
+        (toElement(selected.el) as HTMLElement | undefined)?.focus()
       }
     })
   }
@@ -148,7 +151,7 @@
       }
       const item = all[index]
       if (item && !toValue(item.disabled)) {
-        nextTick(() => (toValue(item.el) as HTMLElement | undefined)?.focus())
+        nextTick(() => (toElement(item.el) as HTMLElement | undefined)?.focus())
         return
       }
       index += direction
@@ -158,7 +161,7 @@
 
   function focusEdge (edge: 'first' | 'last') {
     const item = tabs.seek(edge)
-    if (item) nextTick(() => (toValue(item.el) as HTMLElement | undefined)?.focus())
+    if (item) nextTick(() => (toElement(item.el) as HTMLElement | undefined)?.focus())
   }
 
   function onKeydown (e: KeyboardEvent) {

--- a/packages/0/src/components/Tabs/index.browser.test.ts
+++ b/packages/0/src/components/Tabs/index.browser.test.ts
@@ -2028,5 +2028,75 @@ describe('tabs', () => {
       expect(selected.value).toBe('tab-2')
       expect(document.activeElement).toBe(second)
     })
+
+    it('should leave focus in place on Home when as is null and el is omitted (manual)', async () => {
+      const selected = ref('tab-2')
+      const captured: Record<string, any> = {}
+
+      wrapper = mount(Tabs.Root, {
+        attachTo: document.body,
+        props: {
+          'activation': 'manual',
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Tabs.Item as any, { as: null, value: 'tab-1' }, {
+              default: (props: any) => h('button', { ...props.attrs, type: 'button' }, 'Tab 1'),
+            }),
+            h(Tabs.Item as any, { as: null, value: 'tab-2' }, {
+              default: (props: any) => {
+                captured.tab2 = props
+                return h('button', { ...props.attrs, type: 'button' }, 'Tab 2')
+              },
+            }),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      const [first, second] = tabs()
+      second!.focus()
+      expect(document.activeElement).toBe(second)
+
+      captured.tab2.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(document.activeElement).toBe(second)
+      expect(document.activeElement).not.toBe(first)
+    })
+
+    it('should no-op focusEdge when every tab is disabled', async () => {
+      const captured: Record<string, any> = {}
+
+      wrapper = mount(Tabs.Root, {
+        attachTo: document.body,
+        props: {
+          activation: 'manual',
+          mandatory: false,
+        },
+        slots: {
+          default: () => [
+            h(Tabs.Item as any, { value: 'tab-1', disabled: true }, {
+              default: (props: any) => {
+                captured.tab1 = props
+                return 'Tab 1'
+              },
+            }),
+            h(Tabs.Item as any, { value: 'tab-2', disabled: true }, () => 'Tab 2'),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      expect(() => captured.tab1.attrs.onKeydown(key('Home'))).not.toThrow()
+      await nextTick()
+    })
   })
 })

--- a/packages/0/src/components/Tabs/index.browser.test.ts
+++ b/packages/0/src/components/Tabs/index.browser.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { renderToString } from 'vue/server-renderer'
 
 import { Tabs } from './index'
 
 // Utilities
 import { mount } from '@vue/test-utils'
-import { createSSRApp, defineComponent, h, nextTick, ref } from 'vue'
+import { createSSRApp, defineComponent, h, nextTick, ref, useTemplateRef } from 'vue'
 
 describe('tabs', () => {
   describe('root', () => {
@@ -1765,6 +1765,268 @@ describe('tabs', () => {
       expect(panelProps.isSelected).toBe(false)
       // ID falls back to value when ticket is null
       expect(panelProps.attrs.id).toContain('orphan')
+    })
+  })
+
+  describe('renderless el focus target', () => {
+    let wrapper: ReturnType<typeof mount>
+
+    afterEach(() => {
+      wrapper?.unmount()
+    })
+
+    function key (name: string) {
+      return new KeyboardEvent('keydown', { key: name })
+    }
+
+    function tabs () {
+      return wrapper.findAll('[role="tab"]').map(node => node.element as HTMLElement)
+    }
+
+    it('should update selection without moving focus when as is null and el is omitted', async () => {
+      const selected = ref('tab-1')
+      const captured: Record<string, any> = {}
+
+      wrapper = mount(Tabs.Root, {
+        attachTo: document.body,
+        props: {
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Tabs.Item as any, { as: null, value: 'tab-1' }, {
+              default: (props: any) => {
+                captured.tab1 = props
+                return h('button', { ...props.attrs, type: 'button' }, 'Tab 1')
+              },
+            }),
+            h(Tabs.Item as any, { as: null, value: 'tab-2' }, {
+              default: (props: any) => h('button', { ...props.attrs, type: 'button' }, 'Tab 2'),
+            }),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      const [first, second] = tabs()
+      first!.focus()
+      expect(document.activeElement).toBe(first)
+
+      captured.tab1.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(document.activeElement).toBe(first)
+      expect(document.activeElement).not.toBe(second)
+    })
+
+    function mountWithEl (activation: 'automatic' | 'manual' = 'automatic') {
+      const selected = ref('tab-1')
+      const captured: Record<string, any> = {}
+
+      const Harness = defineComponent({
+        setup () {
+          const tab1 = useTemplateRef<HTMLElement>('tab1')
+          const tab2 = useTemplateRef<HTMLElement>('tab2')
+          const tab3 = useTemplateRef<HTMLElement>('tab3')
+
+          return () => h(Tabs.Root as any, {
+            activation,
+            'modelValue': selected.value,
+            'onUpdate:modelValue': (v: unknown) => {
+              selected.value = v as string
+            },
+          }, () => [
+            h(Tabs.Item as any, { as: null, el: tab1, value: 'tab-1' }, {
+              default: (props: any) => {
+                captured.tab1 = props
+                return h('button', { ...props.attrs, ref: 'tab1', type: 'button' }, 'Tab 1')
+              },
+            }),
+            h(Tabs.Item as any, { as: null, el: tab2, value: 'tab-2' }, {
+              default: (props: any) => {
+                captured.tab2 = props
+                return h('button', { ...props.attrs, ref: 'tab2', type: 'button' }, 'Tab 2')
+              },
+            }),
+            h(Tabs.Item as any, { as: null, el: tab3, value: 'tab-3' }, {
+              default: (props: any) => {
+                captured.tab3 = props
+                return h('button', { ...props.attrs, ref: 'tab3', type: 'button' }, 'Tab 3')
+              },
+            }),
+          ])
+        },
+      })
+
+      wrapper = mount(Harness, { attachTo: document.body })
+
+      return { selected, captured }
+    }
+
+    it('should move selection and focus on ArrowRight when as is null and el is supplied', async () => {
+      const { selected, captured } = mountWithEl()
+      await nextTick()
+
+      const [first, second] = tabs()
+      first!.focus()
+      expect(document.activeElement).toBe(first)
+
+      captured.tab1.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(document.activeElement).toBe(second)
+    })
+
+    it('should move selection and focus on ArrowLeft when as is null and el is supplied', async () => {
+      const { selected, captured } = mountWithEl()
+      await nextTick()
+
+      const [first, second] = tabs()
+      captured.tab2.select()
+      await nextTick()
+      second!.focus()
+      expect(selected.value).toBe('tab-2')
+
+      captured.tab2.attrs.onKeydown(key('ArrowLeft'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('should move selection and focus on Home when as is null and el is supplied', async () => {
+      const { selected, captured } = mountWithEl()
+      await nextTick()
+
+      const [first, , last] = tabs()
+      captured.tab3.select()
+      await nextTick()
+      last!.focus()
+
+      captured.tab3.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('should move selection and focus on End when as is null and el is supplied', async () => {
+      const { selected, captured } = mountWithEl()
+      await nextTick()
+
+      const [first, , last] = tabs()
+      first!.focus()
+
+      captured.tab1.attrs.onKeydown(key('End'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-3')
+      expect(document.activeElement).toBe(last)
+    })
+
+    it('should move focus only on ArrowRight in manual mode when el is supplied', async () => {
+      const { selected, captured } = mountWithEl('manual')
+      await nextTick()
+
+      const [first, second] = tabs()
+      first!.focus()
+
+      captured.tab1.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+      expect(document.activeElement).toBe(second)
+    })
+
+    it('should move focus only on ArrowLeft in manual mode when el is supplied', async () => {
+      const { selected, captured } = mountWithEl('manual')
+      await nextTick()
+
+      const [first, second] = tabs()
+      captured.tab2.select()
+      await nextTick()
+      second!.focus()
+      expect(selected.value).toBe('tab-2')
+
+      captured.tab2.attrs.onKeydown(key('ArrowLeft'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('should move focus only on Home in manual mode when el is supplied', async () => {
+      const { selected, captured } = mountWithEl('manual')
+      await nextTick()
+
+      const [first, , last] = tabs()
+      captured.tab3.select()
+      await nextTick()
+      last!.focus()
+
+      captured.tab3.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-3')
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('should move focus only on End in manual mode when el is supplied', async () => {
+      const { selected, captured } = mountWithEl('manual')
+      await nextTick()
+
+      const [first, , last] = tabs()
+      first!.focus()
+
+      captured.tab1.attrs.onKeydown(key('End'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+      expect(document.activeElement).toBe(last)
+    })
+
+    it('should focus the Atom host on ArrowRight without passing el', async () => {
+      const selected = ref('tab-1')
+      const captured: Record<string, any> = {}
+
+      wrapper = mount(Tabs.Root, {
+        attachTo: document.body,
+        props: {
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Tabs.Item as any, { value: 'tab-1' }, {
+              default: (props: any) => {
+                captured.tab1 = props
+                return 'Tab 1'
+              },
+            }),
+            h(Tabs.Item as any, { value: 'tab-2' }, () => 'Tab 2'),
+          ],
+        },
+      })
+
+      await nextTick()
+
+      const [first, second] = tabs()
+      first!.focus()
+      expect(document.activeElement).toBe(first)
+
+      captured.tab1.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(document.activeElement).toBe(second)
     })
   })
 })

--- a/packages/0/src/components/Tabs/index.test.ts
+++ b/packages/0/src/components/Tabs/index.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Tabs } from './index'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+import { h, nextTick, ref } from 'vue'
+
+describe('tabs', () => {
+  describe('renderless el focus target', () => {
+    function key (name: string) {
+      return new KeyboardEvent('keydown', { key: name })
+    }
+
+    function mountPair (options: {
+      activation?: 'automatic' | 'manual'
+      as?: null
+      firstEl?: HTMLElement
+      secondEl?: HTMLElement
+      firstDisabled?: boolean
+      secondDisabled?: boolean
+      mandatory?: boolean | 'force'
+    } = {}) {
+      const selected = ref('tab-1')
+      const captured: Record<string, { attrs: { onKeydown: (e: KeyboardEvent) => void } }> = {}
+
+      mount(Tabs.Root, {
+        props: {
+          'activation': options.activation ?? 'automatic',
+          'mandatory': options.mandatory,
+          'modelValue': selected.value,
+          'onUpdate:modelValue': (v: unknown) => {
+            selected.value = v as string
+          },
+        },
+        slots: {
+          default: () => [
+            h(Tabs.Item as never, {
+              as: options.as,
+              el: options.firstEl,
+              value: 'tab-1',
+              disabled: options.firstDisabled,
+            }, {
+              default: (props: { attrs: { onKeydown: (e: KeyboardEvent) => void } }) => {
+                captured.tab1 = props
+                return h('button', props.attrs, 'Tab 1')
+              },
+            }),
+            h(Tabs.Item as never, {
+              as: options.as,
+              el: options.secondEl,
+              value: 'tab-2',
+              disabled: options.secondDisabled,
+            }, {
+              default: (props: { attrs: { onKeydown: (e: KeyboardEvent) => void } }) => {
+                captured.tab2 = props
+                return h('button', props.attrs, 'Tab 2')
+              },
+            }),
+          ],
+        },
+      })
+
+      return { selected, captured }
+    }
+
+    it('should call focus on the supplied el after ArrowRight', async () => {
+      const first = document.createElement('button')
+      const second = document.createElement('button')
+      const focus = vi.spyOn(second, 'focus')
+
+      const { selected, captured } = mountPair({ as: null, firstEl: first, secondEl: second })
+      await nextTick()
+
+      captured.tab1!.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+      expect(focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call focus on the supplied el after Home in manual mode', async () => {
+      const first = document.createElement('button')
+      const second = document.createElement('button')
+      const focus = vi.spyOn(first, 'focus')
+
+      const { selected, captured } = mountPair({
+        activation: 'manual',
+        as: null,
+        firstEl: first,
+        secondEl: second,
+      })
+      await nextTick()
+
+      captured.tab2!.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+      expect(focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call focus when as is null and el is omitted', async () => {
+      const { selected, captured } = mountPair({ as: null })
+      await nextTick()
+
+      captured.tab1!.attrs.onKeydown(key('ArrowRight'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-2')
+    })
+
+    it('should not call focus on Home when as is null and el is omitted (manual)', async () => {
+      const { selected, captured } = mountPair({ activation: 'manual', as: null })
+      await nextTick()
+
+      captured.tab2!.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(selected.value).toBe('tab-1')
+    })
+
+    it('should not call focus on Home when every tab is disabled (manual)', async () => {
+      const first = document.createElement('button')
+      const second = document.createElement('button')
+      const focusFirst = vi.spyOn(first, 'focus')
+      const focusSecond = vi.spyOn(second, 'focus')
+
+      const { captured } = mountPair({
+        activation: 'manual',
+        firstEl: first,
+        secondEl: second,
+        firstDisabled: true,
+        secondDisabled: true,
+        mandatory: false,
+      })
+      await nextTick()
+
+      captured.tab1!.attrs.onKeydown(key('Home'))
+      await nextTick()
+
+      expect(focusFirst).not.toHaveBeenCalled()
+      expect(focusSecond).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/bulma/SPEC.md
+++ b/packages/bulma/SPEC.md
@@ -70,14 +70,6 @@ markup against bulma.io's documented fixtures.
 - **Esc closes a `blocking` BuModal:** matches v0 Dialog semantics (`blocking` gates
   scrim-click dismissal only, mirroring native `<dialog>` cancel). Revisit if the DS wants
   `blocking` to gate keyboard dismissal too.
-- **BuTab arrow keys move selection, not focus:** Tabs.Item renders renderless (the
-  fixture demands `li > a` with `is-active` on the `li`), so it registers no element and
-  v0's `focusSelectedTab`/`focusAdjacent` are no-ops — ArrowLeft/ArrowRight update
-  selection, panels, and `aria-selected`, but the visible focus ring and screen-reader
-  announcement stay on the previously focused anchor (APG tabs deviation the axe sweep
-  cannot catch). v0-core follow-up: let TabsItem accept an element input via
-  registration so renderless consumers can supply the focus target
-  ([#912](https://github.com/vuetifyjs/0/issues/912)).
 - **BuBreadcrumb hand-rolls its markup:** v0 BreadcrumbsRoot's overflow watcher hides
   middle crumbs whenever measured capacity < crumb count even with no Ellipsis
   registered — crumbs silently disappear where upstream Bulma flex-wraps. Since

--- a/packages/bulma/src/components/BuTab/BuTab.vue
+++ b/packages/bulma/src/components/BuTab/BuTab.vue
@@ -3,7 +3,7 @@
   import { Tabs } from '@vuetify/v0'
 
   // Utilities
-  import { useAttrs } from 'vue'
+  import { useAttrs, useTemplateRef } from 'vue'
 
   export interface BuTabProps<V = unknown> {
     /** Value matched against the BuTabs v-model and BuTabPanel */
@@ -31,23 +31,23 @@
     value,
     disabled = false,
   } = defineProps<BuTabProps<V>>()
+
+  const anchor = useTemplateRef('anchor')
 </script>
 
 <template>
   <!--
     :as="null" (NOT the renderless prop): `as` feeds TabsItem's button
     polyfill, so `renderless` alone would emit type="button" + disabled onto
-    the anchor. Renderless items register no element, so v0's arrow-key focus
-    moves (focusSelectedTab/focusAdjacent) are no-ops here: selection, panels,
-    and aria-selected update but DOM focus stays on the previously selected
-    anchor. Known Tier-1 limitation — see SPEC.md. role="presentation" lifts
-    the <li> out of the accessibility tree so role=tablist directly owns the
-    role=tab anchors (axe aria-required-children/-parent).
+    the anchor. :el points arrow-key focus at the <a>. role="presentation"
+    lifts the <li> out of the accessibility tree so role=tablist directly
+    owns the role=tab anchors (axe aria-required-children/-parent).
   -->
   <Tabs.Item
     v-slot="{ isSelected, attrs: tab }"
     :as="null"
     :disabled
+    :el="anchor"
     :value
   >
     <li
@@ -55,7 +55,7 @@
       :class="{ 'is-active': isSelected }"
       role="presentation"
     >
-      <a v-bind="tab">
+      <a ref="anchor" v-bind="tab">
         <slot :is-selected />
       </a>
     </li>


### PR DESCRIPTION
Renderless `Tabs.Item` (`as={null}`) registered Atom's null host, so arrow-key focus-follow was a no-op. Selection, panels, and `aria-selected` still updated.

`Tabs.Item` now accepts an optional `el` focus target. `BuTab` passes the `<a>`.

Closes #912
https://github.com/vuetifyjs/0/issues/912