### PR TITLE
fix(play): republish with installable dependency ranges

### DIFF
--- a/.changeset/play-installable-deps.md
+++ b/.changeset/play-installable-deps.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/play": patch
+---
+
+fix(play): make `npm install @vuetify/play` resolve its dependencies
+
+`0.1.0` shipped `@vuetify/v0` and `fflate` as workspace/catalog protocol strings, which npm cannot fetch. This republish writes semver ranges for both.


### PR DESCRIPTION
## Summary

`@vuetify/play@0.1.0` is uninstallable from npm: the first-create `npm publish` left `@vuetify/v0: workspace:^` and `fflate: catalog:` in the tarball.

`pnpm pack` already rewrites those to `^1.2.0` / `^0.8.3`. A play-only patch changeset puts `0.1.1` on the current Version Packages PR (#934) so this cut publishes an installable tarball in the same `release.yml` run as v0 `1.2.1`.

Emerald and bulma `0.1.1` already in #934 get the same rewrite for free. Genesis is installable (`^1.0.5`) and stays put.

## Test plan

- [x] `pnpm pack` in `packages/play` emits `@vuetify/v0: ^1.2.0` and `fflate: ^0.8.3`
- [ ] After merge, #934 adds `@vuetify/play@0.1.1`
- [ ] After Version Packages merge, `npm view @vuetify/play@0.1.1 dependencies` is semver, not workspace/catalog