### PR TITLE
fix: drop theme color apply, track filter keys, align philosophy

### DIFF
--- a/.changeset/filter-keys-reactive.md
+++ b/.changeset/filter-keys-reactive.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(createFilter): track reactive `keys`
+
+`keys` now accepts a ref or getter (`MaybeRefOrGetter<readonly string[]>`), so changing which fields are searched re-runs the filter. Passing a plain `string[]` is unchanged.

--- a/.changeset/theme-adapter-no-color.md
+++ b/.changeset/theme-adapter-no-color.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(useTheme): stop emitting element-level color on `[data-theme]`
+
+`ThemeAdapter.generate()` still writes custom properties and `:root { color-scheme }`. It no longer sets `color: var(--*-on-background)` on the theme selector — applying tokens is Paper's job. Unstyled hosts that relied on that inherited `color` need to set it themselves.

--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -162,7 +162,9 @@ const {
 
 **Never re-declare inherited `AtomProps`** (`as`, `renderless`). [intent:166]
 
-## Slot Props Pattern (100% enforced)
+## Slot Props Pattern (interactive controls)
+
+Interactive controls follow this shape. Structural / passthrough slots (AvatarRoot chrome, SelectPlaceholder, ComboboxDescription) may bind a single field without an `attrs` object — PHILOSOPHY §3.5.
 
 ```ts
 export interface ComponentRootSlotProps {
@@ -192,8 +194,8 @@ const slotProps = toRef((): ComponentRootSlotProps => ({
 
 - Boolean state named `is<State>` (isDisabled, isSelected, isOpen). [intent:167]
 - `attrs` object includes ARIA + data + handlers. [intent:168]
-- Always computed via `toRef`. [intent:169]
-- Template always uses `<slot v-bind="slotProps" />`. [intent:170]
+- Computed via `toRef` on the control path. [intent:169]
+- Interactive controls use `<slot v-bind="slotProps" />`; structural slots may bind a single field. [intent:170]
 
 ## Data Attribute Pattern (100% enforced)
 
@@ -210,11 +212,13 @@ const slotProps = toRef((): ComponentRootSlotProps => ({
 
 ## ARIA Pattern (WAI-ARIA compliant)
 
-Every interactive component ships a correct `role`, `aria-*` state attributes, keyboard handlers, and locale-driven strings via `useLocale()` (canonical: `locale.ti(key) ?? '<English default>'`). `aria-disabled` is always concrete `boolean` (not `true | undefined`). Tests assert `toBeDefined()` on the locale strings, not exact values. [intent:174, intent:175, intent:176, intent:177]
+Every interactive component ships a correct `role`, `aria-*` state attributes, keyboard handlers, and locale-driven strings via `useLocale()` (canonical: `locale.ti(key) ?? '<English default>'`). `aria-disabled` is a concrete `boolean` on non-button hosts; native `<button>` uses the `disabled` attribute and omits `aria-disabled`. Translatable copy goes through `useLocale`; ARIA role tokens (`aria-roledescription: 'carousel'`) stay as spec strings — PHILOSOPHY §5.5. Tests assert `toBeDefined()` on locale strings, not exact values. [intent:174, intent:175, intent:176, intent:177]
 
 The full ARIA vocabulary, WCAG success-criterion mapping, and worked precedents live under [WCAG Accessibility — how we apply the patterns](#wcag-accessibility--how-we-apply-the-patterns) below. Don't restate the table here.
 
 ## Disabled Pattern (three-pronged, 100% enforced)
+
+Non-button hosts (`as !== 'button'`):
 
 ```ts
 attrs: {
@@ -224,7 +228,7 @@ attrs: {
 }
 ```
 
-[intent:178]
+Native `<button>` (`as === 'button'`): `disabled` attribute, omit `aria-disabled`, keep `data-disabled` + `tabindex`. [intent:178]
 
 ## Hidden Input Pattern (PHILOSOPHY §5.4)
 
@@ -283,6 +287,7 @@ attrs: {
 ```
 
 - **Do not** attach Enter/Space `onKeydown` when `as === 'button'` (avoids double-activation).
+- Native `<button>` uses `disabled` and omits `aria-disabled`; the polyfill path (`as !== 'button'`) emits concrete `aria-disabled`.
 - Specialized roles (`checkbox`, `radio`, `switch`, `tab`, `combobox`) keep their own APG — do not force `role="button"`.
 - Spinbutton steppers that intentionally use `tabindex: -1` (NumberField ±) are out of this contract.
 
@@ -365,8 +370,8 @@ A wrapper that supplies shared defaults or context to a compound family's Roots 
 
 ## Template Pattern (100% enforced)
 
-- DOM-rendering Roots use `<Atom :as :renderless>`; pure context-provider Roots (`Group`, `Selection`, `Single`, `Step`, `Tabs`, `Treeview`) render only `<slot v-bind="slotProps" />` with no `Atom`. [intent:186, intent:336] (PHILOSOPHY §5.3)
-- Slot props via `<slot v-bind="slotProps" />`.
+- DOM-rendering Roots use `<Atom :as :renderless>`; pure context-provider Roots (`Group`, `Selection`, `Single`, `Step`, `Tabs`, `Treeview`, plus DataGrid/DataTable/Portal/Presence) render only `<slot v-bind="slotProps" />` with no `Atom`. Overlay context Roots (`AlertDialog`, `Combobox`, `Dialog`, `Popover`, `Select`, `Tooltip`) wrap a renderless Atom. `Locale` is a dual-mode provider (wrapper or renderless slot), not slot-only. [intent:186, intent:336] (PHILOSOPHY §5.3)
+- Slot props via `<slot v-bind="slotProps" />` on interactive controls; structural slots may bind a single field (PHILOSOPHY §3.5).
 - Hidden inputs conditionally rendered: `<ComponentHiddenInput v-if="name" />`. [intent:187]
 - `v-if` for structural conditionals; `v-show` only when the element must stay mounted to preserve state. [intent:188]
   - **Registry-driven visibility** — child registered with a Root for measurement or selection (Breadcrumbs item/divider/ellipsis, Overflow item).
@@ -469,7 +474,7 @@ PHILOSOPHY §5.5 mandates that every interactive component ships correct `role`,
 | Attribute | Purpose | Value shape | Example |
 |-----------|---------|-------------|---------|
 | `role` | Semantic role | WAI-ARIA 1.2 role name | `role="combobox"`, `role="alertdialog"` |
-| `aria-disabled` | Announce disabled state | `boolean` (always concrete) | `'aria-disabled': isDisabled.value` [intent:175] |
+| `aria-disabled` | Announce disabled state | `boolean` on non-button hosts; omit on native `<button>` (use `disabled`) | `'aria-disabled': isDisabled.value` [intent:175] |
 | `aria-selected` | Announce selection | `boolean` | Item in a listbox/tablist |
 | `aria-expanded` | Announce disclosure | `boolean` | Activator toggles content |
 | `aria-controls` | Activator → content linkage | Content element ID | `aria-controls="popover-123"` |
@@ -686,15 +691,15 @@ When uncertain, don't hook up. Adding a plugin later is a non-breaking change; r
 - [ ] `defineOptions({ name: '...' })` present
 - [ ] Props interface extends `AtomProps` and does not re-declare `as` / `renderless`
 - [ ] Defaults in destructuring, never in interface
-- [ ] Slot props typed as `ComponentRootSlotProps` with `is<State>` booleans and `attrs` object
-- [ ] `slotProps` computed via `toRef`
+- [ ] Interactive-control slot props typed as `ComponentRootSlotProps` with `is<State>` booleans and `attrs` object; structural slots may bind a single field
+- [ ] `slotProps` computed via `toRef` on the control path
 - [ ] Data attributes use `true | undefined`, not `true | false`
-- [ ] `aria-disabled` always boolean; `data-disabled` always `true | undefined`
-- [ ] All user-facing strings through `useLocale()`
-- [ ] Three-pronged disabled (`aria-disabled`, `data-disabled`, tabindex)
+- [ ] `aria-disabled` concrete boolean on non-button hosts; native `<button>` uses `disabled` and omits `aria-disabled`; `data-disabled` always `true | undefined`
+- [ ] Translatable copy through `useLocale()`; ARIA role tokens stay as spec strings
+- [ ] Three-pronged disabled on the polyfill path (`aria-disabled`, `data-disabled`, tabindex)
 - [ ] Hidden input conditionally rendered with `v-if="name"`
 - [ ] Barrel: no `export *` from `.vue`, named exports plus compound object
-- [ ] Template root is `<Atom :as :renderless>` (DOM-rendering Roots) or a bare `<slot v-bind="slotProps" />` (pure context-provider Roots — §5.3)
+- [ ] Template root is `<Atom :as :renderless>` (DOM-rendering Roots), a bare `<slot v-bind="slotProps" />` (pure context-provider Roots), or a renderless Atom (overlay context Roots — §5.3)
 - [ ] `v-if` for structural conditionals; `v-show` only when the element must stay mounted (registry-driven visibility, load-state preservation, virtualization)
 - [ ] `onBeforeUnmount` for deregistration, not `onUnmounted`
 - [ ] Zero utility classes; all `:style` bindings structural

--- a/.claude/rules/composables.md
+++ b/.claude/rules/composables.md
@@ -139,9 +139,9 @@ Skip `@example` only for trivial types whose example would just restate the type
 | `computed(() => ...)` | Derived state: filtering, mapping, aggregation. Only when caching matters. [intent:127] |
 | `toRef(() => ...)` | Default derivation: simple property access, ternaries, cheap composition. [intent:128] |
 | `ref(value)` | Mutable objects/arrays that need deep tracking. [intent:129] |
-| `readonly()` / `shallowReadonly()` | Plugin singletons exposed to consumers. [intent:130] |
+| `readonly()` / `shallowReadonly()` | Plugin singletons **and their fallbacks**. [intent:130] |
 
-**Rule.** Registry collections stay mutable; plugin singletons get readonly wrapping. [intent:131, PHILOSOPHY §4.2]
+**Rule.** Registry collections stay mutable; plugin singletons get readonly wrapping at runtime (`shallowReadonly`). Factory composables type `Readonly<Ref<T>>` and return the bare ref — that is the §8.3 factory shape, not a leak. Canonical wrap: `createReducedMotionFallback`. [intent:131, PHILOSOPHY §4.2 / §8.3]
 
 ## Options Reactivity (100% enforced)
 
@@ -152,6 +152,8 @@ Skip `@example` only for trivial types whose example would just restate the type
 | Reactive logic (keys, filters) | `MaybeRefOrGetter<T>` | `keys?: MaybeRefOrGetter<string[]>` [intent:134] |
 
 When destructuring the options object, the rest variable is `options`, never `modelOptions` or `registryOptions`. [intent:287]
+
+When the required input is a `Ref` that belongs with the rest of a field's config (`createInput`, `createValidation`), the bag is the signature — `createInput(options)` with `value: Ref<T>` inside. Do not split that positional-first (PHILOSOPHY §3.2).
 
 ```ts
 // Right
@@ -566,6 +568,7 @@ If you skip the calls in uniform mode (treating it as "items don't need to measu
 - [ ] Options destructured as `options` rest var with literal defaults
 - [ ] Extension via `{ ...parent, newProperty }`, never override
 - [ ] Reactive primitive matches §4.1 table (`toRef` default, `computed` for expensive)
+- [ ] Plugin singletons and fallbacks wrap consumer refs with `shallowReadonly`; factory `Readonly<Ref<T>>` returns stay type-only
 - [ ] UI-state options are `MaybeRefOrGetter<T>`, config options plain `T`
 - [ ] Error handling uses three-way split (throw/warn/return)
 - [ ] DOM observers/listeners clean up in `onScopeDispose`

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -11,7 +11,7 @@ Scope-specific mechanics for `apps/docs/**`. Covers page types, frontmatter, int
 - §2.1 Headless contract — applies to example files (utility classes are allowed in examples, forbidden in source)
 - §3.5 Slot conventions (`v-bind="attrs"` double-fire hazard)
 - §3.6 Boolean data attributes (data-driven examples)
-- §5.5 Locale-first strings
+- §5.5 Locale-first strings (translatable copy through `useLocale`; ARIA role tokens stay as spec strings)
 
 Cross-cutting authoring patterns (data-attribute styling in examples, composable-instance naming, renderless toggle) are defined in `components.md` and `composables.md` — this file scopes to docs-page mechanics only.
 

--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -66,7 +66,7 @@ A headless lib exposes a small, fixed set of injection / DoS sinks, and v0 alrea
 |-----------|-------|--------------------|
 | Build a plain object keyed by caller- or registry-supplied strings | Skip keys in `UNSAFE_KEYS` (`#v0/utilities`) — `__proto__` / `constructor` / `prototype` | `mergeDeep` has it; `usePermissions` didn't |
 | Interpolate a value into a CSS string or `<style>` text | Mirror `ThemeAdapter` — validate keys with `SAFE_IDENT`, reject values matching `UNSAFE_CSS` (`useTheme/adapters/adapter.ts`) | v0 `ThemeAdapter` has it; paper `useTheme` didn't |
-| Build a `querySelector` string from a runtime id or value | Wrap the dynamic part in `CSS.escape()` | `createCombobox`, `Select` have it |
+| Build a `querySelector` string from a runtime id or value | Wrap the dynamic part in `CSS.escape()` | Component-owned ids (ComboboxItem / SelectItem `#${id}-option-${ticket.id}`). A composable must not `querySelector` for the node — PHILOSOPHY §2.5. |
 | Allocate an array from a caller-controlled count (`range(n)`, …) | Bound it — `clamp(Math.floor(n), 0, CAP)`, or the `n > Number.MAX_SAFE_INTEGER → []` guard | `createPagination` has it; `createRating` didn't |
 
 `UNSAFE_KEYS` is importable from `#v0/utilities`; the `ThemeAdapter` CSS sanitizer is a `private static` pattern to mirror, not import. Registry / selection / nested / tokens keyed state is `Map`-based and prototype-pollution-immune by construction — keep it that way; never swap a keyed `Map` for a plain `{}` index.
@@ -115,7 +115,8 @@ interface RegistryTicket {
 **Naming pair (enforced).** Input/output types always pair: `FooTicketInput` → `FooTicket`. Defined together, exported together. [intent:97]
 
 **Ticket state typing (enforced).**
-- Boolean state: `Readonly<Ref<boolean>>` — e.g., `isSelected`, `isMixed`. [intent:98]
+- Boolean state on **selection-chain** tickets: `Readonly<Ref<boolean>>` — e.g., `isSelected`, `isMixed`. [intent:98]
+- Queue / form tickets may use plain booleans for upsert-patched data fields (`QueueTicket.isPaused: boolean`). Do not force those onto `Readonly<Ref<boolean>>`.
 - Methods: plain functions, no parameters — self-reference via closure. [intent:99]
 - Config input: `MaybeRefOrGetter<T>`. Config output: plain `T`. [intent:100]
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -287,7 +287,7 @@ const wrapper = mount(Component.Root, {
 
 ## Locale string assertions (PHILOSOPHY §5.5)
 
-Assert `toBeDefined()` for locale strings, not exact text values. Tests must not pin to an English rendering. [intent:177]
+Assert `toBeDefined()` for **translatable copy** (aria-label, errors, visible names), not exact text values. Tests must not pin to an English rendering. [intent:177] ARIA role tokens (`aria-roledescription: 'carousel'`) are spec strings, not locale copy — pin those.
 
 ```ts
 // Right

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ when violated, not a stylistic preference.
 - **Headless contract** — no styling, CSS, or utility classes in package source. The
   library ships logic only; visual concerns belong to consumers. Structural inline
   styles a primitive genuinely needs (e.g. positioning) are the only exception.
+  Theme adapters may emit CSS custom properties and `color-scheme`; they must not
+  set element-level `color` / `background` / `padding`. Applying tokens is Paper.
 - **Events belong to components, not composables** — composables never attach or
   handle DOM events; only components (`.vue`) do. A `window.addEventListener` or
   `el.addEventListener` inside a composable body is a violation.

--- a/apps/docs/src/pages/composables/data/create-filter.md
+++ b/apps/docs/src/pages/composables/data/create-filter.md
@@ -88,7 +88,7 @@ flowchart LR
 | Option | Type | Default | Notes |
 | - | - | - | - |
 | `mode` | `'some' \| 'every' \| 'union' \| 'intersection'` | `'some'` | Multi-query matching strategy. See Filter Modes below |
-| `keys` | `string[]` | — | Object keys to filter on. When omitted, all values are checked |
+| `keys` | `MaybeRefOrGetter<readonly string[]>` | — | Object keys to filter on. When omitted, all values are checked. Tracks refs and getters. |
 | `customFilter` | `(query, item) => boolean` | — | Bypass built-in logic entirely with a custom predicate |
 
 ```ts
@@ -125,9 +125,10 @@ When the query is an array, each mode controls how multiple queries are matched 
 | - | :-: | - |
 | `query` | <AppSuccessIcon /> | ShallowRef, updated on each `apply()` |
 | `items` (from apply) | <AppSuccessIcon /> | Computed, filters reactively |
+| `keys` | <AppSuccessIcon /> | `MaybeRefOrGetter` — changing the keys re-runs the filter |
 
 > [!TIP] Reactive filtering
-> Both the query and items passed to `apply()` can be reactive. The filtered result automatically updates when either changes.
+> The query, items, and `keys` passed to `apply()` / `createFilter()` can be reactive. The filtered result automatically updates when any of them change.
 
 ## Examples
 
@@ -161,7 +162,7 @@ Both pass when any query matches, but `some` tests each field value independentl
 
 ??? How do I limit filtering to specific object fields?
 
-Pass `keys: ['name', 'email']` in the options. When `keys` is omitted, every value on the item is checked.
+Pass `keys: ['name', 'email']` in the options — a ref or getter is also accepted and tracked. When `keys` is omitted, every value on the item is checked.
 
 ??? When should I use createFilter vs createDataTable?
 

--- a/packages/0/PHILOSOPHY.md
+++ b/packages/0/PHILOSOPHY.md
@@ -69,6 +69,8 @@ Non-negotiable. Each axiom carries a statement, a rationale, and a concrete anti
 
 **Allowed.** Structural inline `:style` bindings when layout cannot work otherwise (flex directions, CSS custom properties for depth, visually-hidden positioning for hidden inputs, z-index from `useStack`). [intent:279]
 
+**Allowed — plugin CSS adapters.** `useTheme` adapters may inject a stylesheet of **custom properties** (`--{prefix}-{token}: …`) and `:root { color-scheme }`. They must not set element-level visual properties (`color`, `background`, `padding`, `font-*`, …). Applying tokens to rendered pixels is Paper's job. RTL and reduced-motion adapters write HTML `dir` / `data-*` attributes, not CSS. [intent:297]
+
 **Encouraged.** Data attributes for every state (`data-state`, `data-layer`, `data-disabled`, `data-orientation`). These are the consumer's styling hooks. [intent:280]
 
 **Anti-example.** Grep `class="(flex|px-|py-|bg-|text-|w-|h-|m-|gap-|grid)"` across `packages/0/src/**/*.vue` currently returns zero hits. Keep it that way. The single JSDoc example in `packages/0/src/components/Radio/RadioRoot.vue:176` is prose, not rendered.
@@ -81,10 +83,11 @@ Non-negotiable. Each axiom carries a statement, a rationale, and a concrete anti
 
 **Why.** `any` silently disables type-checking downstream. A single `as any` in a composable propagates into every consumer that spreads it. `unknown` forces the consumer to narrow, which is the correct contract.
 
-**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` in `packages/0/src/` — with two sanctioned exceptions:
+**Current state.** Zero `as any` casts in source. The one place reaching into a foreign private shape — `packages/0/src/components/Locale/Locale.vue:69`, accessing `vue-i18n`'s `_rootT`/`_rootN` — declares those fields on a local `ScopedLocale` interface and uses a typed intersection cast (`parent as typeof parent & ScopedLocale`), so the shape is documented rather than erased. No `: any`, `as any`, or `<any>` in `packages/0/src/` — with three sanctioned exceptions:
 
-1. **Slot returns** — `defineSlots<{ default: (props: SlotProps) => any }>()`, which Volar requires for correct slot inference (see §8.8). That `=> any` types the slot's *return*, never a value or argument, so it disables no downstream checking.
+1. **Slot returns** — `defineSlots<{ default: (props: SlotProps) => any }>()`. That `=> any` types the slot's *return*, never a value or argument, so it disables no downstream checking. `=> unknown` also typechecks and is in use; either is acceptable (see §8.8).
 2. **`isObject` predicate** — `item is Record<string, any>` in `packages/0/src/utilities/helpers.ts`. `Record<string, unknown>` is *incorrect* as a type predicate: TypeScript never grants interfaces an implicit index signature, so the guard destroys known property types and fails to subtract `Record<string, any>` members in the `else` branch (issue #723). The `any` is only the *index* type of the predicate; it is not a value typed `any`, and it is not a license for `as any` elsewhere. Call sites that walk untyped trees and need checked property access must pin the read: `const inner: unknown = value.$value`. The private `isPlainObject` helper used by `mergeDeep` stays on `Record<string, unknown>` deliberately — it is not a public predicate and must keep index reads as `unknown`.
+3. **Atom generic default** — `generic="T extends Record<string, any> = {}"` on `Atom.vue`. The `any` is the index of an unconstrained attrs bag so consumers can pass arbitrary attribute shapes; no call site instantiates `Atom<T>`. Same class as (1): it does not type a value as `any`.
 
 **Anti-example (do not do this).**
 ```ts
@@ -150,6 +153,8 @@ import { createRegistry } from '../createRegistry'
 - System composables that compose those primitives against an **explicitly injected** `MaybeRefOrGetter<EventTarget>` target, or a global (`document` / `window`) for session-scoped behavior. `useRovingFocus` and `useVirtualFocus` bind `keydown` to an injected container ref; `useDragDrop` adapters bind `pointer*` to `document`; `useStorage` listens for `storage` on `window`. The consumer supplies (or globally scopes) the target, so no tree is stolen — consistent with §5.2's `MaybeRefOrGetter<EventTarget>` input contract.
 
 **Anti-example (do not introduce).** A `createSlider` that calls `document.querySelector('.thumb')` (or renders and binds its own element) to attach `pointermove`. The correct shape exposes `onPointerdown`, `onPointermove`, `onPointerup` and the `SliderThumb.vue` component wires them — or, if it must own the listener, takes the thumb element as an injected `MaybeRefOrGetter<EventTarget>` rather than finding it.
+
+§6.3's DOM-query alternative is a **component Root**, fire-and-forget read. It does not license `querySelector` inside a `create*` / `use*` factory, and it does not license a standing `el: () => document.querySelector(...)` getter. **Known misses:** `createCombobox` and `SelectRoot` still ship that standing getter for option nodes.
 
 ---
 
@@ -334,6 +339,7 @@ Choose 3.1.3 only when there is literally one useful return. Any time you reach 
 - **Positional required input first**, then `options` object. `createFoo(required, options?)`.
 - **Options object is destructured inside the factory** using literal defaults, never `withDefaults`. [intent:9]
 - **Rest variable is named `options`** when destructuring — not `modelOptions`, not `registryOptions`. [intent:287]
+- **Required ref inside a field-options bag.** When the required input is a `Ref` that belongs with the rest of a field's config (`createInput`, `createValidation` — `value` next to `rules`, `error`, `disabled`), the bag *is* the signature: `createInput(options)` with `value: Ref<T>` inside. Do not split that positional-first; the ref is one option among several, not a standalone source.
 
 ```ts
 // Right
@@ -401,12 +407,14 @@ Why: destructuring defaults compose cleanly with Vapor mode and keep the prop su
 
 ### 3.5 Slot conventions
 
-All interactive components emit one slot, default, bound via `<slot v-bind="slotProps" />`. `slotProps` is a `toRef` with two shapes of content:
+**Interactive controls** (Checkbox, Switch, Dialog Action, Tabs Item, …) emit one default slot bound via `<slot v-bind="slotProps" />`. `slotProps` is a `toRef` with two shapes of content:
 
 - **Boolean state fields** named `is<State>`: `isDisabled`, `isSelected`, `isOpen`, `isMixed`, etc.
 - **An `attrs` object** containing ARIA attributes, data attributes, and event handlers, pre-merged via `mergeProps`. [intent:168, intent:169, intent:170]
 
-Slot props are always computed through `toRef`, never inline and never through `computed` unless the shape is legitimately expensive. [intent:169]
+Slot props on that path are always computed through `toRef`, never inline and never through `computed` unless the shape is legitimately expensive. [intent:169]
+
+**Structural / passthrough slots** — a chrome wrapper (AvatarRoot), a placeholder that only needs `hasValue`/`isEmpty`, a description that only forwards an `id` — may bind a single field (`<slot :id />`) without inventing an empty `attrs` object. Do not force the control shape onto a slot that has no ARIA or handlers to emit.
 
 Consumers in **non-renderless** components must not spread `attrs` onto a child — the handlers are already bound to the outer `<Atom>`. Spreading doubles the event. The rule is enforced in examples and lives in the docs rules file. [intent:189, intent:206, intent:207]
 
@@ -416,7 +424,7 @@ Boolean data attributes (`data-disabled`, `data-open`, `data-selected`) are alwa
 
 Token-valued attributes (`data-state`, `data-orientation`) use their string union plus `undefined` to omit. Splitter's `data-pending` is `'collapse' | 'expand' | undefined` — not the boolean `'' | undefined` used by AlertDialogAction.
 
-`aria-disabled` is the exception: always `boolean`, so assistive tech reads a concrete value. [intent:175]
+`aria-disabled` is the exception on **non-button hosts**: always a concrete `boolean`, so assistive tech reads a value. Native `<button>` hosts (`as === 'button'`) use the `disabled` attribute and **omit** `aria-disabled` — APG treats native `disabled` as the signal; duplicating it with `aria-disabled` is noise. The three-pronged pattern (`aria-disabled` + `data-disabled` + `tabindex`) applies on the polyfill path (`as !== 'button'`). [intent:175]
 
 ### 3.7 Comments: why, not what
 
@@ -460,7 +468,7 @@ The choice is **data shape × mutation scope**:
 | `reactive(obj)` | Deeply-nested object | Deep mutation tracked | **Rare.** Only when consumers must mutate nested fields and we cannot hand them a ref. Prefer `ref()` on the owner, `toRef(() => root.field)` for read-only access by subtrees. |
 | `toRef(() => expr)` | Derivation | Read-through (no cache) | Default for derivations — property access, booleans, ternaries, cheap composition. [intent:12, intent:37, intent:128] |
 | `computed(() => expr)` | Derivation | Cached until deps change | Only when the work is expensive: filtering, mapping, aggregation. [intent:38, intent:127] |
-| `readonly(obj)` / `shallowReadonly(ref)` | Any | Freezes writes | Plugin singletons and boundary-exposed state. [intent:130, intent:131] |
+| `readonly(obj)` / `shallowReadonly(ref)` | Any | Freezes writes | Plugin singletons and their fallbacks. Factory returns use type-only `Readonly<Ref<T>>` — see §4.2 / §8.3. [intent:130, intent:131] |
 
 The default is `toRef`. Reach for `computed` only when you would otherwise pay the same cost on every read. This keeps the mental model simple: "`toRef` is a getter, `computed` is a getter that remembers."
 
@@ -477,7 +485,11 @@ The default is `toRef`. Reach for `computed` only when you would otherwise pay t
 
 **Canonical form.** `shallowReadonly(state)` or `readonly(state)` for scalar state (interchangeable on a primitive `shallowRef`), `readonly(registry)` for deep collections.
 
-**The `Readonly<Ref<T>>` return-type pattern.** When a composable exposes a ref to consumers and does NOT want them to write to it, the returned interface types the field as `Readonly<Ref<T>>`. The type is load-bearing — consumers read it as a promise ("you cannot write this") and IDEs flag `.value = ...` as a type error. Wrapping with `shallowReadonly()` at runtime reinforces the same contract. [intent:252]
+**The `Readonly<Ref<T>>` return-type pattern.** When a composable exposes a ref to consumers and does NOT want them to write to it, the returned interface types the field as `Readonly<Ref<T>>`. The type is load-bearing — consumers read it as a promise ("you cannot write this") and IDEs flag `.value = ...` as a type error. [intent:252]
+
+**Runtime wrap is for plugin singletons.** `shallowReadonly()` / `readonly()` on the returned value is required on plugin contexts **and their fallbacks** — the value outlives a single setup scope and is reached from templates across the app. Factory composables (`createInput`, `createOtp`, `createValidation`, …) type the same contract as `Readonly<Ref<T>>` and return the bare ref; that is correct, not a leak. A `shallowReadonly` wrapper without the `Readonly<…>` type is useless; a `ShallowRef<T>` type on a value nobody should mutate is a leak.
+
+**Canonical runtime wrap.** `createReducedMotionFallback` wraps both `selectedMode` and `isReduced` with `shallowReadonly`. The live `createReducedMotion` wraps `selectedMode` only — `isReduced` is already a readonly `toRef`. A plugin fallback that returns a bare `shallowRef` for a field typed `Readonly<Ref<T>>` is the miss (`createThemeFallback`).
 
 ```ts
 // Right — boundary contract clear from both value and type
@@ -510,7 +522,7 @@ Always use `.value` when reading these in templates. Never rely on Vue's auto-un
 
 **Audit (resolved).** `useRovingFocus` and `createFocusTraversal` each expose a single consumer-visible ref (`focusedId` / `activeId`), both declared `ShallowRef<ID | undefined>` in their return interface (`RovingFocusReturn` / `TraversalReturn`). These are intentionally mutable — consumers set focus by writing the ref — so the `ShallowRef<T>` type is the correct contract; no `shallowReadonly` boundary wrapper is required. (Design note: writing the ref directly bypasses the internal `applyFocus()` DOM-focus side-effect; switch to `Readonly<Ref>` + a `focus()` method if direct writes should be disallowed.)
 
-**Resolution rule.** Any mutable return at a boundary must be intentional and declared in the return interface. If the type says `ShallowRef<boolean>`, the contract is "you can write this." If the type says `Readonly<Ref<boolean>>`, the contract is "do not write this." The type is load-bearing — a `shallowReadonly` wrapper on the value without updating the type is useless; a `ShallowRef<T>` type on a value nobody should mutate is a leak. [intent:252]
+**Resolution rule.** Any mutable return at a boundary must be intentional and declared in the return interface. If the type says `ShallowRef<boolean>`, the contract is "you can write this." If the type says `Readonly<Ref<boolean>>`, the contract is "do not write this." The type is load-bearing. Runtime `shallowReadonly` is an additional requirement on plugin singletons and fallbacks only — see above and §8.3. [intent:252]
 
 ### 4.3 `MaybeRefOrGetter<T>` at composable inputs
 
@@ -609,7 +621,11 @@ This is an acid test, not a vibe. If the only way to get state X to render diffe
 - **No utility classes.** Zero `class="px-4"`, zero `class="bg-primary"`. [intent:278]
 - **Structural-only `:style`.** `display: flex`, `flex-grow`, `visibility`, z-index from `useStack`, CSS custom properties for depth, visually-hidden positioning. If your `:style` sets `color` or `padding`, it is not structural. [intent:279]
 - **Data attributes as styling hooks.** `data-state="open"`, `data-disabled`, `data-orientation="vertical"`. Consumers style against these. [intent:280]
-- **DOM-rendering Roots use `<Atom :as :renderless>`.** The universal wrapper that lets consumers swap the tag and strip it. Provider / slot-only Roots — `DataGrid`, `DataTable`, `Group`, `Locale`, `Portal`, `Presence`, `Selection`, `Single`, `Step`, `Tabs`, `Treeview` — render only `<slot v-bind="slotProps" />` (or teleport their children) with no `Atom` wrapper, because their DOM is emitted by sub-components or the wrapper would be meaningless. [intent:186, intent:336]
+- **Three Root shapes.** [intent:186, intent:336]
+  - **DOM-rendering Roots** use `<Atom :as :renderless>`. The universal wrapper that lets consumers swap the tag and strip it.
+  - **Provider / slot-only Roots** — `DataGrid`, `DataTable`, `Group`, `Portal`, `Presence`, `Selection`, `Single`, `Step`, `Tabs`, `Treeview` — render only `<slot v-bind="slotProps" />` (or teleport their children) with no `Atom` wrapper, because their DOM is emitted by sub-components or the wrapper would be meaningless.
+  - **Overlay context Roots** — `AlertDialog`, `Combobox`, `Dialog`, `Popover`, `Select`, `Tooltip` — wrap a **renderless** Atom (`as` default `null`, `renderless` static `true`) so they provide context without emitting a host node. The visible surface is Activator / Content.
+  - **`Locale`** is a dual-mode provider: default wrapper `<component :is="as">` (`as = 'div'`), or renderless slot. It does not use `Atom` today; that is a known gap versus `Theme` / `Form`, not a slot-only Root. Do not list it with the provider-only set.
 
 ### 5.4 Hidden inputs
 
@@ -620,7 +636,13 @@ Interactive inputs with a `name` prop render a `<ComponentHiddenInput>` for nati
 
 ### 5.5 Locale-first strings
 
-Every user-facing string (`aria-label`, error messages, day-of-week names, month names) goes through `useLocale()`. The canonical pattern is `locale.ti(key) ?? '<English default>'` — `ti()` ("translate if exists") returns `undefined` for a missing key, where `t()` echoes the raw key back, and the `??` supplies an English fallback for the no-adapter case. Never hardcode a string with no `useLocale` path. Tests assert localizability — either via `toBeDefined()` or by asserting the English default plus a translated-locale value (e.g. Pagination `'Next page'` / `'Nächste Seite'`) — never by pinning a single hardcoded English string as the only expectation. [intent:176, intent:177]
+Three classes of string, three paths. Do not treat them as one rule. [intent:176, intent:177]
+
+1. **Translatable copy** — `aria-label`, error messages, visible names, day-of-week / month names. Goes through `useLocale()`. Canonical: `locale.ti(key) ?? '<English default>'` — `ti()` ("translate if exists") returns `undefined` for a missing key, where `t()` echoes the raw key back, and the `??` supplies an English fallback for the no-adapter case. Hardcoding `'Invalid code'` / `'Close dialog'` with no `useLocale` path is the miss.
+2. **ARIA role tokens** — spec tokens used as `role` or `aria-roledescription` values (`'carousel'`, `'slide'`, `'dialog'`, `'tablist'`). These are WAI-ARIA vocabulary, not locale copy. Leave them as the spec string.
+3. **Formatted numbers / dates / percents** — `aria-valuetext`, visible numeric labels. Go through `locale.n` / `useDate` when an adapter exists. A template literal `` `${pct}%` `` is a locale miss; `'carousel'` is not.
+
+Tests assert localizability of class (1) — either via `toBeDefined()` or by asserting the English default plus a translated-locale value (e.g. Pagination `'Next page'` / `'Nächste Seite'`) — never by pinning a single hardcoded English string as the only expectation.
 
 ---
 
@@ -659,7 +681,16 @@ Element refs shared between sub-components must propagate through registry regis
 
 **Carve-out — singleton 1:1 sub-components.** When the Root owns exactly one well-known sub-component (Popover's Activator, Slider's Track, Combobox's Control), the Root may expose a single boundary-typed `Readonly<Ref<Element | null>>` on its context and the sub-component writes to it directly on mount. The trade-off the registry pattern is solving (deregistration races for an unbounded set of children) does not apply when N is provably 1. The same Root must clear the field in `onBeforeUnmount` of the sub-component so the contract is symmetric.
 
-**Alternative — DOM query.** A Root that only needs the element for a one-shot read (measurement, focus on open) can query for it via a well-known data attribute the sub-component sets (illustratively, something like `[data-v0-popover-activator]` — note v0 does not currently ship a `data-v0-*` attribute convention) instead of holding a ref. The DOM query is acceptable for fire-and-forget reads; reactive observation (ResizeObserver, IntersectionObserver) still needs the ref so the observer can rebind across re-mounts.
+**Alternative — DOM query (component Root, fire-and-forget only).** A **`.vue` Root** that needs the element for a one-shot read (measurement, focus on open) may query a well-known data attribute the sub-component sets (illustratively `[data-v0-popover-activator]` — v0 does not currently ship a `data-v0-*` convention) instead of holding a ref.
+
+All four of these must hold or it is a §2.5 violation, not this carve-out:
+
+- The caller is a component Root, never a `create*` / `use*` composable.
+- The read is fire-and-forget (once on open, once on measure) — not a standing `el` getter re-run on every cursor move.
+- The selector is a data attribute the sub-component owns, not a reconstructed id (`#${id}-option-${ticket.id}`).
+- Reactive observation (ResizeObserver, IntersectionObserver, virtual-focus `el`) still needs a ref so the observer can rebind across re-mounts. Pass that ref from the component that renders the node.
+
+**Known misses.** `createCombobox` (`index.ts`) and `SelectRoot.vue` still feed virtual-focus `el` via a standing `document.querySelector` on a reconstructed `#${id}-option-${ticket.id}`. That is a §2.5 violation, not this carve-out — do not cite them as precedent.
 
 ### 6.4 Optional injection
 
@@ -869,19 +900,33 @@ When a type is genuinely indeterminate (e.g., ticket `value`), it is `unknown`. 
 
 ### 8.3 `Readonly<Ref<T>>` return contract
 
-Composable return interfaces type consumer-visible refs as `Readonly<Ref<T>>` when the caller must not mutate them. Cross-linked from §4.2. The wrapper is TypeScript-level *and* runtime-level: `shallowReadonly(ref)` on the value, `Readonly<Ref<T>>` in the return interface. [intent:252]
+Composable return interfaces type consumer-visible refs as `Readonly<Ref<T>>` when the caller must not mutate them. The type is the contract. Cross-linked from §4.2. [intent:252]
+
+Runtime `shallowReadonly(ref)` / `readonly(ref)` is required on **plugin singletons and their fallbacks** only. Factory composables type `Readonly<Ref<T>>` and return the bare ref.
 
 ```ts
-// Right
-export interface BreakpointsContext {
-  width: Readonly<ShallowRef<number>>
+// Right — plugin singleton (and its fallback): type + runtime wrap
+export interface ReducedMotionContext {
+  selectedMode: Readonly<Ref<ReducedMotionMode>>
+  isReduced: Readonly<Ref<boolean>>
 }
 
-function useBreakpoints (): BreakpointsContext {
-  const width = shallowRef(window.innerWidth)
-  return { width: readonly(width) }
+function createReducedMotionFallback (): ReducedMotionContext {
+  return {
+    selectedMode: shallowReadonly(shallowRef<ReducedMotionMode>('system')),
+    isReduced: shallowReadonly(shallowRef(false)),
+    select: () => {},
+    dispose: () => {},
+  }
+}
+
+// Right — factory: type-only. Returning the bare ref is not a leak.
+export interface InputContext {
+  isPristine: Readonly<Ref<boolean>>
 }
 ```
+
+A plugin fallback that returns `isDark: shallowRef(false)` for a field typed `Readonly<Ref<boolean>>` is the miss (`createThemeFallback`). Do not "fix" `createInput.isPristine` by wrapping it — that is the factory shape.
 
 ### 8.4 `MaybeRefOrGetter<T>` at composable inputs
 
@@ -946,9 +991,11 @@ export function createSortable<
 > (_options: SortableOptions = {}): SortableContext<Z, E>
 ```
 
+**Exception — `createQueue`.** Registry-based and on the §6.10 list, but not parameterized: `createQueue(): QueueContext`. Queue tickets are data records patched via `upsert` (`isPaused: boolean`), not selection-style `Readonly<Ref<boolean>>` ticket state. Do not add `Z`/`E` unless a caller needs custom ticket fields.
+
 ### 8.8 Slot type guardrails
 
-Components explicitly type slots via `defineSlots<{ default: (props: SlotProps) => any }>()`. Never `export *` from `.vue` files — it breaks Volar slot inference. [intent:184, intent:337, intent:338]
+Components explicitly type slots via `defineSlots<{ default: (props: SlotProps) => any }>()`. `=> any` is conventional for Volar slot inference; `=> unknown` also typechecks in this package and is in use. Either is acceptable — do not churn existing sites, and do not treat `=> unknown` as a §2.2 violation. Never `export *` from `.vue` files — it breaks Volar slot inference. [intent:184, intent:337, intent:338]
 
 ---
 
@@ -1018,33 +1065,33 @@ Reason: §2.3.
 
 ### 10.2 Unwrapped mutable state at a boundary
 
-**Before (wrong — illustrative; the live `useResizeObserver` delegates to `createObserver`, and the sibling `useElementSize` already wraps `isActive` in `shallowReadonly`).**
+Applies to **plugin singletons and their fallbacks**. Factory composables type `Readonly<Ref<T>>` and return the bare ref — that is the §8.3 factory shape, not this anti-pattern.
+
+**Before (wrong — a plugin fallback returning a bare ref for a field typed `Readonly<Ref<T>>`).**
 ```ts
-return {
-  width: shallowReadonly(width),
-  height: shallowReadonly(height),
-  isActive,                              // mutable — inconsistent
-  isPaused: shallowReadonly(isPaused),
-  pause,
-  resume,
-  stop,
+function createReducedMotionFallback (): ReducedMotionContext {
+  return {
+    selectedMode: shallowReadonly(shallowRef<ReducedMotionMode>('system')),
+    isReduced: shallowRef(false),        // typed Readonly<Ref<boolean>>, returned mutable
+    select: () => {},
+    dispose: () => {},
+  }
 }
 ```
 
 **After (right).**
 ```ts
-return {
-  width: shallowReadonly(width),
-  height: shallowReadonly(height),
-  isActive: shallowReadonly(isActive),
-  isPaused: shallowReadonly(isPaused),
-  pause,
-  resume,
-  stop,
+function createReducedMotionFallback (): ReducedMotionContext {
+  return {
+    selectedMode: shallowReadonly(shallowRef<ReducedMotionMode>('system')),
+    isReduced: shallowReadonly(shallowRef(false)),
+    select: () => {},
+    dispose: () => {},
+  }
 }
 ```
 
-Reason: §4.2. Either all boundary state is readonly, or the interface explicitly declares mutability with `ShallowRef<T>`.
+Reason: §4.2 / §8.3. On a plugin surface, either wrap at runtime or declare mutability with `ShallowRef<T>`. Do not mix.
 
 ---
 
@@ -1297,11 +1344,14 @@ Reason: §6.3, [intent:270].
 
 ### 10.13 Hardcoded English strings
 
+Class (1) from §5.5 — translatable copy. ARIA role tokens (`aria-roledescription: 'carousel'`) are class (2) and are not this anti-pattern.
+
 **Before (wrong).**
 ```ts
 attrs: {
   'aria-label': 'Close dialog',
 }
+errorMessages.value = ['Invalid code']
 ```
 
 **After (right).**
@@ -1310,6 +1360,7 @@ const locale = useLocale()
 attrs: {
   'aria-label': locale.ti('Dialog.close') ?? 'Close',
 }
+errorMessages.value = [locale.ti('Otp.invalid') ?? 'Invalid code']
 ```
 
 Reason: §5.5, [intent:176].

--- a/packages/0/src/composables/createCombobox/adapters/client.test.ts
+++ b/packages/0/src/composables/createCombobox/adapters/client.test.ts
@@ -125,6 +125,25 @@ describe('clientComboboxAdapter', () => {
       expect(result.filtered.value.has('a')).toBe(true)
       expect(result.filtered.value.has('b')).toBe(false)
     })
+
+    it('should re-filter when keys is a ref that changes', () => {
+      const keys = shallowRef(['name'])
+      const adapter = new ClientComboboxAdapter({ keys })
+      const items = [
+        makeTicket('a', { name: 'Apple', desc: 'red fruit' }),
+        makeTicket('b', { name: 'Banana', desc: 'yellow fruit' }),
+      ]
+      const ctx = createContext(items, 'fruit')
+      const result = adapter.setup(ctx)
+
+      expect(result.filtered.value.has('a')).toBe(false)
+      expect(result.filtered.value.has('b')).toBe(false)
+
+      keys.value = ['desc']
+
+      expect(result.filtered.value.has('a')).toBe(true)
+      expect(result.filtered.value.has('b')).toBe(true)
+    })
   })
 
   describe('whitespace query', () => {

--- a/packages/0/src/composables/createCombobox/adapters/client.ts
+++ b/packages/0/src/composables/createCombobox/adapters/client.ts
@@ -18,12 +18,13 @@ import { computed, shallowRef, toRef } from 'vue'
 import type { FilterItem, FilterMode } from '#v0/composables/createFilter'
 import type { ID } from '#v0/types'
 import type { ComboboxAdapterContext, ComboboxAdapterResult } from './adapter'
+import type { MaybeRefOrGetter } from 'vue'
 
 export interface ClientComboboxAdapterOptions {
   /** Filter matching mode */
   mode?: FilterMode
   /** Object keys to match against (for object values) */
-  keys?: string[]
+  keys?: MaybeRefOrGetter<readonly string[]>
   /** Custom filter function — overrides default matching */
   filter?: (query: string, value: unknown) => boolean
 }

--- a/packages/0/src/composables/createDataTable/adapters/adapter.ts
+++ b/packages/0/src/composables/createDataTable/adapters/adapter.ts
@@ -114,7 +114,7 @@ export abstract class DataTableAdapter<T extends object> {
     // are observed at filter-call time rather than at setup time.
     const filterOptions: FilterOptions = {
       ...context.filterOptions,
-      keys: [...toValue(context.filterableKeys)],
+      keys: context.filterableKeys,
       customFilter: context.filterOptions.customFilter ?? ((query, item) => {
         const columnFilters = toValue(context.customColumnFilters)
         const keys = toValue(context.filterableKeys)

--- a/packages/0/src/composables/createFilter/index.test.ts
+++ b/packages/0/src/composables/createFilter/index.test.ts
@@ -43,6 +43,32 @@ describe('createFilter.apply', () => {
     expect(filtered.value[0]?.name).toBe('banana')
   })
 
+  it('should re-filter when keys is a ref that changes', () => {
+    const keys = shallowRef(['color'])
+    const filter = createFilter({ keys })
+    const { items: filtered } = filter.apply('apple', items)
+
+    expect(filtered.value).toHaveLength(1)
+    expect(filtered.value[0]?.name).toBe('apple juice')
+
+    keys.value = ['name']
+
+    expect(filtered.value).toHaveLength(3)
+    expect(filtered.value.every(i => i.name.includes('apple'))).toBe(true)
+  })
+
+  it('should re-filter when keys is a getter that changes', () => {
+    const keys = shallowRef(['color'])
+    const filter = createFilter({ keys: () => keys.value })
+    const { items: filtered } = filter.apply('apple', items)
+
+    expect(filtered.value).toHaveLength(1)
+
+    keys.value = ['name']
+
+    expect(filtered.value).toHaveLength(3)
+  })
+
   it('should require all keys to match query with mode: every', () => {
     const filter = createFilter({ keys: ['name', 'color'], mode: 'every' })
     const { items: filtered } = filter.apply('apple', items)

--- a/packages/0/src/composables/createFilter/index.ts
+++ b/packages/0/src/composables/createFilter/index.ts
@@ -49,7 +49,7 @@ export type FilterFunction = (query: Primitive | Primitive[], item: FilterItem) 
 
 export interface FilterOptions {
   customFilter?: FilterFunction
-  keys?: string[]
+  keys?: MaybeRefOrGetter<readonly string[]>
   mode?: FilterMode
 }
 
@@ -61,7 +61,7 @@ export interface FilterContext<Z extends FilterItem = FilterItem> {
   /** The filter mode */
   mode: FilterMode
   /** Keys to filter on for object items */
-  keys: string[] | undefined
+  keys: MaybeRefOrGetter<readonly string[]> | undefined
   /** Custom filter function */
   customFilter: FilterFunction | undefined
   /** Current query ref */
@@ -83,7 +83,7 @@ export interface FilterContextOptions extends FilterOptions {
 function defaultFilter (
   query: Primitive | Primitive[],
   item: FilterItem,
-  keys?: string[],
+  keys?: readonly string[],
   mode: FilterMode = 'some',
 ): boolean {
   const queries = toArray(query).map(q => String(q).toLowerCase())
@@ -145,7 +145,7 @@ export function createFilter<
   E extends FilterContext<Z> = FilterContext<Z>,
 > (options: FilterOptions = {}): E {
   const { customFilter, keys, mode = 'some' } = options
-  const filterFunction = customFilter ?? ((q, i) => defaultFilter(q, i, keys, mode))
+  const filterFunction = customFilter ?? ((q, i) => defaultFilter(q, i, toValue(keys), mode))
   const query = shallowRef<Primitive | Primitive[]>('')
 
   function apply<T extends Z> (

--- a/packages/0/src/composables/useTheme/adapters/adapter.ts
+++ b/packages/0/src/composables/useTheme/adapters/adapter.ts
@@ -55,7 +55,7 @@ export abstract class ThemeAdapter {
         .map(([key, val]) => `  --${this.prefix}-${key}: ${this.rgb ? this.decompose(val) : val};`)
         .join('\n')
 
-      css += `[data-theme="${theme}"] {\n${vars}\n  color: var(--${this.prefix}-on-background);\n}\n`
+      css += `[data-theme="${theme}"] {\n${vars}\n}\n`
     }
 
     if (!isUndefined(isDark)) {

--- a/packages/0/src/composables/useTheme/adapters/v0.test.ts
+++ b/packages/0/src/composables/useTheme/adapters/v0.test.ts
@@ -421,6 +421,7 @@ describe('v0StyleSheetThemeAdapter', () => {
       expect(css).toContain('--v0-primary: #1976d2')
       expect(css).toContain('--v0-secondary: #424242')
       expect(css).toContain('color-scheme: light')
+      expect(css).not.toContain('color: var(')
     })
 
     it('should generate dark color-scheme when isDark is true', () => {

--- a/packages/0/src/composables/useTheme/index.test.ts
+++ b/packages/0/src/composables/useTheme/index.test.ts
@@ -1025,6 +1025,7 @@ describe('createTheme', () => {
       expect(css).toContain('--v0-primary: #1976d2')
       expect(css).toContain('--v0-secondary: #424242')
       expect(css).toContain('color-scheme: light')
+      expect(css).not.toContain('color: var(')
     })
 
     it('should generate dark color-scheme when isDark is true', () => {


### PR DESCRIPTION
Closes the philosophy-vs-source contradictions that the ledger flagged as *doc* problems, plus the two source fixes that those axioms now require.

- **PHILOSOPHY / rules** — readonly is type-load-bearing (runtime wrap on plugin fallbacks only); DOM-query is a component-Root fire-and-forget read; theme adapters emit custom properties + `color-scheme`; slot / `aria-disabled` / locale-string / Locale / overlay-root / `createQueue` claims narrowed to match the tree. `createCombobox` and `SelectRoot` named as known §2.5 misses.
- **useTheme** — `ThemeAdapter.generate()` no longer sets `color: var(--*-on-background)` on `[data-theme]`. Applying tokens is Paper's job.
- **createFilter** — `keys` is `MaybeRefOrGetter<readonly string[]>` and is read via `toValue()` in the apply path. DataTable passes `filterableKeys` through instead of snapshotting at setup.