### PR TITLE
docs: add vuetify add CLI documentation

### DIFF
--- a/apps/docs/src/pages/introduction/getting-started.md
+++ b/apps/docs/src/pages/introduction/getting-started.md
@@ -176,6 +176,48 @@ app.mount('#app')
 > [!NOTE]
 > For additional plugins, theming options, and advanced configuration, see the [Guide](/guide).
 
+## Seed Working Examples
+
+v0 is headless: installing `@vuetify/v0` and importing a component gives you logic, accessibility, and state management — but no rendered UI. To start with a working, styled example you can edit and ship, use `vuetify add` to pull from the [docs registry](https://0.vuetifyjs.com/registry/index.json):
+
+::: code-group no-filename
+
+```bash pnpm
+# Interactive picker
+pnpm dlx @vuetify/cli add
+
+# Seed a Dialog example
+pnpm dlx @vuetify/cli add dialog
+
+# Seed a composable plugin
+pnpm dlx @vuetify/cli add use-theme
+```
+
+```bash npm
+npx @vuetify/cli add
+npx @vuetify/cli add dialog
+npx @vuetify/cli add use-theme
+```
+
+```bash yarn
+yarn dlx @vuetify/cli add
+yarn dlx @vuetify/cli add dialog
+yarn dlx @vuetify/cli add use-theme
+```
+
+```bash bun
+bunx @vuetify/cli add
+bunx @vuetify/cli add dialog
+bunx @vuetify/cli add use-theme
+```
+
+:::
+
+The CLI writes example files into your project, installs any missing dependencies, and records the install in `vuetify.json` so you can diff or refresh later.
+
+> [!TIP]
+> See the [Vuetify CLI guide](/guide/tooling/vuetify-cli) for the full command list, registry options, and `vuetify.json` tracking.
+
 ## Requirements
 
 - Vue 3.5.0 or higher
@@ -491,6 +533,7 @@ Now that v0 is installed, choose your path:
 | Understand the architecture | [Components](/guide/fundamentals/components) → [Composables](/guide/fundamentals/composables) → [Core](/guide/fundamentals/core) |
 | Build production UIs now | [Theming](/guide/features/theming) → [Accessibility](/guide/features/accessibility) |
 | Build a component library | [Building Frameworks](/guide/fundamentals/building-frameworks) |
+| Seed styled examples | [Vuetify CLI](/guide/tooling/vuetify-cli) (`vuetify add`) |
 | Set up an AI agent | [Agents](/guide/tooling/agents) → [AI Tools](/guide/tooling/ai-tools) |
 | Explore interactively | [Playground](/playground) |
 

--- a/packages/0/README.md
+++ b/packages/0/README.md
@@ -69,6 +69,35 @@ yarn add @vuetify/v0
 bun add @vuetify/v0
 ```
 
+## CLI
+
+The Vuetify CLI scaffolds projects and seeds working examples from the docs registry.
+
+### Create a Project
+
+```bash
+pnpm create vuetify0
+# or
+pnpm dlx @vuetify/cli init
+```
+
+### Seed Examples
+
+v0 is headless — importing a component gives you logic and accessibility, not a rendered UI. Use `vuetify add` to pull a styled example from the [docs registry](https://0.vuetifyjs.com/registry/index.json) into your project:
+
+```bash
+# Interactive picker
+pnpm dlx @vuetify/cli add
+
+# Seed a specific component
+pnpm dlx @vuetify/cli add dialog
+
+# Seed a composable plugin
+pnpm dlx @vuetify/cli add use-theme
+```
+
+See the [CLI guide](https://0.vuetifyjs.com/guide/tooling/vuetify-cli) for registry options, `vuetify.json` tracking, and the full command list.
+
 ## Exports
 
 The package provides tree-shakeable subpath exports:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the `vuetify add` workflow discoverable from the monorepo README and Getting Started page.

**Changes:**

1. **Getting Started page** (`apps/docs/src/pages/introduction/getting-started.md`)
   - Added "Seed Working Examples" section after Manual Setup explaining why `vuetify add` exists (v0 is headless)
   - Shows example commands with code-group pattern (pnpm/npm/yarn/bun): interactive `add`, `add dialog`, `add use-theme`
   - Links to `/guide/tooling/vuetify-cli` for full command list
   - Added "Seed styled examples" row to Next Steps table

2. **README.md** (repo root, symlinked to `packages/0/README.md`)
   - Added CLI section after Installation covering project creation and seeding
   - Links to https://0.vuetifyjs.com/guide/tooling/vuetify-cli

Both additions are concise and link to the canonical CLI guide rather than duplicating its content.

## Test plan

1. Verify README renders correctly on GitHub
2. Build docs locally (`pnpm dev:docs`) and check:
   - Getting Started page shows "Seed Working Examples" section with proper code-group tabs
   - Next Steps table includes CLI row
   - Links to CLI guide work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77d207f5-d8f3-4d62-8959-8c7416d17dad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77d207f5-d8f3-4d62-8959-8c7416d17dad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

