### PR TITLE
docs: mobile polish — mermaid readability, touch targets, and scroll affordances

### DIFF
--- a/apps/docs/src/components/app/AppFooter.vue
+++ b/apps/docs/src/components/app/AppFooter.vue
@@ -84,7 +84,7 @@
             <AppTooltip
               v-if="app.stats.commit"
               as="a"
-              class="flex items-center gap-1 hover:text-primary hover:underline"
+              class="flex items-center gap-1 min-h-9 hover:text-primary hover:underline"
               :href="app.stats.commit.html_url"
               rel="noopener nofollow"
               target="_blank"
@@ -99,7 +99,7 @@
 
       <div class="flex items-center gap-4">
         <router-link
-          class="text-sm opacity-60 hover:opacity-100 hover:text-primary transition-opacity"
+          class="inline-flex items-center min-h-9 text-sm opacity-60 hover:opacity-100 hover:text-primary transition-opacity"
           to="/services"
         >
           Services

--- a/apps/docs/src/components/app/AppNav.vue
+++ b/apps/docs/src/components/app/AppNav.vue
@@ -160,17 +160,17 @@
     step="navigation"
     :style="{ zIndex: isMobile ? ticket.zIndex.value : undefined }"
   >
+    <!-- Mobile header — outside the scroll container so scroll-active-into-view can't push it out of reach -->
+    <header class="md:hidden shrink-0 px-4 py-3 border-b border-divider flex items-center justify-between bg-surface">
+      <div class="flex items-center gap-2">
+        <AppIcon class="text-primary" icon="menu" />
+        <span class="font-medium">Navigation</span>
+      </div>
+
+      <AppCloseButton label="Close navigation" @click="navigation.close" />
+    </header>
+
     <div class="nav-scroll flex-1 min-h-0 overflow-y-auto py-4">
-      <!-- Mobile header -->
-      <header class="md:hidden shrink-0 px-4 py-3 -mt-4 mb-4 border-b border-divider flex items-center justify-between bg-surface">
-        <div class="flex items-center gap-2">
-          <AppIcon class="text-primary" icon="menu" />
-          <span class="font-medium">Navigation</span>
-        </div>
-
-        <AppCloseButton label="Close navigation" @click="navigation.close" />
-      </header>
-
       <!-- URL filter banner -->
       <div v-if="navConfig.activeFeatures.value" class="-mt-4 px-4 py-3 mb-4 bg-surface-variant-50 border-b border-divider">
         <p class="text-xs text-on-surface-variant mb-2">

--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -145,7 +145,7 @@
         v-if="isCollapsible"
         :aria-controls="`nav-section-${id}`"
         :aria-expanded="isOpen ? 'true' : 'false'"
-        class="size-5 media-[(pointer:coarse)]:h-9 flex items-center justify-center shrink-0 rounded hover:bg-surface-tint focus-visible:bg-surface-tint focus-visible:outline-none"
+        class="size-5 media-[(pointer:coarse)]:size-9 flex items-center justify-center shrink-0 rounded hover:bg-surface-tint focus-visible:bg-surface-tint focus-visible:outline-none"
         type="button"
         @click.stop="onToggle"
       >
@@ -157,7 +157,7 @@
       </button>
 
       <!-- Dash prefix for top-level solo links (only when collapsible nav is enabled) -->
-      <span v-else-if="isTopLevel && !navConfig.flatMode.value" aria-hidden="true" class="size-5 shrink-0 flex items-center justify-center text-divider">–</span>
+      <span v-else-if="isTopLevel && !navConfig.flatMode.value" aria-hidden="true" class="size-5 media-[(pointer:coarse)]:w-9 shrink-0 flex items-center justify-center text-divider">–</span>
 
       <!-- External link -->
       <Atom

--- a/apps/docs/src/components/app/AppNavLink.vue
+++ b/apps/docs/src/components/app/AppNavLink.vue
@@ -145,7 +145,7 @@
         v-if="isCollapsible"
         :aria-controls="`nav-section-${id}`"
         :aria-expanded="isOpen ? 'true' : 'false'"
-        class="size-5 flex items-center justify-center shrink-0 rounded hover:bg-surface-tint focus-visible:bg-surface-tint focus-visible:outline-none"
+        class="size-5 media-[(pointer:coarse)]:h-9 flex items-center justify-center shrink-0 rounded hover:bg-surface-tint focus-visible:bg-surface-tint focus-visible:outline-none"
         type="button"
         @click.stop="onToggle"
       >
@@ -163,7 +163,7 @@
       <Atom
         v-if="to && isExternal"
         as="a"
-        class="font-semibold icon-text flex-1 min-w-0"
+        class="font-semibold icon-text flex-1 min-w-0 media-[(pointer:coarse)]:py-2"
         :class="[
           'hover:underline hover:text-primary focus-visible:underline focus-visible:text-primary',
           !isTopLevel && !hasChildren && 'opacity-70 hover:opacity-100 focus-visible:opacity-100',
@@ -180,7 +180,7 @@
         v-else-if="to"
         :aria-current="isActive ? 'page' : undefined"
         :as
-        class="font-semibold icon-text flex-1 min-w-0 scroll-my-[100px]"
+        class="font-semibold icon-text flex-1 min-w-0 scroll-my-[100px] media-[(pointer:coarse)]:py-2"
         :class="[
           'hover:underline hover:text-primary focus-visible:underline focus-visible:text-primary',
           !isTopLevel && !hasChildren && 'opacity-70 hover:opacity-100 focus-visible:opacity-100',
@@ -203,7 +203,7 @@
       <!-- Category header (not navigable) -->
       <span
         v-else
-        class="font-semibold flex-1 min-w-0 truncate"
+        class="font-semibold flex-1 min-w-0 truncate media-[(pointer:coarse)]:py-2"
         :class="[
           isCollapsible && 'cursor-pointer hover:text-primary focus-visible:text-primary',
           containsActivePage && 'text-primary underline',

--- a/apps/docs/src/components/docs/DocsApiIndex.vue
+++ b/apps/docs/src/components/docs/DocsApiIndex.vue
@@ -147,10 +147,11 @@
   /* These index tables are two columns where the name is a single unbreakable
      token, so the phone-width max-content rule in App.vue parks the whole
      Description column off-screen. Squeeze back to container width — names
-     keep their natural width and descriptions wrap beside them. Outranks the
-     App.vue rule structurally: (0,4,2) over (0,3,2). */
+     keep their natural width and descriptions wrap beside them. The
+     .markdown-body prefix outranks App.vue's nested rule structurally:
+     (0,4,2) over (0,3,2), instead of by import order. */
   @media (max-width: 767px) {
-    div.docs-api-index.docs-table.overflow-x-auto > table {
+    .markdown-body div.docs-api-index.docs-table.overflow-x-auto > table {
       width: 100%;
       max-width: none;
     }

--- a/apps/docs/src/components/docs/DocsApiIndex.vue
+++ b/apps/docs/src/components/docs/DocsApiIndex.vue
@@ -87,7 +87,7 @@
       <template v-for="[category, entries] in componentGroups" :key="`c-${category}`">
         <DocsHeaderAnchor :id="`components-${toKebab(category)}`" class="text-2xl leading-8 mt-6 mb-2" tag="h3">{{ toTitle(category) }}</DocsHeaderAnchor>
 
-        <div class="docs-table overflow-x-auto mb-4">
+        <div class="docs-api-index docs-table overflow-x-auto mb-4">
           <table>
             <thead>
               <tr>
@@ -118,7 +118,7 @@
       <template v-for="[category, entries] in composableGroups" :key="`e-${category}`">
         <DocsHeaderAnchor :id="`composables-${toKebab(category)}`" class="text-2xl leading-8 mt-6 mb-2" tag="h3">{{ toTitle(category) }}</DocsHeaderAnchor>
 
-        <div class="docs-table overflow-x-auto mb-4">
+        <div class="docs-api-index docs-table overflow-x-auto mb-4">
           <table>
             <thead>
               <tr>
@@ -142,3 +142,17 @@
     </template>
   </div>
 </template>
+
+<style>
+  /* These index tables are two columns where the name is a single unbreakable
+     token, so the phone-width max-content rule in App.vue parks the whole
+     Description column off-screen. Squeeze back to container width — names
+     keep their natural width and descriptions wrap beside them. Outranks the
+     App.vue rule structurally: (0,4,2) over (0,3,2). */
+  @media (max-width: 767px) {
+    div.docs-api-index.docs-table.overflow-x-auto > table {
+      width: 100%;
+      max-width: none;
+    }
+  }
+</style>

--- a/apps/docs/src/components/docs/DocsGenesisExample.vue
+++ b/apps/docs/src/components/docs/DocsGenesisExample.vue
@@ -265,6 +265,14 @@
     backdrop-filter: blur(12px);
   }
 
+  /* The glass skin above replaces the description's surface-tint background,
+     which leaves genesis's truncation fade painting the wrong color — the
+     collapsed text stays fully legible and the Expand pill lands on top of
+     it. Re-point the fade at the surface the glass resolves over. */
+  :deep(.genesis-docs-example-description__fade) {
+    background: linear-gradient(transparent, var(--v0-surface));
+  }
+
   .docs-genesis-example-pane {
     position: relative;
   }

--- a/apps/docs/src/components/docs/DocsMermaid.vue
+++ b/apps/docs/src/components/docs/DocsMermaid.vue
@@ -183,6 +183,7 @@
   const decodedCode = toRef(() => decodeBase64(props.code))
 
   const svg = ref('')
+  const width = shallowRef(0)
   const id = `mermaid-${useId()}`
 
   async function render () {
@@ -191,6 +192,10 @@
       const m = await loadMermaid()
       const { svg: rendered } = await m.render(id, decodedCode.value)
       svg.value = rendered
+      // useMaxWidth serializes the natural width as an inline max-width;
+      // the phone floor below needs it as a CSS variable
+      const natural = rendered.match(/max-width:\s*([\d.]+)px/)
+      width.value = natural ? Number(natural[1]) : 0
     } catch (error) {
       logger.error('Mermaid render error', error)
       svg.value = `<pre class="text-error">${decodedCode.value}</pre>`
@@ -277,7 +282,10 @@
 
 <template>
   <Dialog.Root v-model="isOpen">
-    <Dialog.Activator class="docs-mermaid flex justify-center w-full my-4 overflow-x-auto cursor-pointer">
+    <Dialog.Activator
+      class="docs-mermaid flex justify-center w-full my-4 overflow-x-auto cursor-pointer"
+      :style="{ '--mermaid-w': `${width}px` }"
+    >
       <figure class="flex flex-col items-center w-full">
         <div class="flex justify-center w-full" v-html="svg" />
 
@@ -406,6 +414,44 @@
   .docs-mermaid svg {
     max-width: 100%;
     height: auto;
+  }
+
+  /* Wide diagrams scale to fit the column, and at phone widths that renders
+     labels as microtext. Below md, floor the svg at 80% of its natural width
+     (min-width outranks the max-width cap) so oversized diagrams scroll in
+     the activator instead of shrinking; a fitting diagram is unaffected. The
+     :not() guard keeps the dialog's pan-zoom svg on its own sizing. */
+  @media (max-width: 767px) {
+    /* Auto margins re-center the figure without the justify-center overflow
+       trap that would clip the scrolled-out start edge. */
+    .docs-mermaid:not(.docs-mermaid-panzoom) {
+      justify-content: flex-start;
+    }
+
+    .docs-mermaid:not(.docs-mermaid-panzoom) figure {
+      /* flex-shrink would collapse the max-content width back to the
+         activator, leaving the overflow unreachable */
+      flex: none;
+      width: max-content;
+      min-width: 100%;
+      margin-inline: auto;
+    }
+
+    .docs-mermaid:not(.docs-mermaid-panzoom) figure > div {
+      width: max-content;
+      min-width: 100%;
+    }
+
+    .docs-mermaid:not(.docs-mermaid-panzoom) svg {
+      min-width: calc(var(--mermaid-w, 0px) * 0.8);
+    }
+
+    /* Pin the caption to the visible slice while the diagram scrolls. */
+    .docs-mermaid:not(.docs-mermaid-panzoom) figcaption {
+      position: sticky;
+      inset-inline-start: 0;
+      max-width: calc(100vw - 3rem);
+    }
   }
 
   /* Rounded nodes */

--- a/apps/docs/src/components/docs/DocsMermaid.vue
+++ b/apps/docs/src/components/docs/DocsMermaid.vue
@@ -446,10 +446,14 @@
       min-width: calc(var(--mermaid-w, 0px) * 0.8);
     }
 
-    /* Pin the caption to the visible slice while the diagram scrolls. */
+    /* Pin the caption to the visible slice while the diagram scrolls.
+       align-self overrides the figure's items-center — a centered caption
+       on a max-content figure starts off-screen at rest, and the sticky
+       inset only clamps leftward. */
     .docs-mermaid:not(.docs-mermaid-panzoom) figcaption {
       position: sticky;
       inset-inline-start: 0;
+      align-self: flex-start;
       max-width: calc(100vw - 3rem);
     }
   }

--- a/apps/docs/src/components/docs/DocsSearch.vue
+++ b/apps/docs/src/components/docs/DocsSearch.vue
@@ -275,7 +275,7 @@
                   <AppTooltip
                     aria-label="Remove from favorites"
                     as="span"
-                    class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+                    class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                     role="button"
                     tabindex="0"
                     text="Remove from favorites"
@@ -334,7 +334,7 @@
                     <AppTooltip
                       aria-label="Add to favorites"
                       as="span"
-                      class="btn-action text-on-surface/60 hover:text-warning focus-visible:text-warning opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+                      class="btn-action text-on-surface/60 hover:text-warning focus-visible:text-warning opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
                       text="Add to favorites"
@@ -348,7 +348,7 @@
                     <AppTooltip
                       aria-label="Remove from recent searches"
                       as="span"
-                      class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+                      class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
                       text="Remove from recent"
@@ -444,7 +444,7 @@
                         as="span"
                         :class="[
                           'btn-action cursor-pointer',
-                          search.isFavorite(group.items[0].id) || discovery.isActive.value ? 'opacity-100 text-warning' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
+                          search.isFavorite(group.items[0].id) || discovery.isActive.value ? 'opacity-100 text-warning' : 'opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
                         ]"
                         role="button"
                         tabindex="0"
@@ -472,7 +472,7 @@
                         as="span"
                         :class="[
                           'btn-action text-on-surface/60 hover:text-primary focus-visible:text-primary cursor-pointer',
-                          discovery.isActive.value ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                          discovery.isActive.value ? 'opacity-100' : 'opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100',
                         ]"
                         role="button"
                         tabindex="0"
@@ -496,7 +496,7 @@
                         as="span"
                         :class="[
                           'btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant cursor-pointer',
-                          discovery.isActive.value ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                          discovery.isActive.value ? 'opacity-100' : 'opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100',
                         ]"
                         role="button"
                         tabindex="0"
@@ -546,7 +546,7 @@
                       as="span"
                       :class="[
                         'btn-action cursor-pointer',
-                        search.isFavorite(result.id) ? 'opacity-100 text-warning' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
+                        search.isFavorite(result.id) ? 'opacity-100 text-warning' : 'opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 text-on-surface/60 hover:text-warning focus-visible:text-warning',
                       ]"
                       role="button"
                       tabindex="0"
@@ -565,7 +565,7 @@
                     <AppTooltip
                       aria-label="Ask AI about this page"
                       as="span"
-                      class="btn-action text-on-surface/60 hover:text-primary focus-visible:text-primary opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+                      class="btn-action text-on-surface/60 hover:text-primary focus-visible:text-primary opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
                       text="Ask AI"
@@ -579,7 +579,7 @@
                     <AppTooltip
                       aria-label="Dismiss result"
                       as="span"
-                      class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
+                      class="btn-action text-on-surface/60 hover:text-on-surface-variant focus-visible:text-on-surface-variant opacity-0 media-[(pointer:coarse)]:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 cursor-pointer"
                       role="button"
                       tabindex="0"
                       text="Dismiss result"
@@ -596,8 +596,8 @@
           </div>
         </Discovery.Activator>
 
-        <div class="flex items-center justify-between px-4 py-2 border-t border-divider text-xs text-on-surface-variant">
-          <div class="flex items-center gap-4">
+        <div class="flex items-center justify-between max-sm:justify-center px-4 py-2 border-t border-divider text-xs text-on-surface-variant">
+          <div class="hidden sm:flex items-center gap-4">
             <span class="flex items-center gap-1">
               <kbd class="px-1.5 py-0.5 rounded bg-surface-variant font-mono">↑</kbd>
               <kbd class="px-1.5 py-0.5 rounded bg-surface-variant font-mono">↓</kbd>

--- a/apps/docs/src/components/home/HomePrimarySponsor.vue
+++ b/apps/docs/src/components/home/HomePrimarySponsor.vue
@@ -27,10 +27,10 @@
 
     <AppLink v-else class="relative block hover:bg-surface-tint transition-colors" no-suffix to="/sponsor">
       <div class="mx-auto max-w-[900px] px-4 py-4 text-center">
-        <p>
+        <p class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
           <span class="section-overline">PRIMARY SPONSOR</span>
-          <span class="ml-2 text-on-surface-variant">·</span>
-          <span class="ml-2 text-sm"><AppRainbowText :delay="3">This spot is available</AppRainbowText></span>
+          <span class="text-on-surface-variant max-sm:hidden">·</span>
+          <span class="text-sm whitespace-nowrap"><AppRainbowText :delay="3">This spot is available</AppRainbowText></span>
         </p>
       </div>
     </AppLink>

--- a/apps/docs/src/examples/systems/emerald/kanban/basic.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/basic.vue
@@ -27,7 +27,7 @@
 </script>
 
 <template>
-  <EmKanban label="Release board">
+  <EmKanban class="emerald-docs-kanban" label="Release board">
     <EmKanbanColumn
       v-for="column in columns"
       :key="column.title"
@@ -45,5 +45,49 @@
     margin: 0;
     font-size: var(--emerald-text-b2-size, 14px);
     line-height: 1.4;
+  }
+
+  /* The board scrolls horizontally by design, but overlay scrollbars leave no
+     signal that columns extend past the example edge. Fade the clipped edge;
+     the fade tracks scroll position and vanishes at the reached edge, and an
+     inactive timeline (board fits) keeps the no-fade base values. Example
+     styles are document-global, so this rides the dedicated class shared by
+     the kanban examples. */
+  @property --kanban-fade-start {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --kanban-fade-end {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @supports (animation-timeline: scroll(self x)) {
+    .emerald-docs-kanban {
+      mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      animation: emerald-docs-kanban-fade linear both;
+      animation-timeline: scroll(self x);
+    }
+
+    [dir='rtl'] .emerald-docs-kanban {
+      mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+    }
+  }
+
+  @keyframes emerald-docs-kanban-fade {
+    0% {
+      --kanban-fade-start: 0px;
+      --kanban-fade-end: 2.5rem;
+    }
+
+    100% {
+      --kanban-fade-start: 2.5rem;
+      --kanban-fade-end: 0px;
+    }
   }
 </style>

--- a/apps/docs/src/examples/systems/emerald/kanban/disabled.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/disabled.vue
@@ -60,4 +60,48 @@
     font-size: var(--emerald-text-b2-size, 14px);
     line-height: 1.4;
   }
+
+  /* The board scrolls horizontally by design, but overlay scrollbars leave no
+     signal that columns extend past the example edge. Fade the clipped edge;
+     the fade tracks scroll position and vanishes at the reached edge, and an
+     inactive timeline (board fits) keeps the no-fade base values. Example
+     styles are document-global, so this rides the dedicated class shared by
+     the kanban examples. */
+  @property --kanban-fade-start {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --kanban-fade-end {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @supports (animation-timeline: scroll(self x)) {
+    .emerald-docs-kanban {
+      mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      animation: emerald-docs-kanban-fade linear both;
+      animation-timeline: scroll(self x);
+    }
+
+    [dir='rtl'] .emerald-docs-kanban {
+      mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+    }
+  }
+
+  @keyframes emerald-docs-kanban-fade {
+    0% {
+      --kanban-fade-start: 0px;
+      --kanban-fade-end: 2.5rem;
+    }
+
+    100% {
+      --kanban-fade-start: 2.5rem;
+      --kanban-fade-end: 0px;
+    }
+  }
 </style>

--- a/apps/docs/src/examples/systems/emerald/kanban/disabled.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/disabled.vue
@@ -34,7 +34,7 @@
       </EmButton>
     </div>
 
-    <EmKanban :disabled="frozen" label="Roadmap board">
+    <EmKanban class="emerald-docs-kanban" :disabled="frozen" label="Roadmap board">
       <EmKanbanColumn
         v-for="column in columns"
         :key="column.title"

--- a/apps/docs/src/examples/systems/emerald/kanban/move.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/move.vue
@@ -75,4 +75,48 @@
     font-size: var(--emerald-text-b2-size, 14px);
     color: var(--emerald-on-surface-variant);
   }
+
+  /* The board scrolls horizontally by design, but overlay scrollbars leave no
+     signal that columns extend past the example edge. Fade the clipped edge;
+     the fade tracks scroll position and vanishes at the reached edge, and an
+     inactive timeline (board fits) keeps the no-fade base values. Example
+     styles are document-global, so this rides the dedicated class shared by
+     the kanban examples. */
+  @property --kanban-fade-start {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --kanban-fade-end {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @supports (animation-timeline: scroll(self x)) {
+    .emerald-docs-kanban {
+      mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      animation: emerald-docs-kanban-fade linear both;
+      animation-timeline: scroll(self x);
+    }
+
+    [dir='rtl'] .emerald-docs-kanban {
+      mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+    }
+  }
+
+  @keyframes emerald-docs-kanban-fade {
+    0% {
+      --kanban-fade-start: 0px;
+      --kanban-fade-end: 2.5rem;
+    }
+
+    100% {
+      --kanban-fade-start: 2.5rem;
+      --kanban-fade-end: 0px;
+    }
+  }
 </style>

--- a/apps/docs/src/examples/systems/emerald/kanban/move.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/move.vue
@@ -39,7 +39,7 @@
 
 <template>
   <div class="emerald-docs-stack">
-    <EmKanban ref="board" label="Weekly board" @move="onMove">
+    <EmKanban ref="board" class="emerald-docs-kanban" label="Weekly board" @move="onMove">
       <EmKanbanColumn
         v-for="column in columns"
         :key="column.title"

--- a/apps/docs/src/examples/systems/emerald/kanban/tones.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/tones.vue
@@ -42,7 +42,7 @@
 </script>
 
 <template>
-  <EmKanban label="Component board">
+  <EmKanban class="emerald-docs-kanban" label="Component board">
     <EmKanbanColumn
       v-for="column in columns"
       :key="column.title"

--- a/apps/docs/src/examples/systems/emerald/kanban/tones.vue
+++ b/apps/docs/src/examples/systems/emerald/kanban/tones.vue
@@ -63,4 +63,48 @@
     font-size: var(--emerald-text-b2-size, 14px);
     line-height: 1.4;
   }
+
+  /* The board scrolls horizontally by design, but overlay scrollbars leave no
+     signal that columns extend past the example edge. Fade the clipped edge;
+     the fade tracks scroll position and vanishes at the reached edge, and an
+     inactive timeline (board fits) keeps the no-fade base values. Example
+     styles are document-global, so this rides the dedicated class shared by
+     the kanban examples. */
+  @property --kanban-fade-start {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --kanban-fade-end {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @supports (animation-timeline: scroll(self x)) {
+    .emerald-docs-kanban {
+      mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      animation: emerald-docs-kanban-fade linear both;
+      animation-timeline: scroll(self x);
+    }
+
+    [dir='rtl'] .emerald-docs-kanban {
+      mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+      -webkit-mask-image: linear-gradient(to left, transparent 0, black var(--kanban-fade-start), black calc(100% - var(--kanban-fade-end)), transparent 100%);
+    }
+  }
+
+  @keyframes emerald-docs-kanban-fade {
+    0% {
+      --kanban-fade-start: 0px;
+      --kanban-fade-end: 2.5rem;
+    }
+
+    100% {
+      --kanban-fade-start: 2.5rem;
+      --kanban-fade-end: 0px;
+    }
+  }
 </style>

--- a/apps/docs/src/pages/components/primitives/atom.md
+++ b/apps/docs/src/pages/components/primitives/atom.md
@@ -126,7 +126,7 @@ Atom is an advanced, low-level primitive that enables **polymorphic components**
 A polymorphic component is one where the **consumer decides** how it renders. The component provides behavior and attributes; the consumer chooses the element — or opts out of an element entirely.
 
 ```mermaid "Polymorphic Rendering"
-flowchart LR
+flowchart TD
   Component["Your Component"]:::primary
   Rendered["Rendered"]
   Renderless["Renderless"]
@@ -217,7 +217,7 @@ This is the core value of building on Atom: one component definition, two consum
 When you build a component on Atom, the first decision is: **should it render an element by default, or should it be renderless?**
 
 ```mermaid "Choosing a Default"
-flowchart LR
+flowchart TD
   Start["Needs DOM?"]:::primary
   Interactive{"Interactive?"}
   Semantic{"Specific element?"}

--- a/apps/docs/src/pages/composables/plugins/use-date.md
+++ b/apps/docs/src/pages/composables/plugins/use-date.md
@@ -242,7 +242,7 @@ The `formatByString()` method supports these tokens:
 The adapter pattern decouples date operations from the underlying library. When you call `adapter.format()`, the request flows through the provided adapter to its underlying date library:
 
 ```mermaid "Adapter Pattern Flow"
-flowchart LR
+flowchart TD
   subgraph Setup["Plugin Setup"]
     plugin["createDatePlugin"]
     opts["adapter option"]

--- a/apps/docs/src/pages/composables/plugins/use-features.md
+++ b/apps/docs/src/pages/composables/plugins/use-features.md
@@ -276,7 +276,7 @@ class WindowFeaturesAdapter extends FeaturesAdapter {
 The adapter pattern decouples feature flags from the underlying provider.
 
 ```mermaid "Adapter Data Flow"
-flowchart LR
+flowchart TD
   subgraph Setup
     plugin[createFeaturesPlugin]
     adapter[Adapter]

--- a/apps/docs/src/pages/composables/plugins/use-reduced-motion.md
+++ b/apps/docs/src/pages/composables/plugins/use-reduced-motion.md
@@ -95,7 +95,7 @@ app.use(createReducedMotionPlugin({ adapter: new ClassReducedMotionAdapter() }))
 `useReducedMotion` uses the plugin pattern with a media-query core and a DOM adapter:
 
 ```mermaid "Reduced Motion Plugin"
-flowchart LR
+flowchart TD
   plugin[createReducedMotionPlugin] --> context[createReducedMotion]
   context --> media[usePrefersReducedMotion]
   context --> adapter[ReducedMotionAdapter]

--- a/apps/docs/src/pages/guide/fundamentals/core.md
+++ b/apps/docs/src/pages/guide/fundamentals/core.md
@@ -141,7 +141,7 @@ interface RegistryTicket {
 ### Extension Chain
 
 ```mermaid "Extension Chain"
-flowchart LR
+flowchart TD
     R[createRegistry] --> M[createModel]
     M --> S[createSelection]
     M --> Sl[createSlider]


### PR DESCRIPTION
Final mobile-polish wave. **Stacked on #963** — GitHub will retarget to master when it merges; only the 13 commits past that branch belong to this PR.

- **Mermaid diagrams**: below `md`, inline diagrams keep at least 80% of their natural width and scroll inside the existing wrapper instead of scaling to microtext (one renderer change covering ~31 routes); captions stay start-aligned and sticky to the visible slice; the pan-zoom dialog is untouched. Five genuinely branchy flowcharts converted LR→TD (nodes/edges unchanged) — linear pipelines keep LR and now scroll legibly.
- **Search overlay**: footer kbd hints hidden below `sm` (they collided with the MiniSearch credit at 320); result-row actions (favorite/dismiss) were hover-only and invisible on touch — now always visible on coarse pointers. Desktop hover behavior unchanged; hybrid trackpad devices keep hover-only.
- **Drawer**: the mobile header (with close button) sits outside the nav scroll container so it can't scroll away; drawer links and the expand chevron are 36px+ touch targets on coarse pointers (desktop metrics unchanged); footer links bumped likewise.
- **API index**: two-column category tables fit the viewport again so Description renders on-screen at 375.
- **Example chrome**: the genesis peek-header description fade paints against the docs glass skin again (the Expand pill no longer overlaps raw text); emerald kanban boards get the scroll edge-fade affordance (the fixed drop indicator's slight dimming inside the fade band is cosmetic-only, verified); the home sponsor band wraps cleanly at 320.

Deferred with rationale: a touch trigger for the API hover cards needs a designed discoverability treatment, not a polish one-liner.

Verified with 320/375 screenshots, touch-emulated interaction probes, and desktop/430 regression checks per fix; no page-level horizontal scroll introduced.

https://claude.ai/code/session_01UTCx471779RNB2pVGuW1RQ