### PR TITLE
fix(Toggle): emit native disabled on the default button host

### DIFF
--- a/.changeset/toggle-native-disabled.md
+++ b/.changeset/toggle-native-disabled.md
@@ -1,0 +1,7 @@
+---
+"@vuetify/v0": patch
+---
+
+fix(Toggle): emit native `disabled` on the default button host
+
+Disabled `Toggle.Root` now sets the HTML `disabled` attribute when `as` is `"button"` (the default) and omits `aria-disabled` on that path. Non-button hosts still get `aria-disabled`.

--- a/apps/docs/src/pages/components/actions/toggle.md
+++ b/apps/docs/src/pages/components/actions/toggle.md
@@ -82,7 +82,8 @@ Toggle renders as a native `<button>` element with proper ARIA attributes:
 | Attribute | Value | Description |
 |-----------|-------|-------------|
 | `aria-pressed` | `true` / `false` | Reflects the pressed state |
-| `aria-disabled` | `true` / absent | Present when disabled |
+| `disabled` | present / absent | Native `<button>` host (the default) when disabled |
+| `aria-disabled` | `true` / `false` | Non-button hosts (`as` is not `button`) |
 
 ### Group ARIA
 

--- a/packages/0/src/components/Toggle/ToggleRoot.vue
+++ b/packages/0/src/components/Toggle/ToggleRoot.vue
@@ -56,7 +56,8 @@
       'type': 'button' | undefined
       'role': 'button' | undefined
       'aria-pressed': boolean
-      'aria-disabled': boolean
+      'aria-disabled': boolean | undefined
+      'disabled': boolean | undefined
       'tabindex': 0 | -1
       'data-state': 'on' | 'off'
       'data-disabled': true | undefined
@@ -174,7 +175,8 @@
       'type': as === 'button' ? 'button' : undefined,
       'role': as === 'button' ? undefined : 'button',
       'aria-pressed': isPressed.value,
-      'aria-disabled': isDisabled.value,
+      'aria-disabled': as === 'button' ? undefined : isDisabled.value,
+      'disabled': as === 'button' ? isDisabled.value : undefined,
       'tabindex': isDisabled.value ? -1 : 0,
       'data-state': isPressed.value ? 'on' : 'off',
       'data-disabled': isDisabled.value ? true : undefined,

--- a/packages/0/src/components/Toggle/index.browser.test.ts
+++ b/packages/0/src/components/Toggle/index.browser.test.ts
@@ -188,8 +188,28 @@ describe('toggle', () => {
 
         expect(model.value).toBe(false)
         expect(props().isDisabled).toBe(true)
+        expect(props().attrs.disabled).toBe(true)
+        expect(props().attrs['aria-disabled']).toBeUndefined()
+        expect(props().attrs['data-disabled']).toBe(true)
+        expect(wrapper.attributes('disabled')).toBe('')
+      })
+
+      it('should emit aria-disabled on a non-button host', async () => {
+        const model = ref(false)
+        const { wrapper, props, wait } = mountToggle({
+          model,
+          props: { disabled: true, as: 'div' },
+        })
+
+        await wrapper.trigger('click')
+        await wait()
+
+        expect(model.value).toBe(false)
+        expect(props().attrs.disabled).toBeUndefined()
         expect(props().attrs['aria-disabled']).toBe(true)
         expect(props().attrs['data-disabled']).toBe(true)
+        expect(wrapper.attributes('disabled')).toBeUndefined()
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
       })
 
       it('should expose toggle function in slot props', () => {
@@ -444,6 +464,9 @@ describe('toggle', () => {
 
         expect(model.value).toBeUndefined()
         expect(itemProps('a').isDisabled).toBe(true)
+        expect(itemProps('a').attrs.disabled).toBe(true)
+        expect(itemProps('a').attrs['aria-disabled']).toBeUndefined()
+        expect(buttons[0].attributes('disabled')).toBe('')
       })
 
       it('should reflect group disabled in group slot props', () => {


### PR DESCRIPTION
Disabled `Toggle.Root` now sets the HTML `disabled` attribute when `as` is `"button"` (the default) and omits `aria-disabled` on that path. Non-button hosts still get `aria-disabled`.

Matches the default-button host contract already used by Collapsible.Activator.