### PR TITLE
chore(docs): deploy 0-dev.vuetifyjs.com from the dev branch

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'master' && 'Production' || 'Dev' }}
+    environment: ${{ github.ref_name == 'master' && 'Production' || github.ref_name }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,7 +1,7 @@
 name: Docs Deploy
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     # Single paths list with `!` negations — GitHub does not allow both
     # `paths` and `paths-ignore` on the same event. Order matters: a negation
     # after a positive match wins, so a test-only src commit is excluded.
@@ -23,13 +23,13 @@ on:
       - '!packages/0/src/**/*.ssr.test.ts'
 
 concurrency:
-  group: docs-deploy
+  group: docs-deploy-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: Production
+    environment: ${{ github.ref_name == 'master' && 'Production' || 'Dev' }}
     permissions:
       contents: read
       packages: write
@@ -55,6 +55,8 @@ jobs:
         env:
           VITE_API_SERVER_URL: ${{ vars.API_SERVER_URL }}
           VITE_GITHUB_SHA: ${{ github.sha }}
+          VITE_INDEX: ${{ github.ref_name == 'master' && 'true' || 'false' }}
+          VITE_SITE_URL: ${{ github.ref_name == 'master' && 'https://0.vuetifyjs.com' || 'https://0-dev.vuetifyjs.com' }}
       - uses: vuetifyjs/coolify-action@37a9c5a532f4c489e941d43edffd73fd2af00ec2 # master
         with:
           imageName: v0-docs

--- a/apps/docs/build/site.test.ts
+++ b/apps/docs/build/site.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { isIndexable, PREVIEW_ROBOTS_TXT, PROD_ROBOTS_TXT, robotsTxt } from './site'
+
+describe('docs site robots', () => {
+  it('should treat an unset VITE_INDEX as indexable', () => {
+    expect(isIndexable({})).toBe(true)
+    expect(isIndexable({ VITE_INDEX: 'true' })).toBe(true)
+  })
+
+  it('should treat VITE_INDEX=false as a preview (noindex) build', () => {
+    expect(isIndexable({ VITE_INDEX: 'false' })).toBe(false)
+  })
+
+  it('should disallow all crawlers on a preview build', () => {
+    expect(robotsTxt(false)).toBe(PREVIEW_ROBOTS_TXT)
+    expect(robotsTxt(false)).toContain('Disallow: /')
+    expect(robotsTxt(false)).not.toContain('Sitemap:')
+  })
+
+  it('should keep the prod sitemap advertisement when indexable', () => {
+    expect(robotsTxt(true)).toBe(PROD_ROBOTS_TXT)
+    expect(robotsTxt(true)).toContain('Sitemap: https://0.vuetifyjs.com/sitemap.xml')
+  })
+})

--- a/apps/docs/build/site.ts
+++ b/apps/docs/build/site.ts
@@ -1,0 +1,27 @@
+export const PROD_SITE_URL = 'https://0.vuetifyjs.com'
+
+export const PROD_ROBOTS_TXT = `User-agent: *
+Allow: /
+
+Sitemap: ${PROD_SITE_URL}/sitemap.xml
+
+# LLM context bundles — curated documentation for AI assistants.
+# Index:     ${PROD_SITE_URL}/llms.txt
+# Full text: ${PROD_SITE_URL}/llms-full.txt
+# Agent skill: ${PROD_SITE_URL}/SKILL.md
+# Every docs page also serves its source markdown at the same path + ".md"
+# (e.g. ${PROD_SITE_URL}/composables/data/create-filter.md), advertised
+# per-page via <link rel="alternate" type="text/markdown">.
+`
+
+export const PREVIEW_ROBOTS_TXT = `User-agent: *
+Disallow: /
+`
+
+export function isIndexable (env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.VITE_INDEX !== 'false'
+}
+
+export function robotsTxt (indexable = isIndexable()): string {
+  return indexable ? PROD_ROBOTS_TXT : PREVIEW_ROBOTS_TXT
+}

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -22,6 +22,9 @@
   import { useSearch } from '@/composables/useSearch'
   import { useSettings } from '@/composables/useSettings'
 
+  // Constants
+  import { INDEXABLE, PROD_SITE_URL } from '@/constants/site'
+
   // Stores
   import { useAppStore } from '@/stores/app'
 
@@ -74,7 +77,7 @@
     return false
   })
 
-  const url = toRef(() => `https://0.vuetifyjs.com${route.path}`)
+  const url = toRef(() => `${PROD_SITE_URL}${route.path}`)
   const breadcrumbs = useBreadcrumbItems()
 
   // Advertise the page's markdown twin so agent fetchers and AI crawlers can
@@ -88,7 +91,7 @@
       key: 'alternate-markdown',
       rel: 'alternate',
       type: 'text/markdown',
-      href: `https://0.vuetifyjs.com${twin}`,
+      href: `${PROD_SITE_URL}${twin}`,
     }]
   })
 
@@ -112,7 +115,7 @@
             'position': index + 1,
             name,
           }
-          if (!isLast && item.to) entry.item = `https://0.vuetifyjs.com${item.to}`
+          if (!isLast && item.to) entry.item = `${PROD_SITE_URL}${item.to}`
           return entry
         }),
       }),
@@ -140,7 +143,7 @@
         '@type': 'TechArticle',
         headline,
         'url': url.value,
-        'isPartOf': { '@type': 'WebSite', 'name': 'Vuetify0', 'url': 'https://0.vuetifyjs.com' },
+        'isPartOf': { '@type': 'WebSite', 'name': 'Vuetify0', 'url': PROD_SITE_URL },
         'about': { '@type': 'SoftwareSourceCode', 'name': '@vuetify/v0', 'programmingLanguage': 'TypeScript' },
         'publisher': { '@type': 'Organization', 'name': 'Vuetify', 'url': 'https://vuetifyjs.com' },
         ...dates?.updated ? { dateModified: dates.updated } : {},
@@ -179,8 +182,8 @@
       { key: 'canonical', rel: 'canonical', href: url.value },
       // Site-wide LLM context bundles. Documented for humans on
       // /guide/tooling/ai-tools; these make them machine-discoverable.
-      { key: 'llms', rel: 'alternate', type: 'text/plain', href: 'https://0.vuetifyjs.com/llms.txt', title: 'llms.txt' },
-      { key: 'llms-full', rel: 'alternate', type: 'text/plain', href: 'https://0.vuetifyjs.com/llms-full.txt', title: 'llms-full.txt' },
+      { key: 'llms', rel: 'alternate', type: 'text/plain', href: `${PROD_SITE_URL}/llms.txt`, title: 'llms.txt' },
+      { key: 'llms-full', rel: 'alternate', type: 'text/plain', href: `${PROD_SITE_URL}/llms-full.txt`, title: 'llms-full.txt' },
       ...markdown.value,
     ]),
     meta: [
@@ -192,6 +195,7 @@
       { key: 'og:image', property: 'og:image', content: 'https://cdn.vuetifyjs.com/docs/images/one/logos/vzero-logo-og.png' },
       { key: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
       { key: 'twitter:site', name: 'twitter:site', content: '@VuetifyJS' },
+      ...INDEXABLE ? [] : [{ key: 'robots', name: 'robots', content: 'noindex, nofollow' }],
     ],
     style: [{
       key: 'emerald-docs-tokens',
@@ -209,7 +213,7 @@
           '@context': 'https://schema.org',
           '@type': 'WebSite',
           'name': 'Vuetify0',
-          'url': 'https://0.vuetifyjs.com',
+          'url': PROD_SITE_URL,
           'description': 'Headless components and composables for building modern applications and design systems',
           'publisher': {
             '@type': 'Organization',

--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -2,6 +2,9 @@
   // Framework
   import { IN_BROWSER, Atom, useNotifications, useStorage } from '@vuetify/v0'
 
+  // Constants
+  import { INDEXABLE, PROD_SITE_URL } from '@/constants/site'
+
   // Utilities
   import { onScopeDispose, toRef, watchEffect } from 'vue'
 
@@ -15,7 +18,7 @@
 
   // Bump BANNER_ID whenever the banner content changes — a new id re-shows the
   // banner even for readers who dismissed the previous one.
-  const BANNER_ID = 'v1.0-live'
+  const BANNER_ID = INDEXABLE ? 'v1.0-live' : 'docs-dev-unreleased'
   const SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
   // Snooze is owned by the notifications plugin (persist: true). Dismiss is a
@@ -23,7 +26,7 @@
   if (!notifications.has(BANNER_ID)) {
     notifications.register({
       id: BANNER_ID,
-      subject: 'Vuetify0 v1.0 is here',
+      subject: INDEXABLE ? 'Vuetify0 v1.0 is here' : 'Unreleased dev docs',
       severity: 'warning',
       data: { type: 'banner' },
     })
@@ -69,7 +72,13 @@
     <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 
     <div class="min-w-0 truncate pe-6">
-      {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <a class="underline underline-offset-2" href="https://vtfy.link/announcing-vuetify0-v1" rel="noopener" target="_blank">announcement</a>.</span>
+      <template v-if="INDEXABLE">
+        {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <a class="underline underline-offset-2" href="https://vtfy.link/announcing-vuetify0-v1" rel="noopener" target="_blank">announcement</a>.</span>
+      </template>
+
+      <template v-else>
+        {{ banner?.subject }}<span class="hidden sm:inline"> — queued features, not a release.</span><span class="hidden md:inline"> Stable docs: <a class="underline underline-offset-2" :href="PROD_SITE_URL" rel="noopener">0.vuetifyjs.com</a>.</span>
+      </template>
     </div>
 
     <div class="absolute end-2 flex items-center gap-2">

--- a/apps/docs/src/constants/site.ts
+++ b/apps/docs/src/constants/site.ts
@@ -1,0 +1,9 @@
+/**
+ * Canonical public docs origin. Staging (`0-dev.vuetifyjs.com`) still
+ * points canonicals, JSON-LD, and llms links here so unreleased pages
+ * do not compete with prod in search or LLM indexes.
+ */
+export const PROD_SITE_URL = 'https://0.vuetifyjs.com'
+
+/** False on the `dev`-branch docs build (`VITE_INDEX=false`). */
+export const INDEXABLE = import.meta.env.VITE_INDEX !== 'false'

--- a/apps/docs/src/plugins/analytics.ts
+++ b/apps/docs/src/plugins/analytics.ts
@@ -13,6 +13,6 @@ async function initAnalytics () {
   Swetrix.trackErrors()
 }
 
-if (IN_BROWSER) {
+if (IN_BROWSER && import.meta.env.VITE_INDEX !== 'false') {
   useIdleCallback(initAnalytics, 2000)
 }

--- a/apps/docs/src/vite-env.d.ts
+++ b/apps/docs/src/vite-env.d.ts
@@ -2,6 +2,14 @@
 /// <reference types="vue-router/auto" />
 /// <reference types="vite-plugin-vue-layouts-next/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_API_SERVER_URL?: string
+  readonly VITE_GITHUB_SHA?: string
+  readonly VITE_INDEX?: string
+  readonly VITE_PLAYGROUND_URL?: string
+  readonly VITE_SITE_URL?: string
+}
+
 declare module '*.md' {
   // Types
   import type { ComponentOptions } from 'vue'

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs'
+import { readdirSync, writeFileSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
 import UnocssVitePlugin from 'unocss/vite'
@@ -27,6 +27,7 @@ import generateTestCountPlugin from './build/generate-test-count'
 import generateTipsPlugin from './build/generate-tips'
 import Markdown from './build/markdown'
 import mdRoutesPlugin from './build/md-routes'
+import { isIndexable, PROD_SITE_URL, robotsTxt } from './build/site'
 import { getSkillzSlugs } from './build/skillz-tours'
 import pkg from './package.json' with { type: 'json' }
 
@@ -78,13 +79,20 @@ export default defineConfig({
       return [...filtered, ...apiRoutes, ...skillzRoutes, '/404']
     },
     async onFinished () {
-      generateSitemap({
-        hostname: 'https://0.vuetifyjs.com',
-        generateRobotsTxt: false,
-        changefreq: 'daily',
-        priority: 0.7,
-        exclude: ['/404'],
-      })
+      const indexable = isIndexable()
+      if (indexable) {
+        generateSitemap({
+          hostname: PROD_SITE_URL,
+          generateRobotsTxt: false,
+          changefreq: 'daily',
+          priority: 0.7,
+          exclude: ['/404'],
+        })
+      }
+      writeFileSync(
+        fileURLToPath(new URL('dist/robots.txt', import.meta.url)),
+        robotsTxt(indexable),
+      )
       await generateOgImages()
     },
   } as ViteSSGOptions,


### PR DESCRIPTION
## Summary

Staging docs host for the `dev` branch. Canonicals, JSON-LD, and llms links stay on **https://0.vuetifyjs.com**. The `dev` Coolify deploy sets `VITE_INDEX=false` so the build is `noindex`, `robots Disallow: /`, no sitemap, Swetrix off, and an unreleased banner.

`docs-deploy.yml` now runs on `master` and `dev`, keyed by `docs-deploy-${{ github.ref_name }}`, using GitHub environment **Production** vs **Dev**.

Depends on (not in this PR):
- GitHub environment `Dev` with `COOLIFY_WEBHOOK` for the new Coolify app
- Coolify app pinned to `ghcr.io/vuetifyjs/v0-docs:dev`
- API CORS allowlist for `https://0-dev.vuetifyjs.com`

After merge: `master` → `dev` (`--no-ff`) so the workflow exists on `dev`.

## Test plan

- [ ] `VITE_INDEX=false pnpm --filter=docs exec vitest run build/site.test.ts` (already green)
- [ ] Prod `master` deploy still indexable; `dev` deploy noindex + banner
- [ ] Confirm Coolify prod is **not** tracking a tag this job would overwrite