### PR TITLE
fix(Breadcrumbs): skip overflow truncation when no Ellipsis is registered

### DIFF
--- a/.changeset/breadcrumbs-ellipsis-omit.md
+++ b/.changeset/breadcrumbs-ellipsis-omit.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Breadcrumbs): keep every crumb visible when Ellipsis is omitted (#911)
+
+Truncation only runs when `Breadcrumbs.Ellipsis` is composed.

--- a/apps/docs/src/pages/components/semantic/breadcrumbs.md
+++ b/apps/docs/src/pages/components/semantic/breadcrumbs.md
@@ -319,6 +319,10 @@ Use `Breadcrumbs.Link` for navigable crumbs and `Breadcrumbs.Page` for the curre
 
 The `gap` prop (default `8`) must match your actual CSS gap. If they differ, the overflow capacity calculation drifts — set `:gap` to your pixel gap.
 
+??? Why did my crumbs disappear when I didn't add an Ellipsis?
+
+Omitting `Breadcrumbs.Ellipsis` skips truncation; every crumb stays visible. Wrap is consumer CSS. Composing Ellipsis is the overflow-UI opt-in.
+
 ??? How do I render crumbs as Vue Router links?
 
 Pass `:as="RouterLink"` along with `to` on `Breadcrumbs.Link`.

--- a/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
+++ b/packages/0/src/components/Breadcrumbs/BreadcrumbsRoot.vue
@@ -201,9 +201,14 @@
       const eW = ellipsisWidth.value
       const reserved = fI + gap + fD + gap + eW + gap
 
-      if (capacity === Infinity || capacity >= measuredCount) {
-        // Everything fits — show all content, hide ellipsis. Truncation is
-        // gone, so a disclosure left open from a narrower viewport is stale.
+      if (
+        ellipsisTickets.length === 0 ||
+        capacity === Infinity ||
+        capacity >= measuredCount
+      ) {
+        // Everything fits, or no overflow UI composed — show all content, hide
+        // ellipsis. Truncation is gone, so a disclosure left open from a
+        // narrower viewport is stale.
         hiddenCount.value = 0
         if (expanded.value) expanded.value = false
         for (const t of ellipsisTickets) group.unselect(t.id)

--- a/packages/0/src/components/Breadcrumbs/index.browser.test.ts
+++ b/packages/0/src/components/Breadcrumbs/index.browser.test.ts
@@ -1464,6 +1464,34 @@ describe('breadcrumbs', () => {
       el.remove()
     })
 
+    it('should keep all crumbs visible when overflowing with no Ellipsis registered', async () => {
+      // 4 items + 3 dividers = 7 content, measuredCount = 5
+      const { context } = mountOverflowTree({ itemCount: 4, withEllipsis: false })
+      await nextTick()
+      const ctx = context()
+
+      const el = createMeasurableElement(20)
+      ctx.measureElement(0, 'item', el)
+      ctx.measureElement(0, 'divider', el)
+      await nextTick()
+
+      // reserved = 20+8+20+8 = 56 (no ellipsisWidth); width=50 => capacity=0 < measuredCount
+      triggerResize(50)
+      await nextTick()
+
+      expect(ctx.overflow.capacity.value).toBe(0)
+
+      for (const t of ctx.group.values()) {
+        if (t.type !== 'ellipsis' && t.type !== 'activator') {
+          expect(t.isSelected.value).toBe(true)
+        }
+      }
+
+      expect(ctx.hiddenCount.value).toBe(0)
+
+      el.remove()
+    })
+
     it('should hide first divider when w < reserved + fD in capacity=0', async () => {
       const { context } = mountOverflowTree({ itemCount: 4, withEllipsis: true })
       await nextTick()


### PR DESCRIPTION
Without `Breadcrumbs.Ellipsis` composed, Root still collapsed middle crumbs whenever measured capacity was below the item count. Items vanished via `v-show` with no overflow UI.

The visibility watcher now takes the show-all path when no ellipsis ticket is registered. Composing `Breadcrumbs.Ellipsis` is the overflow-UI opt-in; omitting it leaves every crumb visible.

Closes #911
https://github.com/vuetifyjs/0/issues/911