### PR TITLE
chore(bench): regenerate metrics

### DIFF
--- a/apps/docs/src/data/metrics/1.2.1.json
+++ b/apps/docs/src/data/metrics/1.2.1.json
@@ -1,0 +1,9987 @@
+{
+  "version": "1.2.1",
+  "generatedAt": "2026-09-05T01:37:12.798Z",
+  "env": {
+    "cpu": "Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz",
+    "cores": 36,
+    "arch": "x64",
+    "platform": "linux",
+    "node": "v26.0.0",
+    "pnpm": "11.16.0",
+    "imageOs": null,
+    "imageVersion": null,
+    "ci": false,
+    "busy": 0.0005555555555555556,
+    "peak": 0.010101010101010102,
+    "governor": "performance"
+  },
+  "items": {
+    "helpers": {
+      "benchmarks": {
+        "_groups": {
+          "mergeDeep benchmarks": {
+            "shallow merge (2 objects, 5 keys each)": {
+              "name": "shallow merge (2 objects, 5 keys each)",
+              "hz": 720550,
+              "hzLabel": "720.5k ops/s",
+              "mean": 0.001387829347019067,
+              "meanLabel": "1.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "deep nested merge (3 levels)": {
+              "name": "deep nested merge (3 levels)",
+              "hz": 368350,
+              "hzLabel": "368.3k ops/s",
+              "mean": 0.0027148103162082343,
+              "meanLabel": "2.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "many sources (5 objects)": {
+              "name": "many sources (5 objects)",
+              "hz": 870770,
+              "hzLabel": "870.8k ops/s",
+              "mean": 0.001148408283660012,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "realistic theme merge": {
+              "name": "realistic theme merge",
+              "hz": 545700,
+              "hzLabel": "545.7k ops/s",
+              "mean": 0.0018325080904514378,
+              "meanLabel": "1.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "large flat object (50 keys)": {
+              "name": "large flat object (50 keys)",
+              "hz": 61384,
+              "hzLabel": "61.4k ops/s",
+              "mean": 0.01629091890374885,
+              "meanLabel": "16.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "many sources (5 objects)",
+              "hz": 870770,
+              "hzLabel": "870.8k ops/s",
+              "mean": 0.001148408283660012,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "large flat object (50 keys)",
+              "hz": 61384,
+              "hzLabel": "61.4k ops/s",
+              "mean": 0.01629091890374885,
+              "meanLabel": "16.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "shallow merge (2 objects, 5 keys each)": {
+          "name": "shallow merge (2 objects, 5 keys each)",
+          "hz": 720550,
+          "hzLabel": "720.5k ops/s",
+          "mean": 0.001387829347019067,
+          "meanLabel": "1.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "deep nested merge (3 levels)": {
+          "name": "deep nested merge (3 levels)",
+          "hz": 368350,
+          "hzLabel": "368.3k ops/s",
+          "mean": 0.0027148103162082343,
+          "meanLabel": "2.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "many sources (5 objects)": {
+          "name": "many sources (5 objects)",
+          "hz": 870770,
+          "hzLabel": "870.8k ops/s",
+          "mean": 0.001148408283660012,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "realistic theme merge": {
+          "name": "realistic theme merge",
+          "hz": 545700,
+          "hzLabel": "545.7k ops/s",
+          "mean": 0.0018325080904514378,
+          "meanLabel": "1.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "large flat object (50 keys)": {
+          "name": "large flat object (50 keys)",
+          "hz": 61384,
+          "hzLabel": "61.4k ops/s",
+          "mean": 0.01629091890374885,
+          "meanLabel": "16.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "many sources (5 objects)",
+          "hz": 870770,
+          "hzLabel": "870.8k ops/s",
+          "mean": 0.001148408283660012,
+          "meanLabel": "1.1μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "large flat object (50 keys)",
+          "hz": 61384,
+          "hzLabel": "61.4k ops/s",
+          "mean": 0.01629091890374885,
+          "meanLabel": "16.3μs",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createDataGrid": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create grid (1,000 items)": {
+              "name": "Create grid (1,000 items)",
+              "hz": 233,
+              "hzLabel": "233 ops/s",
+              "mean": 4.294412358974351,
+              "meanLabel": "4.29ms",
+              "rme": 5.4,
+              "tier": "fast"
+            },
+            "Create grid (10,000 items)": {
+              "name": "Create grid (10,000 items)",
+              "hz": 26,
+              "hzLabel": "26 ops/s",
+              "mean": 39.1900126153845,
+              "meanLabel": "39.19ms",
+              "rme": 3.4,
+              "tier": "good"
+            },
+            "Create grid with pinned columns (1,000 items)": {
+              "name": "Create grid with pinned columns (1,000 items)",
+              "hz": 247,
+              "hzLabel": "247 ops/s",
+              "mean": 4.0451713629032575,
+              "meanLabel": "4.05ms",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Create grid with editable columns (1,000 items)": {
+              "name": "Create grid with editable columns (1,000 items)",
+              "hz": 242,
+              "hzLabel": "242 ops/s",
+              "mean": 4.12482763114753,
+              "meanLabel": "4.12ms",
+              "rme": 9.1,
+              "tier": "fast"
+            },
+            "Create grid with all options (1,000 items)": {
+              "name": "Create grid with all options (1,000 items)",
+              "hz": 261,
+              "hzLabel": "261 ops/s",
+              "mean": 3.8248605419847443,
+              "meanLabel": "3.82ms",
+              "rme": 4.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create grid with all options (1,000 items)",
+              "hz": 261,
+              "hzLabel": "261 ops/s",
+              "mean": 3.8248605419847443,
+              "meanLabel": "3.82ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create grid (10,000 items)",
+              "hz": 26,
+              "hzLabel": "26 ops/s",
+              "mean": 39.1900126153845,
+              "meanLabel": "39.19ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1720,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5813122334494754,
+              "meanLabel": "581.3μs",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 167,
+              "hzLabel": "167 ops/s",
+              "mean": 5.988649857142837,
+              "meanLabel": "5.99ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1720,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5813122334494754,
+              "meanLabel": "581.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 167,
+              "hzLabel": "167 ops/s",
+              "mean": 5.988649857142837,
+              "meanLabel": "5.99ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3604,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.27749106159821507,
+              "meanLabel": "277.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 446,
+              "hzLabel": "446 ops/s",
+              "mean": 2.2444159596412816,
+              "meanLabel": "2.24ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3264,
+              "hzLabel": "3.3k ops/s",
+              "mean": 0.3063523943661863,
+              "meanLabel": "306.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 114,
+              "hzLabel": "114 ops/s",
+              "mean": 8.78650547368415,
+              "meanLabel": "8.79ms",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3604,
+              "hzLabel": "3.6k ops/s",
+              "mean": 0.27749106159821507,
+              "meanLabel": "277.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 114,
+              "hzLabel": "114 ops/s",
+              "mean": 8.78650547368415,
+              "meanLabel": "8.79ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "column layout": {
+            "Pin column (1,000 items)": {
+              "name": "Pin column (1,000 items)",
+              "hz": 16648,
+              "hzLabel": "16.6k ops/s",
+              "mean": 0.060068500961078526,
+              "meanLabel": "60.1μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Resize column (1,000 items)": {
+              "name": "Resize column (1,000 items)",
+              "hz": 14223,
+              "hzLabel": "14.2k ops/s",
+              "mean": 0.07030900464004101,
+              "meanLabel": "70.3μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Resize column 10 times (1,000 items)": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5558,
+              "hzLabel": "5.6k ops/s",
+              "mean": 0.17993654480029198,
+              "meanLabel": "179.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Reorder column (1,000 items)": {
+              "name": "Reorder column (1,000 items)",
+              "hz": 11392,
+              "hzLabel": "11.4k ops/s",
+              "mean": 0.0877777598736218,
+              "meanLabel": "87.8μs",
+              "rme": 8,
+              "tier": "blazing"
+            },
+            "Reset layout (1,000 items)": {
+              "name": "Reset layout (1,000 items)",
+              "hz": 14022,
+              "hzLabel": "14.0k ops/s",
+              "mean": 0.07131514960070351,
+              "meanLabel": "71.3μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Pin column (1,000 items)",
+              "hz": 16648,
+              "hzLabel": "16.6k ops/s",
+              "mean": 0.060068500961078526,
+              "meanLabel": "60.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize column 10 times (1,000 items)",
+              "hz": 5558,
+              "hzLabel": "5.6k ops/s",
+              "mean": 0.17993654480029198,
+              "meanLabel": "179.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "cell editing": {
+            "Edit cell (1,000 items)": {
+              "name": "Edit cell (1,000 items)",
+              "hz": 270518,
+              "hzLabel": "270.5k ops/s",
+              "mean": 0.003696612772533199,
+              "meanLabel": "3.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Edit then commit (1,000 items)": {
+              "name": "Edit then commit (1,000 items)",
+              "hz": 141052,
+              "hzLabel": "141.1k ops/s",
+              "mean": 0.007089575609336836,
+              "meanLabel": "7.1μs",
+              "rme": 1.6,
+              "tier": "blazing"
+            },
+            "Edit then cancel (1,000 items)": {
+              "name": "Edit then cancel (1,000 items)",
+              "hz": 265962,
+              "hzLabel": "266.0k ops/s",
+              "mean": 0.0037599411570091675,
+              "meanLabel": "3.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Edit with validation failure (1,000 items)": {
+              "name": "Edit with validation failure (1,000 items)",
+              "hz": 149593,
+              "hzLabel": "149.6k ops/s",
+              "mean": 0.006684808976297996,
+              "meanLabel": "6.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Edit 10 cells sequentially (1,000 items)": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 15475,
+              "hzLabel": "15.5k ops/s",
+              "mean": 0.06462159498578361,
+              "meanLabel": "64.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Edit cell (1,000 items)",
+              "hz": 270518,
+              "hzLabel": "270.5k ops/s",
+              "mean": 0.003696612772533199,
+              "meanLabel": "3.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Edit 10 cells sequentially (1,000 items)",
+              "hz": 15475,
+              "hzLabel": "15.5k ops/s",
+              "mean": 0.06462159498578361,
+              "meanLabel": "64.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row ordering": {
+            "Move row (1,000 items)": {
+              "name": "Move row (1,000 items)",
+              "hz": 1103,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9068964329710228,
+              "meanLabel": "906.9μs",
+              "rme": 2.7,
+              "tier": "blazing"
+            },
+            "Move 10 rows (1,000 items)": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1023,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9778282949219026,
+              "meanLabel": "977.8μs",
+              "rme": 2.9,
+              "tier": "blazing"
+            },
+            "Reset row order (1,000 items)": {
+              "name": "Reset row order (1,000 items)",
+              "hz": 1233,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8109040810372296,
+              "meanLabel": "810.9μs",
+              "rme": 1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reset row order (1,000 items)",
+              "hz": 1233,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8109040810372296,
+              "meanLabel": "810.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move 10 rows (1,000 items)",
+              "hz": 1023,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9778282949219026,
+              "meanLabel": "977.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "row spanning": {
+            "Compute spans (1,000 items, 1 column)": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 244,
+              "hzLabel": "244 ops/s",
+              "mean": 4.103029286885162,
+              "meanLabel": "4.10ms",
+              "rme": 4.2,
+              "tier": "fast"
+            },
+            "Compute spans (10,000 items, 1 column)": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 23,
+              "hzLabel": "23 ops/s",
+              "mean": 42.75984184615412,
+              "meanLabel": "42.76ms",
+              "rme": 9.3,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Compute spans (1,000 items, 1 column)",
+              "hz": 244,
+              "hzLabel": "244 ops/s",
+              "mean": 4.103029286885162,
+              "meanLabel": "4.10ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Compute spans (10,000 items, 1 column)",
+              "hz": 23,
+              "hzLabel": "23 ops/s",
+              "mean": 42.75984184615412,
+              "meanLabel": "42.76ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 449400,
+              "hzLabel": "449.4k ops/s",
+              "mean": 0.002225187115329161,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 453554,
+              "hzLabel": "453.6k ops/s",
+              "mean": 0.0022048067757881188,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 777613,
+              "hzLabel": "777.6k ops/s",
+              "mean": 0.0012859874024939814,
+              "meanLabel": "1.3μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access layout.columns 100 times (1,000 items, cached)": {
+              "name": "Access layout.columns 100 times (1,000 items, cached)",
+              "hz": 785748,
+              "hzLabel": "785.7k ops/s",
+              "mean": 0.0012726723054397667,
+              "meanLabel": "1.3μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access layout.pinned 100 times (1,000 items, cached)": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 793836,
+              "hzLabel": "793.8k ops/s",
+              "mean": 0.001259705897165827,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access layout.pinned 100 times (1,000 items, cached)",
+              "hz": 793836,
+              "hzLabel": "793.8k ops/s",
+              "mean": 0.001259705897165827,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 449400,
+              "hzLabel": "449.4k ops/s",
+              "mean": 0.002225187115329161,
+              "meanLabel": "2.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1369,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.730551445255606,
+              "meanLabel": "730.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 148,
+              "hzLabel": "148 ops/s",
+              "mean": 6.745101306666766,
+              "meanLabel": "6.75ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (1,000 items)": {
+              "name": "Search + sort + paginate + layout (1,000 items)",
+              "hz": 1222,
+              "hzLabel": "1.2k ops/s",
+              "mean": 0.8180999460784578,
+              "meanLabel": "818.1μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate + layout (10,000 items)": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 145,
+              "hzLabel": "145 ops/s",
+              "mean": 6.8890468493150925,
+              "meanLabel": "6.89ms",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1369,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.730551445255606,
+              "meanLabel": "730.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate + layout (10,000 items)",
+              "hz": 145,
+              "hzLabel": "145 ops/s",
+              "mean": 6.8890468493150925,
+              "meanLabel": "6.89ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create grid (1,000 items)": {
+          "name": "Create grid (1,000 items)",
+          "hz": 233,
+          "hzLabel": "233 ops/s",
+          "mean": 4.294412358974351,
+          "meanLabel": "4.29ms",
+          "rme": 5.4,
+          "tier": "fast"
+        },
+        "Create grid (10,000 items)": {
+          "name": "Create grid (10,000 items)",
+          "hz": 26,
+          "hzLabel": "26 ops/s",
+          "mean": 39.1900126153845,
+          "meanLabel": "39.19ms",
+          "rme": 3.4,
+          "tier": "good"
+        },
+        "Create grid with pinned columns (1,000 items)": {
+          "name": "Create grid with pinned columns (1,000 items)",
+          "hz": 247,
+          "hzLabel": "247 ops/s",
+          "mean": 4.0451713629032575,
+          "meanLabel": "4.05ms",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Create grid with editable columns (1,000 items)": {
+          "name": "Create grid with editable columns (1,000 items)",
+          "hz": 242,
+          "hzLabel": "242 ops/s",
+          "mean": 4.12482763114753,
+          "meanLabel": "4.12ms",
+          "rme": 9.1,
+          "tier": "fast"
+        },
+        "Create grid with all options (1,000 items)": {
+          "name": "Create grid with all options (1,000 items)",
+          "hz": 261,
+          "hzLabel": "261 ops/s",
+          "mean": 3.8248605419847443,
+          "meanLabel": "3.82ms",
+          "rme": 4.1,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1720,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.5813122334494754,
+          "meanLabel": "581.3μs",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 167,
+          "hzLabel": "167 ops/s",
+          "mean": 5.988649857142837,
+          "meanLabel": "5.99ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3604,
+          "hzLabel": "3.6k ops/s",
+          "mean": 0.27749106159821507,
+          "meanLabel": "277.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 446,
+          "hzLabel": "446 ops/s",
+          "mean": 2.2444159596412816,
+          "meanLabel": "2.24ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 3264,
+          "hzLabel": "3.3k ops/s",
+          "mean": 0.3063523943661863,
+          "meanLabel": "306.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 114,
+          "hzLabel": "114 ops/s",
+          "mean": 8.78650547368415,
+          "meanLabel": "8.79ms",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Pin column (1,000 items)": {
+          "name": "Pin column (1,000 items)",
+          "hz": 16648,
+          "hzLabel": "16.6k ops/s",
+          "mean": 0.060068500961078526,
+          "meanLabel": "60.1μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Resize column (1,000 items)": {
+          "name": "Resize column (1,000 items)",
+          "hz": 14223,
+          "hzLabel": "14.2k ops/s",
+          "mean": 0.07030900464004101,
+          "meanLabel": "70.3μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Resize column 10 times (1,000 items)": {
+          "name": "Resize column 10 times (1,000 items)",
+          "hz": 5558,
+          "hzLabel": "5.6k ops/s",
+          "mean": 0.17993654480029198,
+          "meanLabel": "179.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Reorder column (1,000 items)": {
+          "name": "Reorder column (1,000 items)",
+          "hz": 11392,
+          "hzLabel": "11.4k ops/s",
+          "mean": 0.0877777598736218,
+          "meanLabel": "87.8μs",
+          "rme": 8,
+          "tier": "blazing"
+        },
+        "Reset layout (1,000 items)": {
+          "name": "Reset layout (1,000 items)",
+          "hz": 14022,
+          "hzLabel": "14.0k ops/s",
+          "mean": 0.07131514960070351,
+          "meanLabel": "71.3μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Edit cell (1,000 items)": {
+          "name": "Edit cell (1,000 items)",
+          "hz": 270518,
+          "hzLabel": "270.5k ops/s",
+          "mean": 0.003696612772533199,
+          "meanLabel": "3.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Edit then commit (1,000 items)": {
+          "name": "Edit then commit (1,000 items)",
+          "hz": 141052,
+          "hzLabel": "141.1k ops/s",
+          "mean": 0.007089575609336836,
+          "meanLabel": "7.1μs",
+          "rme": 1.6,
+          "tier": "blazing"
+        },
+        "Edit then cancel (1,000 items)": {
+          "name": "Edit then cancel (1,000 items)",
+          "hz": 265962,
+          "hzLabel": "266.0k ops/s",
+          "mean": 0.0037599411570091675,
+          "meanLabel": "3.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Edit with validation failure (1,000 items)": {
+          "name": "Edit with validation failure (1,000 items)",
+          "hz": 149593,
+          "hzLabel": "149.6k ops/s",
+          "mean": 0.006684808976297996,
+          "meanLabel": "6.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Edit 10 cells sequentially (1,000 items)": {
+          "name": "Edit 10 cells sequentially (1,000 items)",
+          "hz": 15475,
+          "hzLabel": "15.5k ops/s",
+          "mean": 0.06462159498578361,
+          "meanLabel": "64.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move row (1,000 items)": {
+          "name": "Move row (1,000 items)",
+          "hz": 1103,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9068964329710228,
+          "meanLabel": "906.9μs",
+          "rme": 2.7,
+          "tier": "blazing"
+        },
+        "Move 10 rows (1,000 items)": {
+          "name": "Move 10 rows (1,000 items)",
+          "hz": 1023,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9778282949219026,
+          "meanLabel": "977.8μs",
+          "rme": 2.9,
+          "tier": "blazing"
+        },
+        "Reset row order (1,000 items)": {
+          "name": "Reset row order (1,000 items)",
+          "hz": 1233,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8109040810372296,
+          "meanLabel": "810.9μs",
+          "rme": 1,
+          "tier": "blazing"
+        },
+        "Compute spans (1,000 items, 1 column)": {
+          "name": "Compute spans (1,000 items, 1 column)",
+          "hz": 244,
+          "hzLabel": "244 ops/s",
+          "mean": 4.103029286885162,
+          "meanLabel": "4.10ms",
+          "rme": 4.2,
+          "tier": "fast"
+        },
+        "Compute spans (10,000 items, 1 column)": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 23,
+          "hzLabel": "23 ops/s",
+          "mean": 42.75984184615412,
+          "meanLabel": "42.76ms",
+          "rme": 9.3,
+          "tier": "good"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 449400,
+          "hzLabel": "449.4k ops/s",
+          "mean": 0.002225187115329161,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 453554,
+          "hzLabel": "453.6k ops/s",
+          "mean": 0.0022048067757881188,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 777613,
+          "hzLabel": "777.6k ops/s",
+          "mean": 0.0012859874024939814,
+          "meanLabel": "1.3μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access layout.columns 100 times (1,000 items, cached)": {
+          "name": "Access layout.columns 100 times (1,000 items, cached)",
+          "hz": 785748,
+          "hzLabel": "785.7k ops/s",
+          "mean": 0.0012726723054397667,
+          "meanLabel": "1.3μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access layout.pinned 100 times (1,000 items, cached)": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 793836,
+          "hzLabel": "793.8k ops/s",
+          "mean": 0.001259705897165827,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1369,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.730551445255606,
+          "meanLabel": "730.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 148,
+          "hzLabel": "148 ops/s",
+          "mean": 6.745101306666766,
+          "meanLabel": "6.75ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (1,000 items)": {
+          "name": "Search + sort + paginate + layout (1,000 items)",
+          "hz": 1222,
+          "hzLabel": "1.2k ops/s",
+          "mean": 0.8180999460784578,
+          "meanLabel": "818.1μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate + layout (10,000 items)": {
+          "name": "Search + sort + paginate + layout (10,000 items)",
+          "hz": 145,
+          "hzLabel": "145 ops/s",
+          "mean": 6.8890468493150925,
+          "meanLabel": "6.89ms",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access layout.pinned 100 times (1,000 items, cached)",
+          "hz": 793836,
+          "hzLabel": "793.8k ops/s",
+          "mean": 0.001259705897165827,
+          "meanLabel": "1.3μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Compute spans (10,000 items, 1 column)",
+          "hz": 23,
+          "hzLabel": "23 ops/s",
+          "mean": 42.75984184615412,
+          "meanLabel": "42.76ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createDataTable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create table (1,000 items)": {
+              "name": "Create table (1,000 items)",
+              "hz": 930,
+              "hzLabel": "930 ops/s",
+              "mean": 1.0754662709678047,
+              "meanLabel": "1.08ms",
+              "rme": 3.5,
+              "tier": "fast"
+            },
+            "Create table (10,000 items)": {
+              "name": "Create table (10,000 items)",
+              "hz": 89,
+              "hzLabel": "89 ops/s",
+              "mean": 11.207151458333405,
+              "meanLabel": "11.21ms",
+              "rme": 11.6,
+              "tier": "fast"
+            },
+            "Create table with groupBy (1,000 items)": {
+              "name": "Create table with groupBy (1,000 items)",
+              "hz": 755,
+              "hzLabel": "755 ops/s",
+              "mean": 1.325204288359687,
+              "meanLabel": "1.33ms",
+              "rme": 14.2,
+              "tier": "fast"
+            },
+            "Create table with all options (1,000 items)": {
+              "name": "Create table with all options (1,000 items)",
+              "hz": 581,
+              "hzLabel": "581 ops/s",
+              "mean": 1.7208981924401068,
+              "meanLabel": "1.72ms",
+              "rme": 2.9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create table (1,000 items)",
+              "hz": 930,
+              "hzLabel": "930 ops/s",
+              "mean": 1.0754662709678047,
+              "meanLabel": "1.08ms",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create table (10,000 items)",
+              "hz": 89,
+              "hzLabel": "89 ops/s",
+              "mean": 11.207151458333405,
+              "meanLabel": "11.21ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "search pipeline": {
+            "Search then read filtered items (1,000 items)": {
+              "name": "Search then read filtered items (1,000 items)",
+              "hz": 1641,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6094724116930402,
+              "meanLabel": "609.5μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search then read filtered items (10,000 items)": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 164,
+              "hzLabel": "164 ops/s",
+              "mean": 6.091314132530831,
+              "meanLabel": "6.09ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (1,000 items)": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1742,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5739355412843664,
+              "meanLabel": "573.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Search with custom column filter (10,000 items)": {
+              "name": "Search with custom column filter (10,000 items)",
+              "hz": 172,
+              "hzLabel": "172 ops/s",
+              "mean": 5.828635930232595,
+              "meanLabel": "5.83ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Update search 10 times (1,000 items)": {
+              "name": "Update search 10 times (1,000 items)",
+              "hz": 164,
+              "hzLabel": "164 ops/s",
+              "mean": 6.081220638554288,
+              "meanLabel": "6.08ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Search with custom column filter (1,000 items)",
+              "hz": 1742,
+              "hzLabel": "1.7k ops/s",
+              "mean": 0.5739355412843664,
+              "meanLabel": "573.9μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search then read filtered items (10,000 items)",
+              "hz": 164,
+              "hzLabel": "164 ops/s",
+              "mean": 6.091314132530831,
+              "meanLabel": "6.09ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "sort pipeline": {
+            "Sort by string column ascending (1,000 items)": {
+              "name": "Sort by string column ascending (1,000 items)",
+              "hz": 3141,
+              "hzLabel": "3.1k ops/s",
+              "mean": 0.3183646849143824,
+              "meanLabel": "318.4μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by string column ascending (10,000 items)": {
+              "name": "Sort by string column ascending (10,000 items)",
+              "hz": 385,
+              "hzLabel": "385 ops/s",
+              "mean": 2.5993507564772216,
+              "meanLabel": "2.60ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (1,000 items)": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3243,
+              "hzLabel": "3.2k ops/s",
+              "mean": 0.30831167262626413,
+              "meanLabel": "308.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Sort by custom comparator (10,000 items)": {
+              "name": "Sort by custom comparator (10,000 items)",
+              "hz": 109,
+              "hzLabel": "109 ops/s",
+              "mean": 9.196244618182325,
+              "meanLabel": "9.20ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Multi-sort two columns (1,000 items)": {
+              "name": "Multi-sort two columns (1,000 items)",
+              "hz": 962,
+              "hzLabel": "962 ops/s",
+              "mean": 1.0389943568468774,
+              "meanLabel": "1.04ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Multi-sort two columns (10,000 items)": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 91,
+              "hzLabel": "91 ops/s",
+              "mean": 10.992180413042977,
+              "meanLabel": "10.99ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "Toggle sort cycle 3 times (1,000 items)": {
+              "name": "Toggle sort cycle 3 times (1,000 items)",
+              "hz": 1566,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6384622551019433,
+              "meanLabel": "638.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Sort by custom comparator (1,000 items)",
+              "hz": 3243,
+              "hzLabel": "3.2k ops/s",
+              "mean": 0.30831167262626413,
+              "meanLabel": "308.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Multi-sort two columns (10,000 items)",
+              "hz": 91,
+              "hzLabel": "91 ops/s",
+              "mean": 10.992180413042977,
+              "meanLabel": "10.99ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 943813,
+              "hzLabel": "943.8k ops/s",
+              "mean": 0.001059531443678594,
+              "meanLabel": "1.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all items (1,000 items)": {
+              "name": "Select all items (1,000 items)",
+              "hz": 1873,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5339262924223739,
+              "meanLabel": "533.9μs",
+              "rme": 5.5,
+              "tier": "blazing"
+            },
+            "Select all items (10,000 items)": {
+              "name": "Select all items (10,000 items)",
+              "hz": 183,
+              "hzLabel": "183 ops/s",
+              "mean": 5.471651717391859,
+              "meanLabel": "5.47ms",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Select all with itemSelectable (1,000 items)": {
+              "name": "Select all with itemSelectable (1,000 items)",
+              "hz": 2403,
+              "hzLabel": "2.4k ops/s",
+              "mean": 0.4161651339436291,
+              "meanLabel": "416.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle all then check isAllSelected (1,000 items)": {
+              "name": "Toggle all then check isAllSelected (1,000 items)",
+              "hz": 874,
+              "hzLabel": "874 ops/s",
+              "mean": 1.1447170366134438,
+              "meanLabel": "1.14ms",
+              "rme": 0.4,
+              "tier": "fast"
+            },
+            "Toggle 100 individual rows (1,000 items)": {
+              "name": "Toggle 100 individual rows (1,000 items)",
+              "hz": 8551,
+              "hzLabel": "8.6k ops/s",
+              "mean": 0.11694396725896455,
+              "meanLabel": "116.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 943813,
+              "hzLabel": "943.8k ops/s",
+              "mean": 0.001059531443678594,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all items (10,000 items)",
+              "hz": 183,
+              "hzLabel": "183 ops/s",
+              "mean": 5.471651717391859,
+              "meanLabel": "5.47ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "grouping": {
+            "Compute groups (1,000 items, 8 groups)": {
+              "name": "Compute groups (1,000 items, 8 groups)",
+              "hz": 743,
+              "hzLabel": "743 ops/s",
+              "mean": 1.346205247311993,
+              "meanLabel": "1.35ms",
+              "rme": 7.4,
+              "tier": "fast"
+            },
+            "Compute groups (10,000 items, 8 groups)": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 76,
+              "hzLabel": "76 ops/s",
+              "mean": 13.095873846154204,
+              "meanLabel": "13.10ms",
+              "rme": 10.5,
+              "tier": "fast"
+            },
+            "Open all then close all groups (1,000 items)": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 211508,
+              "hzLabel": "211.5k ops/s",
+              "mean": 0.0047279477471405245,
+              "meanLabel": "4.7μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Create with openAll (1,000 items)": {
+              "name": "Create with openAll (1,000 items)",
+              "hz": 591,
+              "hzLabel": "591 ops/s",
+              "mean": 1.6927025202694004,
+              "meanLabel": "1.69ms",
+              "rme": 3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Open all then close all groups (1,000 items)",
+              "hz": 211508,
+              "hzLabel": "211.5k ops/s",
+              "mean": 0.0047279477471405245,
+              "meanLabel": "4.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Compute groups (10,000 items, 8 groups)",
+              "hz": 76,
+              "hzLabel": "76 ops/s",
+              "mean": 13.095873846154204,
+              "meanLabel": "13.10ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 824540,
+              "hzLabel": "824.5k ops/s",
+              "mean": 0.001212796946660968,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 810954,
+              "hzLabel": "811.0k ops/s",
+              "mean": 0.0012331159473925146,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access sortedItems 100 times (1,000 items, cached)": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 828323,
+              "hzLabel": "828.3k ops/s",
+              "mean": 0.0012072578025039175,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access total 100 times (1,000 items, cached)": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 593946,
+              "hzLabel": "593.9k ops/s",
+              "mean": 0.0016836543502018412,
+              "meanLabel": "1.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access sortedItems 100 times (1,000 items, cached)",
+              "hz": 828323,
+              "hzLabel": "828.3k ops/s",
+              "mean": 0.0012072578025039175,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access total 100 times (1,000 items, cached)",
+              "hz": 593946,
+              "hzLabel": "593.9k ops/s",
+              "mean": 0.0016836543502018412,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "full pipeline": {
+            "Search + sort + paginate (1,000 items)": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1430,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6991708477654462,
+              "meanLabel": "699.2μs",
+              "rme": 5.6,
+              "tier": "blazing"
+            },
+            "Search + sort + paginate (10,000 items)": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 159,
+              "hzLabel": "159 ops/s",
+              "mean": 6.273678462499811,
+              "meanLabel": "6.27ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Search + multi-sort + paginate (1,000 items)": {
+              "name": "Search + multi-sort + paginate (1,000 items)",
+              "hz": 598,
+              "hzLabel": "598 ops/s",
+              "mean": 1.671587683333152,
+              "meanLabel": "1.67ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Search + sort + paginate (1,000 items)",
+              "hz": 1430,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.6991708477654462,
+              "meanLabel": "699.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Search + sort + paginate (10,000 items)",
+              "hz": 159,
+              "hzLabel": "159 ops/s",
+              "mean": 6.273678462499811,
+              "meanLabel": "6.27ms",
+              "tier": "blazing"
+            },
+            "_tier": "fast"
+          },
+          "adapter comparison": {
+            "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+              "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+              "hz": 383,
+              "hzLabel": "383 ops/s",
+              "mean": 2.6110482760410227,
+              "meanLabel": "2.61ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 384,
+              "hzLabel": "384 ops/s",
+              "mean": 2.6069826197926886,
+              "meanLabel": "2.61ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "ClientDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 161,
+              "hzLabel": "161 ops/s",
+              "mean": 6.218556790124699,
+              "meanLabel": "6.22ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 158,
+              "hzLabel": "158 ops/s",
+              "mean": 6.33689122784885,
+              "meanLabel": "6.34ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+              "hz": 384,
+              "hzLabel": "384 ops/s",
+              "mean": 2.6069826197926886,
+              "meanLabel": "2.61ms",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+              "hz": 158,
+              "hzLabel": "158 ops/s",
+              "mean": 6.33689122784885,
+              "meanLabel": "6.34ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create table (1,000 items)": {
+          "name": "Create table (1,000 items)",
+          "hz": 930,
+          "hzLabel": "930 ops/s",
+          "mean": 1.0754662709678047,
+          "meanLabel": "1.08ms",
+          "rme": 3.5,
+          "tier": "fast"
+        },
+        "Create table (10,000 items)": {
+          "name": "Create table (10,000 items)",
+          "hz": 89,
+          "hzLabel": "89 ops/s",
+          "mean": 11.207151458333405,
+          "meanLabel": "11.21ms",
+          "rme": 11.6,
+          "tier": "fast"
+        },
+        "Create table with groupBy (1,000 items)": {
+          "name": "Create table with groupBy (1,000 items)",
+          "hz": 755,
+          "hzLabel": "755 ops/s",
+          "mean": 1.325204288359687,
+          "meanLabel": "1.33ms",
+          "rme": 14.2,
+          "tier": "fast"
+        },
+        "Create table with all options (1,000 items)": {
+          "name": "Create table with all options (1,000 items)",
+          "hz": 581,
+          "hzLabel": "581 ops/s",
+          "mean": 1.7208981924401068,
+          "meanLabel": "1.72ms",
+          "rme": 2.9,
+          "tier": "fast"
+        },
+        "Search then read filtered items (1,000 items)": {
+          "name": "Search then read filtered items (1,000 items)",
+          "hz": 1641,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6094724116930402,
+          "meanLabel": "609.5μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search then read filtered items (10,000 items)": {
+          "name": "Search then read filtered items (10,000 items)",
+          "hz": 164,
+          "hzLabel": "164 ops/s",
+          "mean": 6.091314132530831,
+          "meanLabel": "6.09ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (1,000 items)": {
+          "name": "Search with custom column filter (1,000 items)",
+          "hz": 1742,
+          "hzLabel": "1.7k ops/s",
+          "mean": 0.5739355412843664,
+          "meanLabel": "573.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Search with custom column filter (10,000 items)": {
+          "name": "Search with custom column filter (10,000 items)",
+          "hz": 172,
+          "hzLabel": "172 ops/s",
+          "mean": 5.828635930232595,
+          "meanLabel": "5.83ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Update search 10 times (1,000 items)": {
+          "name": "Update search 10 times (1,000 items)",
+          "hz": 164,
+          "hzLabel": "164 ops/s",
+          "mean": 6.081220638554288,
+          "meanLabel": "6.08ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (1,000 items)": {
+          "name": "Sort by string column ascending (1,000 items)",
+          "hz": 3141,
+          "hzLabel": "3.1k ops/s",
+          "mean": 0.3183646849143824,
+          "meanLabel": "318.4μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by string column ascending (10,000 items)": {
+          "name": "Sort by string column ascending (10,000 items)",
+          "hz": 385,
+          "hzLabel": "385 ops/s",
+          "mean": 2.5993507564772216,
+          "meanLabel": "2.60ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (1,000 items)": {
+          "name": "Sort by custom comparator (1,000 items)",
+          "hz": 3243,
+          "hzLabel": "3.2k ops/s",
+          "mean": 0.30831167262626413,
+          "meanLabel": "308.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Sort by custom comparator (10,000 items)": {
+          "name": "Sort by custom comparator (10,000 items)",
+          "hz": 109,
+          "hzLabel": "109 ops/s",
+          "mean": 9.196244618182325,
+          "meanLabel": "9.20ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Multi-sort two columns (1,000 items)": {
+          "name": "Multi-sort two columns (1,000 items)",
+          "hz": 962,
+          "hzLabel": "962 ops/s",
+          "mean": 1.0389943568468774,
+          "meanLabel": "1.04ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Multi-sort two columns (10,000 items)": {
+          "name": "Multi-sort two columns (10,000 items)",
+          "hz": 91,
+          "hzLabel": "91 ops/s",
+          "mean": 10.992180413042977,
+          "meanLabel": "10.99ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Toggle sort cycle 3 times (1,000 items)": {
+          "name": "Toggle sort cycle 3 times (1,000 items)",
+          "hz": 1566,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6384622551019433,
+          "meanLabel": "638.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 943813,
+          "hzLabel": "943.8k ops/s",
+          "mean": 0.001059531443678594,
+          "meanLabel": "1.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all items (1,000 items)": {
+          "name": "Select all items (1,000 items)",
+          "hz": 1873,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5339262924223739,
+          "meanLabel": "533.9μs",
+          "rme": 5.5,
+          "tier": "blazing"
+        },
+        "Select all items (10,000 items)": {
+          "name": "Select all items (10,000 items)",
+          "hz": 183,
+          "hzLabel": "183 ops/s",
+          "mean": 5.471651717391859,
+          "meanLabel": "5.47ms",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Select all with itemSelectable (1,000 items)": {
+          "name": "Select all with itemSelectable (1,000 items)",
+          "hz": 2403,
+          "hzLabel": "2.4k ops/s",
+          "mean": 0.4161651339436291,
+          "meanLabel": "416.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle all then check isAllSelected (1,000 items)": {
+          "name": "Toggle all then check isAllSelected (1,000 items)",
+          "hz": 874,
+          "hzLabel": "874 ops/s",
+          "mean": 1.1447170366134438,
+          "meanLabel": "1.14ms",
+          "rme": 0.4,
+          "tier": "fast"
+        },
+        "Toggle 100 individual rows (1,000 items)": {
+          "name": "Toggle 100 individual rows (1,000 items)",
+          "hz": 8551,
+          "hzLabel": "8.6k ops/s",
+          "mean": 0.11694396725896455,
+          "meanLabel": "116.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Compute groups (1,000 items, 8 groups)": {
+          "name": "Compute groups (1,000 items, 8 groups)",
+          "hz": 743,
+          "hzLabel": "743 ops/s",
+          "mean": 1.346205247311993,
+          "meanLabel": "1.35ms",
+          "rme": 7.4,
+          "tier": "fast"
+        },
+        "Compute groups (10,000 items, 8 groups)": {
+          "name": "Compute groups (10,000 items, 8 groups)",
+          "hz": 76,
+          "hzLabel": "76 ops/s",
+          "mean": 13.095873846154204,
+          "meanLabel": "13.10ms",
+          "rme": 10.5,
+          "tier": "fast"
+        },
+        "Open all then close all groups (1,000 items)": {
+          "name": "Open all then close all groups (1,000 items)",
+          "hz": 211508,
+          "hzLabel": "211.5k ops/s",
+          "mean": 0.0047279477471405245,
+          "meanLabel": "4.7μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Create with openAll (1,000 items)": {
+          "name": "Create with openAll (1,000 items)",
+          "hz": 591,
+          "hzLabel": "591 ops/s",
+          "mean": 1.6927025202694004,
+          "meanLabel": "1.69ms",
+          "rme": 3,
+          "tier": "fast"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 824540,
+          "hzLabel": "824.5k ops/s",
+          "mean": 0.001212796946660968,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 810954,
+          "hzLabel": "811.0k ops/s",
+          "mean": 0.0012331159473925146,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access sortedItems 100 times (1,000 items, cached)": {
+          "name": "Access sortedItems 100 times (1,000 items, cached)",
+          "hz": 828323,
+          "hzLabel": "828.3k ops/s",
+          "mean": 0.0012072578025039175,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access total 100 times (1,000 items, cached)": {
+          "name": "Access total 100 times (1,000 items, cached)",
+          "hz": 593946,
+          "hzLabel": "593.9k ops/s",
+          "mean": 0.0016836543502018412,
+          "meanLabel": "1.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (1,000 items)": {
+          "name": "Search + sort + paginate (1,000 items)",
+          "hz": 1430,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.6991708477654462,
+          "meanLabel": "699.2μs",
+          "rme": 5.6,
+          "tier": "blazing"
+        },
+        "Search + sort + paginate (10,000 items)": {
+          "name": "Search + sort + paginate (10,000 items)",
+          "hz": 159,
+          "hzLabel": "159 ops/s",
+          "mean": 6.273678462499811,
+          "meanLabel": "6.27ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Search + multi-sort + paginate (1,000 items)": {
+          "name": "Search + multi-sort + paginate (1,000 items)",
+          "hz": 598,
+          "hzLabel": "598 ops/s",
+          "mean": 1.671587683333152,
+          "meanLabel": "1.67ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "ClientDataTableAdapter: sort + paginate (10,000 items)": {
+          "name": "ClientDataTableAdapter: sort + paginate (10,000 items)",
+          "hz": 383,
+          "hzLabel": "383 ops/s",
+          "mean": 2.6110482760410227,
+          "meanLabel": "2.61ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: sort, no pagination (10,000 items)": {
+          "name": "VirtualDataTableAdapter: sort, no pagination (10,000 items)",
+          "hz": 384,
+          "hzLabel": "384 ops/s",
+          "mean": 2.6069826197926886,
+          "meanLabel": "2.61ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "ClientDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "ClientDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 161,
+          "hzLabel": "161 ops/s",
+          "mean": 6.218556790124699,
+          "meanLabel": "6.22ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "VirtualDataTableAdapter: full pipeline (10,000 items)": {
+          "name": "VirtualDataTableAdapter: full pipeline (10,000 items)",
+          "hz": 158,
+          "hzLabel": "158 ops/s",
+          "mean": 6.33689122784885,
+          "meanLabel": "6.34ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Select single item (1,000 items)",
+          "hz": 943813,
+          "hzLabel": "943.8k ops/s",
+          "mean": 0.001059531443678594,
+          "meanLabel": "1.1μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Compute groups (10,000 items, 8 groups)",
+          "hz": 76,
+          "hzLabel": "76 ops/s",
+          "mean": 13.095873846154204,
+          "meanLabel": "13.10ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createFilter": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty filter": {
+              "name": "Create empty filter",
+              "hz": 7473735,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013380191379342522,
+              "meanLabel": "134ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Create filter with keys constraint": {
+              "name": "Create filter with keys constraint",
+              "hz": 7151737,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013982616700503294,
+              "meanLabel": "140ns",
+              "rme": 3.5,
+              "tier": "blazing"
+            },
+            "Create filter with custom matcher": {
+              "name": "Create filter with custom matcher",
+              "hz": 6393557,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015640745918544266,
+              "meanLabel": "156ns",
+              "rme": 2.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty filter",
+              "hz": 7473735,
+              "hzLabel": "7.5M ops/s",
+              "mean": 0.00013380191379342522,
+              "meanLabel": "134ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create filter with custom matcher",
+              "hz": 6393557,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015640745918544266,
+              "meanLabel": "156ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "primitive filtering": {
+            "Filter 1,000 string primitives with single query": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 7341970,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001362032189820004,
+              "meanLabel": "136ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 10,000 string primitives with single query": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 7337569,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013628492184510838,
+              "meanLabel": "136ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 string primitives with single query",
+              "hz": 7341970,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001362032189820004,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 10,000 string primitives with single query",
+              "hz": 7337569,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013628492184510838,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "object filtering": {
+            "Filter 1,000 objects across all keys": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 7357303,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.0001359193672010686,
+              "meanLabel": "136ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with single key constraint": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 7106615,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014071396513128708,
+              "meanLabel": "141ns",
+              "rme": 4.2,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects across all keys": {
+              "name": "Filter 10,000 objects across all keys",
+              "hz": 7202935,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013883229061383186,
+              "meanLabel": "139ns",
+              "rme": 3.2,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with single key constraint": {
+              "name": "Filter 10,000 objects with single key constraint",
+              "hz": 7238556,
+              "hzLabel": "7.2M ops/s",
+              "mean": 0.00013814910294805382,
+              "meanLabel": "138ns",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 1,000 objects across all keys",
+              "hz": 7357303,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.0001359193672010686,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects with single key constraint",
+              "hz": 7106615,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.00014071396513128708,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "filter modes": {
+            "Filter 1,000 objects with some mode": {
+              "name": "Filter 1,000 objects with some mode",
+              "hz": 7283416,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013729820696668825,
+              "meanLabel": "137ns",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with every mode": {
+              "name": "Filter 1,000 objects with every mode",
+              "hz": 7276592,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013742697571104729,
+              "meanLabel": "137ns",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with union mode (2 queries)": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 7072050,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001414017080146571,
+              "meanLabel": "141ns",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "Filter 1,000 objects with intersection mode (2 queries)": {
+              "name": "Filter 1,000 objects with intersection mode (2 queries)",
+              "hz": 7106555,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001407151489368491,
+              "meanLabel": "141ns",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with some mode": {
+              "name": "Filter 10,000 objects with some mode",
+              "hz": 7260377,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013773389677408654,
+              "meanLabel": "138ns",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "Filter 10,000 objects with every mode": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 7375135,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013559074490293734,
+              "meanLabel": "136ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Filter 10,000 objects with every mode",
+              "hz": 7375135,
+              "hzLabel": "7.4M ops/s",
+              "mean": 0.00013559074490293734,
+              "meanLabel": "136ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Filter 1,000 objects with union mode (2 queries)",
+              "hz": 7072050,
+              "hzLabel": "7.1M ops/s",
+              "mean": 0.0001414017080146571,
+              "meanLabel": "141ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Access filtered 100 times (1,000 items, cached)": {
+              "name": "Access filtered 100 times (1,000 items, cached)",
+              "hz": 1114433,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0008973172013984207,
+              "meanLabel": "897ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Access filtered 100 times (10,000 items, cached)": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 1130969,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0008841974429157225,
+              "meanLabel": "884ns",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Update query 10 times (1,000 items)": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 484882,
+              "hzLabel": "484.9k ops/s",
+              "mean": 0.0020623579056780568,
+              "meanLabel": "2.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Update query 10 times (10,000 items)": {
+              "name": "Update query 10 times (10,000 items)",
+              "hz": 540124,
+              "hzLabel": "540.1k ops/s",
+              "mean": 0.0018514258487846802,
+              "meanLabel": "1.9μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access filtered 100 times (10,000 items, cached)",
+              "hz": 1130969,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0008841974429157225,
+              "meanLabel": "884ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Update query 10 times (1,000 items)",
+              "hz": 484882,
+              "hzLabel": "484.9k ops/s",
+              "mean": 0.0020623579056780568,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "native comparison": {
+            "Native Array.filter 1,000 objects": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1874,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5335705490409409,
+              "meanLabel": "533.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Native Array.filter 10,000 objects": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 182,
+              "hzLabel": "182 ops/s",
+              "mean": 5.507136703294876,
+              "meanLabel": "5.51ms",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Native Array.filter 1,000 objects",
+              "hz": 1874,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5335705490409409,
+              "meanLabel": "533.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Native Array.filter 10,000 objects",
+              "hz": 182,
+              "hzLabel": "182 ops/s",
+              "mean": 5.507136703294876,
+              "meanLabel": "5.51ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty filter": {
+          "name": "Create empty filter",
+          "hz": 7473735,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013380191379342522,
+          "meanLabel": "134ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Create filter with keys constraint": {
+          "name": "Create filter with keys constraint",
+          "hz": 7151737,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013982616700503294,
+          "meanLabel": "140ns",
+          "rme": 3.5,
+          "tier": "blazing"
+        },
+        "Create filter with custom matcher": {
+          "name": "Create filter with custom matcher",
+          "hz": 6393557,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.00015640745918544266,
+          "meanLabel": "156ns",
+          "rme": 2.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 string primitives with single query": {
+          "name": "Filter 1,000 string primitives with single query",
+          "hz": 7341970,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001362032189820004,
+          "meanLabel": "136ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 10,000 string primitives with single query": {
+          "name": "Filter 10,000 string primitives with single query",
+          "hz": 7337569,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013628492184510838,
+          "meanLabel": "136ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects across all keys": {
+          "name": "Filter 1,000 objects across all keys",
+          "hz": 7357303,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.0001359193672010686,
+          "meanLabel": "136ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with single key constraint": {
+          "name": "Filter 1,000 objects with single key constraint",
+          "hz": 7106615,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.00014071396513128708,
+          "meanLabel": "141ns",
+          "rme": 4.2,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects across all keys": {
+          "name": "Filter 10,000 objects across all keys",
+          "hz": 7202935,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013883229061383186,
+          "meanLabel": "139ns",
+          "rme": 3.2,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with single key constraint": {
+          "name": "Filter 10,000 objects with single key constraint",
+          "hz": 7238556,
+          "hzLabel": "7.2M ops/s",
+          "mean": 0.00013814910294805382,
+          "meanLabel": "138ns",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with some mode": {
+          "name": "Filter 1,000 objects with some mode",
+          "hz": 7283416,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013729820696668825,
+          "meanLabel": "137ns",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with every mode": {
+          "name": "Filter 1,000 objects with every mode",
+          "hz": 7276592,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013742697571104729,
+          "meanLabel": "137ns",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with union mode (2 queries)": {
+          "name": "Filter 1,000 objects with union mode (2 queries)",
+          "hz": 7072050,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.0001414017080146571,
+          "meanLabel": "141ns",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Filter 1,000 objects with intersection mode (2 queries)": {
+          "name": "Filter 1,000 objects with intersection mode (2 queries)",
+          "hz": 7106555,
+          "hzLabel": "7.1M ops/s",
+          "mean": 0.0001407151489368491,
+          "meanLabel": "141ns",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with some mode": {
+          "name": "Filter 10,000 objects with some mode",
+          "hz": 7260377,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013773389677408654,
+          "meanLabel": "138ns",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Filter 10,000 objects with every mode": {
+          "name": "Filter 10,000 objects with every mode",
+          "hz": 7375135,
+          "hzLabel": "7.4M ops/s",
+          "mean": 0.00013559074490293734,
+          "meanLabel": "136ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (1,000 items, cached)": {
+          "name": "Access filtered 100 times (1,000 items, cached)",
+          "hz": 1114433,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0008973172013984207,
+          "meanLabel": "897ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Access filtered 100 times (10,000 items, cached)": {
+          "name": "Access filtered 100 times (10,000 items, cached)",
+          "hz": 1130969,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0008841974429157225,
+          "meanLabel": "884ns",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Update query 10 times (1,000 items)": {
+          "name": "Update query 10 times (1,000 items)",
+          "hz": 484882,
+          "hzLabel": "484.9k ops/s",
+          "mean": 0.0020623579056780568,
+          "meanLabel": "2.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Update query 10 times (10,000 items)": {
+          "name": "Update query 10 times (10,000 items)",
+          "hz": 540124,
+          "hzLabel": "540.1k ops/s",
+          "mean": 0.0018514258487846802,
+          "meanLabel": "1.9μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Native Array.filter 1,000 objects": {
+          "name": "Native Array.filter 1,000 objects",
+          "hz": 1874,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5335705490409409,
+          "meanLabel": "533.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Native Array.filter 10,000 objects": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 182,
+          "hzLabel": "182 ops/s",
+          "mean": 5.507136703294876,
+          "meanLabel": "5.51ms",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Create empty filter",
+          "hz": 7473735,
+          "hzLabel": "7.5M ops/s",
+          "mean": 0.00013380191379342522,
+          "meanLabel": "134ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Native Array.filter 10,000 objects",
+          "hz": 182,
+          "hzLabel": "182 ops/s",
+          "mean": 5.507136703294876,
+          "meanLabel": "5.51ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "createGroup": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty group": {
+              "name": "Create empty group",
+              "hz": 28034,
+              "hzLabel": "28.0k ops/s",
+              "mean": 0.03567076850755739,
+              "meanLabel": "35.7μs",
+              "rme": 10.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 364,
+              "hzLabel": "364 ops/s",
+              "mean": 2.747968263736706,
+              "meanLabel": "2.75ms",
+              "rme": 11.8,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 37,
+              "hzLabel": "37 ops/s",
+              "mean": 26.982708000008163,
+              "meanLabel": "26.98ms",
+              "rme": 3.4,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 392,
+              "hzLabel": "392 ops/s",
+              "mean": 2.5485588578695815,
+              "meanLabel": "2.55ms",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 35,
+              "hzLabel": "35 ops/s",
+              "mean": 28.676487333325593,
+              "meanLabel": "28.68ms",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty group",
+              "hz": 28034,
+              "hzLabel": "28.0k ops/s",
+              "mean": 0.03567076850755739,
+              "meanLabel": "35.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 35,
+              "hzLabel": "35 ops/s",
+              "mean": 28.676487333325593,
+              "meanLabel": "28.68ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2368506,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004222071660412991,
+              "meanLabel": "422ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2378169,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004204914963990805,
+              "meanLabel": "420ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2378169,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004204914963990805,
+              "meanLabel": "420ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2368506,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004222071660412991,
+              "meanLabel": "422ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1002437,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.000997568583709552,
+              "meanLabel": "998ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 999796,
+              "hzLabel": "999.8k ops/s",
+              "mean": 0.0010002041136802516,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 571334,
+              "hzLabel": "571.3k ops/s",
+              "mean": 0.0017502901164335764,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 558731,
+              "hzLabel": "558.7k ops/s",
+              "mean": 0.001789768944641114,
+              "meanLabel": "1.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 703876,
+              "hzLabel": "703.9k ops/s",
+              "mean": 0.0014207055276863202,
+              "meanLabel": "1.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 692865,
+              "hzLabel": "692.9k ops/s",
+              "mean": 0.001443281933316579,
+              "meanLabel": "1.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1002437,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.000997568583709552,
+              "meanLabel": "998ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 558731,
+              "hzLabel": "558.7k ops/s",
+              "mean": 0.001789768944641114,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mixed state": {
+            "Mix single item (1,000 items)": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 435041,
+              "hzLabel": "435.0k ops/s",
+              "mean": 0.0022986317688489743,
+              "meanLabel": "2.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unmix single item (1,000 items)": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 615883,
+              "hzLabel": "615.9k ops/s",
+              "mean": 0.0016236861259952336,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Unmix single item (1,000 items)",
+              "hz": 615883,
+              "hzLabel": "615.9k ops/s",
+              "mean": 0.0016236861259952336,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mix single item (1,000 items)",
+              "hz": 435041,
+              "hzLabel": "435.0k ops/s",
+              "mean": 0.0022986317688489743,
+              "meanLabel": "2.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1024,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9762626452232823,
+              "meanLabel": "976.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.308781102038349,
+              "meanLabel": "10.31ms",
+              "rme": 0.6,
+              "tier": "fast"
+            },
+            "Unselect all 1,000 items (from full)": {
+              "name": "Unselect all 1,000 items (from full)",
+              "hz": 1039,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9621273538462657,
+              "meanLabel": "962.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle all 1,000 items (none→all)": {
+              "name": "Toggle all 1,000 items (none→all)",
+              "hz": 946,
+              "hzLabel": "946 ops/s",
+              "mean": 1.0567838818576327,
+              "meanLabel": "1.06ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Toggle all 1,000 items (all→none)": {
+              "name": "Toggle all 1,000 items (all→none)",
+              "hz": 677,
+              "hzLabel": "677 ops/s",
+              "mean": 1.4779902359885906,
+              "meanLabel": "1.48ms",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Unselect all 1,000 items (from full)",
+              "hz": 1039,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9621273538462657,
+              "meanLabel": "962.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all 10,000 items",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.308781102038349,
+              "meanLabel": "10.31ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+              "hz": 780184,
+              "hzLabel": "780.2k ops/s",
+              "mean": 0.0012817492873915747,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 828739,
+              "hzLabel": "828.7k ops/s",
+              "mean": 0.0012066519607710003,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access isAllSelected 100 times (partial, cached)": {
+              "name": "Access isAllSelected 100 times (partial, cached)",
+              "hz": 813916,
+              "hzLabel": "813.9k ops/s",
+              "mean": 0.0012286272842457608,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isNoneSelected 100 times (partial, cached)": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43605,
+              "hzLabel": "43.6k ops/s",
+              "mean": 0.02293326409192335,
+              "meanLabel": "22.9μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access isMixed 100 times (partial, cached)": {
+              "name": "Access isMixed 100 times (partial, cached)",
+              "hz": 783497,
+              "hzLabel": "783.5k ops/s",
+              "mean": 0.001276329407323161,
+              "meanLabel": "1.3μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 828739,
+              "hzLabel": "828.7k ops/s",
+              "mean": 0.0012066519607710003,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access isNoneSelected 100 times (partial, cached)",
+              "hz": 43605,
+              "hzLabel": "43.6k ops/s",
+              "mean": 0.02293326409192335,
+              "meanLabel": "22.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty group": {
+          "name": "Create empty group",
+          "hz": 28034,
+          "hzLabel": "28.0k ops/s",
+          "mean": 0.03567076850755739,
+          "meanLabel": "35.7μs",
+          "rme": 10.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 364,
+          "hzLabel": "364 ops/s",
+          "mean": 2.747968263736706,
+          "meanLabel": "2.75ms",
+          "rme": 11.8,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 37,
+          "hzLabel": "37 ops/s",
+          "mean": 26.982708000008163,
+          "meanLabel": "26.98ms",
+          "rme": 3.4,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 392,
+          "hzLabel": "392 ops/s",
+          "mean": 2.5485588578695815,
+          "meanLabel": "2.55ms",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 35,
+          "hzLabel": "35 ops/s",
+          "mean": 28.676487333325593,
+          "meanLabel": "28.68ms",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2368506,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.0004222071660412991,
+          "meanLabel": "422ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2378169,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.0004204914963990805,
+          "meanLabel": "420ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 1002437,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.000997568583709552,
+          "meanLabel": "998ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 999796,
+          "hzLabel": "999.8k ops/s",
+          "mean": 0.0010002041136802516,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 571334,
+          "hzLabel": "571.3k ops/s",
+          "mean": 0.0017502901164335764,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 558731,
+          "hzLabel": "558.7k ops/s",
+          "mean": 0.001789768944641114,
+          "meanLabel": "1.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 703876,
+          "hzLabel": "703.9k ops/s",
+          "mean": 0.0014207055276863202,
+          "meanLabel": "1.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 692865,
+          "hzLabel": "692.9k ops/s",
+          "mean": 0.001443281933316579,
+          "meanLabel": "1.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Mix single item (1,000 items)": {
+          "name": "Mix single item (1,000 items)",
+          "hz": 435041,
+          "hzLabel": "435.0k ops/s",
+          "mean": 0.0022986317688489743,
+          "meanLabel": "2.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unmix single item (1,000 items)": {
+          "name": "Unmix single item (1,000 items)",
+          "hz": 615883,
+          "hzLabel": "615.9k ops/s",
+          "mean": 0.0016236861259952336,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1024,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9762626452232823,
+          "meanLabel": "976.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.308781102038349,
+          "meanLabel": "10.31ms",
+          "rme": 0.6,
+          "tier": "fast"
+        },
+        "Unselect all 1,000 items (from full)": {
+          "name": "Unselect all 1,000 items (from full)",
+          "hz": 1039,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9621273538462657,
+          "meanLabel": "962.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle all 1,000 items (none→all)": {
+          "name": "Toggle all 1,000 items (none→all)",
+          "hz": 946,
+          "hzLabel": "946 ops/s",
+          "mean": 1.0567838818576327,
+          "meanLabel": "1.06ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Toggle all 1,000 items (all→none)": {
+          "name": "Toggle all 1,000 items (all→none)",
+          "hz": 677,
+          "hzLabel": "677 ops/s",
+          "mean": 1.4779902359885906,
+          "meanLabel": "1.48ms",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "Access selectedIndexes 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (100 of 1,000 selected, cached)",
+          "hz": 780184,
+          "hzLabel": "780.2k ops/s",
+          "mean": 0.0012817492873915747,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedIndexes 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 828739,
+          "hzLabel": "828.7k ops/s",
+          "mean": 0.0012066519607710003,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access isAllSelected 100 times (partial, cached)": {
+          "name": "Access isAllSelected 100 times (partial, cached)",
+          "hz": 813916,
+          "hzLabel": "813.9k ops/s",
+          "mean": 0.0012286272842457608,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isNoneSelected 100 times (partial, cached)": {
+          "name": "Access isNoneSelected 100 times (partial, cached)",
+          "hz": 43605,
+          "hzLabel": "43.6k ops/s",
+          "mean": 0.02293326409192335,
+          "meanLabel": "22.9μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access isMixed 100 times (partial, cached)": {
+          "name": "Access isMixed 100 times (partial, cached)",
+          "hz": 783497,
+          "hzLabel": "783.5k ops/s",
+          "mean": 0.001276329407323161,
+          "meanLabel": "1.3μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2378169,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.0004204914963990805,
+          "meanLabel": "420ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 35,
+          "hzLabel": "35 ops/s",
+          "mean": 28.676487333325593,
+          "meanLabel": "28.68ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createModel": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty model": {
+              "name": "Create empty model",
+              "hz": 80695,
+              "hzLabel": "80.7k ops/s",
+              "mean": 0.012392304178637698,
+              "meanLabel": "12.4μs",
+              "rme": 10.9,
+              "tier": "fast"
+            },
+            "Register 1,000 items": {
+              "name": "Register 1,000 items",
+              "hz": 342,
+              "hzLabel": "342 ops/s",
+              "mean": 2.9257512046781584,
+              "meanLabel": "2.93ms",
+              "rme": 15.9,
+              "tier": "fast"
+            },
+            "Register 10,000 items": {
+              "name": "Register 10,000 items",
+              "hz": 37,
+              "hzLabel": "37 ops/s",
+              "mean": 26.81616931578978,
+              "meanLabel": "26.82ms",
+              "rme": 3.8,
+              "tier": "fast"
+            },
+            "Register 1,000 items (disabled)": {
+              "name": "Register 1,000 items (disabled)",
+              "hz": 673,
+              "hzLabel": "673 ops/s",
+              "mean": 1.4867432997043821,
+              "meanLabel": "1.49ms",
+              "rme": 6.3,
+              "tier": "fast"
+            },
+            "Register 10,000 items (disabled)": {
+              "name": "Register 10,000 items (disabled)",
+              "hz": 62,
+              "hzLabel": "62 ops/s",
+              "mean": 16.194786870969466,
+              "meanLabel": "16.19ms",
+              "rme": 7.8,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty model",
+              "hz": 80695,
+              "hzLabel": "80.7k ops/s",
+              "mean": 0.012392304178637698,
+              "meanLabel": "12.4μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items",
+              "hz": 37,
+              "hzLabel": "37 ops/s",
+              "mean": 26.81616931578978,
+              "meanLabel": "26.82ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2317470,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004315049553813238,
+              "meanLabel": "432ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2322221,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043062231775405573,
+              "meanLabel": "431ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8080835,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.0001237495895131748,
+              "meanLabel": "124ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8053561,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012416867492796589,
+              "meanLabel": "124ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6399264,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.0001562679685734764,
+              "meanLabel": "156ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6364851,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015711287049325706,
+              "meanLabel": "157ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8080835,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.0001237495895131748,
+              "meanLabel": "124ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2317470,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.0004315049553813238,
+              "meanLabel": "432ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 860427,
+              "hzLabel": "860.4k ops/s",
+              "mean": 0.0011622143143377554,
+              "meanLabel": "1.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 847187,
+              "hzLabel": "847.2k ops/s",
+              "mean": 0.0011803772291411661,
+              "meanLabel": "1.2μs",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 640344,
+              "hzLabel": "640.3k ops/s",
+              "mean": 0.001561660564725091,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 628384,
+              "hzLabel": "628.4k ops/s",
+              "mean": 0.001591383254918846,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 825697,
+              "hzLabel": "825.7k ops/s",
+              "mean": 0.001211098178804314,
+              "meanLabel": "1.2μs",
+              "rme": 3.3,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 847844,
+              "hzLabel": "847.8k ops/s",
+              "mean": 0.001179461737136055,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select disabled item (1,000 items)": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7263669,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001376714685553536,
+              "meanLabel": "138ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select disabled item (1,000 items)",
+              "hz": 7263669,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.0001376714685553536,
+              "meanLabel": "138ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 628384,
+              "hzLabel": "628.4k ops/s",
+              "mean": 0.001591383254918846,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "apply operations": {
+            "Apply static value (1,000 items)": {
+              "name": "Apply static value (1,000 items)",
+              "hz": 284382,
+              "hzLabel": "284.4k ops/s",
+              "mean": 0.003516400812938041,
+              "meanLabel": "3.5μs",
+              "rme": 2.5,
+              "tier": "blazing"
+            },
+            "Apply static value (10,000 items)": {
+              "name": "Apply static value (10,000 items)",
+              "hz": 252989,
+              "hzLabel": "253.0k ops/s",
+              "mean": 0.003952737499566718,
+              "meanLabel": "4.0μs",
+              "rme": 5.5,
+              "tier": "blazing"
+            },
+            "Apply ref value (1,000 items)": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 55552,
+              "hzLabel": "55.6k ops/s",
+              "mean": 0.018001188688040494,
+              "meanLabel": "18.0μs",
+              "rme": 9.3,
+              "tier": "blazing"
+            },
+            "Apply undefined (1,000 items)": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 286002,
+              "hzLabel": "286.0k ops/s",
+              "mean": 0.003496472965420664,
+              "meanLabel": "3.5μs",
+              "rme": 3.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Apply undefined (1,000 items)",
+              "hz": 286002,
+              "hzLabel": "286.0k ops/s",
+              "mean": 0.003496472965420664,
+              "meanLabel": "3.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Apply ref value (1,000 items)",
+              "hz": 55552,
+              "hzLabel": "55.6k ops/s",
+              "mean": 0.018001188688040494,
+              "meanLabel": "18.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 1,000 then offboard 100 items": {
+              "name": "Onboard 1,000 then offboard 100 items",
+              "hz": 364,
+              "hzLabel": "364 ops/s",
+              "mean": 2.7438087103846405,
+              "meanLabel": "2.74ms",
+              "rme": 3.8,
+              "tier": "fast"
+            },
+            "Onboard 10,000 then offboard 1,000 items": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 35,
+              "hzLabel": "35 ops/s",
+              "mean": 28.7868848888902,
+              "meanLabel": "28.79ms",
+              "rme": 3.5,
+              "tier": "fast"
+            },
+            "Reset (1,000 items)": {
+              "name": "Reset (1,000 items)",
+              "hz": 650347,
+              "hzLabel": "650.3k ops/s",
+              "mean": 0.001537641573482646,
+              "meanLabel": "1.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Reset (10,000 items)": {
+              "name": "Reset (10,000 items)",
+              "hz": 624556,
+              "hzLabel": "624.6k ops/s",
+              "mean": 0.0016011377842699752,
+              "meanLabel": "1.6μs",
+              "rme": 4.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reset (1,000 items)",
+              "hz": 650347,
+              "hzLabel": "650.3k ops/s",
+              "mean": 0.001537641573482646,
+              "meanLabel": "1.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 1,000 items",
+              "hz": 35,
+              "hzLabel": "35 ops/s",
+              "mean": 28.7868848888902,
+              "meanLabel": "28.79ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 608628,
+              "hzLabel": "608.6k ops/s",
+              "mean": 0.0016430408197344512,
+              "meanLabel": "1.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+              "hz": 621143,
+              "hzLabel": "621.1k ops/s",
+              "mean": 0.0016099347622359275,
+              "meanLabel": "1.6μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 817583,
+              "hzLabel": "817.6k ops/s",
+              "mean": 0.0012231174387104776,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+              "hz": 784082,
+              "hzLabel": "784.1k ops/s",
+              "mean": 0.0012753761892853968,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+              "hz": 817583,
+              "hzLabel": "817.6k ops/s",
+              "mean": 0.0012231174387104776,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+              "hz": 608628,
+              "hzLabel": "608.6k ops/s",
+              "mean": 0.0016430408197344512,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty model": {
+          "name": "Create empty model",
+          "hz": 80695,
+          "hzLabel": "80.7k ops/s",
+          "mean": 0.012392304178637698,
+          "meanLabel": "12.4μs",
+          "rme": 10.9,
+          "tier": "fast"
+        },
+        "Register 1,000 items": {
+          "name": "Register 1,000 items",
+          "hz": 342,
+          "hzLabel": "342 ops/s",
+          "mean": 2.9257512046781584,
+          "meanLabel": "2.93ms",
+          "rme": 15.9,
+          "tier": "fast"
+        },
+        "Register 10,000 items": {
+          "name": "Register 10,000 items",
+          "hz": 37,
+          "hzLabel": "37 ops/s",
+          "mean": 26.81616931578978,
+          "meanLabel": "26.82ms",
+          "rme": 3.8,
+          "tier": "fast"
+        },
+        "Register 1,000 items (disabled)": {
+          "name": "Register 1,000 items (disabled)",
+          "hz": 673,
+          "hzLabel": "673 ops/s",
+          "mean": 1.4867432997043821,
+          "meanLabel": "1.49ms",
+          "rme": 6.3,
+          "tier": "fast"
+        },
+        "Register 10,000 items (disabled)": {
+          "name": "Register 10,000 items (disabled)",
+          "hz": 62,
+          "hzLabel": "62 ops/s",
+          "mean": 16.194786870969466,
+          "meanLabel": "16.19ms",
+          "rme": 7.8,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2317470,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.0004315049553813238,
+          "meanLabel": "432ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2322221,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00043062231775405573,
+          "meanLabel": "431ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8080835,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.0001237495895131748,
+          "meanLabel": "124ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8053561,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012416867492796589,
+          "meanLabel": "124ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6399264,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.0001562679685734764,
+          "meanLabel": "156ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6364851,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.00015711287049325706,
+          "meanLabel": "157ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 860427,
+          "hzLabel": "860.4k ops/s",
+          "mean": 0.0011622143143377554,
+          "meanLabel": "1.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 847187,
+          "hzLabel": "847.2k ops/s",
+          "mean": 0.0011803772291411661,
+          "meanLabel": "1.2μs",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 640344,
+          "hzLabel": "640.3k ops/s",
+          "mean": 0.001561660564725091,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 628384,
+          "hzLabel": "628.4k ops/s",
+          "mean": 0.001591383254918846,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 825697,
+          "hzLabel": "825.7k ops/s",
+          "mean": 0.001211098178804314,
+          "meanLabel": "1.2μs",
+          "rme": 3.3,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 847844,
+          "hzLabel": "847.8k ops/s",
+          "mean": 0.001179461737136055,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select disabled item (1,000 items)": {
+          "name": "Select disabled item (1,000 items)",
+          "hz": 7263669,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.0001376714685553536,
+          "meanLabel": "138ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Apply static value (1,000 items)": {
+          "name": "Apply static value (1,000 items)",
+          "hz": 284382,
+          "hzLabel": "284.4k ops/s",
+          "mean": 0.003516400812938041,
+          "meanLabel": "3.5μs",
+          "rme": 2.5,
+          "tier": "blazing"
+        },
+        "Apply static value (10,000 items)": {
+          "name": "Apply static value (10,000 items)",
+          "hz": 252989,
+          "hzLabel": "253.0k ops/s",
+          "mean": 0.003952737499566718,
+          "meanLabel": "4.0μs",
+          "rme": 5.5,
+          "tier": "blazing"
+        },
+        "Apply ref value (1,000 items)": {
+          "name": "Apply ref value (1,000 items)",
+          "hz": 55552,
+          "hzLabel": "55.6k ops/s",
+          "mean": 0.018001188688040494,
+          "meanLabel": "18.0μs",
+          "rme": 9.3,
+          "tier": "blazing"
+        },
+        "Apply undefined (1,000 items)": {
+          "name": "Apply undefined (1,000 items)",
+          "hz": 286002,
+          "hzLabel": "286.0k ops/s",
+          "mean": 0.003496472965420664,
+          "meanLabel": "3.5μs",
+          "rme": 3.5,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 then offboard 100 items": {
+          "name": "Onboard 1,000 then offboard 100 items",
+          "hz": 364,
+          "hzLabel": "364 ops/s",
+          "mean": 2.7438087103846405,
+          "meanLabel": "2.74ms",
+          "rme": 3.8,
+          "tier": "fast"
+        },
+        "Onboard 10,000 then offboard 1,000 items": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 35,
+          "hzLabel": "35 ops/s",
+          "mean": 28.7868848888902,
+          "meanLabel": "28.79ms",
+          "rme": 3.5,
+          "tier": "fast"
+        },
+        "Reset (1,000 items)": {
+          "name": "Reset (1,000 items)",
+          "hz": 650347,
+          "hzLabel": "650.3k ops/s",
+          "mean": 0.001537641573482646,
+          "meanLabel": "1.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Reset (10,000 items)": {
+          "name": "Reset (10,000 items)",
+          "hz": 624556,
+          "hzLabel": "624.6k ops/s",
+          "mean": 0.0016011377842699752,
+          "meanLabel": "1.6μs",
+          "rme": 4.2,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 1,000 selected, cached)",
+          "hz": 608628,
+          "hzLabel": "608.6k ops/s",
+          "mean": 0.0016430408197344512,
+          "meanLabel": "1.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1 of 10,000 selected, cached)",
+          "hz": 621143,
+          "hzLabel": "621.1k ops/s",
+          "mean": 0.0016099347622359275,
+          "meanLabel": "1.6μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 1,000 selected, cached)",
+          "hz": 817583,
+          "hzLabel": "817.6k ops/s",
+          "mean": 0.0012231174387104776,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1 of 10,000 selected, cached)",
+          "hz": 784082,
+          "hzLabel": "784.1k ops/s",
+          "mean": 0.0012753761892853968,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8080835,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.0001237495895131748,
+          "meanLabel": "124ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 1,000 items",
+          "hz": 35,
+          "hzLabel": "35 ops/s",
+          "mean": 28.7868848888902,
+          "meanLabel": "28.79ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createNested": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty nested": {
+              "name": "Create empty nested",
+              "hz": 17434,
+              "hzLabel": "17.4k ops/s",
+              "mean": 0.057359637604692024,
+              "meanLabel": "57.4μs",
+              "rme": 7.8,
+              "tier": "fast"
+            },
+            "Onboard 1,000 flat items": {
+              "name": "Onboard 1,000 flat items",
+              "hz": 142,
+              "hzLabel": "142 ops/s",
+              "mean": 7.056196126760485,
+              "meanLabel": "7.06ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 flat items": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 11,
+              "hzLabel": "11 ops/s",
+              "mean": 87.60015680000033,
+              "meanLabel": "87.60ms",
+              "rme": 34.8,
+              "tier": "good"
+            },
+            "Onboard ~1,000 tree items (depth 3)": {
+              "name": "Onboard ~1,000 tree items (depth 3)",
+              "hz": 145,
+              "hzLabel": "145 ops/s",
+              "mean": 6.908882575342581,
+              "meanLabel": "6.91ms",
+              "rme": 5.5,
+              "tier": "fast"
+            },
+            "Onboard ~10,000 tree items (depth 4)": {
+              "name": "Onboard ~10,000 tree items (depth 4)",
+              "hz": 14,
+              "hzLabel": "14 ops/s",
+              "mean": 71.23881890000084,
+              "meanLabel": "71.24ms",
+              "rme": 1.9,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Create empty nested",
+              "hz": 17434,
+              "hzLabel": "17.4k ops/s",
+              "mean": 0.057359637604692024,
+              "meanLabel": "57.4μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 flat items",
+              "hz": 11,
+              "hzLabel": "11 ops/s",
+              "mean": 87.60015680000033,
+              "meanLabel": "87.60ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "lookup operations": {
+            "Get by id (1,000 flat items)": {
+              "name": "Get by id (1,000 flat items)",
+              "hz": 7881053,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012688660323949603,
+              "meanLabel": "127ns",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 flat items)": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 7974537,
+              "hzLabel": "8.0M ops/s",
+              "mean": 0.00012539913259008772,
+              "meanLabel": "125ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Check isLeaf (1,000 tree items)": {
+              "name": "Check isLeaf (1,000 tree items)",
+              "hz": 1807567,
+              "hzLabel": "1.8M ops/s",
+              "mean": 0.0005532299232998907,
+              "meanLabel": "553ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Check isLeaf (10,000 tree items)": {
+              "name": "Check isLeaf (10,000 tree items)",
+              "hz": 1858373,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005381051370763328,
+              "meanLabel": "538ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Get depth (1,000 tree items)": {
+              "name": "Get depth (1,000 tree items)",
+              "hz": 611382,
+              "hzLabel": "611.4k ops/s",
+              "mean": 0.0016356389491283875,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get depth (10,000 tree items)": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 474364,
+              "hzLabel": "474.4k ops/s",
+              "mean": 0.0021080864483858427,
+              "meanLabel": "2.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check opened state (1,000 items)": {
+              "name": "Check opened state (1,000 items)",
+              "hz": 2314538,
+              "hzLabel": "2.3M ops/s",
+              "mean": 0.00043205163704073714,
+              "meanLabel": "432ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Check selected state (1,000 items)": {
+              "name": "Check selected state (1,000 items)",
+              "hz": 2352930,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004250019422574547,
+              "meanLabel": "425ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 flat items)",
+              "hz": 7974537,
+              "hzLabel": "8.0M ops/s",
+              "mean": 0.00012539913259008772,
+              "meanLabel": "125ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get depth (10,000 tree items)",
+              "hz": 474364,
+              "hzLabel": "474.4k ops/s",
+              "mean": 0.0021080864483858427,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "traversal operations": {
+            "Get path to deep node (1,000 tree items)": {
+              "name": "Get path to deep node (1,000 tree items)",
+              "hz": 613361,
+              "hzLabel": "613.4k ops/s",
+              "mean": 0.0016303605048880562,
+              "meanLabel": "1.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get path to deep node (10,000 tree items)": {
+              "name": "Get path to deep node (10,000 tree items)",
+              "hz": 482090,
+              "hzLabel": "482.1k ops/s",
+              "mean": 0.002074299594264522,
+              "meanLabel": "2.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (1,000 tree items)": {
+              "name": "Get ancestors of deep node (1,000 tree items)",
+              "hz": 606393,
+              "hzLabel": "606.4k ops/s",
+              "mean": 0.001649096198184847,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get ancestors of deep node (10,000 tree items)": {
+              "name": "Get ancestors of deep node (10,000 tree items)",
+              "hz": 472604,
+              "hzLabel": "472.6k ops/s",
+              "mean": 0.002115937778780386,
+              "meanLabel": "2.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (1,000 tree items)": {
+              "name": "Get descendants of root node (1,000 tree items)",
+              "hz": 19520,
+              "hzLabel": "19.5k ops/s",
+              "mean": 0.051229238397764096,
+              "meanLabel": "51.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Get descendants of root node (10,000 tree items)": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1898,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5269198703897217,
+              "meanLabel": "526.9μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Access roots (1,000 tree items)": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7590269,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013174762768626384,
+              "meanLabel": "132ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access leaves (1,000 tree items)": {
+              "name": "Access leaves (1,000 tree items)",
+              "hz": 7307180,
+              "hzLabel": "7.3M ops/s",
+              "mean": 0.00013685169823192953,
+              "meanLabel": "137ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access roots (1,000 tree items)",
+              "hz": 7590269,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013174762768626384,
+              "meanLabel": "132ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Get descendants of root node (10,000 tree items)",
+              "hz": 1898,
+              "hzLabel": "1.9k ops/s",
+              "mean": 0.5269198703897217,
+              "meanLabel": "526.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open/close operations": {
+            "Open single node (1,000 tree items)": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1693043,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005906524473057388,
+              "meanLabel": "591ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open single node (10,000 tree items)": {
+              "name": "Open single node (10,000 tree items)",
+              "hz": 1432101,
+              "hzLabel": "1.4M ops/s",
+              "mean": 0.0006982746829475678,
+              "meanLabel": "698ns",
+              "rme": 10.6,
+              "tier": "blazing"
+            },
+            "Close single node (1,000 tree items)": {
+              "name": "Close single node (1,000 tree items)",
+              "hz": 647933,
+              "hzLabel": "647.9k ops/s",
+              "mean": 0.0015433684140654554,
+              "meanLabel": "1.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Toggle open (1,000 tree items)": {
+              "name": "Toggle open (1,000 tree items)",
+              "hz": 867869,
+              "hzLabel": "867.9k ops/s",
+              "mean": 0.001152246995513519,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Expand all (1,000 tree items)": {
+              "name": "Expand all (1,000 tree items)",
+              "hz": 21708,
+              "hzLabel": "21.7k ops/s",
+              "mean": 0.046065613726393506,
+              "meanLabel": "46.1μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Expand all (10,000 tree items)": {
+              "name": "Expand all (10,000 tree items)",
+              "hz": 2157,
+              "hzLabel": "2.2k ops/s",
+              "mean": 0.4637079796107902,
+              "meanLabel": "463.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Collapse all (1,000 tree items)": {
+              "name": "Collapse all (1,000 tree items)",
+              "hz": 16449,
+              "hzLabel": "16.4k ops/s",
+              "mean": 0.06079215124622854,
+              "meanLabel": "60.8μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "Collapse all (10,000 tree items)": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1588,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6297974269522002,
+              "meanLabel": "629.8μs",
+              "rme": 1.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open single node (1,000 tree items)",
+              "hz": 1693043,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005906524473057388,
+              "meanLabel": "591ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Collapse all (10,000 tree items)",
+              "hz": 1588,
+              "hzLabel": "1.6k ops/s",
+              "mean": 0.6297974269522002,
+              "meanLabel": "629.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select leaf node (1,000 tree items)": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 74412,
+              "hzLabel": "74.4k ops/s",
+              "mean": 0.013438698516367564,
+              "meanLabel": "13.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (1,000 tree items)": {
+              "name": "Select root node with cascade (1,000 tree items)",
+              "hz": 7571,
+              "hzLabel": "7.6k ops/s",
+              "mean": 0.13207832910720282,
+              "meanLabel": "132.1μs",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "Select root node with cascade (10,000 tree items)": {
+              "name": "Select root node with cascade (10,000 tree items)",
+              "hz": 746,
+              "hzLabel": "746 ops/s",
+              "mean": 1.340671343163482,
+              "meanLabel": "1.34ms",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Unselect root node with cascade (1,000 tree items)": {
+              "name": "Unselect root node with cascade (1,000 tree items)",
+              "hz": 3478,
+              "hzLabel": "3.5k ops/s",
+              "mean": 0.2875529212192344,
+              "meanLabel": "287.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle selection (1,000 tree items)": {
+              "name": "Toggle selection (1,000 tree items)",
+              "hz": 6928,
+              "hzLabel": "6.9k ops/s",
+              "mean": 0.144331599711438,
+              "meanLabel": "144.3μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (1,000 tree items)": {
+              "name": "Select all via selectAll (1,000 tree items)",
+              "hz": 2704,
+              "hzLabel": "2.7k ops/s",
+              "mean": 0.3697917420547188,
+              "meanLabel": "369.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select all via selectAll (10,000 tree items)": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 263,
+              "hzLabel": "263 ops/s",
+              "mean": 3.802884295454781,
+              "meanLabel": "3.80ms",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select leaf node (1,000 tree items)",
+              "hz": 74412,
+              "hzLabel": "74.4k ops/s",
+              "mean": 0.013438698516367564,
+              "meanLabel": "13.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select all via selectAll (10,000 tree items)",
+              "hz": 263,
+              "hzLabel": "263 ops/s",
+              "mean": 3.802884295454781,
+              "meanLabel": "3.80ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single root item": {
+              "name": "Register single root item",
+              "hz": 14414,
+              "hzLabel": "14.4k ops/s",
+              "mean": 0.06937910420432908,
+              "meanLabel": "69.4μs",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "Register item with parent (1,000 items)": {
+              "name": "Register item with parent (1,000 items)",
+              "hz": 129,
+              "hzLabel": "129 ops/s",
+              "mean": 7.748088661538741,
+              "meanLabel": "7.75ms",
+              "rme": 6.1,
+              "tier": "fast"
+            },
+            "Unregister leaf node (1,000 tree items)": {
+              "name": "Unregister leaf node (1,000 tree items)",
+              "hz": 126,
+              "hzLabel": "126 ops/s",
+              "mean": 7.912169906250483,
+              "meanLabel": "7.91ms",
+              "rme": 7,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (1,000 tree items)": {
+              "name": "Unregister root with cascade (1,000 tree items)",
+              "hz": 112,
+              "hzLabel": "112 ops/s",
+              "mean": 8.90928631579006,
+              "meanLabel": "8.91ms",
+              "rme": 20.5,
+              "tier": "fast"
+            },
+            "Unregister root with cascade (10,000 tree items)": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 13,
+              "hzLabel": "13 ops/s",
+              "mean": 78.41679190000067,
+              "meanLabel": "78.42ms",
+              "rme": 2.1,
+              "tier": "good"
+            },
+            "_fastest": {
+              "name": "Register single root item",
+              "hz": 14414,
+              "hzLabel": "14.4k ops/s",
+              "mean": 0.06937910420432908,
+              "meanLabel": "69.4μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Unregister root with cascade (10,000 tree items)",
+              "hz": 13,
+              "hzLabel": "13 ops/s",
+              "mean": 78.41679190000067,
+              "meanLabel": "78.42ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 tree items": {
+              "name": "Onboard then clear 1,000 tree items",
+              "hz": 140,
+              "hzLabel": "140 ops/s",
+              "mean": 7.146186714285224,
+              "meanLabel": "7.15ms",
+              "rme": 5.5,
+              "tier": "fast"
+            },
+            "Onboard then clear 10,000 tree items": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 12,
+              "hzLabel": "12 ops/s",
+              "mean": 86.22488530000119,
+              "meanLabel": "86.22ms",
+              "rme": 28.6,
+              "tier": "good"
+            },
+            "toFlat conversion (1,000 tree items)": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2031,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.4924553218502333,
+              "meanLabel": "492.5μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "toFlat conversion (10,000 tree items)": {
+              "name": "toFlat conversion (10,000 tree items)",
+              "hz": 195,
+              "hzLabel": "195 ops/s",
+              "mean": 5.1158308673470945,
+              "meanLabel": "5.12ms",
+              "rme": 0.5,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "toFlat conversion (1,000 tree items)",
+              "hz": 2031,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.4924553218502333,
+              "meanLabel": "492.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard then clear 10,000 tree items",
+              "hz": 12,
+              "hzLabel": "12 ops/s",
+              "mean": 86.22488530000119,
+              "meanLabel": "86.22ms",
+              "tier": "good"
+            },
+            "_tier": "good"
+          },
+          "selection mode comparison": {
+            "Select root - cascade mode (1,000 tree items)": {
+              "name": "Select root - cascade mode (1,000 tree items)",
+              "hz": 7744,
+              "hzLabel": "7.7k ops/s",
+              "mean": 0.12913153653501971,
+              "meanLabel": "129.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select root - independent mode (1,000 tree items)": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 915043,
+              "hzLabel": "915.0k ops/s",
+              "mean": 0.001092844394366449,
+              "meanLabel": "1.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select root - leaf mode (1,000 tree items)": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5424,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1843639277551456,
+              "meanLabel": "184.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select root - independent mode (1,000 tree items)",
+              "hz": 915043,
+              "hzLabel": "915.0k ops/s",
+              "mean": 0.001092844394366449,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Select root - leaf mode (1,000 tree items)",
+              "hz": 5424,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1843639277551456,
+              "meanLabel": "184.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "open mode comparison": {
+            "Open 3 nodes - multiple mode (1,000 tree items)": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 637128,
+              "hzLabel": "637.1k ops/s",
+              "mean": 0.0015695435140275385,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Open 3 nodes - single mode (1,000 tree items)": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 114013,
+              "hzLabel": "114.0k ops/s",
+              "mean": 0.00877093730597697,
+              "meanLabel": "8.8μs",
+              "rme": 3.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+              "hz": 637128,
+              "hzLabel": "637.1k ops/s",
+              "mean": 0.0015695435140275385,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Open 3 nodes - single mode (1,000 tree items)",
+              "hz": 114013,
+              "hzLabel": "114.0k ops/s",
+              "mean": 0.00877093730597697,
+              "meanLabel": "8.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty nested": {
+          "name": "Create empty nested",
+          "hz": 17434,
+          "hzLabel": "17.4k ops/s",
+          "mean": 0.057359637604692024,
+          "meanLabel": "57.4μs",
+          "rme": 7.8,
+          "tier": "fast"
+        },
+        "Onboard 1,000 flat items": {
+          "name": "Onboard 1,000 flat items",
+          "hz": 142,
+          "hzLabel": "142 ops/s",
+          "mean": 7.056196126760485,
+          "meanLabel": "7.06ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 flat items": {
+          "name": "Onboard 10,000 flat items",
+          "hz": 11,
+          "hzLabel": "11 ops/s",
+          "mean": 87.60015680000033,
+          "meanLabel": "87.60ms",
+          "rme": 34.8,
+          "tier": "good"
+        },
+        "Onboard ~1,000 tree items (depth 3)": {
+          "name": "Onboard ~1,000 tree items (depth 3)",
+          "hz": 145,
+          "hzLabel": "145 ops/s",
+          "mean": 6.908882575342581,
+          "meanLabel": "6.91ms",
+          "rme": 5.5,
+          "tier": "fast"
+        },
+        "Onboard ~10,000 tree items (depth 4)": {
+          "name": "Onboard ~10,000 tree items (depth 4)",
+          "hz": 14,
+          "hzLabel": "14 ops/s",
+          "mean": 71.23881890000084,
+          "meanLabel": "71.24ms",
+          "rme": 1.9,
+          "tier": "good"
+        },
+        "Get by id (1,000 flat items)": {
+          "name": "Get by id (1,000 flat items)",
+          "hz": 7881053,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012688660323949603,
+          "meanLabel": "127ns",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 flat items)": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 7974537,
+          "hzLabel": "8.0M ops/s",
+          "mean": 0.00012539913259008772,
+          "meanLabel": "125ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Check isLeaf (1,000 tree items)": {
+          "name": "Check isLeaf (1,000 tree items)",
+          "hz": 1807567,
+          "hzLabel": "1.8M ops/s",
+          "mean": 0.0005532299232998907,
+          "meanLabel": "553ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Check isLeaf (10,000 tree items)": {
+          "name": "Check isLeaf (10,000 tree items)",
+          "hz": 1858373,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005381051370763328,
+          "meanLabel": "538ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Get depth (1,000 tree items)": {
+          "name": "Get depth (1,000 tree items)",
+          "hz": 611382,
+          "hzLabel": "611.4k ops/s",
+          "mean": 0.0016356389491283875,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get depth (10,000 tree items)": {
+          "name": "Get depth (10,000 tree items)",
+          "hz": 474364,
+          "hzLabel": "474.4k ops/s",
+          "mean": 0.0021080864483858427,
+          "meanLabel": "2.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check opened state (1,000 items)": {
+          "name": "Check opened state (1,000 items)",
+          "hz": 2314538,
+          "hzLabel": "2.3M ops/s",
+          "mean": 0.00043205163704073714,
+          "meanLabel": "432ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Check selected state (1,000 items)": {
+          "name": "Check selected state (1,000 items)",
+          "hz": 2352930,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.0004250019422574547,
+          "meanLabel": "425ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get path to deep node (1,000 tree items)": {
+          "name": "Get path to deep node (1,000 tree items)",
+          "hz": 613361,
+          "hzLabel": "613.4k ops/s",
+          "mean": 0.0016303605048880562,
+          "meanLabel": "1.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get path to deep node (10,000 tree items)": {
+          "name": "Get path to deep node (10,000 tree items)",
+          "hz": 482090,
+          "hzLabel": "482.1k ops/s",
+          "mean": 0.002074299594264522,
+          "meanLabel": "2.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (1,000 tree items)": {
+          "name": "Get ancestors of deep node (1,000 tree items)",
+          "hz": 606393,
+          "hzLabel": "606.4k ops/s",
+          "mean": 0.001649096198184847,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get ancestors of deep node (10,000 tree items)": {
+          "name": "Get ancestors of deep node (10,000 tree items)",
+          "hz": 472604,
+          "hzLabel": "472.6k ops/s",
+          "mean": 0.002115937778780386,
+          "meanLabel": "2.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (1,000 tree items)": {
+          "name": "Get descendants of root node (1,000 tree items)",
+          "hz": 19520,
+          "hzLabel": "19.5k ops/s",
+          "mean": 0.051229238397764096,
+          "meanLabel": "51.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Get descendants of root node (10,000 tree items)": {
+          "name": "Get descendants of root node (10,000 tree items)",
+          "hz": 1898,
+          "hzLabel": "1.9k ops/s",
+          "mean": 0.5269198703897217,
+          "meanLabel": "526.9μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access roots (1,000 tree items)": {
+          "name": "Access roots (1,000 tree items)",
+          "hz": 7590269,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.00013174762768626384,
+          "meanLabel": "132ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access leaves (1,000 tree items)": {
+          "name": "Access leaves (1,000 tree items)",
+          "hz": 7307180,
+          "hzLabel": "7.3M ops/s",
+          "mean": 0.00013685169823192953,
+          "meanLabel": "137ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Open single node (1,000 tree items)": {
+          "name": "Open single node (1,000 tree items)",
+          "hz": 1693043,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005906524473057388,
+          "meanLabel": "591ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open single node (10,000 tree items)": {
+          "name": "Open single node (10,000 tree items)",
+          "hz": 1432101,
+          "hzLabel": "1.4M ops/s",
+          "mean": 0.0006982746829475678,
+          "meanLabel": "698ns",
+          "rme": 10.6,
+          "tier": "blazing"
+        },
+        "Close single node (1,000 tree items)": {
+          "name": "Close single node (1,000 tree items)",
+          "hz": 647933,
+          "hzLabel": "647.9k ops/s",
+          "mean": 0.0015433684140654554,
+          "meanLabel": "1.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Toggle open (1,000 tree items)": {
+          "name": "Toggle open (1,000 tree items)",
+          "hz": 867869,
+          "hzLabel": "867.9k ops/s",
+          "mean": 0.001152246995513519,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Expand all (1,000 tree items)": {
+          "name": "Expand all (1,000 tree items)",
+          "hz": 21708,
+          "hzLabel": "21.7k ops/s",
+          "mean": 0.046065613726393506,
+          "meanLabel": "46.1μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Expand all (10,000 tree items)": {
+          "name": "Expand all (10,000 tree items)",
+          "hz": 2157,
+          "hzLabel": "2.2k ops/s",
+          "mean": 0.4637079796107902,
+          "meanLabel": "463.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Collapse all (1,000 tree items)": {
+          "name": "Collapse all (1,000 tree items)",
+          "hz": 16449,
+          "hzLabel": "16.4k ops/s",
+          "mean": 0.06079215124622854,
+          "meanLabel": "60.8μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Collapse all (10,000 tree items)": {
+          "name": "Collapse all (10,000 tree items)",
+          "hz": 1588,
+          "hzLabel": "1.6k ops/s",
+          "mean": 0.6297974269522002,
+          "meanLabel": "629.8μs",
+          "rme": 1.3,
+          "tier": "blazing"
+        },
+        "Select leaf node (1,000 tree items)": {
+          "name": "Select leaf node (1,000 tree items)",
+          "hz": 74412,
+          "hzLabel": "74.4k ops/s",
+          "mean": 0.013438698516367564,
+          "meanLabel": "13.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (1,000 tree items)": {
+          "name": "Select root node with cascade (1,000 tree items)",
+          "hz": 7571,
+          "hzLabel": "7.6k ops/s",
+          "mean": 0.13207832910720282,
+          "meanLabel": "132.1μs",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Select root node with cascade (10,000 tree items)": {
+          "name": "Select root node with cascade (10,000 tree items)",
+          "hz": 746,
+          "hzLabel": "746 ops/s",
+          "mean": 1.340671343163482,
+          "meanLabel": "1.34ms",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Unselect root node with cascade (1,000 tree items)": {
+          "name": "Unselect root node with cascade (1,000 tree items)",
+          "hz": 3478,
+          "hzLabel": "3.5k ops/s",
+          "mean": 0.2875529212192344,
+          "meanLabel": "287.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle selection (1,000 tree items)": {
+          "name": "Toggle selection (1,000 tree items)",
+          "hz": 6928,
+          "hzLabel": "6.9k ops/s",
+          "mean": 0.144331599711438,
+          "meanLabel": "144.3μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (1,000 tree items)": {
+          "name": "Select all via selectAll (1,000 tree items)",
+          "hz": 2704,
+          "hzLabel": "2.7k ops/s",
+          "mean": 0.3697917420547188,
+          "meanLabel": "369.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all via selectAll (10,000 tree items)": {
+          "name": "Select all via selectAll (10,000 tree items)",
+          "hz": 263,
+          "hzLabel": "263 ops/s",
+          "mean": 3.802884295454781,
+          "meanLabel": "3.80ms",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single root item": {
+          "name": "Register single root item",
+          "hz": 14414,
+          "hzLabel": "14.4k ops/s",
+          "mean": 0.06937910420432908,
+          "meanLabel": "69.4μs",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Register item with parent (1,000 items)": {
+          "name": "Register item with parent (1,000 items)",
+          "hz": 129,
+          "hzLabel": "129 ops/s",
+          "mean": 7.748088661538741,
+          "meanLabel": "7.75ms",
+          "rme": 6.1,
+          "tier": "fast"
+        },
+        "Unregister leaf node (1,000 tree items)": {
+          "name": "Unregister leaf node (1,000 tree items)",
+          "hz": 126,
+          "hzLabel": "126 ops/s",
+          "mean": 7.912169906250483,
+          "meanLabel": "7.91ms",
+          "rme": 7,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (1,000 tree items)": {
+          "name": "Unregister root with cascade (1,000 tree items)",
+          "hz": 112,
+          "hzLabel": "112 ops/s",
+          "mean": 8.90928631579006,
+          "meanLabel": "8.91ms",
+          "rme": 20.5,
+          "tier": "fast"
+        },
+        "Unregister root with cascade (10,000 tree items)": {
+          "name": "Unregister root with cascade (10,000 tree items)",
+          "hz": 13,
+          "hzLabel": "13 ops/s",
+          "mean": 78.41679190000067,
+          "meanLabel": "78.42ms",
+          "rme": 2.1,
+          "tier": "good"
+        },
+        "Onboard then clear 1,000 tree items": {
+          "name": "Onboard then clear 1,000 tree items",
+          "hz": 140,
+          "hzLabel": "140 ops/s",
+          "mean": 7.146186714285224,
+          "meanLabel": "7.15ms",
+          "rme": 5.5,
+          "tier": "fast"
+        },
+        "Onboard then clear 10,000 tree items": {
+          "name": "Onboard then clear 10,000 tree items",
+          "hz": 12,
+          "hzLabel": "12 ops/s",
+          "mean": 86.22488530000119,
+          "meanLabel": "86.22ms",
+          "rme": 28.6,
+          "tier": "good"
+        },
+        "toFlat conversion (1,000 tree items)": {
+          "name": "toFlat conversion (1,000 tree items)",
+          "hz": 2031,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.4924553218502333,
+          "meanLabel": "492.5μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "toFlat conversion (10,000 tree items)": {
+          "name": "toFlat conversion (10,000 tree items)",
+          "hz": 195,
+          "hzLabel": "195 ops/s",
+          "mean": 5.1158308673470945,
+          "meanLabel": "5.12ms",
+          "rme": 0.5,
+          "tier": "blazing"
+        },
+        "Select root - cascade mode (1,000 tree items)": {
+          "name": "Select root - cascade mode (1,000 tree items)",
+          "hz": 7744,
+          "hzLabel": "7.7k ops/s",
+          "mean": 0.12913153653501971,
+          "meanLabel": "129.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select root - independent mode (1,000 tree items)": {
+          "name": "Select root - independent mode (1,000 tree items)",
+          "hz": 915043,
+          "hzLabel": "915.0k ops/s",
+          "mean": 0.001092844394366449,
+          "meanLabel": "1.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select root - leaf mode (1,000 tree items)": {
+          "name": "Select root - leaf mode (1,000 tree items)",
+          "hz": 5424,
+          "hzLabel": "5.4k ops/s",
+          "mean": 0.1843639277551456,
+          "meanLabel": "184.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - multiple mode (1,000 tree items)": {
+          "name": "Open 3 nodes - multiple mode (1,000 tree items)",
+          "hz": 637128,
+          "hzLabel": "637.1k ops/s",
+          "mean": 0.0015695435140275385,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Open 3 nodes - single mode (1,000 tree items)": {
+          "name": "Open 3 nodes - single mode (1,000 tree items)",
+          "hz": 114013,
+          "hzLabel": "114.0k ops/s",
+          "mean": 0.00877093730597697,
+          "meanLabel": "8.8μs",
+          "rme": 3.8,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 flat items)",
+          "hz": 7974537,
+          "hzLabel": "8.0M ops/s",
+          "mean": 0.00012539913259008772,
+          "meanLabel": "125ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 flat items",
+          "hz": 11,
+          "hzLabel": "11 ops/s",
+          "mean": 87.60015680000033,
+          "meanLabel": "87.60ms",
+          "tier": "good"
+        },
+        "_tier": "good"
+      }
+    },
+    "createRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty registry": {
+              "name": "Create empty registry",
+              "hz": 284653,
+              "hzLabel": "284.7k ops/s",
+              "mean": 0.003513043333115962,
+              "meanLabel": "3.5μs",
+              "rme": 11.7,
+              "tier": "blazing"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 1149,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.8700364904349123,
+              "meanLabel": "870.0μs",
+              "rme": 3.7,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 104,
+              "hzLabel": "104 ops/s",
+              "mean": 9.618571730769103,
+              "meanLabel": "9.62ms",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty registry",
+              "hz": 284653,
+              "hzLabel": "284.7k ops/s",
+              "mean": 0.003513043333115962,
+              "meanLabel": "3.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 104,
+              "hzLabel": "104 ops/s",
+              "mean": 9.618571730769103,
+              "meanLabel": "9.62ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 7935458,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012601666469414752,
+              "meanLabel": "126ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8065788,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012398044258838151,
+              "meanLabel": "124ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Lookup by index (1,000 items)": {
+              "name": "Lookup by index (1,000 items)",
+              "hz": 7915061,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012634142196364662,
+              "meanLabel": "126ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Lookup by index (10,000 items)": {
+              "name": "Lookup by index (10,000 items)",
+              "hz": 7857003,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012727498981249092,
+              "meanLabel": "127ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Browse by value (1,000 items)": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6325939,
+              "hzLabel": "6.3M ops/s",
+              "mean": 0.00015807928845162572,
+              "meanLabel": "158ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Browse by value (10,000 items)": {
+              "name": "Browse by value (10,000 items)",
+              "hz": 6383200,
+              "hzLabel": "6.4M ops/s",
+              "mean": 0.00015666124013810837,
+              "meanLabel": "157ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (1,000 items)": {
+              "name": "Check has (1,000 items)",
+              "hz": 8069752,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012391954600070857,
+              "meanLabel": "124ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Check has (10,000 items)": {
+              "name": "Check has (10,000 items)",
+              "hz": 8174479,
+              "hzLabel": "8.2M ops/s",
+              "mean": 0.000122331956773124,
+              "meanLabel": "122ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check has (10,000 items)",
+              "hz": 8174479,
+              "hzLabel": "8.2M ops/s",
+              "mean": 0.000122331956773124,
+              "meanLabel": "122ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Browse by value (1,000 items)",
+              "hz": 6325939,
+              "hzLabel": "6.3M ops/s",
+              "mean": 0.00015807928845162572,
+              "meanLabel": "158ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 2003191,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0004992034662652655,
+              "meanLabel": "499ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 2028224,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0004930421412620976,
+              "meanLabel": "493ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Register single item": {
+              "name": "Register single item",
+              "hz": 212850,
+              "hzLabel": "212.8k ops/s",
+              "mean": 0.00469815090641851,
+              "meanLabel": "4.7μs",
+              "rme": 11.2,
+              "tier": "blazing"
+            },
+            "Register then unregister single item": {
+              "name": "Register then unregister single item",
+              "hz": 196883,
+              "hzLabel": "196.9k ops/s",
+              "mean": 0.005079149762164275,
+              "meanLabel": "5.1μs",
+              "rme": 10.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 2028224,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0004930421412620976,
+              "meanLabel": "493ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register then unregister single item",
+              "hz": 196883,
+              "hzLabel": "196.9k ops/s",
+              "mean": 0.005079149762164275,
+              "meanLabel": "5.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard then clear 1,000 items": {
+              "name": "Onboard then clear 1,000 items",
+              "hz": 1271,
+              "hzLabel": "1.3k ops/s",
+              "mean": 0.7867336430815541,
+              "meanLabel": "786.7μs",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "Onboard then clear 10,000 items": {
+              "name": "Onboard then clear 10,000 items",
+              "hz": 106,
+              "hzLabel": "106 ops/s",
+              "mean": 9.422083629629386,
+              "meanLabel": "9.42ms",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 1,000 items": {
+              "name": "Onboard then reindex 1,000 items",
+              "hz": 1079,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9264884907409497,
+              "meanLabel": "926.5μs",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "Onboard then reindex 10,000 items": {
+              "name": "Onboard then reindex 10,000 items",
+              "hz": 88,
+              "hzLabel": "88 ops/s",
+              "mean": 11.393669159091091,
+              "meanLabel": "11.39ms",
+              "rme": 8.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 then offboard 500 items": {
+              "name": "Onboard 1,000 then offboard 500 items",
+              "hz": 898,
+              "hzLabel": "898 ops/s",
+              "mean": 1.113858472160511,
+              "meanLabel": "1.11ms",
+              "rme": 2.2,
+              "tier": "fast"
+            },
+            "Onboard 10,000 then offboard 5,000 items": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.189079916667753,
+              "meanLabel": "14.19ms",
+              "rme": 7.8,
+              "tier": "fast"
+            },
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 5353,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1868268883078569,
+              "meanLabel": "186.8μs",
+              "rme": 5.2,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 307,
+              "hzLabel": "307 ops/s",
+              "mean": 3.2608821363635845,
+              "meanLabel": "3.26ms",
+              "rme": 8.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 5353,
+              "hzLabel": "5.4k ops/s",
+              "mean": 0.1868268883078569,
+              "meanLabel": "186.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 then offboard 5,000 items",
+              "hz": 70,
+              "hzLabel": "70 ops/s",
+              "mean": 14.189079916667753,
+              "meanLabel": "14.19ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access keys 100 times (1,000 items, cached)": {
+              "name": "Access keys 100 times (1,000 items, cached)",
+              "hz": 810488,
+              "hzLabel": "810.5k ops/s",
+              "mean": 0.0012338251226530884,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, cached)": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 806371,
+              "hzLabel": "806.4k ops/s",
+              "mean": 0.0012401237542970412,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, cached)": {
+              "name": "Access values 100 times (1,000 items, cached)",
+              "hz": 822274,
+              "hzLabel": "822.3k ops/s",
+              "mean": 0.0012161394933103897,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, cached)": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 845482,
+              "hzLabel": "845.5k ops/s",
+              "mean": 0.001182757747636317,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, cached)": {
+              "name": "Access entries 100 times (1,000 items, cached)",
+              "hz": 840100,
+              "hzLabel": "840.1k ops/s",
+              "mean": 0.0011903343832051112,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, cached)": {
+              "name": "Access entries 100 times (10,000 items, cached)",
+              "hz": 843253,
+              "hzLabel": "843.3k ops/s",
+              "mean": 0.0011858831289323112,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access values 100 times (10,000 items, cached)",
+              "hz": 845482,
+              "hzLabel": "845.5k ops/s",
+              "mean": 0.001182757747636317,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access keys 100 times (10,000 items, cached)",
+              "hz": 806371,
+              "hzLabel": "806.4k ops/s",
+              "mean": 0.0012401237542970412,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reactive access": {
+            "Access keys 100 times (1,000 items, reactive)": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 752916,
+              "hzLabel": "752.9k ops/s",
+              "mean": 0.0013281702500694125,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access keys 100 times (10,000 items, reactive)": {
+              "name": "Access keys 100 times (10,000 items, reactive)",
+              "hz": 723583,
+              "hzLabel": "723.6k ops/s",
+              "mean": 0.0013820124076481578,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (1,000 items, reactive)": {
+              "name": "Access values 100 times (1,000 items, reactive)",
+              "hz": 703404,
+              "hzLabel": "703.4k ops/s",
+              "mean": 0.0014216573500940334,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access values 100 times (10,000 items, reactive)": {
+              "name": "Access values 100 times (10,000 items, reactive)",
+              "hz": 724141,
+              "hzLabel": "724.1k ops/s",
+              "mean": 0.001380946662402046,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (1,000 items, reactive)": {
+              "name": "Access entries 100 times (1,000 items, reactive)",
+              "hz": 705866,
+              "hzLabel": "705.9k ops/s",
+              "mean": 0.001416698694404085,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access entries 100 times (10,000 items, reactive)": {
+              "name": "Access entries 100 times (10,000 items, reactive)",
+              "hz": 729564,
+              "hzLabel": "729.6k ops/s",
+              "mean": 0.0013706808678252437,
+              "meanLabel": "1.4μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (1,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 223205,
+              "hzLabel": "223.2k ops/s",
+              "mean": 0.004480188588106225,
+              "meanLabel": "4.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Rebuild snapshot 100 times (10,000 items, reactive)": {
+              "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+              "hz": 227431,
+              "hzLabel": "227.4k ops/s",
+              "mean": 0.004396940131603007,
+              "meanLabel": "4.4μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access keys 100 times (1,000 items, reactive)",
+              "hz": 752916,
+              "hzLabel": "752.9k ops/s",
+              "mean": 0.0013281702500694125,
+              "meanLabel": "1.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+              "hz": 223205,
+              "hzLabel": "223.2k ops/s",
+              "mean": 0.004480188588106225,
+              "meanLabel": "4.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "seek operations": {
+            "Seek first (1,000 items)": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7931528,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.0001260791078061034,
+              "meanLabel": "126ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Seek first (10,000 items)": {
+              "name": "Seek first (10,000 items)",
+              "hz": 7918267,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012629025363305739,
+              "meanLabel": "126ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek last (1,000 items)": {
+              "name": "Seek last (1,000 items)",
+              "hz": 7864506,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012715357202477804,
+              "meanLabel": "127ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Seek last (10,000 items)": {
+              "name": "Seek last (10,000 items)",
+              "hz": 7868604,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012708734025556454,
+              "meanLabel": "127ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (1,000 items)": {
+              "name": "Seek with predicate (1,000 items)",
+              "hz": 785962,
+              "hzLabel": "786.0k ops/s",
+              "mean": 0.0012723269089127368,
+              "meanLabel": "1.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Seek with predicate (10,000 items)": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 12553,
+              "hzLabel": "12.6k ops/s",
+              "mean": 0.07966443954125738,
+              "meanLabel": "79.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Seek first (1,000 items)",
+              "hz": 7931528,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.0001260791078061034,
+              "meanLabel": "126ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Seek with predicate (10,000 items)",
+              "hz": 12553,
+              "hzLabel": "12.6k ops/s",
+              "mean": 0.07966443954125738,
+              "meanLabel": "79.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty registry": {
+          "name": "Create empty registry",
+          "hz": 284653,
+          "hzLabel": "284.7k ops/s",
+          "mean": 0.003513043333115962,
+          "meanLabel": "3.5μs",
+          "rme": 11.7,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 1149,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.8700364904349123,
+          "meanLabel": "870.0μs",
+          "rme": 3.7,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 104,
+          "hzLabel": "104 ops/s",
+          "mean": 9.618571730769103,
+          "meanLabel": "9.62ms",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 7935458,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012601666469414752,
+          "meanLabel": "126ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8065788,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012398044258838151,
+          "meanLabel": "124ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Lookup by index (1,000 items)": {
+          "name": "Lookup by index (1,000 items)",
+          "hz": 7915061,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012634142196364662,
+          "meanLabel": "126ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Lookup by index (10,000 items)": {
+          "name": "Lookup by index (10,000 items)",
+          "hz": 7857003,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012727498981249092,
+          "meanLabel": "127ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Browse by value (1,000 items)": {
+          "name": "Browse by value (1,000 items)",
+          "hz": 6325939,
+          "hzLabel": "6.3M ops/s",
+          "mean": 0.00015807928845162572,
+          "meanLabel": "158ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Browse by value (10,000 items)": {
+          "name": "Browse by value (10,000 items)",
+          "hz": 6383200,
+          "hzLabel": "6.4M ops/s",
+          "mean": 0.00015666124013810837,
+          "meanLabel": "157ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (1,000 items)": {
+          "name": "Check has (1,000 items)",
+          "hz": 8069752,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012391954600070857,
+          "meanLabel": "124ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Check has (10,000 items)": {
+          "name": "Check has (10,000 items)",
+          "hz": 8174479,
+          "hzLabel": "8.2M ops/s",
+          "mean": 0.000122331956773124,
+          "meanLabel": "122ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 2003191,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0004992034662652655,
+          "meanLabel": "499ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 2028224,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0004930421412620976,
+          "meanLabel": "493ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Register single item": {
+          "name": "Register single item",
+          "hz": 212850,
+          "hzLabel": "212.8k ops/s",
+          "mean": 0.00469815090641851,
+          "meanLabel": "4.7μs",
+          "rme": 11.2,
+          "tier": "blazing"
+        },
+        "Register then unregister single item": {
+          "name": "Register then unregister single item",
+          "hz": 196883,
+          "hzLabel": "196.9k ops/s",
+          "mean": 0.005079149762164275,
+          "meanLabel": "5.1μs",
+          "rme": 10.4,
+          "tier": "blazing"
+        },
+        "Onboard then clear 1,000 items": {
+          "name": "Onboard then clear 1,000 items",
+          "hz": 1271,
+          "hzLabel": "1.3k ops/s",
+          "mean": 0.7867336430815541,
+          "meanLabel": "786.7μs",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "Onboard then clear 10,000 items": {
+          "name": "Onboard then clear 10,000 items",
+          "hz": 106,
+          "hzLabel": "106 ops/s",
+          "mean": 9.422083629629386,
+          "meanLabel": "9.42ms",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 1,000 items": {
+          "name": "Onboard then reindex 1,000 items",
+          "hz": 1079,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9264884907409497,
+          "meanLabel": "926.5μs",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "Onboard then reindex 10,000 items": {
+          "name": "Onboard then reindex 10,000 items",
+          "hz": 88,
+          "hzLabel": "88 ops/s",
+          "mean": 11.393669159091091,
+          "meanLabel": "11.39ms",
+          "rme": 8.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 then offboard 500 items": {
+          "name": "Onboard 1,000 then offboard 500 items",
+          "hz": 898,
+          "hzLabel": "898 ops/s",
+          "mean": 1.113858472160511,
+          "meanLabel": "1.11ms",
+          "rme": 2.2,
+          "tier": "fast"
+        },
+        "Onboard 10,000 then offboard 5,000 items": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.189079916667753,
+          "meanLabel": "14.19ms",
+          "rme": 7.8,
+          "tier": "fast"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 5353,
+          "hzLabel": "5.4k ops/s",
+          "mean": 0.1868268883078569,
+          "meanLabel": "186.8μs",
+          "rme": 5.2,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 307,
+          "hzLabel": "307 ops/s",
+          "mean": 3.2608821363635845,
+          "meanLabel": "3.26ms",
+          "rme": 8.3,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, cached)": {
+          "name": "Access keys 100 times (1,000 items, cached)",
+          "hz": 810488,
+          "hzLabel": "810.5k ops/s",
+          "mean": 0.0012338251226530884,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, cached)": {
+          "name": "Access keys 100 times (10,000 items, cached)",
+          "hz": 806371,
+          "hzLabel": "806.4k ops/s",
+          "mean": 0.0012401237542970412,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, cached)": {
+          "name": "Access values 100 times (1,000 items, cached)",
+          "hz": 822274,
+          "hzLabel": "822.3k ops/s",
+          "mean": 0.0012161394933103897,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, cached)": {
+          "name": "Access values 100 times (10,000 items, cached)",
+          "hz": 845482,
+          "hzLabel": "845.5k ops/s",
+          "mean": 0.001182757747636317,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, cached)": {
+          "name": "Access entries 100 times (1,000 items, cached)",
+          "hz": 840100,
+          "hzLabel": "840.1k ops/s",
+          "mean": 0.0011903343832051112,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, cached)": {
+          "name": "Access entries 100 times (10,000 items, cached)",
+          "hz": 843253,
+          "hzLabel": "843.3k ops/s",
+          "mean": 0.0011858831289323112,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (1,000 items, reactive)": {
+          "name": "Access keys 100 times (1,000 items, reactive)",
+          "hz": 752916,
+          "hzLabel": "752.9k ops/s",
+          "mean": 0.0013281702500694125,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access keys 100 times (10,000 items, reactive)": {
+          "name": "Access keys 100 times (10,000 items, reactive)",
+          "hz": 723583,
+          "hzLabel": "723.6k ops/s",
+          "mean": 0.0013820124076481578,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (1,000 items, reactive)": {
+          "name": "Access values 100 times (1,000 items, reactive)",
+          "hz": 703404,
+          "hzLabel": "703.4k ops/s",
+          "mean": 0.0014216573500940334,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access values 100 times (10,000 items, reactive)": {
+          "name": "Access values 100 times (10,000 items, reactive)",
+          "hz": 724141,
+          "hzLabel": "724.1k ops/s",
+          "mean": 0.001380946662402046,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (1,000 items, reactive)": {
+          "name": "Access entries 100 times (1,000 items, reactive)",
+          "hz": 705866,
+          "hzLabel": "705.9k ops/s",
+          "mean": 0.001416698694404085,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access entries 100 times (10,000 items, reactive)": {
+          "name": "Access entries 100 times (10,000 items, reactive)",
+          "hz": 729564,
+          "hzLabel": "729.6k ops/s",
+          "mean": 0.0013706808678252437,
+          "meanLabel": "1.4μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (1,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (1,000 items, reactive)",
+          "hz": 223205,
+          "hzLabel": "223.2k ops/s",
+          "mean": 0.004480188588106225,
+          "meanLabel": "4.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Rebuild snapshot 100 times (10,000 items, reactive)": {
+          "name": "Rebuild snapshot 100 times (10,000 items, reactive)",
+          "hz": 227431,
+          "hzLabel": "227.4k ops/s",
+          "mean": 0.004396940131603007,
+          "meanLabel": "4.4μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Seek first (1,000 items)": {
+          "name": "Seek first (1,000 items)",
+          "hz": 7931528,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.0001260791078061034,
+          "meanLabel": "126ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Seek first (10,000 items)": {
+          "name": "Seek first (10,000 items)",
+          "hz": 7918267,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012629025363305739,
+          "meanLabel": "126ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek last (1,000 items)": {
+          "name": "Seek last (1,000 items)",
+          "hz": 7864506,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012715357202477804,
+          "meanLabel": "127ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Seek last (10,000 items)": {
+          "name": "Seek last (10,000 items)",
+          "hz": 7868604,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012708734025556454,
+          "meanLabel": "127ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (1,000 items)": {
+          "name": "Seek with predicate (1,000 items)",
+          "hz": 785962,
+          "hzLabel": "786.0k ops/s",
+          "mean": 0.0012723269089127368,
+          "meanLabel": "1.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Seek with predicate (10,000 items)": {
+          "name": "Seek with predicate (10,000 items)",
+          "hz": 12553,
+          "hzLabel": "12.6k ops/s",
+          "mean": 0.07966443954125738,
+          "meanLabel": "79.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check has (10,000 items)",
+          "hz": 8174479,
+          "hzLabel": "8.2M ops/s",
+          "mean": 0.000122331956773124,
+          "meanLabel": "122ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 then offboard 5,000 items",
+          "hz": 70,
+          "hzLabel": "70 ops/s",
+          "mean": 14.189079916667753,
+          "meanLabel": "14.19ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSelection": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty selection": {
+              "name": "Create empty selection",
+              "hz": 50301,
+              "hzLabel": "50.3k ops/s",
+              "mean": 0.019880174386671196,
+              "meanLabel": "19.9μs",
+              "rme": 10.1,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 532,
+              "hzLabel": "532 ops/s",
+              "mean": 1.8800750939844875,
+              "meanLabel": "1.88ms",
+              "rme": 8.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 52,
+              "hzLabel": "52 ops/s",
+              "mean": 19.197295481481383,
+              "meanLabel": "19.20ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (enroll)": {
+              "name": "Onboard 1,000 items (enroll)",
+              "hz": 385,
+              "hzLabel": "385 ops/s",
+              "mean": 2.6002683989645448,
+              "meanLabel": "2.60ms",
+              "rme": 6.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (enroll)": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 34,
+              "hzLabel": "34 ops/s",
+              "mean": 29.506308823529466,
+              "meanLabel": "29.51ms",
+              "rme": 13,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory: force)": {
+              "name": "Onboard 1,000 items (mandatory: force)",
+              "hz": 459,
+              "hzLabel": "459 ops/s",
+              "mean": 2.180371280173733,
+              "meanLabel": "2.18ms",
+              "rme": 6.9,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory: force)": {
+              "name": "Onboard 10,000 items (mandatory: force)",
+              "hz": 41,
+              "hzLabel": "41 ops/s",
+              "mean": 24.12303152380489,
+              "meanLabel": "24.12ms",
+              "rme": 13.1,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty selection",
+              "hz": 50301,
+              "hzLabel": "50.3k ops/s",
+              "mean": 0.019880174386671196,
+              "meanLabel": "19.9μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items (enroll)",
+              "hz": 34,
+              "hzLabel": "34 ops/s",
+              "mean": 29.506308823529466,
+              "meanLabel": "29.51ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2351558,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.00042524996001785053,
+              "meanLabel": "425ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2359865,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.00042375300462032834,
+              "meanLabel": "424ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2359865,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.00042375300462032834,
+              "meanLabel": "424ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2351558,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.00042524996001785053,
+              "meanLabel": "425ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1963794,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005092184180219959,
+              "meanLabel": "509ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 1907602,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005242182339823848,
+              "meanLabel": "524ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 810633,
+              "hzLabel": "810.6k ops/s",
+              "mean": 0.0012336042504985385,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 801507,
+              "hzLabel": "801.5k ops/s",
+              "mean": 0.0012476503316327496,
+              "meanLabel": "1.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 974684,
+              "hzLabel": "974.7k ops/s",
+              "mean": 0.0010259733986275612,
+              "meanLabel": "1.0μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 950826,
+              "hzLabel": "950.8k ops/s",
+              "mean": 0.001051716966691864,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 1963794,
+              "hzLabel": "2.0M ops/s",
+              "mean": 0.0005092184180219959,
+              "meanLabel": "509ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 801507,
+              "hzLabel": "801.5k ops/s",
+              "mean": 0.0012476503316327496,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mandatory enforcement": {
+            "Select with mandatory (1,000 items)": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 888563,
+              "hzLabel": "888.6k ops/s",
+              "mean": 0.0011254121391331298,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect blocked by mandatory (1,000 items)": {
+              "name": "Unselect blocked by mandatory (1,000 items)",
+              "hz": 678119,
+              "hzLabel": "678.1k ops/s",
+              "mean": 0.0014746677844618746,
+              "meanLabel": "1.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Mandate on empty (1,000 items)": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 509974,
+              "hzLabel": "510.0k ops/s",
+              "mean": 0.001960884303899134,
+              "meanLabel": "2.0μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select with mandatory (1,000 items)",
+              "hz": 888563,
+              "hzLabel": "888.6k ops/s",
+              "mean": 0.0011254121391331298,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Mandate on empty (1,000 items)",
+              "hz": 509974,
+              "hzLabel": "510.0k ops/s",
+              "mean": 0.001960884303899134,
+              "meanLabel": "2.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Select all 1,000 items": {
+              "name": "Select all 1,000 items",
+              "hz": 1497,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6678212563418199,
+              "meanLabel": "667.8μs",
+              "rme": 3.2,
+              "tier": "blazing"
+            },
+            "Select all 10,000 items": {
+              "name": "Select all 10,000 items",
+              "hz": 144,
+              "hzLabel": "144 ops/s",
+              "mean": 6.960058624998459,
+              "meanLabel": "6.96ms",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "Select then unselect all 1,000 items": {
+              "name": "Select then unselect all 1,000 items",
+              "hz": 902,
+              "hzLabel": "902 ops/s",
+              "mean": 1.1083445066375714,
+              "meanLabel": "1.11ms",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "Reset selection (1,000 items)": {
+              "name": "Reset selection (1,000 items)",
+              "hz": 383,
+              "hzLabel": "383 ops/s",
+              "mean": 2.6140782072531827,
+              "meanLabel": "2.61ms",
+              "rme": 6.4,
+              "tier": "fast"
+            },
+            "Reset selection (10,000 items)": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 36,
+              "hzLabel": "36 ops/s",
+              "mean": 27.84753699999904,
+              "meanLabel": "27.85ms",
+              "rme": 5.6,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Select all 1,000 items",
+              "hz": 1497,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6678212563418199,
+              "meanLabel": "667.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reset selection (10,000 items)",
+              "hz": 36,
+              "hzLabel": "36 ops/s",
+              "mean": 27.84753699999904,
+              "meanLabel": "27.85ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "computed access": {
+            "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+              "hz": 551369,
+              "hzLabel": "551.4k ops/s",
+              "mean": 0.0018136658904143843,
+              "meanLabel": "1.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 558367,
+              "hzLabel": "558.4k ops/s",
+              "mean": 0.0017909373925545807,
+              "meanLabel": "1.8μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 590670,
+              "hzLabel": "590.7k ops/s",
+              "mean": 0.0016929934989198929,
+              "meanLabel": "1.7μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 834993,
+              "hzLabel": "835.0k ops/s",
+              "mean": 0.0011976146846743852,
+              "meanLabel": "1.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+              "hz": 814748,
+              "hzLabel": "814.7k ops/s",
+              "mean": 0.0012273739340462957,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+              "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+              "hz": 832476,
+              "hzLabel": "832.5k ops/s",
+              "mean": 0.0012012351509261639,
+              "meanLabel": "1.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+              "hz": 834993,
+              "hzLabel": "835.0k ops/s",
+              "mean": 0.0011976146846743852,
+              "meanLabel": "1.2μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+              "hz": 551369,
+              "hzLabel": "551.4k ops/s",
+              "mean": 0.0018136658904143843,
+              "meanLabel": "1.8μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty selection": {
+          "name": "Create empty selection",
+          "hz": 50301,
+          "hzLabel": "50.3k ops/s",
+          "mean": 0.019880174386671196,
+          "meanLabel": "19.9μs",
+          "rme": 10.1,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 532,
+          "hzLabel": "532 ops/s",
+          "mean": 1.8800750939844875,
+          "meanLabel": "1.88ms",
+          "rme": 8.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 52,
+          "hzLabel": "52 ops/s",
+          "mean": 19.197295481481383,
+          "meanLabel": "19.20ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (enroll)": {
+          "name": "Onboard 1,000 items (enroll)",
+          "hz": 385,
+          "hzLabel": "385 ops/s",
+          "mean": 2.6002683989645448,
+          "meanLabel": "2.60ms",
+          "rme": 6.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (enroll)": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 34,
+          "hzLabel": "34 ops/s",
+          "mean": 29.506308823529466,
+          "meanLabel": "29.51ms",
+          "rme": 13,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory: force)": {
+          "name": "Onboard 1,000 items (mandatory: force)",
+          "hz": 459,
+          "hzLabel": "459 ops/s",
+          "mean": 2.180371280173733,
+          "meanLabel": "2.18ms",
+          "rme": 6.9,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory: force)": {
+          "name": "Onboard 10,000 items (mandatory: force)",
+          "hz": 41,
+          "hzLabel": "41 ops/s",
+          "mean": 24.12303152380489,
+          "meanLabel": "24.12ms",
+          "rme": 13.1,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2351558,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.00042524996001785053,
+          "meanLabel": "425ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2359865,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.00042375300462032834,
+          "meanLabel": "424ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 1963794,
+          "hzLabel": "2.0M ops/s",
+          "mean": 0.0005092184180219959,
+          "meanLabel": "509ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 1907602,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005242182339823848,
+          "meanLabel": "524ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 810633,
+          "hzLabel": "810.6k ops/s",
+          "mean": 0.0012336042504985385,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 801507,
+          "hzLabel": "801.5k ops/s",
+          "mean": 0.0012476503316327496,
+          "meanLabel": "1.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 974684,
+          "hzLabel": "974.7k ops/s",
+          "mean": 0.0010259733986275612,
+          "meanLabel": "1.0μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 950826,
+          "hzLabel": "950.8k ops/s",
+          "mean": 0.001051716966691864,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select with mandatory (1,000 items)": {
+          "name": "Select with mandatory (1,000 items)",
+          "hz": 888563,
+          "hzLabel": "888.6k ops/s",
+          "mean": 0.0011254121391331298,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect blocked by mandatory (1,000 items)": {
+          "name": "Unselect blocked by mandatory (1,000 items)",
+          "hz": 678119,
+          "hzLabel": "678.1k ops/s",
+          "mean": 0.0014746677844618746,
+          "meanLabel": "1.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Mandate on empty (1,000 items)": {
+          "name": "Mandate on empty (1,000 items)",
+          "hz": 509974,
+          "hzLabel": "510.0k ops/s",
+          "mean": 0.001960884303899134,
+          "meanLabel": "2.0μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select all 1,000 items": {
+          "name": "Select all 1,000 items",
+          "hz": 1497,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6678212563418199,
+          "meanLabel": "667.8μs",
+          "rme": 3.2,
+          "tier": "blazing"
+        },
+        "Select all 10,000 items": {
+          "name": "Select all 10,000 items",
+          "hz": 144,
+          "hzLabel": "144 ops/s",
+          "mean": 6.960058624998459,
+          "meanLabel": "6.96ms",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Select then unselect all 1,000 items": {
+          "name": "Select then unselect all 1,000 items",
+          "hz": 902,
+          "hzLabel": "902 ops/s",
+          "mean": 1.1083445066375714,
+          "meanLabel": "1.11ms",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "Reset selection (1,000 items)": {
+          "name": "Reset selection (1,000 items)",
+          "hz": 383,
+          "hzLabel": "383 ops/s",
+          "mean": 2.6140782072531827,
+          "meanLabel": "2.61ms",
+          "rme": 6.4,
+          "tier": "fast"
+        },
+        "Reset selection (10,000 items)": {
+          "name": "Reset selection (10,000 items)",
+          "hz": 36,
+          "hzLabel": "36 ops/s",
+          "mean": 27.84753699999904,
+          "meanLabel": "27.85ms",
+          "rme": 5.6,
+          "tier": "fast"
+        },
+        "Access selectedItems 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (100 of 1,000 selected, cached)",
+          "hz": 551369,
+          "hzLabel": "551.4k ops/s",
+          "mean": 0.0018136658904143843,
+          "meanLabel": "1.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 558367,
+          "hzLabel": "558.4k ops/s",
+          "mean": 0.0017909373925545807,
+          "meanLabel": "1.8μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedItems 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedItems 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 590670,
+          "hzLabel": "590.7k ops/s",
+          "mean": 0.0016929934989198929,
+          "meanLabel": "1.7μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (100 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (100 of 1,000 selected, cached)",
+          "hz": 834993,
+          "hzLabel": "835.0k ops/s",
+          "mean": 0.0011976146846743852,
+          "meanLabel": "1.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 1,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 1,000 selected, cached)",
+          "hz": 814748,
+          "hzLabel": "814.7k ops/s",
+          "mean": 0.0012273739340462957,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValues 100 times (1,000 of 10,000 selected, cached)": {
+          "name": "Access selectedValues 100 times (1,000 of 10,000 selected, cached)",
+          "hz": 832476,
+          "hzLabel": "832.5k ops/s",
+          "mean": 0.0012012351509261639,
+          "meanLabel": "1.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2359865,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.00042375300462032834,
+          "meanLabel": "424ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items (enroll)",
+          "hz": 34,
+          "hzLabel": "34 ops/s",
+          "mean": 29.506308823529466,
+          "meanLabel": "29.51ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSingle": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty single": {
+              "name": "Create empty single",
+              "hz": 36033,
+              "hzLabel": "36.0k ops/s",
+              "mean": 0.02775226685894907,
+              "meanLabel": "27.8μs",
+              "rme": 7.3,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 553,
+              "hzLabel": "553 ops/s",
+              "mean": 1.8076027075813441,
+              "meanLabel": "1.81ms",
+              "rme": 7.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 51,
+              "hzLabel": "51 ops/s",
+              "mean": 19.51549419230343,
+              "meanLabel": "19.52ms",
+              "rme": 6.2,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 558,
+              "hzLabel": "558 ops/s",
+              "mean": 1.7927179964149527,
+              "meanLabel": "1.79ms",
+              "rme": 7.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items (mandatory)": {
+              "name": "Onboard 10,000 items (mandatory)",
+              "hz": 51,
+              "hzLabel": "51 ops/s",
+              "mean": 19.50072261538858,
+              "meanLabel": "19.50ms",
+              "rme": 6.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty single",
+              "hz": 36033,
+              "hzLabel": "36.0k ops/s",
+              "mean": 0.02775226685894907,
+              "meanLabel": "27.8μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 51,
+              "hzLabel": "51 ops/s",
+              "mean": 19.51549419230343,
+              "meanLabel": "19.52ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Check selected (1,000 items)": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2373526,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004213140708267358,
+              "meanLabel": "421ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Check selected (10,000 items)": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2404274,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.000415925990121236,
+              "meanLabel": "416ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Check selected (10,000 items)",
+              "hz": 2404274,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.000415925990121236,
+              "meanLabel": "416ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Check selected (1,000 items)",
+              "hz": 2373526,
+              "hzLabel": "2.4M ops/s",
+              "mean": 0.0004213140708267358,
+              "meanLabel": "421ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "selection operations": {
+            "Select single item (1,000 items)": {
+              "name": "Select single item (1,000 items)",
+              "hz": 890716,
+              "hzLabel": "890.7k ops/s",
+              "mean": 0.0011226925372421184,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Select single item (10,000 items)": {
+              "name": "Select single item (10,000 items)",
+              "hz": 885334,
+              "hzLabel": "885.3k ops/s",
+              "mean": 0.0011295174612564178,
+              "meanLabel": "1.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (1,000 items)": {
+              "name": "Unselect single item (1,000 items)",
+              "hz": 623328,
+              "hzLabel": "623.3k ops/s",
+              "mean": 0.0016042922346086862,
+              "meanLabel": "1.6μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Unselect single item (10,000 items)": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 616778,
+              "hzLabel": "616.8k ops/s",
+              "mean": 0.0016213291978942714,
+              "meanLabel": "1.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Toggle single item (1,000 items)": {
+              "name": "Toggle single item (1,000 items)",
+              "hz": 787835,
+              "hzLabel": "787.8k ops/s",
+              "mean": 0.0012693018318962934,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Toggle single item (10,000 items)": {
+              "name": "Toggle single item (10,000 items)",
+              "hz": 794045,
+              "hzLabel": "794.0k ops/s",
+              "mean": 0.0012593737567042648,
+              "meanLabel": "1.3μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Select single item (1,000 items)",
+              "hz": 890716,
+              "hzLabel": "890.7k ops/s",
+              "mean": 0.0011226925372421184,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unselect single item (10,000 items)",
+              "hz": 616778,
+              "hzLabel": "616.8k ops/s",
+              "mean": 0.0016213291978942714,
+              "meanLabel": "1.6μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6292,
+              "hzLabel": "6.3k ops/s",
+              "mean": 0.1589224594852175,
+              "meanLabel": "158.9μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (10,000 items, cached)": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 5921,
+              "hzLabel": "5.9k ops/s",
+              "mean": 0.1688994880103316,
+              "meanLabel": "168.9μs",
+              "rme": 10.3,
+              "tier": "blazing"
+            },
+            "Access selectedItem 100 times (1,000 items, cached)": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 305069,
+              "hzLabel": "305.1k ops/s",
+              "mean": 0.0032779445242571196,
+              "meanLabel": "3.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 272800,
+              "hzLabel": "272.8k ops/s",
+              "mean": 0.0036656923753433366,
+              "meanLabel": "3.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 250179,
+              "hzLabel": "250.2k ops/s",
+              "mean": 0.003997131193593819,
+              "meanLabel": "4.0μs",
+              "rme": 1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedItem 100 times (1,000 items, cached)",
+              "hz": 305069,
+              "hzLabel": "305.1k ops/s",
+              "mean": 0.0032779445242571196,
+              "meanLabel": "3.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (10,000 items, cached)",
+              "hz": 5921,
+              "hzLabel": "5.9k ops/s",
+              "mean": 0.1688994880103316,
+              "meanLabel": "168.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty single": {
+          "name": "Create empty single",
+          "hz": 36033,
+          "hzLabel": "36.0k ops/s",
+          "mean": 0.02775226685894907,
+          "meanLabel": "27.8μs",
+          "rme": 7.3,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 553,
+          "hzLabel": "553 ops/s",
+          "mean": 1.8076027075813441,
+          "meanLabel": "1.81ms",
+          "rme": 7.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 51,
+          "hzLabel": "51 ops/s",
+          "mean": 19.51549419230343,
+          "meanLabel": "19.52ms",
+          "rme": 6.2,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 558,
+          "hzLabel": "558 ops/s",
+          "mean": 1.7927179964149527,
+          "meanLabel": "1.79ms",
+          "rme": 7.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items (mandatory)": {
+          "name": "Onboard 10,000 items (mandatory)",
+          "hz": 51,
+          "hzLabel": "51 ops/s",
+          "mean": 19.50072261538858,
+          "meanLabel": "19.50ms",
+          "rme": 6.5,
+          "tier": "fast"
+        },
+        "Check selected (1,000 items)": {
+          "name": "Check selected (1,000 items)",
+          "hz": 2373526,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.0004213140708267358,
+          "meanLabel": "421ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Check selected (10,000 items)": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2404274,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.000415925990121236,
+          "meanLabel": "416ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Select single item (1,000 items)": {
+          "name": "Select single item (1,000 items)",
+          "hz": 890716,
+          "hzLabel": "890.7k ops/s",
+          "mean": 0.0011226925372421184,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Select single item (10,000 items)": {
+          "name": "Select single item (10,000 items)",
+          "hz": 885334,
+          "hzLabel": "885.3k ops/s",
+          "mean": 0.0011295174612564178,
+          "meanLabel": "1.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (1,000 items)": {
+          "name": "Unselect single item (1,000 items)",
+          "hz": 623328,
+          "hzLabel": "623.3k ops/s",
+          "mean": 0.0016042922346086862,
+          "meanLabel": "1.6μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Unselect single item (10,000 items)": {
+          "name": "Unselect single item (10,000 items)",
+          "hz": 616778,
+          "hzLabel": "616.8k ops/s",
+          "mean": 0.0016213291978942714,
+          "meanLabel": "1.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Toggle single item (1,000 items)": {
+          "name": "Toggle single item (1,000 items)",
+          "hz": 787835,
+          "hzLabel": "787.8k ops/s",
+          "mean": 0.0012693018318962934,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Toggle single item (10,000 items)": {
+          "name": "Toggle single item (10,000 items)",
+          "hz": 794045,
+          "hzLabel": "794.0k ops/s",
+          "mean": 0.0012593737567042648,
+          "meanLabel": "1.3μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6292,
+          "hzLabel": "6.3k ops/s",
+          "mean": 0.1589224594852175,
+          "meanLabel": "158.9μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (10,000 items, cached)": {
+          "name": "Access selectedId 100 times (10,000 items, cached)",
+          "hz": 5921,
+          "hzLabel": "5.9k ops/s",
+          "mean": 0.1688994880103316,
+          "meanLabel": "168.9μs",
+          "rme": 10.3,
+          "tier": "blazing"
+        },
+        "Access selectedItem 100 times (1,000 items, cached)": {
+          "name": "Access selectedItem 100 times (1,000 items, cached)",
+          "hz": 305069,
+          "hzLabel": "305.1k ops/s",
+          "mean": 0.0032779445242571196,
+          "meanLabel": "3.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 272800,
+          "hzLabel": "272.8k ops/s",
+          "mean": 0.0036656923753433366,
+          "meanLabel": "3.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 250179,
+          "hzLabel": "250.2k ops/s",
+          "mean": 0.003997131193593819,
+          "meanLabel": "4.0μs",
+          "rme": 1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Check selected (10,000 items)",
+          "hz": 2404274,
+          "hzLabel": "2.4M ops/s",
+          "mean": 0.000415925990121236,
+          "meanLabel": "416ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 51,
+          "hzLabel": "51 ops/s",
+          "mean": 19.51549419230343,
+          "meanLabel": "19.52ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createSortable": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty sortable": {
+              "name": "Create empty sortable",
+              "hz": 46115,
+              "hzLabel": "46.1k ops/s",
+              "mean": 0.021685092820963425,
+              "meanLabel": "21.7μs",
+              "rme": 11.3,
+              "tier": "fast"
+            },
+            "Create empty sortable (disabled)": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 46615,
+              "hzLabel": "46.6k ops/s",
+              "mean": 0.021452096404694518,
+              "meanLabel": "21.5μs",
+              "rme": 12.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty sortable (disabled)",
+              "hz": 46615,
+              "hzLabel": "46.6k ops/s",
+              "mean": 0.021452096404694518,
+              "meanLabel": "21.5μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create empty sortable",
+              "hz": 46115,
+              "hzLabel": "46.1k ops/s",
+              "mean": 0.021685092820963425,
+              "meanLabel": "21.7μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Get by id (1,000 items)": {
+              "name": "Get by id (1,000 items)",
+              "hz": 8001123,
+              "hzLabel": "8.0M ops/s",
+              "mean": 0.00012498245396787798,
+              "meanLabel": "125ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Get by id (10,000 items)": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8126460,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012305481451695957,
+              "meanLabel": "123ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "Values snapshot (10,000 items)": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7603889,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013151165705551442,
+              "meanLabel": "132ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Get by id (10,000 items)",
+              "hz": 8126460,
+              "hzLabel": "8.1M ops/s",
+              "mean": 0.00012305481451695957,
+              "meanLabel": "123ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Values snapshot (10,000 items)",
+              "hz": 7603889,
+              "hzLabel": "7.6M ops/s",
+              "mean": 0.00013151165705551442,
+              "meanLabel": "132ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "move operations": {
+            "Move first to last (1,000 items)": {
+              "name": "Move first to last (1,000 items)",
+              "hz": 5995,
+              "hzLabel": "6.0k ops/s",
+              "mean": 0.1668073999334701,
+              "meanLabel": "166.8μs",
+              "rme": 10.4,
+              "tier": "blazing"
+            },
+            "Move first to last (10,000 items)": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 449,
+              "hzLabel": "449 ops/s",
+              "mean": 2.2260757312770947,
+              "meanLabel": "2.23ms",
+              "rme": 18.3,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (1,000 items)": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 245932,
+              "hzLabel": "245.9k ops/s",
+              "mean": 0.004066168388012504,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Move mid by 1 (10,000 items)": {
+              "name": "Move mid by 1 (10,000 items)",
+              "hz": 29649,
+              "hzLabel": "29.6k ops/s",
+              "mean": 0.03372797463754149,
+              "meanLabel": "33.7μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move mid by 1 (1,000 items)",
+              "hz": 245932,
+              "hzLabel": "245.9k ops/s",
+              "mean": 0.004066168388012504,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move first to last (10,000 items)",
+              "hz": 449,
+              "hzLabel": "449 ops/s",
+              "mean": 2.2260757312770947,
+              "meanLabel": "2.23ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "swap operations": {
+            "Swap two tickets (1,000 items)": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7501,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13331958757699097,
+              "meanLabel": "133.3μs",
+              "rme": 11,
+              "tier": "blazing"
+            },
+            "Swap two tickets (10,000 items)": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 430,
+              "hzLabel": "430 ops/s",
+              "mean": 2.323013328702574,
+              "meanLabel": "2.32ms",
+              "rme": 5.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Swap two tickets (1,000 items)",
+              "hz": 7501,
+              "hzLabel": "7.5k ops/s",
+              "mean": 0.13331958757699097,
+              "meanLabel": "133.3μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Swap two tickets (10,000 items)",
+              "hz": 430,
+              "hzLabel": "430 ops/s",
+              "mean": 2.323013328702574,
+              "meanLabel": "2.32ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "reorder operations": {
+            "Reorder reverse (1,000 items)": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2706,
+              "hzLabel": "2.7k ops/s",
+              "mean": 0.3695115871493862,
+              "meanLabel": "369.5μs",
+              "rme": 0.8,
+              "tier": "blazing"
+            },
+            "Reorder reverse (10,000 items)": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 158,
+              "hzLabel": "158 ops/s",
+              "mean": 6.331172025315626,
+              "meanLabel": "6.33ms",
+              "rme": 5.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Reorder reverse (1,000 items)",
+              "hz": 2706,
+              "hzLabel": "2.7k ops/s",
+              "mean": 0.3695115871493862,
+              "meanLabel": "369.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Reorder reverse (10,000 items)",
+              "hz": 158,
+              "hzLabel": "158 ops/s",
+              "mean": 6.331172025315626,
+              "meanLabel": "6.33ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch operations": {
+            "Onboard 100 items": {
+              "name": "Onboard 100 items",
+              "hz": 3757,
+              "hzLabel": "3.8k ops/s",
+              "mean": 0.2661863815856069,
+              "meanLabel": "266.2μs",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 397,
+              "hzLabel": "397 ops/s",
+              "mean": 2.5198018894467653,
+              "meanLabel": "2.52ms",
+              "rme": 4.6,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 38,
+              "hzLabel": "38 ops/s",
+              "mean": 26.659916157897033,
+              "meanLabel": "26.66ms",
+              "rme": 3.8,
+              "tier": "fast"
+            },
+            "Register then move to mid (1,000 items)": {
+              "name": "Register then move to mid (1,000 items)",
+              "hz": 363,
+              "hzLabel": "363 ops/s",
+              "mean": 2.7570176538464404,
+              "meanLabel": "2.76ms",
+              "rme": 12.3,
+              "tier": "fast"
+            },
+            "Register then move to mid (10,000 items)": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 37,
+              "hzLabel": "37 ops/s",
+              "mean": 27.391231894739718,
+              "meanLabel": "27.39ms",
+              "rme": 3.8,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Onboard 100 items",
+              "hz": 3757,
+              "hzLabel": "3.8k ops/s",
+              "mean": 0.2661863815856069,
+              "meanLabel": "266.2μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Register then move to mid (10,000 items)",
+              "hz": 37,
+              "hzLabel": "37 ops/s",
+              "mean": 27.391231894739718,
+              "meanLabel": "27.39ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "events overhead": {
+            "Move with no listeners (1,000 items)": {
+              "name": "Move with no listeners (1,000 items)",
+              "hz": 235185,
+              "hzLabel": "235.2k ops/s",
+              "mean": 0.004251979607641298,
+              "meanLabel": "4.3μs",
+              "rme": 4.9,
+              "tier": "blazing"
+            },
+            "Move with listener attached (1,000 items)": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 246778,
+              "hzLabel": "246.8k ops/s",
+              "mean": 0.004052227694529308,
+              "meanLabel": "4.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Move with no listeners (10,000 items)": {
+              "name": "Move with no listeners (10,000 items)",
+              "hz": 29297,
+              "hzLabel": "29.3k ops/s",
+              "mean": 0.03413348057876521,
+              "meanLabel": "34.1μs",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "Move with listener attached (10,000 items)": {
+              "name": "Move with listener attached (10,000 items)",
+              "hz": 29611,
+              "hzLabel": "29.6k ops/s",
+              "mean": 0.03377172443595086,
+              "meanLabel": "33.8μs",
+              "rme": 0.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Move with listener attached (1,000 items)",
+              "hz": 246778,
+              "hzLabel": "246.8k ops/s",
+              "mean": 0.004052227694529308,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Move with no listeners (10,000 items)",
+              "hz": 29297,
+              "hzLabel": "29.3k ops/s",
+              "mean": 0.03413348057876521,
+              "meanLabel": "34.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty sortable": {
+          "name": "Create empty sortable",
+          "hz": 46115,
+          "hzLabel": "46.1k ops/s",
+          "mean": 0.021685092820963425,
+          "meanLabel": "21.7μs",
+          "rme": 11.3,
+          "tier": "fast"
+        },
+        "Create empty sortable (disabled)": {
+          "name": "Create empty sortable (disabled)",
+          "hz": 46615,
+          "hzLabel": "46.6k ops/s",
+          "mean": 0.021452096404694518,
+          "meanLabel": "21.5μs",
+          "rme": 12.5,
+          "tier": "fast"
+        },
+        "Get by id (1,000 items)": {
+          "name": "Get by id (1,000 items)",
+          "hz": 8001123,
+          "hzLabel": "8.0M ops/s",
+          "mean": 0.00012498245396787798,
+          "meanLabel": "125ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Get by id (10,000 items)": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8126460,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012305481451695957,
+          "meanLabel": "123ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "Values snapshot (10,000 items)": {
+          "name": "Values snapshot (10,000 items)",
+          "hz": 7603889,
+          "hzLabel": "7.6M ops/s",
+          "mean": 0.00013151165705551442,
+          "meanLabel": "132ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Move first to last (1,000 items)": {
+          "name": "Move first to last (1,000 items)",
+          "hz": 5995,
+          "hzLabel": "6.0k ops/s",
+          "mean": 0.1668073999334701,
+          "meanLabel": "166.8μs",
+          "rme": 10.4,
+          "tier": "blazing"
+        },
+        "Move first to last (10,000 items)": {
+          "name": "Move first to last (10,000 items)",
+          "hz": 449,
+          "hzLabel": "449 ops/s",
+          "mean": 2.2260757312770947,
+          "meanLabel": "2.23ms",
+          "rme": 18.3,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (1,000 items)": {
+          "name": "Move mid by 1 (1,000 items)",
+          "hz": 245932,
+          "hzLabel": "245.9k ops/s",
+          "mean": 0.004066168388012504,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move mid by 1 (10,000 items)": {
+          "name": "Move mid by 1 (10,000 items)",
+          "hz": 29649,
+          "hzLabel": "29.6k ops/s",
+          "mean": 0.03372797463754149,
+          "meanLabel": "33.7μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "Swap two tickets (1,000 items)": {
+          "name": "Swap two tickets (1,000 items)",
+          "hz": 7501,
+          "hzLabel": "7.5k ops/s",
+          "mean": 0.13331958757699097,
+          "meanLabel": "133.3μs",
+          "rme": 11,
+          "tier": "blazing"
+        },
+        "Swap two tickets (10,000 items)": {
+          "name": "Swap two tickets (10,000 items)",
+          "hz": 430,
+          "hzLabel": "430 ops/s",
+          "mean": 2.323013328702574,
+          "meanLabel": "2.32ms",
+          "rme": 5.6,
+          "tier": "blazing"
+        },
+        "Reorder reverse (1,000 items)": {
+          "name": "Reorder reverse (1,000 items)",
+          "hz": 2706,
+          "hzLabel": "2.7k ops/s",
+          "mean": 0.3695115871493862,
+          "meanLabel": "369.5μs",
+          "rme": 0.8,
+          "tier": "blazing"
+        },
+        "Reorder reverse (10,000 items)": {
+          "name": "Reorder reverse (10,000 items)",
+          "hz": 158,
+          "hzLabel": "158 ops/s",
+          "mean": 6.331172025315626,
+          "meanLabel": "6.33ms",
+          "rme": 5.6,
+          "tier": "blazing"
+        },
+        "Onboard 100 items": {
+          "name": "Onboard 100 items",
+          "hz": 3757,
+          "hzLabel": "3.8k ops/s",
+          "mean": 0.2661863815856069,
+          "meanLabel": "266.2μs",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 397,
+          "hzLabel": "397 ops/s",
+          "mean": 2.5198018894467653,
+          "meanLabel": "2.52ms",
+          "rme": 4.6,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 38,
+          "hzLabel": "38 ops/s",
+          "mean": 26.659916157897033,
+          "meanLabel": "26.66ms",
+          "rme": 3.8,
+          "tier": "fast"
+        },
+        "Register then move to mid (1,000 items)": {
+          "name": "Register then move to mid (1,000 items)",
+          "hz": 363,
+          "hzLabel": "363 ops/s",
+          "mean": 2.7570176538464404,
+          "meanLabel": "2.76ms",
+          "rme": 12.3,
+          "tier": "fast"
+        },
+        "Register then move to mid (10,000 items)": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 37,
+          "hzLabel": "37 ops/s",
+          "mean": 27.391231894739718,
+          "meanLabel": "27.39ms",
+          "rme": 3.8,
+          "tier": "fast"
+        },
+        "Move with no listeners (1,000 items)": {
+          "name": "Move with no listeners (1,000 items)",
+          "hz": 235185,
+          "hzLabel": "235.2k ops/s",
+          "mean": 0.004251979607641298,
+          "meanLabel": "4.3μs",
+          "rme": 4.9,
+          "tier": "blazing"
+        },
+        "Move with listener attached (1,000 items)": {
+          "name": "Move with listener attached (1,000 items)",
+          "hz": 246778,
+          "hzLabel": "246.8k ops/s",
+          "mean": 0.004052227694529308,
+          "meanLabel": "4.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Move with no listeners (10,000 items)": {
+          "name": "Move with no listeners (10,000 items)",
+          "hz": 29297,
+          "hzLabel": "29.3k ops/s",
+          "mean": 0.03413348057876521,
+          "meanLabel": "34.1μs",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Move with listener attached (10,000 items)": {
+          "name": "Move with listener attached (10,000 items)",
+          "hz": 29611,
+          "hzLabel": "29.6k ops/s",
+          "mean": 0.03377172443595086,
+          "meanLabel": "33.8μs",
+          "rme": 0.6,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Get by id (10,000 items)",
+          "hz": 8126460,
+          "hzLabel": "8.1M ops/s",
+          "mean": 0.00012305481451695957,
+          "meanLabel": "123ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register then move to mid (10,000 items)",
+          "hz": 37,
+          "hzLabel": "37 ops/s",
+          "mean": 27.391231894739718,
+          "meanLabel": "27.39ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createStep": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty step": {
+              "name": "Create empty step",
+              "hz": 25622,
+              "hzLabel": "25.6k ops/s",
+              "mean": 0.03902867054317409,
+              "meanLabel": "39.0μs",
+              "rme": 6.5,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items": {
+              "name": "Onboard 1,000 items",
+              "hz": 536,
+              "hzLabel": "536 ops/s",
+              "mean": 1.8666435485084996,
+              "meanLabel": "1.87ms",
+              "rme": 7.5,
+              "tier": "fast"
+            },
+            "Onboard 10,000 items": {
+              "name": "Onboard 10,000 items",
+              "hz": 50,
+              "hzLabel": "50 ops/s",
+              "mean": 19.957435576919053,
+              "meanLabel": "19.96ms",
+              "rme": 6.3,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (circular)": {
+              "name": "Onboard 1,000 items (circular)",
+              "hz": 532,
+              "hzLabel": "532 ops/s",
+              "mean": 1.8809394924829212,
+              "meanLabel": "1.88ms",
+              "rme": 7.9,
+              "tier": "fast"
+            },
+            "Onboard 1,000 items (mandatory)": {
+              "name": "Onboard 1,000 items (mandatory)",
+              "hz": 533,
+              "hzLabel": "533 ops/s",
+              "mean": 1.875025711609844,
+              "meanLabel": "1.88ms",
+              "rme": 7.7,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create empty step",
+              "hz": 25622,
+              "hzLabel": "25.6k ops/s",
+              "mean": 0.03902867054317409,
+              "meanLabel": "39.0μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Onboard 10,000 items",
+              "hz": 50,
+              "hzLabel": "50 ops/s",
+              "mean": 19.957435576919053,
+              "meanLabel": "19.96ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation operations (linear)": {
+            "next() from mid-point (1,000 items)": {
+              "name": "next() from mid-point (1,000 items)",
+              "hz": 114085,
+              "hzLabel": "114.1k ops/s",
+              "mean": 0.008765401364006458,
+              "meanLabel": "8.8μs",
+              "rme": 3.5,
+              "tier": "blazing"
+            },
+            "next() from mid-point (10,000 items)": {
+              "name": "next() from mid-point (10,000 items)",
+              "hz": 117063,
+              "hzLabel": "117.1k ops/s",
+              "mean": 0.008542439058977799,
+              "meanLabel": "8.5μs",
+              "rme": 2.4,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (1,000 items)": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 110805,
+              "hzLabel": "110.8k ops/s",
+              "mean": 0.009024866523466334,
+              "meanLabel": "9.0μs",
+              "rme": 4.3,
+              "tier": "blazing"
+            },
+            "prev() from mid-point (10,000 items)": {
+              "name": "prev() from mid-point (10,000 items)",
+              "hz": 114009,
+              "hzLabel": "114.0k ops/s",
+              "mean": 0.00877123183923428,
+              "meanLabel": "8.8μs",
+              "rme": 2.7,
+              "tier": "blazing"
+            },
+            "first() (1,000 items)": {
+              "name": "first() (1,000 items)",
+              "hz": 402193,
+              "hzLabel": "402.2k ops/s",
+              "mean": 0.002486369030809836,
+              "meanLabel": "2.5μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "last() (1,000 items)": {
+              "name": "last() (1,000 items)",
+              "hz": 382502,
+              "hzLabel": "382.5k ops/s",
+              "mean": 0.002614365723567178,
+              "meanLabel": "2.6μs",
+              "rme": 2.8,
+              "tier": "blazing"
+            },
+            "step(+5) from mid-point (1,000 items)": {
+              "name": "step(+5) from mid-point (1,000 items)",
+              "hz": 116169,
+              "hzLabel": "116.2k ops/s",
+              "mean": 0.008608122355216833,
+              "meanLabel": "8.6μs",
+              "rme": 2.6,
+              "tier": "blazing"
+            },
+            "step(+50) from mid-point (1,000 items)": {
+              "name": "step(+50) from mid-point (1,000 items)",
+              "hz": 112551,
+              "hzLabel": "112.6k ops/s",
+              "mean": 0.008884888886849136,
+              "meanLabel": "8.9μs",
+              "rme": 4.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "first() (1,000 items)",
+              "hz": 402193,
+              "hzLabel": "402.2k ops/s",
+              "mean": 0.002486369030809836,
+              "meanLabel": "2.5μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "prev() from mid-point (1,000 items)",
+              "hz": 110805,
+              "hzLabel": "110.8k ops/s",
+              "mean": 0.009024866523466334,
+              "meanLabel": "9.0μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "navigation operations (circular)": {
+            "next() from mid-point circular (1,000 items)": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 114588,
+              "hzLabel": "114.6k ops/s",
+              "mean": 0.008726927322360793,
+              "meanLabel": "8.7μs",
+              "rme": 3,
+              "tier": "blazing"
+            },
+            "next() wrapping past end circular (1,000 items)": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 143504,
+              "hzLabel": "143.5k ops/s",
+              "mean": 0.006968468892856154,
+              "meanLabel": "7.0μs",
+              "rme": 2,
+              "tier": "blazing"
+            },
+            "prev() wrapping past start circular (1,000 items)": {
+              "name": "prev() wrapping past start circular (1,000 items)",
+              "hz": 138795,
+              "hzLabel": "138.8k ops/s",
+              "mean": 0.007204845571905094,
+              "meanLabel": "7.2μs",
+              "rme": 5.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "next() wrapping past end circular (1,000 items)",
+              "hz": 143504,
+              "hzLabel": "143.5k ops/s",
+              "mean": 0.006968468892856154,
+              "meanLabel": "7.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "next() from mid-point circular (1,000 items)",
+              "hz": 114588,
+              "hzLabel": "114.6k ops/s",
+              "mean": 0.008726927322360793,
+              "meanLabel": "8.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "boundary conditions": {
+            "next() at last item — no-op (1,000 items)": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 252921,
+              "hzLabel": "252.9k ops/s",
+              "mean": 0.003953796648804637,
+              "meanLabel": "4.0μs",
+              "rme": 2.6,
+              "tier": "blazing"
+            },
+            "prev() at first item — no-op (1,000 items)": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 243594,
+              "hzLabel": "243.6k ops/s",
+              "mean": 0.0041051990854169005,
+              "meanLabel": "4.1μs",
+              "rme": 6.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "next() at last item — no-op (1,000 items)",
+              "hz": 252921,
+              "hzLabel": "252.9k ops/s",
+              "mean": 0.003953796648804637,
+              "meanLabel": "4.0μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "prev() at first item — no-op (1,000 items)",
+              "hz": 243594,
+              "hzLabel": "243.6k ops/s",
+              "mean": 0.0041051990854169005,
+              "meanLabel": "4.1μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access selectedIndex 100 times (1,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 280828,
+              "hzLabel": "280.8k ops/s",
+              "mean": 0.0035608938217927466,
+              "meanLabel": "3.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedIndex 100 times (10,000 items, cached)": {
+              "name": "Access selectedIndex 100 times (10,000 items, cached)",
+              "hz": 279651,
+              "hzLabel": "279.7k ops/s",
+              "mean": 0.003575885221701254,
+              "meanLabel": "3.6μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access selectedId 100 times (1,000 items, cached)": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6277,
+              "hzLabel": "6.3k ops/s",
+              "mean": 0.15930187288926814,
+              "meanLabel": "159.3μs",
+              "rme": 5.5,
+              "tier": "blazing"
+            },
+            "Access selectedValue 100 times (1,000 items, cached)": {
+              "name": "Access selectedValue 100 times (1,000 items, cached)",
+              "hz": 269877,
+              "hzLabel": "269.9k ops/s",
+              "mean": 0.0037053905541390886,
+              "meanLabel": "3.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access selectedIndex 100 times (1,000 items, cached)",
+              "hz": 280828,
+              "hzLabel": "280.8k ops/s",
+              "mean": 0.0035608938217927466,
+              "meanLabel": "3.6μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access selectedId 100 times (1,000 items, cached)",
+              "hz": 6277,
+              "hzLabel": "6.3k ops/s",
+              "mean": 0.15930187288926814,
+              "meanLabel": "159.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create empty step": {
+          "name": "Create empty step",
+          "hz": 25622,
+          "hzLabel": "25.6k ops/s",
+          "mean": 0.03902867054317409,
+          "meanLabel": "39.0μs",
+          "rme": 6.5,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items": {
+          "name": "Onboard 1,000 items",
+          "hz": 536,
+          "hzLabel": "536 ops/s",
+          "mean": 1.8666435485084996,
+          "meanLabel": "1.87ms",
+          "rme": 7.5,
+          "tier": "fast"
+        },
+        "Onboard 10,000 items": {
+          "name": "Onboard 10,000 items",
+          "hz": 50,
+          "hzLabel": "50 ops/s",
+          "mean": 19.957435576919053,
+          "meanLabel": "19.96ms",
+          "rme": 6.3,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (circular)": {
+          "name": "Onboard 1,000 items (circular)",
+          "hz": 532,
+          "hzLabel": "532 ops/s",
+          "mean": 1.8809394924829212,
+          "meanLabel": "1.88ms",
+          "rme": 7.9,
+          "tier": "fast"
+        },
+        "Onboard 1,000 items (mandatory)": {
+          "name": "Onboard 1,000 items (mandatory)",
+          "hz": 533,
+          "hzLabel": "533 ops/s",
+          "mean": 1.875025711609844,
+          "meanLabel": "1.88ms",
+          "rme": 7.7,
+          "tier": "fast"
+        },
+        "next() from mid-point (1,000 items)": {
+          "name": "next() from mid-point (1,000 items)",
+          "hz": 114085,
+          "hzLabel": "114.1k ops/s",
+          "mean": 0.008765401364006458,
+          "meanLabel": "8.8μs",
+          "rme": 3.5,
+          "tier": "blazing"
+        },
+        "next() from mid-point (10,000 items)": {
+          "name": "next() from mid-point (10,000 items)",
+          "hz": 117063,
+          "hzLabel": "117.1k ops/s",
+          "mean": 0.008542439058977799,
+          "meanLabel": "8.5μs",
+          "rme": 2.4,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (1,000 items)": {
+          "name": "prev() from mid-point (1,000 items)",
+          "hz": 110805,
+          "hzLabel": "110.8k ops/s",
+          "mean": 0.009024866523466334,
+          "meanLabel": "9.0μs",
+          "rme": 4.3,
+          "tier": "blazing"
+        },
+        "prev() from mid-point (10,000 items)": {
+          "name": "prev() from mid-point (10,000 items)",
+          "hz": 114009,
+          "hzLabel": "114.0k ops/s",
+          "mean": 0.00877123183923428,
+          "meanLabel": "8.8μs",
+          "rme": 2.7,
+          "tier": "blazing"
+        },
+        "first() (1,000 items)": {
+          "name": "first() (1,000 items)",
+          "hz": 402193,
+          "hzLabel": "402.2k ops/s",
+          "mean": 0.002486369030809836,
+          "meanLabel": "2.5μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "last() (1,000 items)": {
+          "name": "last() (1,000 items)",
+          "hz": 382502,
+          "hzLabel": "382.5k ops/s",
+          "mean": 0.002614365723567178,
+          "meanLabel": "2.6μs",
+          "rme": 2.8,
+          "tier": "blazing"
+        },
+        "step(+5) from mid-point (1,000 items)": {
+          "name": "step(+5) from mid-point (1,000 items)",
+          "hz": 116169,
+          "hzLabel": "116.2k ops/s",
+          "mean": 0.008608122355216833,
+          "meanLabel": "8.6μs",
+          "rme": 2.6,
+          "tier": "blazing"
+        },
+        "step(+50) from mid-point (1,000 items)": {
+          "name": "step(+50) from mid-point (1,000 items)",
+          "hz": 112551,
+          "hzLabel": "112.6k ops/s",
+          "mean": 0.008884888886849136,
+          "meanLabel": "8.9μs",
+          "rme": 4.1,
+          "tier": "blazing"
+        },
+        "next() from mid-point circular (1,000 items)": {
+          "name": "next() from mid-point circular (1,000 items)",
+          "hz": 114588,
+          "hzLabel": "114.6k ops/s",
+          "mean": 0.008726927322360793,
+          "meanLabel": "8.7μs",
+          "rme": 3,
+          "tier": "blazing"
+        },
+        "next() wrapping past end circular (1,000 items)": {
+          "name": "next() wrapping past end circular (1,000 items)",
+          "hz": 143504,
+          "hzLabel": "143.5k ops/s",
+          "mean": 0.006968468892856154,
+          "meanLabel": "7.0μs",
+          "rme": 2,
+          "tier": "blazing"
+        },
+        "prev() wrapping past start circular (1,000 items)": {
+          "name": "prev() wrapping past start circular (1,000 items)",
+          "hz": 138795,
+          "hzLabel": "138.8k ops/s",
+          "mean": 0.007204845571905094,
+          "meanLabel": "7.2μs",
+          "rme": 5.3,
+          "tier": "blazing"
+        },
+        "next() at last item — no-op (1,000 items)": {
+          "name": "next() at last item — no-op (1,000 items)",
+          "hz": 252921,
+          "hzLabel": "252.9k ops/s",
+          "mean": 0.003953796648804637,
+          "meanLabel": "4.0μs",
+          "rme": 2.6,
+          "tier": "blazing"
+        },
+        "prev() at first item — no-op (1,000 items)": {
+          "name": "prev() at first item — no-op (1,000 items)",
+          "hz": 243594,
+          "hzLabel": "243.6k ops/s",
+          "mean": 0.0041051990854169005,
+          "meanLabel": "4.1μs",
+          "rme": 6.7,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (1,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (1,000 items, cached)",
+          "hz": 280828,
+          "hzLabel": "280.8k ops/s",
+          "mean": 0.0035608938217927466,
+          "meanLabel": "3.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedIndex 100 times (10,000 items, cached)": {
+          "name": "Access selectedIndex 100 times (10,000 items, cached)",
+          "hz": 279651,
+          "hzLabel": "279.7k ops/s",
+          "mean": 0.003575885221701254,
+          "meanLabel": "3.6μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access selectedId 100 times (1,000 items, cached)": {
+          "name": "Access selectedId 100 times (1,000 items, cached)",
+          "hz": 6277,
+          "hzLabel": "6.3k ops/s",
+          "mean": 0.15930187288926814,
+          "meanLabel": "159.3μs",
+          "rme": 5.5,
+          "tier": "blazing"
+        },
+        "Access selectedValue 100 times (1,000 items, cached)": {
+          "name": "Access selectedValue 100 times (1,000 items, cached)",
+          "hz": 269877,
+          "hzLabel": "269.9k ops/s",
+          "mean": 0.0037053905541390886,
+          "meanLabel": "3.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "first() (1,000 items)",
+          "hz": 402193,
+          "hzLabel": "402.2k ops/s",
+          "mean": 0.002486369030809836,
+          "meanLabel": "2.5μs",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Onboard 10,000 items",
+          "hz": 50,
+          "hzLabel": "50 ops/s",
+          "mean": 19.957435576919053,
+          "meanLabel": "19.96ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createTokens": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create tokens (~100 tokens)": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 5300,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.18866747227473335,
+              "meanLabel": "188.7μs",
+              "rme": 3.1,
+              "tier": "fast"
+            },
+            "Create tokens (1,000 tokens)": {
+              "name": "Create tokens (1,000 tokens)",
+              "hz": 621,
+              "hzLabel": "621 ops/s",
+              "mean": 1.6091569549835683,
+              "meanLabel": "1.61ms",
+              "rme": 5.4,
+              "tier": "fast"
+            },
+            "Create tokens (10,000 tokens)": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 55,
+              "hzLabel": "55 ops/s",
+              "mean": 18.08154489286244,
+              "meanLabel": "18.08ms",
+              "rme": 6.9,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Create tokens (~100 tokens)",
+              "hz": 5300,
+              "hzLabel": "5.3k ops/s",
+              "mean": 0.18866747227473335,
+              "meanLabel": "188.7μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "Create tokens (10,000 tokens)",
+              "hz": 55,
+              "hzLabel": "55 ops/s",
+              "mean": 18.08154489286244,
+              "meanLabel": "18.08ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "lookup operations": {
+            "Resolve primitive token": {
+              "name": "Resolve primitive token",
+              "hz": 4405403,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022699399598831232,
+              "meanLabel": "227ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve nested path (3 levels)": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 4330905,
+              "hzLabel": "4.3M ops/s",
+              "mean": 0.00023089860229376756,
+              "meanLabel": "231ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve deep nested path (5 levels)": {
+              "name": "Resolve deep nested path (5 levels)",
+              "hz": 4431892,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022563726210107657,
+              "meanLabel": "226ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve by id (1,000 tokens)": {
+              "name": "Resolve by id (1,000 tokens)",
+              "hz": 4393497,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022760912101141991,
+              "meanLabel": "228ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Resolve by id (10,000 tokens)": {
+              "name": "Resolve by id (10,000 tokens)",
+              "hz": 4380220,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022829901815866736,
+              "meanLabel": "228ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve deep nested path (5 levels)",
+              "hz": 4431892,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022563726210107657,
+              "meanLabel": "226ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve nested path (3 levels)",
+              "hz": 4330905,
+              "hzLabel": "4.3M ops/s",
+              "mean": 0.00023089860229376756,
+              "meanLabel": "231ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "alias resolution": {
+            "Resolve single alias": {
+              "name": "Resolve single alias",
+              "hz": 4426176,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022592864817451655,
+              "meanLabel": "226ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve chained alias (2 levels)": {
+              "name": "Resolve chained alias (2 levels)",
+              "hz": 4352043,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.0002297771630860747,
+              "meanLabel": "230ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve component alias reference": {
+              "name": "Resolve component alias reference",
+              "hz": 4369746,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022884627113394139,
+              "meanLabel": "229ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (1,000 tokens)": {
+              "name": "Resolve alias (1,000 tokens)",
+              "hz": 4359555,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022938120484977323,
+              "meanLabel": "229ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve alias (10,000 tokens)": {
+              "name": "Resolve alias (10,000 tokens)",
+              "hz": 4367751,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022895076872687375,
+              "meanLabel": "229ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve single alias",
+              "hz": 4426176,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.00022592864817451655,
+              "meanLabel": "226ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve chained alias (2 levels)",
+              "hz": 4352043,
+              "hzLabel": "4.4M ops/s",
+              "mean": 0.0002297771630860747,
+              "meanLabel": "230ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "batch resolution": {
+            "Resolve 5 different paths sequentially": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1398027,
+              "hzLabel": "1.4M ops/s",
+              "mean": 0.0007152939025531806,
+              "meanLabel": "715ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resolve 100 paths (20 unique, repeated)": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 85254,
+              "hzLabel": "85.3k ops/s",
+              "mean": 0.011729655194998028,
+              "meanLabel": "11.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resolve 5 different paths sequentially",
+              "hz": 1398027,
+              "hzLabel": "1.4M ops/s",
+              "mean": 0.0007152939025531806,
+              "meanLabel": "715ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resolve 100 paths (20 unique, repeated)",
+              "hz": 85254,
+              "hzLabel": "85.3k ops/s",
+              "mean": 0.011729655194998028,
+              "meanLabel": "11.7μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access token 100 times (fixture, cached)": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 92710,
+              "hzLabel": "92.7k ops/s",
+              "mean": 0.010786313939992562,
+              "meanLabel": "10.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access token 100 times (1,000 tokens, cached)": {
+              "name": "Access token 100 times (1,000 tokens, cached)",
+              "hz": 92581,
+              "hzLabel": "92.6k ops/s",
+              "mean": 0.010801340346867706,
+              "meanLabel": "10.8μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access token 100 times (10,000 tokens, cached)": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 88994,
+              "hzLabel": "89.0k ops/s",
+              "mean": 0.011236691716456068,
+              "meanLabel": "11.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access token 100 times (fixture, cached)",
+              "hz": 92710,
+              "hzLabel": "92.7k ops/s",
+              "mean": 0.010786313939992562,
+              "meanLabel": "10.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access token 100 times (10,000 tokens, cached)",
+              "hz": 88994,
+              "hzLabel": "89.0k ops/s",
+              "mean": 0.011236691716456068,
+              "meanLabel": "11.2μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create tokens (~100 tokens)": {
+          "name": "Create tokens (~100 tokens)",
+          "hz": 5300,
+          "hzLabel": "5.3k ops/s",
+          "mean": 0.18866747227473335,
+          "meanLabel": "188.7μs",
+          "rme": 3.1,
+          "tier": "fast"
+        },
+        "Create tokens (1,000 tokens)": {
+          "name": "Create tokens (1,000 tokens)",
+          "hz": 621,
+          "hzLabel": "621 ops/s",
+          "mean": 1.6091569549835683,
+          "meanLabel": "1.61ms",
+          "rme": 5.4,
+          "tier": "fast"
+        },
+        "Create tokens (10,000 tokens)": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 55,
+          "hzLabel": "55 ops/s",
+          "mean": 18.08154489286244,
+          "meanLabel": "18.08ms",
+          "rme": 6.9,
+          "tier": "fast"
+        },
+        "Resolve primitive token": {
+          "name": "Resolve primitive token",
+          "hz": 4405403,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022699399598831232,
+          "meanLabel": "227ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve nested path (3 levels)": {
+          "name": "Resolve nested path (3 levels)",
+          "hz": 4330905,
+          "hzLabel": "4.3M ops/s",
+          "mean": 0.00023089860229376756,
+          "meanLabel": "231ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve deep nested path (5 levels)": {
+          "name": "Resolve deep nested path (5 levels)",
+          "hz": 4431892,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022563726210107657,
+          "meanLabel": "226ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve by id (1,000 tokens)": {
+          "name": "Resolve by id (1,000 tokens)",
+          "hz": 4393497,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022760912101141991,
+          "meanLabel": "228ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve by id (10,000 tokens)": {
+          "name": "Resolve by id (10,000 tokens)",
+          "hz": 4380220,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022829901815866736,
+          "meanLabel": "228ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Resolve single alias": {
+          "name": "Resolve single alias",
+          "hz": 4426176,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022592864817451655,
+          "meanLabel": "226ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve chained alias (2 levels)": {
+          "name": "Resolve chained alias (2 levels)",
+          "hz": 4352043,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.0002297771630860747,
+          "meanLabel": "230ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve component alias reference": {
+          "name": "Resolve component alias reference",
+          "hz": 4369746,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022884627113394139,
+          "meanLabel": "229ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (1,000 tokens)": {
+          "name": "Resolve alias (1,000 tokens)",
+          "hz": 4359555,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022938120484977323,
+          "meanLabel": "229ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve alias (10,000 tokens)": {
+          "name": "Resolve alias (10,000 tokens)",
+          "hz": 4367751,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022895076872687375,
+          "meanLabel": "229ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve 5 different paths sequentially": {
+          "name": "Resolve 5 different paths sequentially",
+          "hz": 1398027,
+          "hzLabel": "1.4M ops/s",
+          "mean": 0.0007152939025531806,
+          "meanLabel": "715ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resolve 100 paths (20 unique, repeated)": {
+          "name": "Resolve 100 paths (20 unique, repeated)",
+          "hz": 85254,
+          "hzLabel": "85.3k ops/s",
+          "mean": 0.011729655194998028,
+          "meanLabel": "11.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Access token 100 times (fixture, cached)": {
+          "name": "Access token 100 times (fixture, cached)",
+          "hz": 92710,
+          "hzLabel": "92.7k ops/s",
+          "mean": 0.010786313939992562,
+          "meanLabel": "10.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access token 100 times (1,000 tokens, cached)": {
+          "name": "Access token 100 times (1,000 tokens, cached)",
+          "hz": 92581,
+          "hzLabel": "92.6k ops/s",
+          "mean": 0.010801340346867706,
+          "meanLabel": "10.8μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access token 100 times (10,000 tokens, cached)": {
+          "name": "Access token 100 times (10,000 tokens, cached)",
+          "hz": 88994,
+          "hzLabel": "89.0k ops/s",
+          "mean": 0.011236691716456068,
+          "meanLabel": "11.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Resolve deep nested path (5 levels)",
+          "hz": 4431892,
+          "hzLabel": "4.4M ops/s",
+          "mean": 0.00022563726210107657,
+          "meanLabel": "226ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create tokens (10,000 tokens)",
+          "hz": 55,
+          "hzLabel": "55 ops/s",
+          "mean": 18.08154489286244,
+          "meanLabel": "18.08ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "createVirtual": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create virtual (1,000 items)": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8897,
+              "hzLabel": "8.9k ops/s",
+              "mean": 0.11239835513578086,
+              "meanLabel": "112.4μs",
+              "rme": 4.2,
+              "tier": "blazing"
+            },
+            "Create virtual (10,000 items)": {
+              "name": "Create virtual (10,000 items)",
+              "hz": 995,
+              "hzLabel": "995 ops/s",
+              "mean": 1.0050174136550598,
+              "meanLabel": "1.01ms",
+              "rme": 4.6,
+              "tier": "blazing"
+            },
+            "Create virtual (100,000 items)": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.269491081633273,
+              "meanLabel": "10.27ms",
+              "rme": 1.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create virtual (1,000 items)",
+              "hz": 8897,
+              "hzLabel": "8.9k ops/s",
+              "mean": 0.11239835513578086,
+              "meanLabel": "112.4μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create virtual (100,000 items)",
+              "hz": 97,
+              "hzLabel": "97 ops/s",
+              "mean": 10.269491081633273,
+              "meanLabel": "10.27ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scroll operations": {
+            "Scroll to start position (1,000 items)": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 471933,
+              "hzLabel": "471.9k ops/s",
+              "mean": 0.002118943551426706,
+              "meanLabel": "2.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Scroll to start position (10,000 items)": {
+              "name": "Scroll to start position (10,000 items)",
+              "hz": 467129,
+              "hzLabel": "467.1k ops/s",
+              "mean": 0.002140734870374659,
+              "meanLabel": "2.1μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (1,000 items)": {
+              "name": "Scroll to middle position (1,000 items)",
+              "hz": 459897,
+              "hzLabel": "459.9k ops/s",
+              "mean": 0.0021743987318967703,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to middle position (10,000 items)": {
+              "name": "Scroll to middle position (10,000 items)",
+              "hz": 457921,
+              "hzLabel": "457.9k ops/s",
+              "mean": 0.002183784513513768,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (1,000 items)": {
+              "name": "Scroll to end position (1,000 items)",
+              "hz": 455147,
+              "hzLabel": "455.1k ops/s",
+              "mean": 0.0021970934816448406,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Scroll to end position (10,000 items)": {
+              "name": "Scroll to end position (10,000 items)",
+              "hz": 459728,
+              "hzLabel": "459.7k ops/s",
+              "mean": 0.0021751978943918113,
+              "meanLabel": "2.2μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (1,000 items)": {
+              "name": "Process 100 scroll events (1,000 items)",
+              "hz": 4730,
+              "hzLabel": "4.7k ops/s",
+              "mean": 0.21139473710906345,
+              "meanLabel": "211.4μs",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Process 100 scroll events (10,000 items)": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4727,
+              "hzLabel": "4.7k ops/s",
+              "mean": 0.21153498604075627,
+              "meanLabel": "211.5μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Scroll to start position (1,000 items)",
+              "hz": 471933,
+              "hzLabel": "471.9k ops/s",
+              "mean": 0.002118943551426706,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Process 100 scroll events (10,000 items)",
+              "hz": 4727,
+              "hzLabel": "4.7k ops/s",
+              "mean": 0.21153498604075627,
+              "meanLabel": "211.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "resize operations": {
+            "Resize single item (1,000 items)": {
+              "name": "Resize single item (1,000 items)",
+              "hz": 1025073,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009755402458605218,
+              "meanLabel": "976ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Resize single item (10,000 items)": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1040285,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009612754377193853,
+              "meanLabel": "961ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (1,000 items)": {
+              "name": "Resize 100 items sequentially (1,000 items)",
+              "hz": 12085,
+              "hzLabel": "12.1k ops/s",
+              "mean": 0.08274729786534143,
+              "meanLabel": "82.7μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Resize 100 items sequentially (10,000 items)": {
+              "name": "Resize 100 items sequentially (10,000 items)",
+              "hz": 12063,
+              "hzLabel": "12.1k ops/s",
+              "mean": 0.08289692440313658,
+              "meanLabel": "82.9μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "Resize with variable heights (1,000 items)": {
+              "name": "Resize with variable heights (1,000 items)",
+              "hz": 12162,
+              "hzLabel": "12.2k ops/s",
+              "mean": 0.08222216359766575,
+              "meanLabel": "82.2μs",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Resize single item (10,000 items)",
+              "hz": 1040285,
+              "hzLabel": "1.0M ops/s",
+              "mean": 0.0009612754377193853,
+              "meanLabel": "961ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Resize 100 items sequentially (10,000 items)",
+              "hz": 12063,
+              "hzLabel": "12.1k ops/s",
+              "mean": 0.08289692440313658,
+              "meanLabel": "82.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "scrollTo operations": {
+            "ScrollTo start (1,000 items)": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 469736,
+              "hzLabel": "469.7k ops/s",
+              "mean": 0.002128854250682138,
+              "meanLabel": "2.1μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo start (10,000 items)": {
+              "name": "ScrollTo start (10,000 items)",
+              "hz": 453920,
+              "hzLabel": "453.9k ops/s",
+              "mean": 0.002203033627032502,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (1,000 items)": {
+              "name": "ScrollTo middle (1,000 items)",
+              "hz": 451631,
+              "hzLabel": "451.6k ops/s",
+              "mean": 0.0022141968815469907,
+              "meanLabel": "2.2μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo middle (10,000 items)": {
+              "name": "ScrollTo middle (10,000 items)",
+              "hz": 446800,
+              "hzLabel": "446.8k ops/s",
+              "mean": 0.002238138410931057,
+              "meanLabel": "2.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "ScrollTo end (1,000 items)": {
+              "name": "ScrollTo end (1,000 items)",
+              "hz": 451310,
+              "hzLabel": "451.3k ops/s",
+              "mean": 0.0022157718951871853,
+              "meanLabel": "2.2μs",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "ScrollTo end (10,000 items)": {
+              "name": "ScrollTo end (10,000 items)",
+              "hz": 440221,
+              "hzLabel": "440.2k ops/s",
+              "mean": 0.002271586504079908,
+              "meanLabel": "2.3μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "ScrollTo 5 positions (10,000 items)": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 87084,
+              "hzLabel": "87.1k ops/s",
+              "mean": 0.01148314250276541,
+              "meanLabel": "11.5μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "ScrollTo start (1,000 items)",
+              "hz": 469736,
+              "hzLabel": "469.7k ops/s",
+              "mean": 0.002128854250682138,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "ScrollTo 5 positions (10,000 items)",
+              "hz": 87084,
+              "hzLabel": "87.1k ops/s",
+              "mean": 0.01148314250276541,
+              "meanLabel": "11.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "Access items 100 times (1,000 items, cached)": {
+              "name": "Access items 100 times (1,000 items, cached)",
+              "hz": 1905225,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.0005248723479442972,
+              "meanLabel": "525ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access items 100 times (10,000 items, cached)": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1906768,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.000524447725163904,
+              "meanLabel": "524ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (1,000 items, cached)": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 52964,
+              "hzLabel": "53.0k ops/s",
+              "mean": 0.018880772713385213,
+              "meanLabel": "18.9μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access offset 100 times (10,000 items, cached)": {
+              "name": "Access offset 100 times (10,000 items, cached)",
+              "hz": 53378,
+              "hzLabel": "53.4k ops/s",
+              "mean": 0.018734170063737034,
+              "meanLabel": "18.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (1,000 items, cached)": {
+              "name": "Access size 100 times (1,000 items, cached)",
+              "hz": 53068,
+              "hzLabel": "53.1k ops/s",
+              "mean": 0.01884385520473271,
+              "meanLabel": "18.8μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "Access size 100 times (10,000 items, cached)": {
+              "name": "Access size 100 times (10,000 items, cached)",
+              "hz": 53506,
+              "hzLabel": "53.5k ops/s",
+              "mean": 0.018689545247141597,
+              "meanLabel": "18.7μs",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Access items 100 times (10,000 items, cached)",
+              "hz": 1906768,
+              "hzLabel": "1.9M ops/s",
+              "mean": 0.000524447725163904,
+              "meanLabel": "524ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Access offset 100 times (1,000 items, cached)",
+              "hz": 52964,
+              "hzLabel": "53.0k ops/s",
+              "mean": 0.018880772713385213,
+              "meanLabel": "18.9μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          }
+        },
+        "Create virtual (1,000 items)": {
+          "name": "Create virtual (1,000 items)",
+          "hz": 8897,
+          "hzLabel": "8.9k ops/s",
+          "mean": 0.11239835513578086,
+          "meanLabel": "112.4μs",
+          "rme": 4.2,
+          "tier": "blazing"
+        },
+        "Create virtual (10,000 items)": {
+          "name": "Create virtual (10,000 items)",
+          "hz": 995,
+          "hzLabel": "995 ops/s",
+          "mean": 1.0050174136550598,
+          "meanLabel": "1.01ms",
+          "rme": 4.6,
+          "tier": "blazing"
+        },
+        "Create virtual (100,000 items)": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.269491081633273,
+          "meanLabel": "10.27ms",
+          "rme": 1.9,
+          "tier": "blazing"
+        },
+        "Scroll to start position (1,000 items)": {
+          "name": "Scroll to start position (1,000 items)",
+          "hz": 471933,
+          "hzLabel": "471.9k ops/s",
+          "mean": 0.002118943551426706,
+          "meanLabel": "2.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Scroll to start position (10,000 items)": {
+          "name": "Scroll to start position (10,000 items)",
+          "hz": 467129,
+          "hzLabel": "467.1k ops/s",
+          "mean": 0.002140734870374659,
+          "meanLabel": "2.1μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (1,000 items)": {
+          "name": "Scroll to middle position (1,000 items)",
+          "hz": 459897,
+          "hzLabel": "459.9k ops/s",
+          "mean": 0.0021743987318967703,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to middle position (10,000 items)": {
+          "name": "Scroll to middle position (10,000 items)",
+          "hz": 457921,
+          "hzLabel": "457.9k ops/s",
+          "mean": 0.002183784513513768,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (1,000 items)": {
+          "name": "Scroll to end position (1,000 items)",
+          "hz": 455147,
+          "hzLabel": "455.1k ops/s",
+          "mean": 0.0021970934816448406,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Scroll to end position (10,000 items)": {
+          "name": "Scroll to end position (10,000 items)",
+          "hz": 459728,
+          "hzLabel": "459.7k ops/s",
+          "mean": 0.0021751978943918113,
+          "meanLabel": "2.2μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (1,000 items)": {
+          "name": "Process 100 scroll events (1,000 items)",
+          "hz": 4730,
+          "hzLabel": "4.7k ops/s",
+          "mean": 0.21139473710906345,
+          "meanLabel": "211.4μs",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Process 100 scroll events (10,000 items)": {
+          "name": "Process 100 scroll events (10,000 items)",
+          "hz": 4727,
+          "hzLabel": "4.7k ops/s",
+          "mean": 0.21153498604075627,
+          "meanLabel": "211.5μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize single item (1,000 items)": {
+          "name": "Resize single item (1,000 items)",
+          "hz": 1025073,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.0009755402458605218,
+          "meanLabel": "976ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Resize single item (10,000 items)": {
+          "name": "Resize single item (10,000 items)",
+          "hz": 1040285,
+          "hzLabel": "1.0M ops/s",
+          "mean": 0.0009612754377193853,
+          "meanLabel": "961ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (1,000 items)": {
+          "name": "Resize 100 items sequentially (1,000 items)",
+          "hz": 12085,
+          "hzLabel": "12.1k ops/s",
+          "mean": 0.08274729786534143,
+          "meanLabel": "82.7μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Resize 100 items sequentially (10,000 items)": {
+          "name": "Resize 100 items sequentially (10,000 items)",
+          "hz": 12063,
+          "hzLabel": "12.1k ops/s",
+          "mean": 0.08289692440313658,
+          "meanLabel": "82.9μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "Resize with variable heights (1,000 items)": {
+          "name": "Resize with variable heights (1,000 items)",
+          "hz": 12162,
+          "hzLabel": "12.2k ops/s",
+          "mean": 0.08222216359766575,
+          "meanLabel": "82.2μs",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "ScrollTo start (1,000 items)": {
+          "name": "ScrollTo start (1,000 items)",
+          "hz": 469736,
+          "hzLabel": "469.7k ops/s",
+          "mean": 0.002128854250682138,
+          "meanLabel": "2.1μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo start (10,000 items)": {
+          "name": "ScrollTo start (10,000 items)",
+          "hz": 453920,
+          "hzLabel": "453.9k ops/s",
+          "mean": 0.002203033627032502,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (1,000 items)": {
+          "name": "ScrollTo middle (1,000 items)",
+          "hz": 451631,
+          "hzLabel": "451.6k ops/s",
+          "mean": 0.0022141968815469907,
+          "meanLabel": "2.2μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo middle (10,000 items)": {
+          "name": "ScrollTo middle (10,000 items)",
+          "hz": 446800,
+          "hzLabel": "446.8k ops/s",
+          "mean": 0.002238138410931057,
+          "meanLabel": "2.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "ScrollTo end (1,000 items)": {
+          "name": "ScrollTo end (1,000 items)",
+          "hz": 451310,
+          "hzLabel": "451.3k ops/s",
+          "mean": 0.0022157718951871853,
+          "meanLabel": "2.2μs",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "ScrollTo end (10,000 items)": {
+          "name": "ScrollTo end (10,000 items)",
+          "hz": 440221,
+          "hzLabel": "440.2k ops/s",
+          "mean": 0.002271586504079908,
+          "meanLabel": "2.3μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "ScrollTo 5 positions (10,000 items)": {
+          "name": "ScrollTo 5 positions (10,000 items)",
+          "hz": 87084,
+          "hzLabel": "87.1k ops/s",
+          "mean": 0.01148314250276541,
+          "meanLabel": "11.5μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access items 100 times (1,000 items, cached)": {
+          "name": "Access items 100 times (1,000 items, cached)",
+          "hz": 1905225,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.0005248723479442972,
+          "meanLabel": "525ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access items 100 times (10,000 items, cached)": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1906768,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.000524447725163904,
+          "meanLabel": "524ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (1,000 items, cached)": {
+          "name": "Access offset 100 times (1,000 items, cached)",
+          "hz": 52964,
+          "hzLabel": "53.0k ops/s",
+          "mean": 0.018880772713385213,
+          "meanLabel": "18.9μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access offset 100 times (10,000 items, cached)": {
+          "name": "Access offset 100 times (10,000 items, cached)",
+          "hz": 53378,
+          "hzLabel": "53.4k ops/s",
+          "mean": 0.018734170063737034,
+          "meanLabel": "18.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (1,000 items, cached)": {
+          "name": "Access size 100 times (1,000 items, cached)",
+          "hz": 53068,
+          "hzLabel": "53.1k ops/s",
+          "mean": 0.01884385520473271,
+          "meanLabel": "18.8μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Access size 100 times (10,000 items, cached)": {
+          "name": "Access size 100 times (10,000 items, cached)",
+          "hz": 53506,
+          "hzLabel": "53.5k ops/s",
+          "mean": 0.018689545247141597,
+          "meanLabel": "18.7μs",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "_fastest": {
+          "name": "Access items 100 times (10,000 items, cached)",
+          "hz": 1906768,
+          "hzLabel": "1.9M ops/s",
+          "mean": 0.000524447725163904,
+          "meanLabel": "524ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Create virtual (100,000 items)",
+          "hz": 97,
+          "hzLabel": "97 ops/s",
+          "mean": 10.269491081633273,
+          "meanLabel": "10.27ms",
+          "tier": "blazing"
+        },
+        "_tier": "blazing"
+      }
+    },
+    "useDate": {
+      "benchmarks": {
+        "_groups": {
+          "construction": {
+            "create date from null (now)": {
+              "name": "create date from null (now)",
+              "hz": 643517,
+              "hzLabel": "643.5k ops/s",
+              "mean": 0.001553959867436115,
+              "meanLabel": "1.6μs",
+              "rme": 14.9,
+              "tier": "blazing"
+            },
+            "create date from ISO string": {
+              "name": "create date from ISO string",
+              "hz": 1731270,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005776104990777591,
+              "meanLabel": "578ns",
+              "rme": 19.2,
+              "tier": "blazing"
+            },
+            "create date from timestamp": {
+              "name": "create date from timestamp",
+              "hz": 748889,
+              "hzLabel": "748.9k ops/s",
+              "mean": 0.001335310814643921,
+              "meanLabel": "1.3μs",
+              "rme": 11.6,
+              "tier": "blazing"
+            },
+            "create 1000 dates": {
+              "name": "create 1000 dates",
+              "hz": 2014,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.49641095039595035,
+              "meanLabel": "496.4μs",
+              "rme": 20.6,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "create date from ISO string",
+              "hz": 1731270,
+              "hzLabel": "1.7M ops/s",
+              "mean": 0.0005776104990777591,
+              "meanLabel": "578ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "create 1000 dates",
+              "hz": 2014,
+              "hzLabel": "2.0k ops/s",
+              "mean": 0.49641095039595035,
+              "meanLabel": "496.4μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "formatting": {
+            "format fullDate": {
+              "name": "format fullDate",
+              "hz": 477165,
+              "hzLabel": "477.2k ops/s",
+              "mean": 0.0020957101847389305,
+              "meanLabel": "2.1μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format shortDate": {
+              "name": "format shortDate",
+              "hz": 457729,
+              "hzLabel": "457.7k ops/s",
+              "mean": 0.0021846990408226517,
+              "meanLabel": "2.2μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "format 1000 dates": {
+              "name": "format 1000 dates",
+              "hz": 500,
+              "hzLabel": "500 ops/s",
+              "mean": 2.0018432759984863,
+              "meanLabel": "2.00ms",
+              "rme": 5.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "format fullDate",
+              "hz": 477165,
+              "hzLabel": "477.2k ops/s",
+              "mean": 0.0020957101847389305,
+              "meanLabel": "2.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "format 1000 dates",
+              "hz": 500,
+              "hzLabel": "500 ops/s",
+              "mean": 2.0018432759984863,
+              "meanLabel": "2.00ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "navigation": {
+            "startOfDay": {
+              "name": "startOfDay",
+              "hz": 1095022,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009132237580877341,
+              "meanLabel": "913ns",
+              "rme": 10.1,
+              "tier": "blazing"
+            },
+            "startOfWeek": {
+              "name": "startOfWeek",
+              "hz": 521451,
+              "hzLabel": "521.5k ops/s",
+              "mean": 0.0019177267552424112,
+              "meanLabel": "1.9μs",
+              "rme": 19.4,
+              "tier": "blazing"
+            },
+            "startOfMonth": {
+              "name": "startOfMonth",
+              "hz": 589483,
+              "hzLabel": "589.5k ops/s",
+              "mean": 0.001696402623284408,
+              "meanLabel": "1.7μs",
+              "rme": 16,
+              "tier": "blazing"
+            },
+            "getWeekArray": {
+              "name": "getWeekArray",
+              "hz": 18261,
+              "hzLabel": "18.3k ops/s",
+              "mean": 0.05476176979513846,
+              "meanLabel": "54.8μs",
+              "rme": 33.5,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "startOfDay",
+              "hz": 1095022,
+              "hzLabel": "1.1M ops/s",
+              "mean": 0.0009132237580877341,
+              "meanLabel": "913ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "getWeekArray",
+              "hz": 18261,
+              "hzLabel": "18.3k ops/s",
+              "mean": 0.05476176979513846,
+              "meanLabel": "54.8μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "arithmetic": {
+            "addDays": {
+              "name": "addDays",
+              "hz": 900429,
+              "hzLabel": "900.4k ops/s",
+              "mean": 0.0011105817376322045,
+              "meanLabel": "1.1μs",
+              "rme": 21.5,
+              "tier": "blazing"
+            },
+            "addMonths": {
+              "name": "addMonths",
+              "hz": 787225,
+              "hzLabel": "787.2k ops/s",
+              "mean": 0.0012702842613992466,
+              "meanLabel": "1.3μs",
+              "rme": 29.1,
+              "tier": "blazing"
+            },
+            "chain 10 additions": {
+              "name": "chain 10 additions",
+              "hz": 94968,
+              "hzLabel": "95.0k ops/s",
+              "mean": 0.010529891500150134,
+              "meanLabel": "10.5μs",
+              "rme": 38.3,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "addDays",
+              "hz": 900429,
+              "hzLabel": "900.4k ops/s",
+              "mean": 0.0011105817376322045,
+              "meanLabel": "1.1μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "chain 10 additions",
+              "hz": 94968,
+              "hzLabel": "95.0k ops/s",
+              "mean": 0.010529891500150134,
+              "meanLabel": "10.5μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          },
+          "comparison": {
+            "isAfter": {
+              "name": "isAfter",
+              "hz": 1518449,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006585668477513382,
+              "meanLabel": "659ns",
+              "rme": 29.8,
+              "tier": "blazing"
+            },
+            "isSameDay": {
+              "name": "isSameDay",
+              "hz": 746775,
+              "hzLabel": "746.8k ops/s",
+              "mean": 0.0013390918320758402,
+              "meanLabel": "1.3μs",
+              "rme": 40,
+              "tier": "blazing"
+            },
+            "compare 1000 pairs": {
+              "name": "compare 1000 pairs",
+              "hz": 1416,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7063283149718956,
+              "meanLabel": "706.3μs",
+              "rme": 58.4,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "isAfter",
+              "hz": 1518449,
+              "hzLabel": "1.5M ops/s",
+              "mean": 0.0006585668477513382,
+              "meanLabel": "659ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "compare 1000 pairs",
+              "hz": 1416,
+              "hzLabel": "1.4k ops/s",
+              "mean": 0.7063283149718956,
+              "meanLabel": "706.3μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "getters/setters": {
+            "get components": {
+              "name": "get components",
+              "hz": 6201935,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016124001153140964,
+              "meanLabel": "161ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "set components": {
+              "name": "set components",
+              "hz": 403045,
+              "hzLabel": "403.0k ops/s",
+              "mean": 0.0024811138530304597,
+              "meanLabel": "2.5μs",
+              "rme": 19.3,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "get components",
+              "hz": 6201935,
+              "hzLabel": "6.2M ops/s",
+              "mean": 0.00016124001153140964,
+              "meanLabel": "161ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "set components",
+              "hz": 403045,
+              "hzLabel": "403.0k ops/s",
+              "mean": 0.0024811138530304597,
+              "meanLabel": "2.5μs",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "locale switching": {
+            "locale change + reformat": {
+              "name": "locale change + reformat",
+              "hz": 19694,
+              "hzLabel": "19.7k ops/s",
+              "mean": 0.050777181070563726,
+              "meanLabel": "50.8μs",
+              "rme": 1.7,
+              "tier": "fast"
+            },
+            "toggle locale 10 times": {
+              "name": "toggle locale 10 times",
+              "hz": 1541,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6490660868990525,
+              "meanLabel": "649.1μs",
+              "rme": 0.3,
+              "tier": "fast"
+            },
+            "cache eviction (60 unique formats)": {
+              "name": "cache eviction (60 unique formats)",
+              "hz": 14939,
+              "hzLabel": "14.9k ops/s",
+              "mean": 0.06694023895574237,
+              "meanLabel": "66.9μs",
+              "rme": 0.2,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "locale change + reformat",
+              "hz": 19694,
+              "hzLabel": "19.7k ops/s",
+              "mean": 0.050777181070563726,
+              "meanLabel": "50.8μs",
+              "tier": "fast"
+            },
+            "_slowest": {
+              "name": "toggle locale 10 times",
+              "hz": 1541,
+              "hzLabel": "1.5k ops/s",
+              "mean": 0.6490660868990525,
+              "meanLabel": "649.1μs",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          }
+        },
+        "create date from null (now)": {
+          "name": "create date from null (now)",
+          "hz": 643517,
+          "hzLabel": "643.5k ops/s",
+          "mean": 0.001553959867436115,
+          "meanLabel": "1.6μs",
+          "rme": 14.9,
+          "tier": "blazing"
+        },
+        "create date from ISO string": {
+          "name": "create date from ISO string",
+          "hz": 1731270,
+          "hzLabel": "1.7M ops/s",
+          "mean": 0.0005776104990777591,
+          "meanLabel": "578ns",
+          "rme": 19.2,
+          "tier": "blazing"
+        },
+        "create date from timestamp": {
+          "name": "create date from timestamp",
+          "hz": 748889,
+          "hzLabel": "748.9k ops/s",
+          "mean": 0.001335310814643921,
+          "meanLabel": "1.3μs",
+          "rme": 11.6,
+          "tier": "blazing"
+        },
+        "create 1000 dates": {
+          "name": "create 1000 dates",
+          "hz": 2014,
+          "hzLabel": "2.0k ops/s",
+          "mean": 0.49641095039595035,
+          "meanLabel": "496.4μs",
+          "rme": 20.6,
+          "tier": "blazing"
+        },
+        "format fullDate": {
+          "name": "format fullDate",
+          "hz": 477165,
+          "hzLabel": "477.2k ops/s",
+          "mean": 0.0020957101847389305,
+          "meanLabel": "2.1μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format shortDate": {
+          "name": "format shortDate",
+          "hz": 457729,
+          "hzLabel": "457.7k ops/s",
+          "mean": 0.0021846990408226517,
+          "meanLabel": "2.2μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "format 1000 dates": {
+          "name": "format 1000 dates",
+          "hz": 500,
+          "hzLabel": "500 ops/s",
+          "mean": 2.0018432759984863,
+          "meanLabel": "2.00ms",
+          "rme": 5.2,
+          "tier": "fast"
+        },
+        "startOfDay": {
+          "name": "startOfDay",
+          "hz": 1095022,
+          "hzLabel": "1.1M ops/s",
+          "mean": 0.0009132237580877341,
+          "meanLabel": "913ns",
+          "rme": 10.1,
+          "tier": "blazing"
+        },
+        "startOfWeek": {
+          "name": "startOfWeek",
+          "hz": 521451,
+          "hzLabel": "521.5k ops/s",
+          "mean": 0.0019177267552424112,
+          "meanLabel": "1.9μs",
+          "rme": 19.4,
+          "tier": "blazing"
+        },
+        "startOfMonth": {
+          "name": "startOfMonth",
+          "hz": 589483,
+          "hzLabel": "589.5k ops/s",
+          "mean": 0.001696402623284408,
+          "meanLabel": "1.7μs",
+          "rme": 16,
+          "tier": "blazing"
+        },
+        "getWeekArray": {
+          "name": "getWeekArray",
+          "hz": 18261,
+          "hzLabel": "18.3k ops/s",
+          "mean": 0.05476176979513846,
+          "meanLabel": "54.8μs",
+          "rme": 33.5,
+          "tier": "fast"
+        },
+        "addDays": {
+          "name": "addDays",
+          "hz": 900429,
+          "hzLabel": "900.4k ops/s",
+          "mean": 0.0011105817376322045,
+          "meanLabel": "1.1μs",
+          "rme": 21.5,
+          "tier": "blazing"
+        },
+        "addMonths": {
+          "name": "addMonths",
+          "hz": 787225,
+          "hzLabel": "787.2k ops/s",
+          "mean": 0.0012702842613992466,
+          "meanLabel": "1.3μs",
+          "rme": 29.1,
+          "tier": "blazing"
+        },
+        "chain 10 additions": {
+          "name": "chain 10 additions",
+          "hz": 94968,
+          "hzLabel": "95.0k ops/s",
+          "mean": 0.010529891500150134,
+          "meanLabel": "10.5μs",
+          "rme": 38.3,
+          "tier": "fast"
+        },
+        "isAfter": {
+          "name": "isAfter",
+          "hz": 1518449,
+          "hzLabel": "1.5M ops/s",
+          "mean": 0.0006585668477513382,
+          "meanLabel": "659ns",
+          "rme": 29.8,
+          "tier": "blazing"
+        },
+        "isSameDay": {
+          "name": "isSameDay",
+          "hz": 746775,
+          "hzLabel": "746.8k ops/s",
+          "mean": 0.0013390918320758402,
+          "meanLabel": "1.3μs",
+          "rme": 40,
+          "tier": "blazing"
+        },
+        "compare 1000 pairs": {
+          "name": "compare 1000 pairs",
+          "hz": 1416,
+          "hzLabel": "1.4k ops/s",
+          "mean": 0.7063283149718956,
+          "meanLabel": "706.3μs",
+          "rme": 58.4,
+          "tier": "blazing"
+        },
+        "get components": {
+          "name": "get components",
+          "hz": 6201935,
+          "hzLabel": "6.2M ops/s",
+          "mean": 0.00016124001153140964,
+          "meanLabel": "161ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "set components": {
+          "name": "set components",
+          "hz": 403045,
+          "hzLabel": "403.0k ops/s",
+          "mean": 0.0024811138530304597,
+          "meanLabel": "2.5μs",
+          "rme": 19.3,
+          "tier": "blazing"
+        },
+        "locale change + reformat": {
+          "name": "locale change + reformat",
+          "hz": 19694,
+          "hzLabel": "19.7k ops/s",
+          "mean": 0.050777181070563726,
+          "meanLabel": "50.8μs",
+          "rme": 1.7,
+          "tier": "fast"
+        },
+        "toggle locale 10 times": {
+          "name": "toggle locale 10 times",
+          "hz": 1541,
+          "hzLabel": "1.5k ops/s",
+          "mean": 0.6490660868990525,
+          "meanLabel": "649.1μs",
+          "rme": 0.3,
+          "tier": "fast"
+        },
+        "cache eviction (60 unique formats)": {
+          "name": "cache eviction (60 unique formats)",
+          "hz": 14939,
+          "hzLabel": "14.9k ops/s",
+          "mean": 0.06694023895574237,
+          "meanLabel": "66.9μs",
+          "rme": 0.2,
+          "tier": "fast"
+        },
+        "_fastest": {
+          "name": "get components",
+          "hz": 6201935,
+          "hzLabel": "6.2M ops/s",
+          "mean": 0.00016124001153140964,
+          "meanLabel": "161ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "format 1000 dates",
+          "hz": 500,
+          "hzLabel": "500 ops/s",
+          "mean": 2.0018432759984863,
+          "meanLabel": "2.00ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    },
+    "useProxyRegistry": {
+      "benchmarks": {
+        "_groups": {
+          "initialization": {
+            "Create empty proxy": {
+              "name": "Create empty proxy",
+              "hz": 113762,
+              "hzLabel": "113.8k ops/s",
+              "mean": 0.008790314779997569,
+              "meanLabel": "8.8μs",
+              "rme": 14.6,
+              "tier": "blazing"
+            },
+            "Create proxy (1,000 items)": {
+              "name": "Create proxy (1,000 items)",
+              "hz": 1150,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.8696209565235261,
+              "meanLabel": "869.6μs",
+              "rme": 5.8,
+              "tier": "blazing"
+            },
+            "Create proxy (10,000 items)": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.728466980769344,
+              "meanLabel": "9.73ms",
+              "rme": 5.9,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Create empty proxy",
+              "hz": 113762,
+              "hzLabel": "113.8k ops/s",
+              "mean": 0.008790314779997569,
+              "meanLabel": "8.8μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Create proxy (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.728466980769344,
+              "meanLabel": "9.73ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "computed access": {
+            "registry.keys() (1,000 items)": {
+              "name": "registry.keys() (1,000 items)",
+              "hz": 7894870,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012666452933933362,
+              "meanLabel": "127ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.keys (1,000 items)": {
+              "name": "proxy.keys (1,000 items)",
+              "hz": 3209041,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.0003116195861311173,
+              "meanLabel": "312ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.keys() (10,000 items)": {
+              "name": "registry.keys() (10,000 items)",
+              "hz": 7795398,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012828081409489318,
+              "meanLabel": "128ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.keys (10,000 items)": {
+              "name": "proxy.keys (10,000 items)",
+              "hz": 3206979,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031181990593728316,
+              "meanLabel": "312ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.values() (1,000 items)": {
+              "name": "registry.values() (1,000 items)",
+              "hz": 7839487,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012755937325698846,
+              "meanLabel": "128ns",
+              "rme": 0.4,
+              "tier": "blazing"
+            },
+            "proxy.values (1,000 items)": {
+              "name": "proxy.values (1,000 items)",
+              "hz": 3156705,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.0003167860205874435,
+              "meanLabel": "317ns",
+              "rme": 0.2,
+              "tier": "blazing"
+            },
+            "registry.values() (10,000 items)": {
+              "name": "registry.values() (10,000 items)",
+              "hz": 7826733,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.0001277672275755082,
+              "meanLabel": "128ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.values (10,000 items)": {
+              "name": "proxy.values (10,000 items)",
+              "hz": 3164659,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.0003159897954504943,
+              "meanLabel": "316ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.entries() (1,000 items)": {
+              "name": "registry.entries() (1,000 items)",
+              "hz": 7863956,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012716245916616516,
+              "meanLabel": "127ns",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "proxy.entries (1,000 items)": {
+              "name": "proxy.entries (1,000 items)",
+              "hz": 3162077,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031624785285319775,
+              "meanLabel": "316ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "registry.entries() (10,000 items)": {
+              "name": "registry.entries() (10,000 items)",
+              "hz": 7840850,
+              "hzLabel": "7.8M ops/s",
+              "mean": 0.00012753719355165812,
+              "meanLabel": "128ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "proxy.entries (10,000 items)": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 3103853,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.00032218017601959656,
+              "meanLabel": "322ns",
+              "rme": 0,
+              "tier": "blazing"
+            },
+            "proxy.size (1,000 items)": {
+              "name": "proxy.size (1,000 items)",
+              "hz": 3212889,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.00031124634269382015,
+              "meanLabel": "311ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "proxy.size (10,000 items)": {
+              "name": "proxy.size (10,000 items)",
+              "hz": 3215461,
+              "hzLabel": "3.2M ops/s",
+              "mean": 0.0003109974032020061,
+              "meanLabel": "311ns",
+              "rme": 0.1,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "registry.keys() (1,000 items)",
+              "hz": 7894870,
+              "hzLabel": "7.9M ops/s",
+              "mean": 0.00012666452933933362,
+              "meanLabel": "127ns",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "proxy.entries (10,000 items)",
+              "hz": 3103853,
+              "hzLabel": "3.1M ops/s",
+              "mean": 0.00032218017601959656,
+              "meanLabel": "322ns",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "mutation operations": {
+            "Register single item (1,000 items)": {
+              "name": "Register single item (1,000 items)",
+              "hz": 130975,
+              "hzLabel": "131.0k ops/s",
+              "mean": 0.00763503504447841,
+              "meanLabel": "7.6μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Register single item (10,000 items)": {
+              "name": "Register single item (10,000 items)",
+              "hz": 21568,
+              "hzLabel": "21.6k ops/s",
+              "mean": 0.04636544756578691,
+              "meanLabel": "46.4μs",
+              "rme": 1.1,
+              "tier": "blazing"
+            },
+            "Unregister single item (1,000 items)": {
+              "name": "Unregister single item (1,000 items)",
+              "hz": 1104,
+              "hzLabel": "1.1k ops/s",
+              "mean": 0.9056775406874323,
+              "meanLabel": "905.7μs",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "Unregister single item (10,000 items)": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.710773730773676,
+              "meanLabel": "9.71ms",
+              "rme": 4.3,
+              "tier": "blazing"
+            },
+            "Upsert single item (1,000 items)": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 572938,
+              "hzLabel": "572.9k ops/s",
+              "mean": 0.0017453891158187948,
+              "meanLabel": "1.7μs",
+              "rme": 0.3,
+              "tier": "blazing"
+            },
+            "Upsert single item (10,000 items)": {
+              "name": "Upsert single item (10,000 items)",
+              "hz": 47835,
+              "hzLabel": "47.8k ops/s",
+              "mean": 0.02090526585549861,
+              "meanLabel": "20.9μs",
+              "rme": 0.7,
+              "tier": "blazing"
+            },
+            "_fastest": {
+              "name": "Upsert single item (1,000 items)",
+              "hz": 572938,
+              "hzLabel": "572.9k ops/s",
+              "mean": 0.0017453891158187948,
+              "meanLabel": "1.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Unregister single item (10,000 items)",
+              "hz": 103,
+              "hzLabel": "103 ops/s",
+              "mean": 9.710773730773676,
+              "meanLabel": "9.71ms",
+              "tier": "blazing"
+            },
+            "_tier": "blazing"
+          },
+          "bulk registration": {
+            "Onboard 1,000 items (proxy attached)": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1021,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9797352407040593,
+              "meanLabel": "979.7μs",
+              "rme": 3.4,
+              "tier": "blazing"
+            },
+            "Onboard 10,000 items (proxy attached)": {
+              "name": "Onboard 10,000 items (proxy attached)",
+              "hz": 92,
+              "hzLabel": "92 ops/s",
+              "mean": 10.826294829786576,
+              "meanLabel": "10.83ms",
+              "rme": 2.9,
+              "tier": "fast"
+            },
+            "Register 1,000 items one-by-one (proxy attached)": {
+              "name": "Register 1,000 items one-by-one (proxy attached)",
+              "hz": 913,
+              "hzLabel": "913 ops/s",
+              "mean": 1.0953415120350394,
+              "meanLabel": "1.10ms",
+              "rme": 2.6,
+              "tier": "fast"
+            },
+            "Register 10,000 items one-by-one (proxy attached)": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 82,
+              "hzLabel": "82 ops/s",
+              "mean": 12.211152999995493,
+              "meanLabel": "12.21ms",
+              "rme": 4.8,
+              "tier": "fast"
+            },
+            "_fastest": {
+              "name": "Onboard 1,000 items (proxy attached)",
+              "hz": 1021,
+              "hzLabel": "1.0k ops/s",
+              "mean": 0.9797352407040593,
+              "meanLabel": "979.7μs",
+              "tier": "blazing"
+            },
+            "_slowest": {
+              "name": "Register 10,000 items one-by-one (proxy attached)",
+              "hz": 82,
+              "hzLabel": "82 ops/s",
+              "mean": 12.211152999995493,
+              "meanLabel": "12.21ms",
+              "tier": "fast"
+            },
+            "_tier": "fast"
+          }
+        },
+        "Create empty proxy": {
+          "name": "Create empty proxy",
+          "hz": 113762,
+          "hzLabel": "113.8k ops/s",
+          "mean": 0.008790314779997569,
+          "meanLabel": "8.8μs",
+          "rme": 14.6,
+          "tier": "blazing"
+        },
+        "Create proxy (1,000 items)": {
+          "name": "Create proxy (1,000 items)",
+          "hz": 1150,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.8696209565235261,
+          "meanLabel": "869.6μs",
+          "rme": 5.8,
+          "tier": "blazing"
+        },
+        "Create proxy (10,000 items)": {
+          "name": "Create proxy (10,000 items)",
+          "hz": 103,
+          "hzLabel": "103 ops/s",
+          "mean": 9.728466980769344,
+          "meanLabel": "9.73ms",
+          "rme": 5.9,
+          "tier": "blazing"
+        },
+        "registry.keys() (1,000 items)": {
+          "name": "registry.keys() (1,000 items)",
+          "hz": 7894870,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012666452933933362,
+          "meanLabel": "127ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.keys (1,000 items)": {
+          "name": "proxy.keys (1,000 items)",
+          "hz": 3209041,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.0003116195861311173,
+          "meanLabel": "312ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.keys() (10,000 items)": {
+          "name": "registry.keys() (10,000 items)",
+          "hz": 7795398,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012828081409489318,
+          "meanLabel": "128ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.keys (10,000 items)": {
+          "name": "proxy.keys (10,000 items)",
+          "hz": 3206979,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031181990593728316,
+          "meanLabel": "312ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.values() (1,000 items)": {
+          "name": "registry.values() (1,000 items)",
+          "hz": 7839487,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012755937325698846,
+          "meanLabel": "128ns",
+          "rme": 0.4,
+          "tier": "blazing"
+        },
+        "proxy.values (1,000 items)": {
+          "name": "proxy.values (1,000 items)",
+          "hz": 3156705,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.0003167860205874435,
+          "meanLabel": "317ns",
+          "rme": 0.2,
+          "tier": "blazing"
+        },
+        "registry.values() (10,000 items)": {
+          "name": "registry.values() (10,000 items)",
+          "hz": 7826733,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.0001277672275755082,
+          "meanLabel": "128ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.values (10,000 items)": {
+          "name": "proxy.values (10,000 items)",
+          "hz": 3164659,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.0003159897954504943,
+          "meanLabel": "316ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.entries() (1,000 items)": {
+          "name": "registry.entries() (1,000 items)",
+          "hz": 7863956,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012716245916616516,
+          "meanLabel": "127ns",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "proxy.entries (1,000 items)": {
+          "name": "proxy.entries (1,000 items)",
+          "hz": 3162077,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031624785285319775,
+          "meanLabel": "316ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "registry.entries() (10,000 items)": {
+          "name": "registry.entries() (10,000 items)",
+          "hz": 7840850,
+          "hzLabel": "7.8M ops/s",
+          "mean": 0.00012753719355165812,
+          "meanLabel": "128ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "proxy.entries (10,000 items)": {
+          "name": "proxy.entries (10,000 items)",
+          "hz": 3103853,
+          "hzLabel": "3.1M ops/s",
+          "mean": 0.00032218017601959656,
+          "meanLabel": "322ns",
+          "rme": 0,
+          "tier": "blazing"
+        },
+        "proxy.size (1,000 items)": {
+          "name": "proxy.size (1,000 items)",
+          "hz": 3212889,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.00031124634269382015,
+          "meanLabel": "311ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "proxy.size (10,000 items)": {
+          "name": "proxy.size (10,000 items)",
+          "hz": 3215461,
+          "hzLabel": "3.2M ops/s",
+          "mean": 0.0003109974032020061,
+          "meanLabel": "311ns",
+          "rme": 0.1,
+          "tier": "blazing"
+        },
+        "Register single item (1,000 items)": {
+          "name": "Register single item (1,000 items)",
+          "hz": 130975,
+          "hzLabel": "131.0k ops/s",
+          "mean": 0.00763503504447841,
+          "meanLabel": "7.6μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Register single item (10,000 items)": {
+          "name": "Register single item (10,000 items)",
+          "hz": 21568,
+          "hzLabel": "21.6k ops/s",
+          "mean": 0.04636544756578691,
+          "meanLabel": "46.4μs",
+          "rme": 1.1,
+          "tier": "blazing"
+        },
+        "Unregister single item (1,000 items)": {
+          "name": "Unregister single item (1,000 items)",
+          "hz": 1104,
+          "hzLabel": "1.1k ops/s",
+          "mean": 0.9056775406874323,
+          "meanLabel": "905.7μs",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "Unregister single item (10,000 items)": {
+          "name": "Unregister single item (10,000 items)",
+          "hz": 103,
+          "hzLabel": "103 ops/s",
+          "mean": 9.710773730773676,
+          "meanLabel": "9.71ms",
+          "rme": 4.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (1,000 items)": {
+          "name": "Upsert single item (1,000 items)",
+          "hz": 572938,
+          "hzLabel": "572.9k ops/s",
+          "mean": 0.0017453891158187948,
+          "meanLabel": "1.7μs",
+          "rme": 0.3,
+          "tier": "blazing"
+        },
+        "Upsert single item (10,000 items)": {
+          "name": "Upsert single item (10,000 items)",
+          "hz": 47835,
+          "hzLabel": "47.8k ops/s",
+          "mean": 0.02090526585549861,
+          "meanLabel": "20.9μs",
+          "rme": 0.7,
+          "tier": "blazing"
+        },
+        "Onboard 1,000 items (proxy attached)": {
+          "name": "Onboard 1,000 items (proxy attached)",
+          "hz": 1021,
+          "hzLabel": "1.0k ops/s",
+          "mean": 0.9797352407040593,
+          "meanLabel": "979.7μs",
+          "rme": 3.4,
+          "tier": "blazing"
+        },
+        "Onboard 10,000 items (proxy attached)": {
+          "name": "Onboard 10,000 items (proxy attached)",
+          "hz": 92,
+          "hzLabel": "92 ops/s",
+          "mean": 10.826294829786576,
+          "meanLabel": "10.83ms",
+          "rme": 2.9,
+          "tier": "fast"
+        },
+        "Register 1,000 items one-by-one (proxy attached)": {
+          "name": "Register 1,000 items one-by-one (proxy attached)",
+          "hz": 913,
+          "hzLabel": "913 ops/s",
+          "mean": 1.0953415120350394,
+          "meanLabel": "1.10ms",
+          "rme": 2.6,
+          "tier": "fast"
+        },
+        "Register 10,000 items one-by-one (proxy attached)": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 82,
+          "hzLabel": "82 ops/s",
+          "mean": 12.211152999995493,
+          "meanLabel": "12.21ms",
+          "rme": 4.8,
+          "tier": "fast"
+        },
+        "_fastest": {
+          "name": "registry.keys() (1,000 items)",
+          "hz": 7894870,
+          "hzLabel": "7.9M ops/s",
+          "mean": 0.00012666452933933362,
+          "meanLabel": "127ns",
+          "tier": "blazing"
+        },
+        "_slowest": {
+          "name": "Register 10,000 items one-by-one (proxy attached)",
+          "hz": 82,
+          "hzLabel": "82 ops/s",
+          "mean": 12.211152999995493,
+          "meanLabel": "12.21ms",
+          "tier": "fast"
+        },
+        "_tier": "fast"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add missing @vuetify/v0@1.2.1 metrics history snapshot (apps/docs/src/data/metrics/1.2.1.json)
- Generated on Archbox reference host only via metrics:history --only 1.2.1
- metrics:check passed; live benchmarks.json unchanged

Host: i9-7980XE / node v26.0.0 / governor=performance / busy~0.1%. Not measured on GHA or laptop.

## Test plan
- [ ] Confirm apps/docs/src/data/metrics/1.2.1.json is present and parses
- [ ] Confirm metrics:check / generate-metrics-history --print-missing reports no missing versions
- [ ] Confirm benchmarks.json was not rewritten by this PR
