### PR TITLE
docs: keep tour cards on-screen on mobile and fix the stale API extraction cache

### DIFF
--- a/apps/docs/build/generate-api.ts
+++ b/apps/docs/build/generate-api.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { glob, readdir } from 'node:fs/promises'
+import { glob, readdir, stat } from 'node:fs/promises'
 import { basename, dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -831,6 +831,34 @@ export interface ApiData {
   related: Record<string, string[]>
 }
 
+/**
+ * Fingerprint of the extracted source tree (entry count + newest mtime). The
+ * cache must expire when `packages/0/src` changes: a stale manifest 404s every
+ * `/api/<slug>` route minted for a component the cache predates (DataGrid,
+ * DataTable) and resurrects internals the barrel no longer exports.
+ *
+ * Directories count too — a rename changes neither entry count nor any file's
+ * mtime, only the parent directory's, so the scan must include directory
+ * mtimes (and the roots themselves, for top-level folder renames).
+ */
+async function fingerprint (): Promise<string> {
+  let count = 0
+  let newest = 0
+
+  for (const dir of [COMPONENTS_DIR, COMPOSABLES_DIR]) {
+    for await (const entry of glob(`${dir}/**/*`)) {
+      const info = await stat(entry)
+      count++
+      newest = Math.max(newest, info.mtimeMs)
+    }
+
+    const info = await stat(dir)
+    newest = Math.max(newest, info.mtimeMs)
+  }
+
+  return `${count}:${newest}`
+}
+
 export default function generateApiPlugin (): Plugin {
   let apiData: ApiData | null = null
   let apiPromise: Promise<ApiData> | null = null
@@ -841,10 +869,11 @@ export default function generateApiPlugin (): Plugin {
     // Try to read from cache first (SSR build reuses client build cache)
     if (existsSync(API_CACHE_FILE)) {
       try {
-        const cached = JSON.parse(readFileSync(API_CACHE_FILE, 'utf8')) as Partial<ApiData>
-        // Invalidate caches written before the `related` field existed.
-        if (cached.components && cached.composables && cached.related) {
-          apiData = cached as ApiData
+        const cached = JSON.parse(readFileSync(API_CACHE_FILE, 'utf8')) as Partial<ApiData> & { stamp?: string }
+        // Invalidate caches without a stamp (pre-stamp format) or whose stamp
+        // no longer matches the source tree.
+        if (cached.components && cached.composables && cached.related && cached.stamp === await fingerprint()) {
+          apiData = { components: cached.components, composables: cached.composables, related: cached.related }
           console.log(`[generate-api] Loaded API from cache`)
           return apiData
         }
@@ -865,7 +894,7 @@ export default function generateApiPlugin (): Plugin {
           // Write to cache for subsequent builds (SSR reuses this)
           try {
             mkdirSync(API_CACHE_DIR, { recursive: true })
-            writeFileSync(API_CACHE_FILE, JSON.stringify(data))
+            writeFileSync(API_CACHE_FILE, JSON.stringify({ ...data, stamp: await fingerprint() }))
           } catch {
             // Cache write failed, continue without caching
           }

--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // Framework
-  import { IN_BROWSER, isNullOrUndefined, useBreakpoints, useLogger } from '@vuetify/v0'
+  import { IN_BROWSER, isNull, isNullOrUndefined, useBreakpoints, useLogger } from '@vuetify/v0'
 
   // Context
   import { useDiscoveryRootContext } from './DiscoveryRoot.vue'
@@ -30,10 +30,48 @@
   }>()
 
   const breakpoints = useBreakpoints()
+
+  // Mobile fallback placement, measured per step. A vertical anchor edge alone
+  // can't keep the card on-screen: a full-height target (Ask AI panel, expanded
+  // code pane) leaves no room on the anchored side and `bottom: anchor(top)`
+  // pushes the card past the viewport edge.
+  const flip = shallowRef<string | null>(null)
+
+  // Room a card needs on the anchored side: max-height is unknowable before
+  // render, so budget for a typical tall card (20rem wide, ~15rem tall) + offset.
+  const ROOM = 256
+
+  function measure (el: HTMLElement) {
+    flip.value = null
+    if (!breakpoints.smAndDown.value) return
+
+    const requested = isNullOrUndefined(placementMobile) ? placement : placementMobile
+    if (requested !== 'top' && requested !== 'bottom') return
+
+    const rect = el.getBoundingClientRect()
+    const vh = window.innerHeight
+
+    // A target most of the viewport tall has no roomy side; overlaying it
+    // centered keeps the card (and its buttons) reachable.
+    if (rect.height >= vh * 0.6) {
+      flip.value = 'center'
+      return
+    }
+
+    const room = { top: rect.top, bottom: vh - rect.bottom }
+    if (room[requested] >= ROOM) return
+
+    const other = requested === 'top' ? 'bottom' : 'top'
+    flip.value = room[other] >= ROOM ? other : 'center'
+  }
+
   const activePlacement = toRef(() => {
     // Last step always uses center placement
     if (discovery.isLast.value) return 'center'
-    if (!isNullOrUndefined(placementMobile) && breakpoints.smAndDown.value) return placementMobile
+    if (breakpoints.smAndDown.value) {
+      if (!isNull(flip.value)) return flip.value
+      if (!isNullOrUndefined(placementMobile)) return placementMobile
+    }
     return placement
   })
 
@@ -182,6 +220,7 @@
 
           const activator = discovery.activators.get(root.step)
           if (activator?.element?.value) {
+            measure(activator.element.value)
             // Activator found - wait one more frame for anchor-name CSS
             requestAnimationFrame(() => {
               if (!isUnmounted) isReady.value = true
@@ -198,6 +237,7 @@
         requestAnimationFrame(checkActivator)
       } else {
         isReady.value = false
+        flip.value = null
       }
     },
     { immediate: true },

--- a/apps/docs/src/components/discovery/DiscoveryContent.vue
+++ b/apps/docs/src/components/discovery/DiscoveryContent.vue
@@ -216,14 +216,15 @@
 
         // Poll until activator is registered and DOM element exists (with timeout)
         function checkActivator () {
-          if (isUnmounted) return
+          // A stale loop can outlive its step (next/back/exit while polling)
+          if (isUnmounted || !root.isActive.value) return
 
           const activator = discovery.activators.get(root.step)
           if (activator?.element?.value) {
             measure(activator.element.value)
             // Activator found - wait one more frame for anchor-name CSS
             requestAnimationFrame(() => {
-              if (!isUnmounted) isReady.value = true
+              if (!isUnmounted && root.isActive.value) isReady.value = true
             })
           } else if (performance.now() - startTime > TIMEOUT_MS) {
             logger.warn(`[DiscoveryContent] Activator for step "${root.step}" not found after ${TIMEOUT_MS}ms`)

--- a/apps/docs/src/pages/skillz.[id].vue
+++ b/apps/docs/src/pages/skillz.[id].vue
@@ -122,7 +122,7 @@
             <span class="hidden sm:inline">Back to Skillz</span>
           </RouterLink>
 
-          <div class="flex items-center gap-4">
+          <div class="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
             <SkillDuration class="text-sm text-on-surface-variant" :minutes="tour.minutes" />
 
             <!-- Reset button (shows when there's progress) -->


### PR DESCRIPTION
Two P0s from the mobile audit plus companions.

- **Tour step cards** (`DiscoveryContent`): on small screens the card now measures its target when a step activates — flips top↔bottom when the anchored side has under 256px of room and centers over targets spanning ≥60vh. Previously `placementMobile: 'top'` against a full-viewport target pinned the card above the screen (using-the-docs step 7 was unfinishable on a phone; using-examples clipped its card title). The activator poll loop also bails when a step deactivates, closing a stale-measure race. Known limitation: placement is measured once per step activation, not re-measured on rotate (matches pre-existing behavior).
- **Skillz detail page**: the header action row wraps, so the "Next: …" CTA is no longer clipped at 375px.
- **API extraction cache** (`generate-api.ts`): `/api/data-grid` and `/api/data-table` were rendering the in-app 404 — the cache dated from before the DataGrid merge and never invalidated on source changes. The cache is now stamped with a source fingerprint (entry count + newest mtime across files *and directories*, so renames invalidate too); unstamped caches regenerate. Stale checkouts self-heal on next dev/build.

Verified by driving all three tours end-to-end at 375×812 and 320×658 (every card in-viewport, all buttons tappable, zero console errors) plus a 1280 desktop pass; API pages render live content and the pager links resolve.

https://claude.ai/code/session_01UTCx471779RNB2pVGuW1RQ