### PR TITLE
docs: fix Node version requirement from 22+ to 26+

### DIFF
--- a/apps/docs/src/pages/introduction/frequently-asked.md
+++ b/apps/docs/src/pages/introduction/frequently-asked.md
@@ -60,7 +60,7 @@ Yes. Create a Nuxt plugin that registers v0 plugins, add `@vuetify/v0` to `build
 
 ??? What version of Vue is required?
 
-Vue 3.5.0 or higher. Vuetify0 uses modern Vue features like `useId()` and improved reactivity that require Vue 3.5+. Node 26+ is required for development.
+Vue 3.5.0 or higher. Vuetify0 uses modern Vue features like `useId()` and improved reactivity that require Vue 3.5+. Node 22+ is recommended for application development. Contributing to Vuetify0 requires Node 26+.
 
 ??? Is Vuetify0 tree-shakeable?
 

--- a/apps/docs/src/pages/introduction/frequently-asked.md
+++ b/apps/docs/src/pages/introduction/frequently-asked.md
@@ -60,7 +60,7 @@ Yes. Create a Nuxt plugin that registers v0 plugins, add `@vuetify/v0` to `build
 
 ??? What version of Vue is required?
 
-Vue 3.5.0 or higher. Vuetify0 uses modern Vue features like `useId()` and improved reactivity that require Vue 3.5+. Node 22+ is recommended for development.
+Vue 3.5.0 or higher. Vuetify0 uses modern Vue features like `useId()` and improved reactivity that require Vue 3.5+. Node 26+ is required for development.
 
 ??? Is Vuetify0 tree-shakeable?
 

--- a/apps/docs/src/pages/introduction/getting-started.md
+++ b/apps/docs/src/pages/introduction/getting-started.md
@@ -221,7 +221,7 @@ The CLI writes example files into your project, installs any missing dependencie
 ## Requirements
 
 - Vue 3.5.0 or higher
-- Node 22+
+- Node 26+
 
 ## Usage
 

--- a/apps/docs/src/pages/introduction/getting-started.md
+++ b/apps/docs/src/pages/introduction/getting-started.md
@@ -221,7 +221,7 @@ The CLI writes example files into your project, installs any missing dependencie
 ## Requirements
 
 - Vue 3.5.0 or higher
-- Node 26+
+- Node 22+ recommended for app tooling. Developing Vuetify0 itself requires Node 26+ (see [Contributing](/introduction/contributing)).
 
 ## Usage
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a factual error in the documentation where the Node.js version requirement was incorrectly stated as "Node 22+" when the actual requirement is "Node 26+".

**Evidence:**
- `.nvmrc` specifies `26.0.0`
- `packages/0/README.md` states "Node.js >= 26"
- Documentation pages incorrectly stated "Node 22+"

**Files changed:**
- `apps/docs/src/pages/introduction/getting-started.md` - Requirements section
- `apps/docs/src/pages/introduction/frequently-asked.md` - Vue version FAQ answer

## Test plan

1. Verify the documentation pages render correctly
2. Confirm the Node version requirement matches `.nvmrc` and README
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ae55a4c-38e9-4669-9163-b1a590077813?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ae55a4c-38e9-4669-9163-b1a590077813&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

