### PR TITLE
docs: mobile layout fixes for tables, headings, breadcrumbs, and the app bar

### DIFF
--- a/apps/docs/build/markdown.ts
+++ b/apps/docs/build/markdown.ts
@@ -515,7 +515,7 @@ export function applyMarkdownPlugins (md: MarkdownIt, highlighter: DocsHighlight
     return `<DocsMarkup code="${encodedCode}" language="${lang || 'text'}"${titleAttr}${binTitleAttr}${playgroundAttr}${collapseAttr}${collapseLinesAttr}${hideFilenameAttr}${tourAttr}>${highlighted}</DocsMarkup>`
   }
   // Wrap tables in scrollable container for mobile
-  md.renderer.rules.table_open = () => '<div class="overflow-x-auto mb-4"><table>'
+  md.renderer.rules.table_open = () => '<div class="docs-table overflow-x-auto mb-4"><table>'
   md.renderer.rules.table_close = () => '</table></div>'
 
   // Emit <AppImage> for markdown images: ![alt](src "title") — title maps to caption

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -475,6 +475,16 @@
     table:not([data-grid] table) {
       width: 100%;
       background-color: var(--v0-surface);
+
+      /* Phones: width:100% resolves to max(container, min-content) and
+         squeezes every wrappable column to one word per line. Let the table
+         take its natural width (capped so prose cells still wrap) and scroll
+         inside the overflow-x-auto wrapper markdown.ts provides. */
+      @media (max-width: 767px) {
+        width: max-content;
+        min-width: 100%;
+        max-width: 42rem;
+      }
       border-collapse: separate;
       border-spacing: 0;
       border-radius: 0.5rem;
@@ -499,6 +509,56 @@
       tr:last-child td {
         border-bottom: none;
       }
+    }
+
+    /* Mobile scroll affordance: overlay scrollbars are invisible until
+       touched, leaving no signal that a wide table extends past the
+       viewport. Fade the clipped edge of an overflowing wrapper — the fade
+       tracks scroll position and vanishes at the reached edge (an inactive
+       timeline leaves the no-fade base values, so non-overflowing tables are
+       untouched). Browsers without scroll timelines keep a thin scrollbar. */
+    @media (max-width: 767px) {
+      div.overflow-x-auto:has(> table) {
+        scrollbar-width: thin;
+        scrollbar-color: color-mix(in srgb, var(--v0-on-surface) 40%, transparent) transparent;
+        padding-bottom: 2px;
+      }
+
+      @supports (animation-timeline: scroll(self x)) {
+        div.overflow-x-auto:has(> table) {
+          --table-fade-start: 0px;
+          --table-fade-end: 0px;
+          mask-image: linear-gradient(to right, transparent 0, black var(--table-fade-start), black calc(100% - var(--table-fade-end)), transparent 100%);
+          animation: docs-table-edge-fade linear both;
+          animation-timeline: scroll(self x);
+        }
+      }
+    }
+  }
+
+  /* Registered so the table-wrapper edge fade interpolates smoothly instead
+     of flipping mid-scroll (custom properties animate discretely otherwise). */
+  @property --table-fade-start {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --table-fade-end {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @keyframes docs-table-edge-fade {
+    0% {
+      --table-fade-start: 0px;
+      --table-fade-end: 2.5rem;
+    }
+
+    100% {
+      --table-fade-start: 2.5rem;
+      --table-fade-end: 0px;
     }
   }
 

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -493,16 +493,6 @@
     table:not([data-grid] table) {
       width: 100%;
       background-color: var(--v0-surface);
-
-      /* Phones: width:100% resolves to max(container, min-content) and
-         squeezes every wrappable column to one word per line. Let the table
-         take its natural width (capped so prose cells still wrap) and scroll
-         inside the overflow-x-auto wrapper markdown.ts provides. */
-      @media (max-width: 767px) {
-        width: max-content;
-        min-width: 100%;
-        max-width: 42rem;
-      }
       border-collapse: separate;
       border-spacing: 0;
       border-radius: 0.5rem;
@@ -529,26 +519,48 @@
       }
     }
 
-    /* Mobile scroll affordance: overlay scrollbars are invisible until
-       touched, leaving no signal that a wide table extends past the
-       viewport. Fade the clipped edge of an overflowing wrapper — the fade
-       tracks scroll position and vanishes at the reached edge (an inactive
-       timeline leaves the no-fade base values, so non-overflowing tables are
-       untouched). Browsers without scroll timelines keep a thin scrollbar. */
+    /* Markdown-emitted tables only — .docs-table is the wrapper both
+       markdown pipelines emit (build/markdown.ts, useMarkdown.ts). Example
+       and app tables (data-grid, benchmarks, freshness) manage their own
+       widths and must not be clamped. */
     @media (max-width: 767px) {
-      div.overflow-x-auto:has(> table) {
+      /* width:100% resolves to max(container, min-content) at phone widths
+         and squeezes every wrappable column to one word per line. Let the
+         table take its natural width (capped so prose cells still wrap) and
+         scroll inside its wrapper. */
+      div.docs-table > table {
+        width: max-content;
+        min-width: 100%;
+        max-width: 42rem;
+      }
+
+      /* Scroll affordance: overlay scrollbars are invisible until touched,
+         leaving no signal that a wide table extends past the viewport. Fade
+         the clipped edge of an overflowing wrapper — the fade tracks scroll
+         position and vanishes at the reached edge (an inactive timeline
+         leaves the no-fade base values, so non-overflowing tables are
+         untouched). Browsers without scroll timelines keep a thin
+         scrollbar. */
+      div.docs-table {
         scrollbar-width: thin;
         scrollbar-color: color-mix(in srgb, var(--v0-on-surface) 40%, transparent) transparent;
         padding-bottom: 2px;
       }
 
       @supports (animation-timeline: scroll(self x)) {
-        div.overflow-x-auto:has(> table) {
+        div.docs-table {
           --table-fade-start: 0px;
           --table-fade-end: 0px;
           mask-image: linear-gradient(to right, transparent 0, black var(--table-fade-start), black calc(100% - var(--table-fade-end)), transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--table-fade-start), black calc(100% - var(--table-fade-end)), transparent 100%);
           animation: docs-table-edge-fade linear both;
           animation-timeline: scroll(self x);
+
+          /* RTL scrolls from the right edge, so the fade sides flip. */
+          [dir='rtl'] & {
+            mask-image: linear-gradient(to left, transparent 0, black var(--table-fade-start), black calc(100% - var(--table-fade-end)), transparent 100%);
+            -webkit-mask-image: linear-gradient(to left, transparent 0, black var(--table-fade-start), black calc(100% - var(--table-fade-end)), transparent 100%);
+          }
         }
       }
     }

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -349,9 +349,12 @@
 
     h1, h2, h3, h4, h5, h6 {
       position: relative;
+
       /* Long API tokens (useIntersectionObserver, SUPPORTS_*) must break
          instead of widening the layout viewport on phones. */
-      overflow-wrap: anywhere;
+      @media (max-width: 767px) {
+        overflow-wrap: anywhere;
+      }
 
       > .header-anchor {
         color: inherit;
@@ -377,7 +380,7 @@
           /* Out of flow — an in-flow '#' extends the widest line by ~1em
              and with it the page's scrollWidth on mobile. */
           position: absolute;
-          margin-left: 0.25em;
+          margin-inline-start: 0.25em;
           opacity: 0;
         }
 
@@ -390,6 +393,18 @@
         @media (max-width: 767px) {
           &::before {
             display: none;
+          }
+
+          &::after {
+            /* Explicit offsets, heading-relative: the static position of an
+               abspos child of the inline-flex anchor is the flex alignment
+               origin — over the heading's first characters — and anything
+               hung past the text end re-widens wrapped headings. Pinned to
+               the inline-end of the heading's last line instead: a wrapped
+               heading's first line is full by construction, its last line is
+               the short leftover. */
+            inset-inline-end: 0;
+            bottom: 0;
           }
         }
       }
@@ -434,9 +449,12 @@
 
     code {
       font-family: 'Courier New', Courier, monospace;
+
       /* Inline paths/imports in prose wrap instead of widening the page;
          inert inside pre-formatted (.shiki) blocks. */
-      overflow-wrap: anywhere;
+      @media (max-width: 767px) {
+        overflow-wrap: anywhere;
+      }
     }
 
     p {

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -527,8 +527,10 @@
       /* width:100% resolves to max(container, min-content) at phone widths
          and squeezes every wrappable column to one word per line. Let the
          table take its natural width (capped so prose cells still wrap) and
-         scroll inside its wrapper. */
-      div.docs-table > table {
+         scroll inside its wrapper. Both wrapper classes, so this outranks
+         the base table rule structurally — (0,3,2) over its (0,2,2) —
+         instead of by source order. */
+      div.docs-table.overflow-x-auto > table {
         width: max-content;
         min-width: 100%;
         max-width: 42rem;

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -349,6 +349,9 @@
 
     h1, h2, h3, h4, h5, h6 {
       position: relative;
+      /* Long API tokens (useIntersectionObserver, SUPPORTS_*) must break
+         instead of widening the layout viewport on phones. */
+      overflow-wrap: anywhere;
 
       > .header-anchor {
         color: inherit;
@@ -371,6 +374,9 @@
         }
 
         &::after {
+          /* Out of flow — an in-flow '#' extends the widest line by ~1em
+             and with it the page's scrollWidth on mobile. */
+          position: absolute;
           margin-left: 0.25em;
           opacity: 0;
         }
@@ -428,6 +434,9 @@
 
     code {
       font-family: 'Courier New', Courier, monospace;
+      /* Inline paths/imports in prose wrap instead of widening the page;
+         inert inside pre-formatted (.shiki) blocks. */
+      overflow-wrap: anywhere;
     }
 
     p {

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -40,7 +40,7 @@
 <template>
   <Atom
     :as
-    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,24px)] px-3 text-on-surface border-b border-solid border-divider z-1', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,24px)] px-2 min-[430px]:px-3 text-on-surface border-b border-solid border-divider z-1', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
     data-app-bar
   >
     <div class="flex items-center gap-2">
@@ -96,7 +96,7 @@
       </Discovery.Activator>
     </div>
 
-    <div class="flex align-center items-center gap-3">
+    <div class="flex align-center items-center gap-2 min-[430px]:gap-3">
       <AppSkillFilter v-if="!isHomePage && settings.showSkillFilter.value && breakpoints.width.value >= 440" />
 
       <AppThemeToggle v-if="isHomePage || settings.showThemeToggle.value" />
@@ -105,7 +105,7 @@
         v-if="isHomePage || settings.showSocialLinks.value"
         aria-label="Discord Community (opens in new tab)"
         as="a"
-        class="bg-[#5865F2] text-white pa-1 inline-flex rounded opacity-90 hover:opacity-100"
+        class="bg-[#5865F2] text-white pa-1 hidden min-[430px]:inline-flex rounded opacity-90 hover:opacity-100"
         href="https://discord.gg/vuetify"
         position-area="bottom"
         rel="noopener noreferrer"
@@ -119,7 +119,7 @@
         v-if="isHomePage || settings.showSocialLinks.value"
         aria-label="GitHub Repository (opens in new tab)"
         as="a"
-        class="bg-[#24292f] text-white pa-1 inline-flex rounded opacity-90 hover:opacity-100"
+        class="bg-[#24292f] text-white pa-1 hidden min-[430px]:inline-flex rounded opacity-90 hover:opacity-100"
         href="https://github.com/vuetifyjs/0"
         position-area="bottom"
         rel="noopener noreferrer"

--- a/apps/docs/src/components/app/AppBreadcrumbs.vue
+++ b/apps/docs/src/components/app/AppBreadcrumbs.vue
@@ -13,7 +13,7 @@
 
 <template>
   <Breadcrumbs.Root>
-    <Breadcrumbs.List class="flex items-center gap-2 list-none m-0 p-0 text-sm">
+    <Breadcrumbs.List class="flex flex-wrap items-center gap-2 list-none m-0 p-0 text-sm">
       <template v-for="(item, index) in items" :key="item.text">
         <Breadcrumbs.Divider
           v-if="index > 0"
@@ -29,10 +29,13 @@
           class="text-on-surface-variant list-none shrink-0 m-0"
         />
 
-        <Breadcrumbs.Item class="list-none shrink-0 m-0" :text="item.text">
+        <Breadcrumbs.Item
+          :class="['list-none m-0', item.to ? 'shrink-0' : 'min-w-0']"
+          :text="item.text"
+        >
           <Breadcrumbs.Page
             v-if="!item.to"
-            class="text-on-surface-variant whitespace-nowrap"
+            class="text-on-surface-variant block truncate"
           >
             {{ item.text }}
           </Breadcrumbs.Page>

--- a/apps/docs/src/components/docs/DocsApiIndex.vue
+++ b/apps/docs/src/components/docs/DocsApiIndex.vue
@@ -87,7 +87,7 @@
       <template v-for="[category, entries] in componentGroups" :key="`c-${category}`">
         <DocsHeaderAnchor :id="`components-${toKebab(category)}`" class="text-2xl leading-8 mt-6 mb-2" tag="h3">{{ toTitle(category) }}</DocsHeaderAnchor>
 
-        <div class="overflow-x-auto mb-4">
+        <div class="docs-table overflow-x-auto mb-4">
           <table>
             <thead>
               <tr>
@@ -118,7 +118,7 @@
       <template v-for="[category, entries] in composableGroups" :key="`e-${category}`">
         <DocsHeaderAnchor :id="`composables-${toKebab(category)}`" class="text-2xl leading-8 mt-6 mb-2" tag="h3">{{ toTitle(category) }}</DocsHeaderAnchor>
 
-        <div class="overflow-x-auto mb-4">
+        <div class="docs-table overflow-x-auto mb-4">
           <table>
             <thead>
               <tr>

--- a/apps/docs/src/composables/useMarkdown.ts
+++ b/apps/docs/src/composables/useMarkdown.ts
@@ -79,7 +79,7 @@ function getMarked (hl: Highlighter): Marked {
         }
         const thead = `<thead><tr>${header.map(cell => `<th${cell.align ? ` align="${cell.align}"` : ''}>${parse(cell.text)}</th>`).join('')}</tr></thead>`
         const tbody = `<tbody>${rows.map(row => `<tr>${row.map(cell => `<td${cell.align ? ` align="${cell.align}"` : ''}>${parse(cell.text)}</td>`).join('')}</tr>`).join('')}</tbody>`
-        return `<div class="overflow-x-auto mb-4"><table>${thead}${tbody}</table></div>`
+        return `<div class="docs-table overflow-x-auto mb-4"><table>${thead}${tbody}</table></div>`
       },
       blockquote ({ raw }) {
         // GitHub-style callouts: > [!TIP], > [!NOTE], > [!WARNING], > [!CAUTION], > [!IMPORTANT], > [!TRY], > [!TOUR]

--- a/apps/docs/src/layouts/fullscreen.vue
+++ b/apps/docs/src/layouts/fullscreen.vue
@@ -1,5 +1,5 @@
 <template>
   <AppNav />
   <AppMain class="flex-1 flex flex-col" />
-  <AppFooter inset />
+  <AppFooter />
 </template>

--- a/apps/docs/src/layouts/fullscreen.vue
+++ b/apps/docs/src/layouts/fullscreen.vue
@@ -1,4 +1,5 @@
 <template>
   <AppNav />
   <AppMain class="flex-1 flex flex-col" />
+  <AppFooter inset />
 </template>


### PR DESCRIPTION
Systemic mobile-layout fixes for the docs app at phone widths (320–430px), found by a full-route mobile audit.

- **Prose tables**: mobile tables keep natural column widths and scroll inside their wrapper, with a scroll-driven edge fade (RTL-aware, @supports-guarded, styled-scrollbar fallback) instead of squeezing to one-word-per-line and hiding the last column. Scoped to markdown-emitted tables via a `.docs-table` stamp from both markdown pipelines; component tables (data-grid examples, benchmarks) unaffected.
- **Headings & inline code**: `overflow-wrap: anywhere` under 768px so long camelCase/`SUPPORTS_*` tokens wrap instead of forcing page-wide horizontal scroll (~25 routes affected); the header-anchor `#` is taken out of layout flow on mobile so it no longer widens the page, pinned to the heading box's inline-end (tap still reveals it and sets the hash).
- **Breadcrumbs**: trail wraps at narrow widths; non-link crumbs truncate as a backstop.
- **App bar**: at 320px the right icon cluster previously needed ~384px, leaving Settings and Sign-in unreachable. Discord/GitHub now collapse below 430px (both remain in the footer, including on the fullscreen layout, which now renders it); padding/gaps tighten one step. 430px+ renders identically.

Verified with a headless-Chromium sweep of 14 representative routes × 320/375/430: zero horizontal scroll, tables readable with working affordance, desktop (1280) unchanged.

https://claude.ai/code/session_01UTCx471779RNB2pVGuW1RQ