### PR TITLE
docs: hide stale app banner

### DIFF
--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -246,7 +246,7 @@
       Skip to main content
     </a>
 
-    <div class="app-shell-content pt-[calc(48px+var(--app-banner-h,24px))]">
+    <div class="app-shell-content pt-[calc(48px+var(--app-banner-h,0px))]">
       <AppBanner />
       <AppBar />
 

--- a/apps/docs/src/components/app/AppBanner.vue
+++ b/apps/docs/src/components/app/AppBanner.vue
@@ -2,9 +2,6 @@
   // Framework
   import { IN_BROWSER, Atom, useNotifications, useStorage } from '@vuetify/v0'
 
-  // Constants
-  import { INDEXABLE, PROD_SITE_URL } from '@/constants/site'
-
   // Utilities
   import { onScopeDispose, toRef, watchEffect } from 'vue'
 
@@ -16,21 +13,9 @@
   const notifications = useNotifications()
   const storage = useStorage()
 
-  // Bump BANNER_ID whenever the banner content changes — a new id re-shows the
-  // banner even for readers who dismissed the previous one.
-  const BANNER_ID = INDEXABLE ? 'v1.0-live' : 'docs-dev-unreleased'
+  // No active announcement. Bump BANNER_ID and register a ticket to re-show.
+  const BANNER_ID = 'none'
   const SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
-
-  // Snooze is owned by the notifications plugin (persist: true). Dismiss is a
-  // separate storage key so a content bump still re-shows the banner.
-  if (!notifications.has(BANNER_ID)) {
-    notifications.register({
-      id: BANNER_ID,
-      subject: INDEXABLE ? 'Vuetify0 v1.0 is here' : 'Unreleased dev docs',
-      severity: 'warning',
-      data: { type: 'banner' },
-    })
-  }
 
   const banner = toRef(() => {
     return notifications.values().find(n => n.data?.type === 'banner')
@@ -51,7 +36,6 @@
     banner.value?.snooze(new Date(Date.now() + SNOOZE_MS))
   }
 
-  // Sync banner height to CSS variable so AppBar, AppNav, and layouts can adapt
   watchEffect(() => {
     if (!IN_BROWSER) return
     document.documentElement.style.setProperty('--app-banner-h', visible.value ? '24px' : '0px')
@@ -72,13 +56,7 @@
     <AppIcon class="shrink-0" icon="vuetify-0" :size="14" />
 
     <div class="min-w-0 truncate pe-6">
-      <template v-if="INDEXABLE">
-        {{ banner?.subject }}<span class="hidden sm:inline"> — the stable release is live!</span><span class="hidden md:inline"> Read the <a class="underline underline-offset-2" href="https://vtfy.link/announcing-vuetify0-v1" rel="noopener" target="_blank">announcement</a>.</span>
-      </template>
-
-      <template v-else>
-        {{ banner?.subject }}<span class="hidden sm:inline"> — queued features, not a release.</span><span class="hidden md:inline"> Stable docs: <a class="underline underline-offset-2" :href="PROD_SITE_URL" rel="noopener">0.vuetifyjs.com</a>.</span>
-      </template>
+      {{ banner?.subject }}
     </div>
 
     <div class="absolute end-2 flex items-center gap-2">

--- a/apps/docs/src/components/app/AppBar.vue
+++ b/apps/docs/src/components/app/AppBar.vue
@@ -40,7 +40,7 @@
 <template>
   <Atom
     :as
-    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,24px)] px-2 min-[430px]:px-3 text-on-surface border-b border-solid border-divider z-1', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
+    :class="['flex items-center justify-between h-[48px] fixed inset-x-0 top-[var(--app-banner-h,0px)] px-2 min-[430px]:px-3 text-on-surface border-b border-solid border-divider z-1', settings.showBgGlass.value ? 'bg-glass-surface' : 'bg-surface']"
     data-app-bar
   >
     <div class="flex items-center gap-2">

--- a/apps/docs/src/components/app/AppNav.vue
+++ b/apps/docs/src/components/app/AppNav.vue
@@ -150,7 +150,7 @@
     aria-label="Main navigation"
     as="nav"
     :class="[
-      'flex flex-col fixed w-[230px] top-0 md:top-[calc(48px+var(--app-banner-h,24px))] bottom-0 start-0 -translate-x-full rtl:translate-x-full md:translate-x-0 border-e border-solid border-divider',
+      'flex flex-col fixed w-[230px] top-0 md:top-[calc(48px+var(--app-banner-h,0px))] bottom-0 start-0 -translate-x-full rtl:translate-x-full md:translate-x-0 border-e border-solid border-divider',
       settings.surface.value,
       navigation.isOpen.value && '!translate-x-0',
       !settings.prefersReducedMotion.value && 'transition-transform duration-200 ease-in-out',

--- a/apps/docs/src/components/docs/DocsAskPanel.vue
+++ b/apps/docs/src/components/docs/DocsAskPanel.vue
@@ -154,7 +154,7 @@
       isDesktop && fullscreen
         ? 'fixed inset-4 rounded-lg border border-divider shadow-lg'
         : isDesktop
-          ? 'fixed end-4 top-[calc(48px+var(--app-banner-h,24px)+20px)] w-[clamp(280px,calc(100vw-230px-730px-64px),500px)] h-[calc(100vh-113px-var(--app-banner-h,24px))] rounded-lg border border-divider shadow-lg'
+          ? 'fixed end-4 top-[calc(48px+var(--app-banner-h,0px)+20px)] w-[clamp(280px,calc(100vw-230px-730px-64px),500px)] h-[calc(100vh-113px-var(--app-banner-h,0px))] rounded-lg border border-divider shadow-lg'
           : 'fixed inset-0',
     ]"
     :role="isDesktop ? 'complementary' : 'dialog'"

--- a/apps/docs/src/components/docs/DocsToc.vue
+++ b/apps/docs/src/components/docs/DocsToc.vue
@@ -31,7 +31,7 @@
   <Discovery.Activator
     v-if="toc.headings.value.length > 0 && !ask.isOpen.value"
     as="aside"
-    class="hidden xl:block rounded-lg fixed end-4 top-[calc(48px+var(--app-banner-h,24px)+28px)] w-[210px] max-h-[calc(100vh-121px-var(--app-banner-h,24px))] overflow-y-auto text-sm"
+    class="hidden xl:block rounded-lg fixed end-4 top-[calc(48px+var(--app-banner-h,0px)+28px)] w-[210px] max-h-[calc(100vh-121px-var(--app-banner-h,0px))] overflow-y-auto text-sm"
     :padding="8"
     step="toc"
   >

--- a/apps/docs/src/layouts/default.vue
+++ b/apps/docs/src/layouts/default.vue
@@ -18,7 +18,7 @@
 </script>
 
 <template>
-  <div class="min-h-[calc(100vh-48px-var(--app-banner-h,24px))] flex flex-col">
+  <div class="min-h-[calc(100vh-48px-var(--app-banner-h,0px))] flex flex-col">
     <AppNav />
     <AppMainDocs class="flex-1" />
     <AppFooter inset />


### PR DESCRIPTION
The docs app banner still advertised v1.0 / unreleased-dev copy, which is outdated.

Stop registering that announcement, keep `AppBanner` in place for the next one, and default `--app-banner-h` to `0` so the shell no longer reserves a 24px gap.