### PR TITLE
docs: mobile layout fixes for examples and home components

### DIFF
--- a/apps/docs/src/components/docs/DocsFreshnessTable.vue
+++ b/apps/docs/src/components/docs/DocsFreshnessTable.vue
@@ -175,7 +175,7 @@
 
     <div
       v-if="table.pagination.pages > 1"
-      class="flex items-center justify-between gap-3 mt-4 text-sm"
+      class="flex flex-wrap items-center justify-between gap-3 mt-4 text-sm"
     >
       <span class="text-on-surface-variant text-xs">
         Showing
@@ -191,7 +191,7 @@
         :size="table.filteredItems.value.length"
         :total-visible="5"
       >
-        <Pagination.First class="w-8 h-8 rounded border border-divider flex items-center justify-center bg-surface hover:bg-surface-tint data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed">
+        <Pagination.First class="w-8 h-8 rounded border border-divider hidden sm:flex items-center justify-center bg-surface hover:bg-surface-tint data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed">
           «
         </Pagination.First>
 
@@ -218,7 +218,7 @@
           ›
         </Pagination.Next>
 
-        <Pagination.Last class="w-8 h-8 rounded border border-divider flex items-center justify-center bg-surface hover:bg-surface-tint data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed">
+        <Pagination.Last class="w-8 h-8 rounded border border-divider hidden sm:flex items-center justify-center bg-surface hover:bg-surface-tint data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed">
           »
         </Pagination.Last>
       </Pagination.Root>

--- a/apps/docs/src/components/docs/benchmark/BenchmarkSummaryCards.vue
+++ b/apps/docs/src/components/docs/benchmark/BenchmarkSummaryCards.vue
@@ -17,7 +17,7 @@
 </script>
 
 <template>
-  <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
     <button
       v-for="c in composables"
       :key="c.name"

--- a/apps/docs/src/components/home/HomeEcosystem.vue
+++ b/apps/docs/src/components/home/HomeEcosystem.vue
@@ -179,14 +179,14 @@
             :class="item.type === 'component' ? 'hover:border-primary' : 'hover:border-teal-400'"
             :to="item.to"
           >
-            <div class="flex items-center gap-1.5 mb-1">
+            <div class="flex items-center gap-1.5 mb-1 min-w-0">
               <span
                 class="w-1.75 h-1.75 flex-shrink-0"
                 :class="item.type === 'component' ? 'rounded-full bg-primary' : 'rounded-sm bg-teal-400'"
               />
 
               <span
-                class="font-semibold text-sm transition-colors"
+                class="font-semibold text-sm transition-colors truncate"
                 :class="[
                   item.type === 'composable' ? 'font-mono' : '',
                   item.type === 'component' ? 'group-hover:text-primary' : 'group-hover:text-teal-400',

--- a/apps/docs/src/components/home/HomeHero.vue
+++ b/apps/docs/src/components/home/HomeHero.vue
@@ -97,7 +97,7 @@
     </p>
 
     <div class="relative flex flex-col items-center gap-6 mb-10">
-      <div class="grid grid-cols-2 md:flex gap-4 justify-center">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:flex gap-4 justify-center">
         <router-link
           class="home-hero-cta-primary px-8 py-3.5 bg-primary text-on-primary rounded-xl font-semibold text-lg text-center whitespace-nowrap transition-all duration-150 inline-flex items-center justify-center gap-2"
           to="/introduction/getting-started"

--- a/apps/docs/src/examples/components/number-field/CartLineItems.vue
+++ b/apps/docs/src/examples/components/number-field/CartLineItems.vue
@@ -41,9 +41,9 @@
       <li
         v-for="item in items"
         :key="item.id"
-        class="flex items-center gap-4 p-3"
+        class="flex flex-wrap items-center gap-x-4 gap-y-2 p-3"
       >
-        <div class="flex-1 min-w-0">
+        <div class="w-full sm:w-auto sm:flex-1 min-w-0">
           <p class="text-sm font-medium text-on-surface truncate">{{ item.name }}</p>
 
           <p class="text-xs text-on-surface-variant">
@@ -75,7 +75,7 @@
           </NumberField.Increment>
         </NumberField.Root>
 
-        <p class="w-20 text-right text-sm font-medium text-on-surface tabular-nums">
+        <p class="w-20 ml-auto text-right text-sm font-medium text-on-surface tabular-nums">
           {{ money(lineSubtotal(item)) }}
         </p>
       </li>

--- a/apps/docs/src/examples/components/splitter/playground.vue
+++ b/apps/docs/src/examples/components/splitter/playground.vue
@@ -32,7 +32,7 @@ h1 {
       :max-size="30"
       :min-size="15"
     >
-      <div class="px-3 py-2 text-xs font-semibold text-on-surface-variant uppercase tracking-wide border-b border-divider">
+      <div class="px-3 py-2 text-xs font-semibold text-on-surface-variant uppercase tracking-wide border-b border-divider truncate">
         Explorer
       </div>
 
@@ -41,7 +41,7 @@ h1 {
           v-for="name in Object.keys(files)"
           :key="name"
           :class="[
-            'px-2 py-1 rounded cursor-pointer',
+            'px-2 py-1 rounded cursor-pointer truncate',
             name === active ? 'bg-primary/10 text-primary' : 'hover:bg-surface-tint',
           ]"
           @click="active = name"

--- a/apps/docs/src/examples/components/treeview/settings-panel.vue
+++ b/apps/docs/src/examples/components/treeview/settings-panel.vue
@@ -53,7 +53,7 @@
 </script>
 
 <template>
-  <div class="settings-panel flex gap-4">
+  <div class="settings-panel flex flex-col gap-4 sm:flex-row">
     <Treeview.Root>
       <Treeview.List class="settings-tree flex-1 text-sm text-on-surface select-none min-w-0">
         <SettingNode
@@ -66,7 +66,7 @@
       </Treeview.List>
     </Treeview.Root>
 
-    <div class="w-48 shrink-0 border-l border-divider pl-4 text-sm">
+    <div class="border-t border-divider pt-4 text-sm sm:w-48 sm:shrink-0 sm:border-t-0 sm:border-l sm:pl-4 sm:pt-0">
       <template v-if="active">
         <p class="font-medium text-on-surface">{{ active.label }}</p>
         <p class="mt-1 text-on-surface-variant text-xs leading-relaxed">{{ active.description }}</p>

--- a/apps/docs/src/examples/composables/create-breadcrumbs/basic.vue
+++ b/apps/docs/src/examples/composables/create-breadcrumbs/basic.vue
@@ -26,7 +26,7 @@
 
 <template>
   <div class="space-y-4">
-    <nav class="flex items-center gap-1.5 text-sm">
+    <nav class="flex flex-wrap items-center gap-1.5 text-sm">
       <template
         v-for="(ticket, i) in items"
         :key="ticket.id"

--- a/apps/docs/src/examples/composables/create-rating/StarRating.vue
+++ b/apps/docs/src/examples/composables/create-rating/StarRating.vue
@@ -6,7 +6,7 @@
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-center gap-3">
+    <div class="flex flex-wrap items-center gap-3">
       <div class="flex gap-1" @mouseleave="review.clearHover()">
         <div
           v-for="item in review.display.value"

--- a/apps/docs/src/examples/composables/create-trinity/ToastConsumer.vue
+++ b/apps/docs/src/examples/composables/create-trinity/ToastConsumer.vue
@@ -151,7 +151,7 @@
     </div>
 
     <!-- Trinity tuple breakdown -->
-    <div class="grid grid-cols-3 gap-2 text-center">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-center">
       <div class="p-3 rounded-lg bg-surface-variant/50">
         <p class="text-xs font-mono text-on-surface-variant">useToasts</p>
         <p class="text-[10px] text-on-surface-variant/60 mt-1">Consumer</p>

--- a/apps/docs/src/examples/composables/use-reduced-motion/basic.vue
+++ b/apps/docs/src/examples/composables/use-reduced-motion/basic.vue
@@ -18,7 +18,7 @@
 
 <template>
   <div class="flex flex-col gap-6">
-    <div class="flex items-center gap-3">
+    <div class="flex flex-wrap items-center gap-3">
       <Button.Group
         class="inline-flex rounded-lg bg-surface-variant p-1 gap-1"
         label="Reduced motion mode"

--- a/apps/docs/src/examples/systems/emerald/pagination/summary.vue
+++ b/apps/docs/src/examples/systems/emerald/pagination/summary.vue
@@ -15,6 +15,7 @@
   <EmPagination
     v-slot="{ items, pageStart, pageStop, size }"
     v-model="page"
+    class="emerald-docs-pagination"
     :items-per-page="8"
     :size="87"
   >
@@ -33,6 +34,15 @@
 </template>
 
 <style>
+  .emerald-docs-pagination {
+    max-width: 100%;
+  }
+
+  .emerald-docs-pagination .emerald-pagination__nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
   .emerald-docs-summary {
     margin-right: var(--emerald-spacing-s, 12px);
     color: var(--emerald-on-surface-variant, #757e85);

--- a/apps/docs/src/examples/systems/emerald/tabs/vertical.vue
+++ b/apps/docs/src/examples/systems/emerald/tabs/vertical.vue
@@ -44,7 +44,18 @@
     align-items: flex-start;
   }
 
+  .emerald-docs-tabs-row .emerald-tabs__list {
+    flex-shrink: 0;
+  }
+
   .emerald-docs-tabs-row .emerald-tabs__panel {
     min-width: 0;
+  }
+
+  @media (max-width: 599px) {
+    .emerald-docs-tabs-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
   }
 </style>


### PR DESCRIPTION
Thirteen example/component-level mobile fixes from the audit — each keeps its example's concept intact and restores the desktop layout at `sm:`/`md:`.

- treeview settings-panel: description pane stacks below the tree on phones (was painting under a fixed `w-48` sidebar)
- create-rating: "Rate this product" label wraps instead of crushing to letter slivers at 320
- emerald tabs (vertical): tablist is shrink-guarded and the demo stacks under 600px
- emerald pagination (summary): control row wraps so Next stays tappable at 320 — the underlying `createOverflow` capacity overestimate with text-wide controls is a package bug tracked separately
- benchmark summary cards: single column below `sm`
- /health freshness table: the footer pagination (nine fixed-width buttons) was the page-width offender — it wraps now, First/Last hidden below `sm`
- home hero CTAs stack at 320; ecosystem card labels truncate (closes an intermittent home h-scroll)
- create-trinity tiles stack; number-field cart rows wrap to two lines; reduced-motion chip row wraps; create-breadcrumbs demo trail wraps (deepest crumbs were unreachable behind `overflow: hidden`); splitter playground labels ellipsize

Verified per fix with 320/375 screenshots, interactive probes (pane click, tab switch, pagination tap advancing pages), and 430 regression checks.

https://claude.ai/code/session_01UTCx471779RNB2pVGuW1RQ